### PR TITLE
fix(server): gate wakes by active hold membership

### DIFF
--- a/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
+++ b/server/src/__tests__/heartbeat-dependency-scheduling.test.ts
@@ -28,6 +28,7 @@ import {
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { heartbeatService } from "../services/heartbeat.ts";
+import { issueTreeControlService } from "../services/issue-tree-control.js";
 import { runningProcesses } from "../adapters/index.ts";
 
 const mockAdapterExecute = vi.hoisted(() =>
@@ -939,17 +940,13 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
         responsibleUserId: "responsible-user",
       })),
     ]);
-    const [hold] = await db
-      .insert(issueTreeHolds)
-      .values({
-        companyId,
-        rootIssueId,
-        mode: "pause",
-        status: "active",
-        reason: "security test hold",
-        releasePolicy: { strategy: "manual" },
-      })
-      .returning();
+    const treeControl = issueTreeControlService(db);
+    const { hold } = await treeControl.createHold(companyId, rootIssueId, {
+      mode: "pause",
+      reason: "security test hold",
+      releasePolicy: { strategy: "manual" },
+      actor: { actorType: "user", actorId: "board-user", userId: "board-user" },
+    });
 
     const blockedWake = await heartbeat.wakeup(agentId, {
       source: "automation",
@@ -1022,6 +1019,108 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
     });
   });
 
