### PR TITLE
fix(server): suppress watchdog interaction wait loops

### DIFF
--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -801,6 +801,14 @@ same evaluator used for every agent applies `anyone`, `not_creator`, `human_only
 named-addressee, company-cap, company-boundary, run-attribution, low-trust,
 task-bridge, target-staleness, and exact-once checks.
 
+A pending issue-thread interaction is a live waiting path when its effective
+resolver policy names a supported resolver audience and its continuation policy
+is `wake_assignee` or `wake_assignee_on_accept`. While that path remains pending,
+task-watchdog reconciliation must not classify the source subtree as stopped,
+reopen the reusable watchdog issue, mutate the source posture, or enqueue a
+watchdog wake. Resolution, expiry, withdrawal, or target staleness removes the
+waiting path and lets the next reconciliation evaluate the remaining subtree.
+
 Resolving an interaction does not authorize its downstream effect. In particular,
 an accepted plan still passes normal decomposition/idempotency checks, and a
 governed action still requires its own typed reviewer, permission, or formal
@@ -817,6 +825,7 @@ Implementation, security, UI, and QA work for task watchdogs must prove these co
 - interaction tests prove watchdog runs use the same resolver policy as ordinary agents, without a watchdog-only kind or purpose-marker exception
 - interaction tests cover `anyone`, `not_creator`, `human_only`, named addressees, company caps, stale targets, governed actions, newer user comments, low-trust/task-bridge containment, and cross-company denial
 - scheduler tests prove live runs, queued wakes, and scheduled retries suppress watchdog wakeups, while terminal, cancelled, blocked, and review leaves are still verified when the subtree has no live path
+- scheduler tests prove resumable pending interactions suppress repeated watchdog ticks and reusable-watchdog reopen cycles until the interaction reaches a terminal state
 - tests prove `task_watchdog` origin issues and descendants are excluded from scans so watchdogs do not trigger themselves
 - recovery-batch tests prove batches are capped at 3 allowed mutations, applied all-or-nothing, and aborted with recorded evidence when the observed stop fingerprint went stale mid-batch
 - restoration-verification tests prove a "live path restored" disposition re-fires on an unchanged fingerprint with an incremented attempt count, a failed intermediate-node restoration is not treated as a reviewed stop, and the N-attempt bound escalates to a human with attempt history instead of firing forever

--- a/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
+++ b/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
@@ -681,4 +681,29 @@ describe("issue dependency wakeups in issue routes", () => {
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(mockWakeup).not.toHaveBeenCalled();
   });
+
+  it("does not wake the watched source when a task-watchdog child becomes terminal", async () => {
+    mockIssueService.getById.mockResolvedValue(issueRecord({
+      id: "watchdog-1",
+      identifier: "PAP-102",
+      title: "Watchdog review",
+      status: "in_progress",
+      parentId: "source-1",
+      originKind: "task_watchdog",
+    }));
+    mockIssueService.update.mockResolvedValue(issueRecord({
+      id: "watchdog-1",
+      identifier: "PAP-102",
+      title: "Watchdog review",
+      status: "done",
+      parentId: "source-1",
+      originKind: "task_watchdog",
+    }));
+
+    const res = await request(await createApp()).patch("/api/issues/watchdog-1").send({ status: "done" });
+
+    expect(res.status).toBe(200);
+    expect(mockIssueService.getWakeableParentAfterChildCompletion).not.toHaveBeenCalled();
+    expect(mockWakeup).not.toHaveBeenCalled();
+  });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -4689,6 +4689,62 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
       childIssueSummaryTruncated: false,
     });
   });
+
+  it("excludes task-watchdog children from parent completion readiness", async () => {
+    const companyId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: assigneeAgentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    const parentId = randomUUID();
+    const deliveryChildId = randomUUID();
+    await db.insert(issues).values([
+      {
+        id: parentId,
+        companyId,
+        title: "Parent issue",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId,
+      },
+      {
+        id: deliveryChildId,
+        companyId,
+        parentId,
+        title: "Delivery child",
+        status: "done",
+        priority: "medium",
+      },
+      {
+        id: randomUUID(),
+        companyId,
+        parentId,
+        title: "Watchdog review",
+        status: "in_progress",
+        priority: "medium",
+        originKind: "task_watchdog",
+      },
+    ]);
+
+    expect(await svc.getWakeableParentAfterChildCompletion(parentId)).toMatchObject({
+      id: parentId,
+      childIssueIds: [deliveryChildId],
+    });
+  });
 });
 
 describeEmbeddedPostgres("issueService.create workspace inheritance", () => {

--- a/server/src/__tests__/task-watchdogs-classifier.test.ts
+++ b/server/src/__tests__/task-watchdogs-classifier.test.ts
@@ -50,7 +50,7 @@ describe("task watchdog subtree classifier", () => {
     });
   });
 
-  it("treats terminal and waiting leaves as stopped work that needs verification", () => {
+  it("treats non-resumable waiting leaves as stopped work that needs verification", () => {
     const result = classify({
       issues: [
         issue({ status: "done" }),
@@ -62,6 +62,8 @@ describe("task watchdog subtree classifier", () => {
         id: "interaction-1",
         kind: "request_confirmation",
         status: "pending",
+        continuationPolicy: "none",
+        effectiveResolverPolicy: "human_only",
       }],
     });
 
@@ -84,6 +86,47 @@ describe("task watchdog subtree classifier", () => {
     expect(result.pendingInteractionsByIssueId).toEqual({
       [childId]: [{ id: "interaction-1", kind: "request_confirmation" }],
     });
+  });
+
+  it.each(["blocked", "in_review"])(
+    "treats a %s issue with a resolvable resumable interaction as live",
+    (status) => {
+      const result = classify({
+        issues: [issue({ status })],
+        pendingInteractions: [{
+          companyId,
+          issueId: sourceId,
+          id: "interaction-1",
+          kind: "request_confirmation",
+          status: "pending",
+          continuationPolicy: "wake_assignee",
+          effectiveResolverPolicy: "human_only",
+        }],
+      });
+
+      expect(result).toMatchObject({ state: "live", liveIssueIds: [sourceId] });
+    },
+  );
+
+  it.each([
+    ["no continuation", "none", "human_only"],
+    ["invalid resolver", "wake_assignee", "unknown"],
+    ["resolved interaction", "wake_assignee", "human_only", "accepted"],
+  ])("does not treat an interaction with %s as live", (_label, continuationPolicy, effectiveResolverPolicy, status = "pending") => {
+    const result = classify({
+      issues: [issue({ status: "blocked" })],
+      pendingInteractions: [{
+        companyId,
+        issueId: sourceId,
+        id: "interaction-1",
+        kind: "request_confirmation",
+        status,
+        continuationPolicy,
+        effectiveResolverPolicy,
+      }],
+    });
+
+    expect(result.state).toBe("stopped");
   });
 
   it("keeps the material fingerprint stable across metadata-only ticks", () => {

--- a/server/src/__tests__/task-watchdogs-classifier.test.ts
+++ b/server/src/__tests__/task-watchdogs-classifier.test.ts
@@ -50,6 +50,18 @@ describe("task watchdog subtree classifier", () => {
     });
   });
 
+  it.each([
+    ["active run", { activeRuns: [{ companyId, issueId: sourceId, agentId: "agent-1", status: "running" }] }],
+    ["queued wake", { queuedWakeRequests: [{ companyId, issueId: sourceId, agentId: "agent-1", status: "queued" }] }],
+  ])("keeps a terminal issue live while it retains an %s", (_label, livePath) => {
+    const result = classify({
+      issues: [issue({ status: "done" })],
+      ...livePath,
+    });
+
+    expect(result).toMatchObject({ state: "live", liveIssueIds: [sourceId] });
+  });
+
   it("treats non-resumable waiting leaves as stopped work that needs verification", () => {
     const result = classify({
       issues: [

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -329,6 +329,74 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     expect(watchdogIssues).toHaveLength(0);
   });
 
+  it.each(["blocked", "in_review"])(
+    "does not trigger or reopen a watchdog while a %s source awaits a resumable interaction",
+    async (status) => {
+      const companyId = await seedCompany();
+      const sourceId = await seedIssue(companyId, { identifier: "WDOG-INTERACTION", status });
+      const agentId = await seedAgent(companyId);
+      await seedWatchdog(companyId, sourceId, agentId);
+      const { service, wakes } = createService();
+
+      const initial = await service.reconcileTaskWatchdogs({ companyId });
+      expect(initial).toMatchObject({ checked: 1, triggered: 1 });
+      const [watchdog] = await db.select().from(issueWatchdogs).where(eq(issueWatchdogs.issueId, sourceId));
+      await db.update(issues).set({ status: "done" }).where(eq(issues.id, watchdog!.watchdogIssueId!));
+      await db.insert(issueThreadInteractions).values({
+        companyId,
+        issueId: sourceId,
+        kind: "request_confirmation",
+        status: "pending",
+        continuationPolicy: "wake_assignee",
+        effectiveResolverPolicy: "human_only",
+        payload: { version: 1, prompt: "Confirm the next step." },
+        createdByAgentId: agentId,
+      });
+
+      const firstWaitingTick = await service.reconcileTaskWatchdogs({ companyId });
+      const secondWaitingTick = await service.reconcileTaskWatchdogs({ companyId });
+
+      expect(firstWaitingTick).toMatchObject({ checked: 1, triggered: 0, live: 1 });
+      expect(secondWaitingTick).toMatchObject({ checked: 1, triggered: 0, live: 1 });
+      expect(wakes).toHaveLength(1);
+      const [source] = await db.select().from(issues).where(eq(issues.id, sourceId));
+      const [watchdogIssue] = await db.select().from(issues).where(eq(issues.id, watchdog!.watchdogIssueId!));
+      expect(source?.status).toBe(status);
+      expect(watchdogIssue?.status).toBe("done");
+    },
+  );
+
+  it("recomputes a stopped state once a resumable interaction is no longer pending", async () => {
+    const companyId = await seedCompany();
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-INTERACTION-ENDED", status: "blocked" });
+    const agentId = await seedAgent(companyId);
+    await seedWatchdog(companyId, sourceId, agentId);
+    const [interaction] = await db.insert(issueThreadInteractions).values({
+      companyId,
+      issueId: sourceId,
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "wake_assignee_on_accept",
+      effectiveResolverPolicy: "human_only",
+      payload: { version: 1, prompt: "Confirm the next step." },
+      createdByAgentId: agentId,
+    }).returning();
+    const { service, wakes } = createService();
+
+    const waiting = await service.reconcileTaskWatchdogs({ companyId });
+    expect(waiting).toMatchObject({ checked: 1, triggered: 0, live: 1 });
+
+    await db.update(issueThreadInteractions)
+      .set({ status: "expired", resolvedAt: new Date() })
+      .where(eq(issueThreadInteractions.id, interaction!.id));
+    const ended = await service.reconcileTaskWatchdogs({ companyId });
+    const repeated = await service.reconcileTaskWatchdogs({ companyId });
+
+    expect(ended).toMatchObject({ checked: 1, triggered: 1 });
+    expect(repeated).toMatchObject({ checked: 1, triggered: 0, live: 1 });
+    expect(wakes).toHaveLength(1);
+  });
+
   it("does not trigger while a descendant has a queued assignment wake", async () => {
     const companyId = await seedCompany();
     const sourceId = await seedIssue(companyId, { identifier: "WDOG-WAKE", status: "in_progress" });
@@ -456,6 +524,7 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
       issueId: waitingLeafId,
       kind: "request_confirmation",
       status: "pending",
+      continuationPolicy: "none",
       payload: { version: 1, prompt: "Confirm the stop." },
       createdByAgentId: agentId,
     });
@@ -605,6 +674,7 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
       issueId: sourceId,
       kind: "request_confirmation",
       status: "pending",
+      continuationPolicy: "none",
       payload: { version: 1, prompt: "Confirm the reviewed stop." },
       createdByAgentId: agentId,
     });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -10896,7 +10896,7 @@ export function issueRoutes(
         });
         await destroyReusableSandboxLeasesForTerminalIssue(issue);
       }
-      if (becameTerminal && issue.parentId) {
+      if (becameTerminal && issue.parentId && issue.originKind !== TASK_WATCHDOG_ORIGIN_KIND) {
         const parent = await svc.getWakeableParentAfterChildCompletion(issue.parentId);
         if (parent) {
           addWakeup(parent.assigneeAgentId, {
@@ -12933,7 +12933,7 @@ export function issueRoutes(
         });
         await destroyReusableSandboxLeasesForTerminalIssue(currentIssue);
       }
-      if (becameTerminal && currentIssue.parentId) {
+      if (becameTerminal && currentIssue.parentId && currentIssue.originKind !== TASK_WATCHDOG_ORIGIN_KIND) {
         const parent = await svc.getWakeableParentAfterChildCompletion(currentIssue.parentId);
         if (parent) {
           addWakeup(parent.assigneeAgentId, {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -105,6 +105,7 @@ import {
   summarizeIssueWatchdog,
   upsertIssueWatchdogForIssue,
 } from "./task-watchdogs.js";
+import { TASK_WATCHDOG_ORIGIN_KIND } from "./task-watchdog-scope.js";
 import {
   isVerifiedIssueTreeControlInteractionWake,
   issueTreeControlService,
@@ -6682,7 +6683,11 @@ export function issueService(db: Db) {
           updatedAt: issues.updatedAt,
         })
         .from(issues)
-        .where(and(eq(issues.companyId, parent.companyId), eq(issues.parentId, parentIssueId)))
+        .where(and(
+          eq(issues.companyId, parent.companyId),
+          eq(issues.parentId, parentIssueId),
+          or(isNull(issues.originKind), ne(issues.originKind, TASK_WATCHDOG_ORIGIN_KIND)),
+        ))
         .orderBy(asc(issues.issueNumber), asc(issues.createdAt));
       if (children.length === 0) return null;
       if (!children.every((child) => child.status === "done" || child.status === "cancelled")) {

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -89,6 +89,8 @@ export type TaskWatchdogClassifierWaitingPath = {
   id?: string | null;
   kind?: string | null;
   status: string;
+  continuationPolicy?: string | null;
+  effectiveResolverPolicy?: string | null;
 };
 
 export type TaskWatchdogClassifierRelation = {
@@ -301,6 +303,16 @@ function waitingPathIds(
     .sort();
 }
 
+function isLivePendingInteraction(path: TaskWatchdogClassifierWaitingPath) {
+  return path.status === "pending"
+    && (path.continuationPolicy === "wake_assignee" || path.continuationPolicy === "wake_assignee_on_accept")
+    && (
+      path.effectiveResolverPolicy === "anyone"
+      || path.effectiveResolverPolicy === "not_creator"
+      || path.effectiveResolverPolicy === "human_only"
+    );
+}
+
 function stableStopFingerprint(input: {
   companyId: string;
   watchedIssueId: string;
@@ -411,12 +423,18 @@ export function classifyTaskWatchdogSubtree(input: TaskWatchdogClassifierInput):
   const liveIssueIds = [
     ...pathIssueIds(input.activeRuns, input.watchdog.companyId),
     ...pathIssueIds(input.queuedWakeRequests, input.watchdog.companyId),
-  ].filter((issueId) => includedIdSet.has(issueId));
+    ...(input.pendingInteractions ?? [])
+      .filter((path) => path.companyId === input.watchdog.companyId && isLivePendingInteraction(path))
+      .map((path) => path.issueId),
+  ].filter((issueId) => {
+    const issue = issuesById.get(issueId);
+    return includedIdSet.has(issueId) && issue != null && !isTerminalIssueStatus(issue.status);
+  });
   const uniqueLiveIssueIds = [...new Set(liveIssueIds)].sort();
   if (uniqueLiveIssueIds.length > 0) {
     return {
       state: "live",
-      reason: "At least one issue in the watched subtree has a live run, queued wake, or scheduled retry.",
+      reason: "At least one issue in the watched subtree has a live run, queued wake, scheduled retry, or resumable pending interaction.",
       includedIssueIds: includedIds,
       liveIssueIds: uniqueLiveIssueIds,
     };
@@ -1018,6 +1036,8 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           id: issueThreadInteractions.id,
           kind: issueThreadInteractions.kind,
           status: issueThreadInteractions.status,
+          continuationPolicy: issueThreadInteractions.continuationPolicy,
+          effectiveResolverPolicy: issueThreadInteractions.effectiveResolverPolicy,
         })
         .from(issueThreadInteractions)
         .where(and(

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -424,12 +424,15 @@ export function classifyTaskWatchdogSubtree(input: TaskWatchdogClassifierInput):
     ...pathIssueIds(input.activeRuns, input.watchdog.companyId),
     ...pathIssueIds(input.queuedWakeRequests, input.watchdog.companyId),
     ...(input.pendingInteractions ?? [])
-      .filter((path) => path.companyId === input.watchdog.companyId && isLivePendingInteraction(path))
+      .filter((path) => {
+        const issue = issuesById.get(path.issueId);
+        return path.companyId === input.watchdog.companyId
+          && isLivePendingInteraction(path)
+          && issue != null
+          && !isTerminalIssueStatus(issue.status);
+      })
       .map((path) => path.issueId),
-  ].filter((issueId) => {
-    const issue = issuesById.get(issueId);
-    return includedIdSet.has(issueId) && issue != null && !isTerminalIssueStatus(issue.status);
-  });
+  ].filter((issueId) => includedIdSet.has(issueId));
   const uniqueLiveIssueIds = [...new Set(liveIssueIds)].sort();
   if (uniqueLiveIssueIds.length > 0) {
     return {


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates agent work through explicit execution and waiting paths.
> - Task watchdogs inspect issue subtrees and recover work only when no live path remains.
> - Pending interactions already store a continuation policy and an effective resolver audience.
> - The watchdog classifier recorded these interactions but still classified their source issues as stopped.
> - A reusable watchdog close also used the generic child-completion path to wake its watched source.
> - This pull request treats only resumable, resolvable pending interactions as live and excludes watchdog children from source completion wakes.
> - The benefit is that an intentional human wait stays quiet until its interaction state changes.

## Linked Issues or Issue Description

**What happened?**

A watched issue with a pending interaction, a valid resolver audience, and `wake_assignee` or `wake_assignee_on_accept` was classified as stopped. Reconciliation repeatedly reopened the reusable watchdog. Closing that watchdog could also wake the watched source through the generic child-completion hook.

**Expected behavior**

The pending resumable interaction must remain a live waiting path until it resolves, expires, is withdrawn, or becomes stale. Watchdog lifecycle transitions must not wake the watched source.

**Steps to reproduce**

1. Create a `blocked` or `in_review` issue with a task watchdog.
2. Add a pending `request_confirmation` with `wake_assignee` and a valid effective resolver audience.
3. Run repeated task-watchdog reconciliation ticks.
4. Complete the reusable watchdog issue.
5. Observe that the source is incorrectly recovered or woken even though the interaction did not change.

**Paperclip version or commit**

Reproduced from server behavior before commit `d779339db`.

Related work: #10179 was closed because it treated all board waits as live. This change is narrower because it requires a resumable continuation policy and a valid effective resolver audience. #10532 addresses fingerprint churn when wait identifiers change; it does not suppress the live interaction path or watchdog-child completion wakes.

## What Changed

- Load continuation and effective resolver policy fields into the task-watchdog classifier.
- Treat pending interactions as live only for supported resolver audiences and wake-enabled continuation policies.
- Keep non-resumable interactions in stopped fingerprints and diagnostics.
- Prevent task-watchdog child completion from emitting source child-completion wakes.
- Exclude task-watchdog children from parent completion readiness and summaries.
- Document the interaction wait contract.

## Verification

- `pnpm exec vitest run server/src/__tests__/task-watchdogs-classifier.test.ts server/src/__tests__/task-watchdogs-scheduler.test.ts` passed before the rebase: 2 files and 45 tests.
- Focused route and issue-service task-watchdog tests passed before the rebase: 2 tests passed.
- `pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && pnpm --filter @paperclipai/server exec tsc --noEmit -p tsconfig.json` passed on the rebased head.
- Exact-head CI passed on `d2c81f8b10a060bcd0e7a51987301f49f51490fa`, including build, typecheck, all general and serialized server shards, workspace suites, and E2E shards.
- Greptile passed 5/5 after the terminal execution-liveness review finding was fixed and its thread resolved.
- Current-master Vitest startup is blocked locally by an upstream Vite/Oxc tsconfig lookup for the removed `packages/adapters/droid-local` path. The test process fails before it loads any suite. CI remains the authoritative post-rebase test gate.
- The full server typecheck wrapper is blocked locally because the new runner preparation step requires `cargo`, which is not installed. The direct server TypeScript check passed.

## Risks

- Low behavioral risk. The classifier checks persisted policy fields and does not change the stop fingerprint format.
- A pending interaction with `continuationPolicy: none` or an invalid resolver policy remains eligible for watchdog review.
- Parent completion now ignores task-watchdog children. This prevents watchdog administration from delaying or duplicating delivery completion wakes.
- No schema or migration changes are required.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with GPT-5, agentic repository and terminal tool use, code execution, and focused test verification.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
