### PR TITLE
fix(recovery): do not auto-assign an orphaned blocker back to its creator when that would create a self-check

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -6780,6 +6780,93 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(wakeups).toEqual([]);
   });
 
+  it("does not repost the self-check deferral comment on a later sweep of the same still-unassigned blocker", async () => {
+    // Regression for a defect a reviewer found in the self-check guard above:
+    // a deferred blocker stays unassigned, so it stays a candidate on every
+    // later sweep, and the guard must not post the same "needs independent
+    // owner" comment again each time — only once, until someone assigns it.
+    const companyId = randomUUID();
+    const creatorAndReviewedAssigneeAgentId = randomUUID();
+    const blockerIssueId = randomUUID();
+    const blockedIssueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      defaultResponsibleUserId: "responsible-user",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: creatorAndReviewedAssigneeAgentId,
+        companyId,
+        name: "AuthorAgent",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(issues).values([
+      {
+        id: blockerIssueId,
+        companyId,
+        title: "Independent check of my own ADR",
+        status: "todo",
+        priority: "high",
+        createdByAgentId: creatorAndReviewedAssigneeAgentId,
+        responsibleUserId: "responsible-user",
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      },
+      {
+        id: blockedIssueId,
+        companyId,
+        title: "ADR under review",
+        status: "blocked",
+        priority: "high",
+        assigneeAgentId: creatorAndReviewedAssigneeAgentId,
+        responsibleUserId: "responsible-user",
+        issueNumber: 2,
+        identifier: `${issuePrefix}-2`,
+      },
+    ]);
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: blockedIssueId,
+      type: "blocks",
+      createdByAgentId: creatorAndReviewedAssigneeAgentId,
+    });
+    const heartbeat = heartbeatService(db);
+
+    // Three sweeps in a row over the same still-unassigned blocker, exactly
+    // as a real heartbeat loop would do while nobody has claimed it yet.
+    await heartbeat.reconcileStrandedAssignedIssues();
+    await heartbeat.reconcileStrandedAssignedIssues();
+    const thirdResult = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(thirdResult.issueIds).not.toContain(blockerIssueId);
+
+    const blocker = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, blockerIssueId))
+      .then((rows) => rows[0] ?? null);
+    expect(blocker?.assigneeAgentId).toBeNull();
+
+    const comments = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, blockerIssueId));
+    const selfCheckComments = comments.filter((c) => (c.body ?? "").includes("Orphan Blocker Needs Independent Owner"));
+    // Exactly one deferral comment across three sweeps, not three.
+    expect(selfCheckComments).toHaveLength(1);
+  });
+
   it("keeps assigning an unassigned blocker back to its creator when doing so does not create a self-check", async () => {
     const companyId = randomUUID();
     const creatorAgentId = randomUUID();

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -6691,6 +6691,188 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     }
   });
 