+  it("creates one run when a historical ancestor hold does not include the issue", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const historicalRootIssueId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "LivenessEngineer",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {
+        heartbeat: {
+          wakeOnDemand: true,
+          maxConcurrentRuns: 1,
+        },
+      },
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: historicalRootIssueId,
+      companyId,
+      title: "Historical held root",
+      status: "todo",
+      priority: "medium",
+      responsibleUserId: "responsible-user",
+    });
+
+    const treeControl = issueTreeControlService(db);
+    const historicalHold = await treeControl.createHold(companyId, historicalRootIssueId, {
+      mode: "pause",
+      reason: "historical pause",
+      actor: { actorType: "user", actorId: "board-user", userId: "board-user" },
+    });
+
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      parentId: historicalRootIssueId,
+      title: "Attached after pause snapshot",
+      status: "todo",
+      priority: "critical",
+      assigneeAgentId: agentId,
+      responsibleUserId: "responsible-user",
+    });
+
+    expect(await treeControl.listHolds(companyId, issueId, { status: "active" })).toEqual([]);
+    expect(await treeControl.getHold(companyId, historicalHold.hold.id)).toMatchObject({
+      id: historicalHold.hold.id,
+      status: "active",
+      members: [expect.objectContaining({ issueId: historicalRootIssueId })],
+    });
+
+    const resume = await treeControl.createHold(companyId, issueId, {
+      mode: "resume",
+      reason: "confirm issue is not held",
+      actor: { actorType: "user", actorId: "board-user", userId: "board-user" },
+    });
+    expect(resume.hold).toMatchObject({ status: "released", mode: "resume" });
+    expect(resume.preview.issues).toEqual([
+      expect.objectContaining({ id: issueId, skipped: true, skipReason: "not_held" }),
+    ]);
+    expect(resume.resumedPauseHoldIds).toEqual([]);
+
+    const releasedPause = await treeControl.createHold(companyId, issueId, {
+      mode: "pause",
+      reason: "short-lived target pause",
+      actor: { actorType: "user", actorId: "board-user", userId: "board-user" },
+    });
+    await treeControl.releaseHold(companyId, issueId, releasedPause.hold.id, {
+      reason: "target pause released",
+      actor: { actorType: "user", actorId: "board-user", userId: "board-user" },
+    });
+    expect(await treeControl.getActivePauseHoldGate(companyId, issueId)).toBeNull();
+
+    const wake = await heartbeat.wakeup(agentId, {
+      source: "on_demand",
+      triggerDetail: "manual",
+      reason: "manual",
+      payload: { issueId },
+      contextSnapshot: { issueId, wakeReason: "manual" },
+    });
+    expect(wake).not.toBeNull();
+
+    const runCount = await db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(heartbeatRuns)
+      .where(sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${issueId}`)
+      .then((rows) => rows[0]?.count ?? 0);
+    expect(runCount).toBe(1);
+  });
+
   it("allows comment interaction wakes when a legacy hold has a full_pause note", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();
@@ -1059,13 +1158,12 @@ describeEmbeddedPostgres("heartbeat dependency-aware queued run selection", () =
       assigneeAgentId: agentId,
       responsibleUserId: "responsible-user",
     });
-    await db.insert(issueTreeHolds).values({
-      companyId,
-      rootIssueId,
+    const treeControl = issueTreeControlService(db);
+    await treeControl.createHold(companyId, rootIssueId, {
       mode: "pause",
-      status: "active",
       reason: "full pause",
       releasePolicy: { strategy: "manual", note: "full_pause" },
+      actor: { actorType: "user", actorId: "board-user", userId: "board-user" },
     });
 
     const rootCommentId = randomUUID();

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -106,6 +106,7 @@ import {
   redactDetectedSuccessfulRunProgressSummaryForBoard,
   redactSuccessfulRunHandoffEvidence,
 } from "../services/heartbeat.ts";
+import { issueTreeControlService } from "../services/issue-tree-control.js";
 import {
   readHotRestartIntent,
   resolveLegacyHotRestartIntentPath,
@@ -804,13 +805,11 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     ]);
 
     if (input.activePauseHold) {
-      await db.insert(issueTreeHolds).values({
-        companyId,
-        rootIssueId,
+      await issueTreeControlService(db).createHold(companyId, rootIssueId, {
         mode: "pause",
-        status: "active",
         reason: "pause recovery subtree",
         releasePolicy: { strategy: "manual" },
+        actor: { actorType: "user", actorId: "board-user", userId: "board-user" },
       });
     }
 

--- a/server/src/services/issue-tree-control.ts
+++ b/server/src/services/issue-tree-control.ts
@@ -72,7 +72,6 @@ type RestoreTreeStatusResult = TreeStatusUpdateResult & {
 const TERMINAL_ISSUE_STATUSES = new Set<IssueStatus>(["done", "cancelled"]);
 const ACTIVE_RUN_STATUSES = ["queued", "running"] as const;
 const DEFAULT_RELEASE_POLICY: IssueTreeHoldReleasePolicy = { strategy: "manual" };
-const MAX_PAUSE_HOLD_ANCESTOR_DEPTH = 100;
 export const ISSUE_TREE_CONTROL_INTERACTION_WAKE_REASONS: ReadonlySet<string> = new Set([
   "issue_commented",
   "issue_reopened_via_comment",
@@ -569,7 +568,7 @@ export function issueTreeControlService(db: Db) {
     companyId: string,
     issueId: string,
   ): Promise<ActiveIssueTreePauseHoldGate | null> {
-    const activePauseHolds = await db
+    const hold = await db
       .select({
         id: issueTreeHolds.id,
         rootIssueId: issueTreeHolds.rootIssueId,
@@ -577,48 +576,38 @@ export function issueTreeControlService(db: Db) {
         releasePolicy: issueTreeHolds.releasePolicy,
       })
       .from(issueTreeHolds)
+      .leftJoin(
+        issueTreeHoldMembers,
+        and(
+          eq(issueTreeHoldMembers.holdId, issueTreeHolds.id),
+          eq(issueTreeHoldMembers.companyId, companyId),
+          eq(issueTreeHoldMembers.issueId, issueId),
+        ),
+      )
       .where(
         and(
           eq(issueTreeHolds.companyId, companyId),
           eq(issueTreeHolds.status, "active"),
           eq(issueTreeHolds.mode, "pause"),
+          or(
+            eq(issueTreeHoldMembers.issueId, issueId),
+            eq(issueTreeHolds.rootIssueId, issueId),
+          ),
         ),
       )
-      .orderBy(asc(issueTreeHolds.createdAt), asc(issueTreeHolds.id));
-    if (activePauseHolds.length === 0) return null;
+      .orderBy(asc(issueTreeHolds.createdAt), asc(issueTreeHolds.id))
+      .then((rows) => rows[0] ?? null);
+    if (!hold) return null;
 
-    const holdByRootIssueId = new Map(activePauseHolds.map((hold) => [hold.rootIssueId, hold]));
-    let currentIssueId: string | null = issueId;
-    const visited = new Set<string>();
-
-    while (
-      currentIssueId
-      && !visited.has(currentIssueId)
-      && visited.size < MAX_PAUSE_HOLD_ANCESTOR_DEPTH
-    ) {
-      visited.add(currentIssueId);
-      const hold = holdByRootIssueId.get(currentIssueId);
-      if (hold) {
-        return {
-          holdId: hold.id,
-          rootIssueId: hold.rootIssueId,
-          issueId,
-          isRoot: hold.rootIssueId === issueId,
-          mode: "pause",
-          reason: hold.reason,
-          releasePolicy: (hold.releasePolicy as IssueTreeHoldReleasePolicy | null) ?? null,
-        };
-      }
-
-      const parent: { parentId: string | null } | null = await db
-        .select({ parentId: issues.parentId })
-        .from(issues)
-        .where(and(eq(issues.id, currentIssueId), eq(issues.companyId, companyId)))
-        .then((rows) => rows[0] ?? null);
-      currentIssueId = parent?.parentId ?? null;
-    }
-
-    return null;
+    return {
+      holdId: hold.id,
+      rootIssueId: hold.rootIssueId,
+      issueId,
+      isRoot: hold.rootIssueId === issueId,
+      mode: "pause",
+      reason: hold.reason,
+      releasePolicy: (hold.releasePolicy as IssueTreeHoldReleasePolicy | null) ?? null,
+    };
   }
 
   async function preview(


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane that schedules agent work.
> - Issue-tree pause holds stop wakes for issues that the hold covers.
> - Each hold stores an issue membership snapshot.
> - The wake gate ignored that snapshot and walked the current parent chain.
> - A later child could therefore inherit a historical hold that never covered it.
> - This pull request makes the wake gate use active hold membership.
> - The benefit is that historical and released holds cannot suppress eligible work.

## Linked Issues or Issue Description

**What happened?**

An active pause hold could suppress a wake for an issue that was not in the hold membership snapshot. This happened when the issue became a child of the held root after Paperclip created the hold. The hold list for the issue was empty, but the wake gate returned `issue_tree_hold_active`.

**Expected behavior**

Paperclip must suppress a wake only when an active pause hold applies to that issue. A released hold or a historical ancestor hold without the issue as a member must not suppress the wake.

**Steps to reproduce**

1. Create a pause hold for one root issue.
2. Add a new child issue after Paperclip creates the hold snapshot.
3. Confirm that a resume operation for the child reports `not_held`.
4. Request an on-demand wake for the child.
5. Observe that the old gate suppresses the wake because it walks the current ancestor chain.

**Paperclip version or commit**

Base commit `3ba0e7f64fe3957b80dab0e49a3ab86fbfe6db10`.

**Deployment mode**

Core server behavior. The regression test uses local embedded PostgreSQL.

Related public work: #7674 and #9024.

## What Changed

- Query active pause holds by company, active status, pause mode, and issue membership.
- Keep direct root-hold behavior for compatibility.
- Add a wake regression for a historical ancestor hold, a `not_held` resume, and a released target hold.
- Use complete hold snapshots in existing pause and recovery fixtures.

## Verification

- RED: `pnpm exec vitest run server/src/__tests__/heartbeat-dependency-scheduling.test.ts -t "creates one run when a historical ancestor hold does not include the issue" --maxWorkers=1` failed before the fix. The gate returned the historical ancestor hold instead of `null`.
- PASS: `pnpm exec vitest run server/src/__tests__/heartbeat-dependency-scheduling.test.ts server/src/__tests__/issue-tree-control-service.test.ts server/src/__tests__/heartbeat-process-recovery.test.ts --maxWorkers=1` passed 124 tests in 3 files.
- PASS: `pnpm -r typecheck`.
- PASS: `pnpm build`.
- PARTIAL: `pnpm test:run` passed 5,237 tests and failed 8 unrelated environment-sensitive tests. Three Cursor remote-sandbox tests exited with status 127. Five workspace provisioning tests rejected incomplete temporary fixture configs. The changed files do not overlap those suites.

## Risks

- Low data risk. This change has no schema or migration change.
- Hold membership snapshots become authoritative for descendants. This matches the existing hold member and resume contracts.
- A hold row without member records still gates its root. It does not gate later descendants.
- Related open pull requests change other hold enforcement behavior. A maintainer should check merge order for #7674 and #9024.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, gpt-5.6-sol. Capabilities used: repository analysis, extended reasoning, code editing, Git operations, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