+  it("does not assign an unassigned blocker back to its creator when that would create a self-check", async () => {
+    const companyId = randomUUID();
+    // The creator of the blocker (independent-check issue) is ALSO the
+    // assignee of the issue it blocks — i.e. the work under review. This is
+    // the exact shape that must never be auto-resolved: reassigning the
+    // check back to this agent would make it review its own work.
+    const creatorAndReviewedAssigneeAgentId = randomUUID();
+    const blockerIssueId = randomUUID();
+    const blockedIssueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      defaultResponsibleUserId: "responsible-user",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: creatorAndReviewedAssigneeAgentId,
+        companyId,
+        name: "AuthorAgent",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(issues).values([
+      {
+        id: blockerIssueId,
+        companyId,
+        title: "Independent check of my own ADR",
+        status: "todo",
+        priority: "high",
+        createdByAgentId: creatorAndReviewedAssigneeAgentId,
+        responsibleUserId: "responsible-user",
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      },
+      {
+        id: blockedIssueId,
+        companyId,
+        title: "ADR under review",
+        status: "blocked",
+        priority: "high",
+        assigneeAgentId: creatorAndReviewedAssigneeAgentId,
+        responsibleUserId: "responsible-user",
+        issueNumber: 2,
+        identifier: `${issuePrefix}-2`,
+      },
+    ]);
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: blockedIssueId,
+      type: "blocks",
+      createdByAgentId: creatorAndReviewedAssigneeAgentId,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    // Must not count as a successful auto-assignment.
+    expect(result.issueIds).not.toContain(blockerIssueId);
+
+    const blocker = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, blockerIssueId))
+      .then((rows) => rows[0] ?? null);
+    // The independent-check issue must remain unassigned rather than being
+    // silently handed back to the agent whose own work it exists to check.
+    expect(blocker?.assigneeAgentId).toBeNull();
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, blockerIssueId));
+    expect(comments[0]?.body).toContain("Orphan Blocker Needs Independent Owner");
+    expect(comments[0]?.body).toContain("self-check");
+
+    const wakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, creatorAndReviewedAssigneeAgentId));
+    // No wakeup should be queued for the creator — nothing was assigned to them.
+    expect(wakeups).toEqual([]);
+  });
+
+  it("keeps assigning an unassigned blocker back to its creator when doing so does not create a self-check", async () => {
+    const companyId = randomUUID();
+    const creatorAgentId = randomUUID();
+    const blockedAssigneeAgentId = randomUUID();
+    const blockerIssueId = randomUUID();
+    const blockedIssueId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      defaultResponsibleUserId: "responsible-user",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values([
+      {
+        id: creatorAgentId,
+        companyId,
+        name: "SecurityEngineer2",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: blockedAssigneeAgentId,
+        companyId,
+        name: "CodexCoder2",
+        role: "engineer",
+        status: "idle",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(issues).values([
+      {
+        id: blockerIssueId,
+        companyId,
+        title: "Fix blocker",
+        status: "todo",
+        priority: "high",
+        createdByAgentId: creatorAgentId,
+        responsibleUserId: "responsible-user",
+        issueNumber: 1,
+        identifier: `${issuePrefix}-1`,
+      },
+      {
+        id: blockedIssueId,
+        companyId,
+        title: "Blocked work",
+        status: "blocked",
+        priority: "high",
+        assigneeAgentId: blockedAssigneeAgentId,
+        responsibleUserId: "responsible-user",
+        issueNumber: 2,
+        identifier: `${issuePrefix}-2`,
+      },
+    ]);
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: blockedIssueId,
+      type: "blocks",
+      createdByAgentId: creatorAgentId,
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.orphanBlockersAssigned).toBe(1);
+    expect(result.issueIds).toContain(blockerIssueId);
+
+    const blocker = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, blockerIssueId))
+      .then((rows) => rows[0] ?? null);
+    expect(blocker?.assigneeAgentId).toBe(creatorAgentId);
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, blockerIssueId));
+    expect(comments[0]?.body).toContain("Assigned Orphan Blocker");
+
+    const wakeups = await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.agentId, creatorAgentId));
+    const runId = wakeups[0]?.runId;
+    if (runId) {
+      await waitForRunToSettle(heartbeat, runId);
+    }
+  });
+
   it("re-enqueues continuation for stranded in-progress work with no active run", async () => {
     const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
       status: "in_progress",

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1235,18 +1235,41 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         (blocked) => blocked.assigneeAgentId === creatorAgent.id,
       );
       if (wouldCreateSelfCheck) {
-        await issuesSvc.addComment(
-          candidate.id,
-          [
-            "## Orphan Blocker Needs Independent Owner",
-            "",
-            `Paperclip found this issue is blocking ${blockingLinks} but had no assignee, so no heartbeat could pick it up.`,
-            "",
-            `- Did **not** assign it back to the agent that created it (${creatorAgent.id}): that agent is already the assignee of an issue this one blocks, so auto-assigning would turn a required independent check into a self-check.`,
-            "- Next action: a Board member or independent reviewer must assign this to someone other than the creator.",
-          ].join("\n"),
-          {},
-        );
+        // This candidate stays unassigned after this branch runs, so every
+        // later sweep sees it again. Without a dedup check the deferral
+        // comment below would be reposted on every sweep until someone
+        // assigns the issue. Mirror the marker-based dedup already used for
+        // stranded-recovery escalation comments (see
+        // shouldPostEscalationComment above): look for the marker in any
+        // prior system comment on this issue before posting another.
+        const selfCheckCommentMarker = "## Orphan Blocker Needs Independent Owner";
+        const hasSelfCheckComment = await db
+          .select({ id: issueComments.id, body: issueComments.body })
+          .from(issueComments)
+          .where(
+            and(
+              eq(issueComments.issueId, candidate.id),
+              eq(issueComments.authorType, "system"),
+            ),
+          )
+          .orderBy(desc(issueComments.createdAt))
+          .limit(50)
+          .then((rows) => rows.some((row) => (row.body ?? "").includes(selfCheckCommentMarker)));
+
+        if (!hasSelfCheckComment) {
+          await issuesSvc.addComment(
+            candidate.id,
+            [
+              selfCheckCommentMarker,
+              "",
+              `Paperclip found this issue is blocking ${blockingLinks} but had no assignee, so no heartbeat could pick it up.`,
+              "",
+              `- Did **not** assign it back to the agent that created it (${creatorAgent.id}): that agent is already the assignee of an issue this one blocks, so auto-assigning would turn a required independent check into a self-check.`,
+              "- Next action: a Board member or independent reviewer must assign this to someone other than the creator.",
+            ].join("\n"),
+            {},
+          );
+        }
         skipped += 1;
         continue;
       }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1224,6 +1224,33 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
 
       const relations = await issuesSvc.getRelationSummaries(candidate.id);
       const blockingLinks = formatIssueLinksForComment(relations.blocks);
+
+      // An unassigned blocker whose creator is already the assignee of
+      // something it blocks is exactly the shape of an independent-check
+      // issue (e.g. "review my own work") that was deliberately left
+      // unassigned so an independent owner could claim it. Assigning it
+      // back to its creator would silently manufacture a self-check where
+      // an independent one was required. Flag instead of auto-assigning.
+      const wouldCreateSelfCheck = relations.blocks.some(
+        (blocked) => blocked.assigneeAgentId === creatorAgent.id,
+      );
+      if (wouldCreateSelfCheck) {
+        await issuesSvc.addComment(
+          candidate.id,
+          [
+            "## Orphan Blocker Needs Independent Owner",
+            "",
+            `Paperclip found this issue is blocking ${blockingLinks} but had no assignee, so no heartbeat could pick it up.`,
+            "",
+            `- Did **not** assign it back to the agent that created it (${creatorAgent.id}): that agent is already the assignee of an issue this one blocks, so auto-assigning would turn a required independent check into a self-check.`,
+            "- Next action: a Board member or independent reviewer must assign this to someone other than the creator.",
+          ].join("\n"),
+          {},
+        );
+        skipped += 1;
+        continue;
+      }
+
       const updated = await issuesSvc.update(candidate.id, {
         assigneeAgentId: creatorAgent.id,
         assigneeUserId: null,


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - `reconcileUnassignedBlockingIssues()` in `server/src/services/recovery/service.ts` is the orphan-blocker recovery sweep. It finds unassigned issues that block live work and hands them back to their creator agent, so no blocker sits idle forever.
> - Some blockers are deliberately created unassigned: an agent opens a review or audit issue for its own prior work, and leaves it unassigned on purpose so a different agent or a human can claim it as an independent check.
> - The sweep does not know the difference. It reassigns any unassigned blocker to its creator with no check on whether that creator already owns the work under review. When it does, it silently hands the review back to the same agent that wrote the thing being reviewed.
> - This PR adds one guard: before assigning a blocker back to its creator, check whether that creator is already the assignee of any issue this blocker blocks. If so, skip the auto-assign and leave a comment asking a board member or independent reviewer to pick an owner instead.
> - The benefit is that "leave it unassigned so someone independent can claim it" actually works, instead of being silently defeated by the recovery sweep before anyone else gets a chance to claim it.

## Linked Issues or Issue Description

Refs #10326 — that issue covers a related but different signal (an unassigned blocker whose description declares a `REQUIRED REVIEWERS` role that the sweep ignores). This PR's guard is narrower and does not depend on any convention in the issue body: it only looks at whether the creator is already the assignee of something the candidate blocks. The two fixes are complementary and could both land in the same function without conflicting.

No other public issue tracks this exact defect, so here is the bug report inline, following the bug template:

**Describe the bug**

`reconcileUnassignedBlockingIssues()` reassigns any unassigned blocking issue back to `createdByAgentId`, with no check on the relationship between the blocker and the issue it blocks. When the blocker is an independent-check issue left unassigned on purpose, and its creator is already the assignee of the issue it blocks, this reassigns the check straight back to the person whose work it is meant to check.

**To Reproduce**

1. Agent A is the assignee of issue X (some piece of work).
2. Agent A creates issue Y, sets `type: blocks` from Y to X, and leaves Y unassigned so an independent owner can claim it.
3. The orphan-blocker recovery sweep runs (`reconcileStrandedAssignedIssues` → `reconcileUnassignedBlockingIssues`).
4. Y gets assigned back to Agent A, defeating the independence the unassigned state was meant to preserve.

**Expected behavior**

The sweep should not assign Y back to Agent A, because Agent A already holds the assignee slot on the issue Y blocks. It should leave Y unassigned and post a comment asking a board member or independent reviewer to pick an owner, matching how the sweep already defers cases like board-owned blockers (see #9522 for prior art on a similar guard in the same function).

**Severity / impact observed**

Seen repeatedly in production use: a self-review issue was reassigned to its own author as fast as 56 seconds after creation, leaving no realistic window for a router or a human to claim it first.

## What Changed

- `server/src/services/recovery/service.ts` — in `reconcileUnassignedBlockingIssues()`, added a check: if the blocker's creator is already the `assigneeAgentId` of any issue it blocks, skip the auto-assign, post an "Orphan Blocker Needs Independent Owner" comment, and count it under `skipped` (same code path already used for cases the sweep defers). No change to the existing auto-assign behavior when the creator is not the assignee of anything the blocker blocks.
- `server/src/__tests__/heartbeat-process-recovery.test.ts` — two new tests: one reproduces the self-check scenario and asserts the blocker stays unassigned with the new comment and no wakeup queued for the creator; one confirms the existing auto-assign behavior is unchanged when the creator is unrelated to the blocked issue's assignee.

## Verification

```
pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-process-recovery.test.ts
```

113 passed, 0 failed, including the two new tests above. Run against this branch after rebasing onto current `origin/master` and after `pnpm install`.

Not run locally: `pnpm -r typecheck` (blocked in this environment — `prepare:runner-vendor` needs `cargo`, which is not installed here), `pnpm test:run` (full suite), `pnpm build`, `pnpm test:e2e`. The change is a 25-line, single-function, single-guard addition with no new dependencies or schema changes, so the risk of an unrelated typecheck/build break is low, but this has not been confirmed locally — please let CI confirm before merge.

## Risks

- **Behavior change, narrow scope**: only issues where the creator is already the assignee of something they block change behavior (they now stay unassigned with a comment instead of auto-assigning). All other orphan-blocker candidates are unaffected — covered by the second new test.
- **False positives**: an agent that legitimately owns both a piece of work and a small housekeeping blocker on top of it (not an independent check) will now also be skipped and need manual assignment instead of auto-assignment. This trades a small amount of automation for closing the self-check hole; the sweep already defers other cases it cannot safely resolve (see #9522), so this fits the existing pattern rather than introducing a new one.
- **No schema or migration changes.** Pure logic change inside one function plus two tests.
- Low risk overall.

## Model Used

Claude Sonnet 5 (`anthropic/claude-sonnet-5`), extended reasoning mode, with agentic tool use (file read/edit, shell) inside an OpenCode CLI session. The model wrote the guard, the two regression tests, independently re-ran the target test file before and after rebasing onto current `origin/master`, and drafted this PR description.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (no user-facing docs describe this internal sweep; none found to update)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (not yet run — pending CI on this PR)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending automated review on this PR)
- [x] I will address all Greptile and reviewer comments before requesting merge
