### PR TITLE
fix(acpx-engine): materialize Claude runtime skills into project cwd

### DIFF
--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -1159,20 +1159,57 @@ describe("shared ACPX engine runtime behavior", () => {
     await fs.symlink(outsideRoot, path.join(skill.source, "leak-dir"));
 
     const stateDir = path.join(root, "state");
+    const cwd = path.join(root, "project");
+    await fs.mkdir(cwd, { recursive: true });
     const { meta } = await runExecutor({
       agent: "claude",
       stateDir,
+      cwd,
       paperclipRuntimeSkills: [skill],
       paperclipSkillSync: { desiredSkills: [skill.key] },
     });
 
-    const mountedRoot = await onlyChildDir(path.join(stateDir, "runtime-skills", "claude"));
-    const skillsHome = path.join(mountedRoot, ".claude", "skills");
+    // Skills must land under the project `cwd`'s `.claude/skills` — the only
+    // location the Claude Code SDK's `settingSources` scan actually
+    // discovers skills from. A stateDir-scoped bundle (the pre-fix behavior)
+    // is invisible to the SDK's Skill tool (TRY-1021).
+    const skillsHome = path.join(cwd, ".claude", "skills");
     const materializedSkill = path.join(skillsHome, skill.runtimeName);
     expect(await fs.readFile(path.join(materializedSkill, "SKILL.md"), "utf8")).toContain("# danger");
     expect(await pathExists(path.join(materializedSkill, "leak.txt"))).toBe(false);
     expect(await pathExists(path.join(materializedSkill, "leak-dir"))).toBe(false);
     expect(String(meta[0]?.prompt ?? "")).toContain(`Skill root: ${skillsHome}`);
+  });
+
+  it.skipIf(process.platform === "win32")("revokes removed ACPX Claude skills from the project cwd", async () => {
+    const root = await makeTempRoot();
+    const skillRoot = path.join(root, "skills");
+    const cwd = path.join(root, "project");
+    await fs.mkdir(cwd, { recursive: true });
+    const keep = await createSkill(skillRoot, "keep");
+    const remove = await createSkill(skillRoot, "remove");
+
+    const baseConfig = {
+      agent: "claude",
+      stateDir: path.join(root, "state"),
+      cwd,
+      paperclipRuntimeSkills: [keep, remove],
+    };
+
+    await runExecutor({
+      ...baseConfig,
+      paperclipSkillSync: { desiredSkills: [keep.key, remove.key] },
+    });
+    const skillsHome = path.join(cwd, ".claude", "skills");
+    expect(await pathExists(path.join(skillsHome, remove.runtimeName, "SKILL.md"))).toBe(true);
+
+    await runExecutor({
+      ...baseConfig,
+      paperclipSkillSync: { desiredSkills: [keep.key] },
+    });
+
+    expect(await pathExists(path.join(skillsHome, keep.runtimeName, "SKILL.md"))).toBe(true);
+    expect(await pathExists(path.join(skillsHome, remove.runtimeName))).toBe(false);
   });
 
   it.skipIf(process.platform === "win32")("revokes removed ACPX Codex skills and skips symlinked descendants", async () => {

--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -1212,6 +1212,66 @@ describe("shared ACPX engine runtime behavior", () => {
     expect(await pathExists(path.join(skillsHome, remove.runtimeName))).toBe(false);
   });
 
+  it.skipIf(process.platform === "win32")(
+    "does not clobber a project-authored skill directory with the same name",
+    async () => {
+      const root = await makeTempRoot();
+      const skillRoot = path.join(root, "skills");
+      const cwd = path.join(root, "project");
+      const skill = await createSkill(skillRoot, "infra-deploy");
+
+      const skillsHome = path.join(cwd, ".claude", "skills");
+      const projectOwned = path.join(skillsHome, skill.runtimeName);
+      await fs.mkdir(projectOwned, { recursive: true });
+      await fs.writeFile(path.join(projectOwned, "SKILL.md"), "# hand-authored by the project\n", "utf8");
+
+      await runExecutor({
+        agent: "claude",
+        stateDir: path.join(root, "state"),
+        cwd,
+        paperclipRuntimeSkills: [skill],
+        paperclipSkillSync: { desiredSkills: [skill.key] },
+      });
+
+      // The project's own directory must survive untouched — Paperclip must
+      // never overwrite a same-named skill it didn't create.
+      expect(await fs.readFile(path.join(projectOwned, "SKILL.md"), "utf8")).toContain("hand-authored");
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "does not revoke a project-authored skill directory that reused a formerly-managed name",
+    async () => {
+      const root = await makeTempRoot();
+      const skillRoot = path.join(root, "skills");
+      const cwd = path.join(root, "project");
+      await fs.mkdir(cwd, { recursive: true });
+      const skill = await createSkill(skillRoot, "infra-deploy");
+
+      const baseConfig = {
+        agent: "claude",
+        stateDir: path.join(root, "state"),
+        cwd,
+        paperclipRuntimeSkills: [skill],
+      };
+
+      await runExecutor({ ...baseConfig, paperclipSkillSync: { desiredSkills: [skill.key] } });
+      const skillsHome = path.join(cwd, ".claude", "skills");
+      const target = path.join(skillsHome, skill.runtimeName);
+      expect(await pathExists(path.join(target, "SKILL.md"))).toBe(true);
+
+      // The project owner deselects the catalog skill and hand-authors their
+      // own directory with the same runtime name before the next run.
+      await fs.rm(target, { recursive: true, force: true });
+      await fs.mkdir(target, { recursive: true });
+      await fs.writeFile(path.join(target, "SKILL.md"), "# hand-authored by the project\n", "utf8");
+
+      await runExecutor({ ...baseConfig, paperclipSkillSync: { desiredSkills: [] } });
+
+      expect(await fs.readFile(path.join(target, "SKILL.md"), "utf8")).toContain("hand-authored");
+    },
+  );
+
   it.skipIf(process.platform === "win32")("revokes removed ACPX Codex skills and skips symlinked descendants", async () => {
     const root = await makeTempRoot();
     const skillRoot = path.join(root, "skills");

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -151,7 +151,7 @@ import {
 } from "./startup-timing.js";
 
 const defaultModuleDir = path.dirname(fileURLToPath(import.meta.url));
-const PAPERCLIP_MANAGED_CODEX_SKILLS_MANIFEST = ".paperclip-managed-skills.json";
+const PAPERCLIP_MANAGED_SKILLS_MANIFEST = ".paperclip-managed-skills.json";
 const BENIGN_NES_CLOSE_STDERR = /method: ['"]nes\/close['"].*-32601/;
 
 function routeChildStderr(state: ChildStderrState, chunk: string) {
@@ -937,7 +937,7 @@ async function resolveSelectedRuntimeSkills(
 }
 
 async function prepareClaudeSkillRuntime(input: {
-  stateDir: string;
+  cwd: string;
   config: Record<string, unknown>;
   moduleDir: string;
   onLog: AdapterExecutionContext["onLog"];
@@ -948,26 +948,51 @@ async function prepareClaudeSkillRuntime(input: {
 }> {
   const { allSkills, selectedSkills, desiredSkillNames } = await resolveSelectedRuntimeSkills(input.config, input.moduleDir);
   const skillSetKey = await buildSkillSetKey({ skills: selectedSkills, label: "claude" });
-  const bundleRoot = path.join(input.stateDir, "runtime-skills", "claude", skillSetKey);
-  const skillsHome = path.join(bundleRoot, ".claude", "skills");
-  await fs.mkdir(skillsHome, { recursive: true });
+  // The Claude Code SDK (`settingSources: ["user", "project", "local"]`, see
+  // `writePaperclipClaudeSettings` below) only discovers skills under
+  // `.claude/skills` beneath one of those scanned roots — it never reads an
+  // arbitrary path just because it's named in the system prompt. Skills used
+  // to be bundled under a content-hashed `stateDir/runtime-skills/...` path
+  // that the SDK never scanned, so every `Skill(...)` call for a
+  // Paperclip-managed skill failed with "Unknown skill" (TRY-1021).
+  // Materializing straight into the session's project `cwd` makes them part
+  // of the "project" settings root the SDK actually reads.
+  const skillsHome = path.join(input.cwd, ".claude", "skills");
+  // Unlike the Codex path (whose skillsHome lives under a Paperclip-managed
+  // CODEX_HOME), this directory lives inside the user's actual project
+  // checkout. Only touch it when there is a Paperclip skill catalog to
+  // reconcile at all, so a session with no configured skills doesn't leave a
+  // stray `.claude/skills/.paperclip-managed-skills.json` in every project.
+  if (allSkills.length > 0) {
+    await fs.mkdir(skillsHome, { recursive: true });
 
-  for (const entry of selectedSkills) {
-    const target = path.join(skillsHome, entry.runtimeName);
-    try {
-      const result = await materializePaperclipSkillCopy(entry.source, target);
-      if (result.skippedSymlinks.length > 0) {
+    await reconcileManagedSkills({
+      skillsHome,
+      allSkills,
+      selectedSkills,
+      onLog: input.onLog,
+      agentLabel: "Claude",
+    });
+
+    for (const entry of selectedSkills) {
+      const target = path.join(skillsHome, entry.runtimeName);
+      try {
+        const result = await materializePaperclipSkillCopy(entry.source, target);
+        if (result.skippedSymlinks.length > 0) {
+          await input.onLog(
+            "stdout",
+            `[paperclip] Materialized ACPX Claude skill "${entry.runtimeName}" into ${skillsHome} and skipped ${result.skippedSymlinks.length} symlink(s).\n`,
+          );
+        }
+      } catch (err) {
         await input.onLog(
-          "stdout",
-          `[paperclip] Materialized ACPX Claude skill "${entry.runtimeName}" into ${skillsHome} and skipped ${result.skippedSymlinks.length} symlink(s).\n`,
+          "stderr",
+          `[paperclip] Failed to materialize ACPX Claude skill "${entry.key}" into ${skillsHome}: ${err instanceof Error ? err.message : String(err)}\n`,
         );
       }
-    } catch (err) {
-      await input.onLog(
-        "stderr",
-        `[paperclip] Failed to materialize ACPX Claude skill "${entry.key}" into ${skillsHome}: ${err instanceof Error ? err.message : String(err)}\n`,
-      );
     }
+
+    await writeManagedSkillsManifest(skillsHome, selectedSkills.map((entry) => entry.runtimeName));
   }
 
   const selectedNames = selectedSkills.map((entry) => entry.runtimeName).sort();
@@ -976,7 +1001,7 @@ async function prepareClaudeSkillRuntime(input: {
         "Paperclip has materialized selected runtime skills for this ACPX Claude session.",
         `Skill root: ${skillsHome}`,
         selectedNames.length > 0 ? `Selected skills: ${selectedNames.join(", ")}` : "",
-        "When a task calls for one of these skills, read its SKILL.md from that root and follow it.",
+        "These are registered with the Skill tool under the directory names listed above — invoke them with Skill(skill: \"<name>\") rather than reading SKILL.md manually.",
       ].filter(Boolean).join("\n")
     : "";
 
@@ -995,8 +1020,8 @@ async function prepareClaudeSkillRuntime(input: {
   };
 }
 
-async function readManagedCodexSkillsManifest(skillsHome: string): Promise<Set<string>> {
-  const manifestPath = path.join(skillsHome, PAPERCLIP_MANAGED_CODEX_SKILLS_MANIFEST);
+async function readManagedSkillsManifest(skillsHome: string): Promise<Set<string>> {
+  const manifestPath = path.join(skillsHome, PAPERCLIP_MANAGED_SKILLS_MANIFEST);
   try {
     const raw = JSON.parse(await fs.readFile(manifestPath, "utf8")) as unknown;
     const parsed = parseObject(raw);
@@ -1009,10 +1034,10 @@ async function readManagedCodexSkillsManifest(skillsHome: string): Promise<Set<s
   }
 }
 
-async function writeManagedCodexSkillsManifest(skillsHome: string, skillNames: Iterable<string>): Promise<void> {
+async function writeManagedSkillsManifest(skillsHome: string, skillNames: Iterable<string>): Promise<void> {
   const managedSkillNames = Array.from(new Set(skillNames)).sort();
   await fs.writeFile(
-    path.join(skillsHome, PAPERCLIP_MANAGED_CODEX_SKILLS_MANIFEST),
+    path.join(skillsHome, PAPERCLIP_MANAGED_SKILLS_MANIFEST),
     `${JSON.stringify({ version: 1, managedSkillNames }, null, 2)}\n`,
     "utf8",
   );
@@ -1025,20 +1050,21 @@ async function removeSkillTarget(target: string): Promise<boolean> {
   return true;
 }
 
-async function reconcileManagedCodexSkills(input: {
+async function reconcileManagedSkills(input: {
   skillsHome: string;
   allSkills: PaperclipSkillEntry[];
   selectedSkills: PaperclipSkillEntry[];
   onLog: AdapterExecutionContext["onLog"];
+  agentLabel: string;
 }): Promise<void> {
   const desired = new Set(input.selectedSkills.map((entry) => entry.runtimeName));
-  const managed = await readManagedCodexSkillsManifest(input.skillsHome);
+  const managed = await readManagedSkillsManifest(input.skillsHome);
   const availableByRuntimeName = new Map(input.allSkills.map((entry) => [entry.runtimeName, entry]));
 
   for (const name of managed) {
     if (desired.has(name)) continue;
     if (await removeSkillTarget(path.join(input.skillsHome, name))) {
-      await input.onLog("stdout", `[paperclip] Revoked ACPX Codex skill "${name}" from ${input.skillsHome}\n`);
+      await input.onLog("stdout", `[paperclip] Revoked ACPX ${input.agentLabel} skill "${name}" from ${input.skillsHome}\n`);
     }
   }
 
@@ -1052,14 +1078,14 @@ async function reconcileManagedCodexSkills(input: {
     const resolvedLinkedPath = path.resolve(path.dirname(target), linkedPath);
     if (resolvedLinkedPath !== path.resolve(entry.source)) continue;
     if (await removeSkillTarget(target)) {
-      await input.onLog("stdout", `[paperclip] Revoked legacy ACPX Codex skill "${entry.runtimeName}" from ${input.skillsHome}\n`);
+      await input.onLog("stdout", `[paperclip] Revoked legacy ACPX ${input.agentLabel} skill "${entry.runtimeName}" from ${input.skillsHome}\n`);
     }
   }
 
   for (const name of managed) {
     if (desired.has(name) || availableByRuntimeName.has(name)) continue;
     if (await removeSkillTarget(path.join(input.skillsHome, name))) {
-      await input.onLog("stdout", `[paperclip] Revoked unavailable ACPX Codex skill "${name}" from ${input.skillsHome}\n`);
+      await input.onLog("stdout", `[paperclip] Revoked unavailable ACPX ${input.agentLabel} skill "${name}" from ${input.skillsHome}\n`);
     }
   }
 }
@@ -1116,11 +1142,12 @@ async function prepareCodexSkillRuntime(input: {
     onWallMs: undefined,
   };
   await measureStartupStep({ onEvent: input.onEvent }, now, "skills.reconcile", () =>
-    reconcileManagedCodexSkills({
+    reconcileManagedSkills({
       skillsHome,
       allSkills,
       selectedSkills,
       onLog: input.onLog,
+      agentLabel: "Codex",
     }),
     nestedStepMetrics,
   );
@@ -1142,7 +1169,7 @@ async function prepareCodexSkillRuntime(input: {
       );
     }
   }
-  await writeManagedCodexSkillsManifest(skillsHome, selectedSkills.map((entry) => entry.runtimeName));
+  await writeManagedSkillsManifest(skillsHome, selectedSkills.map((entry) => entry.runtimeName));
 
   input.env.CODEX_HOME = effectiveCodexHome;
 
@@ -1817,7 +1844,7 @@ async function buildRuntime(input: {
   let paperclipClaudeSettings: PaperclipClaudeSettingsResult | null = null;
   if (acpxAgent === "claude") {
     const preparedSkills = await prepareClaudeSkillRuntime({
-      stateDir,
+      cwd,
       config,
       moduleDir: input.engine.moduleDir,
       onLog: input.ctx.onLog,

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -53,6 +53,7 @@ import {
   ensurePathInEnv,
   ensurePaperclipSkillSymlink,
   isForbiddenConfigEnvKey,
+  isForeignSkillTarget,
   isPaperclipRuntimeEnvKey,
   joinPromptSections,
   materializePaperclipSkillCopy,
@@ -1050,6 +1051,27 @@ async function removeSkillTarget(target: string): Promise<boolean> {
   return true;
 }
 
+// Like `removeSkillTarget`, but for entries the manifest remembers as
+// Paperclip-managed *copies* (materialized via `materializePaperclipSkillCopy`).
+// The manifest only records a name, not an ownership proof, so if a project
+// owner deletes the Paperclip selection and then hand-authors their own
+// `.claude/skills/<same-name>` directory, a stale manifest entry must not be
+// allowed to delete it. Skip (and log) instead of removing when the target no
+// longer carries Paperclip's own materialization sentinel.
+async function removeManagedSkillCopyTarget(
+  target: string,
+  onLog: AdapterExecutionContext["onLog"],
+): Promise<boolean> {
+  if (await isForeignSkillTarget(target)) {
+    await onLog(
+      "stdout",
+      `[paperclip] Skipped revoking "${target}": it is no longer a Paperclip-managed skill directory.\n`,
+    );
+    return false;
+  }
+  return removeSkillTarget(target);
+}
+
 async function reconcileManagedSkills(input: {
   skillsHome: string;
   allSkills: PaperclipSkillEntry[];
@@ -1063,7 +1085,7 @@ async function reconcileManagedSkills(input: {
 
   for (const name of managed) {
     if (desired.has(name)) continue;
-    if (await removeSkillTarget(path.join(input.skillsHome, name))) {
+    if (await removeManagedSkillCopyTarget(path.join(input.skillsHome, name), input.onLog)) {
       await input.onLog("stdout", `[paperclip] Revoked ACPX ${input.agentLabel} skill "${name}" from ${input.skillsHome}\n`);
     }
   }
@@ -1084,7 +1106,7 @@ async function reconcileManagedSkills(input: {
 
   for (const name of managed) {
     if (desired.has(name) || availableByRuntimeName.has(name)) continue;
-    if (await removeSkillTarget(path.join(input.skillsHome, name))) {
+    if (await removeManagedSkillCopyTarget(path.join(input.skillsHome, name), input.onLog)) {
       await input.onLog("stdout", `[paperclip] Revoked unavailable ACPX ${input.agentLabel} skill "${name}" from ${input.skillsHome}\n`);
     }
   }

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -3132,14 +3132,31 @@ async function hashSkillDirectory(root: string): Promise<string> {
   return hash.digest("hex");
 }
 
-async function materializedSkillFingerprintMatches(targetRoot: string, sourceFingerprint: string): Promise<boolean> {
+async function readMaterializedSkillSentinel(targetRoot: string): Promise<Record<string, unknown> | null> {
   try {
     const raw = JSON.parse(await fs.readFile(path.join(targetRoot, MATERIALIZED_SKILL_SENTINEL), "utf8")) as unknown;
     const parsed = parseObject(raw);
-    return parsed.version === 1 && parsed.sourceFingerprint === sourceFingerprint;
+    return parsed.version === 1 ? parsed : null;
   } catch {
-    return false;
+    return null;
   }
+}
+
+async function materializedSkillFingerprintMatches(targetRoot: string, sourceFingerprint: string): Promise<boolean> {
+  const sentinel = await readMaterializedSkillSentinel(targetRoot);
+  return sentinel?.sourceFingerprint === sourceFingerprint;
+}
+
+// Guards against clobbering a directory Paperclip didn't create. Skill
+// targets used to live under a Paperclip-owned state dir where nothing else
+// could collide; now Claude skills materialize straight into the project's
+// own `cwd/.claude/skills`, which can also hold project-authored skills the
+// project owner hand-wrote. Only a directory carrying our own sentinel file
+// is safe to overwrite/delete on the next reconcile.
+export async function isForeignSkillTarget(targetRoot: string): Promise<boolean> {
+  const existing = await fs.lstat(targetRoot).catch(() => null);
+  if (!existing) return false;
+  return (await readMaterializedSkillSentinel(targetRoot)) === null;
 }
 
 async function acquireMaterializeLock(lockDir: string): Promise<() => Promise<void>> {
@@ -3261,6 +3278,12 @@ export async function materializePaperclipSkillCopy(
   }
 
   try {
+    if (await isForeignSkillTarget(targetRoot)) {
+      throw new Error(
+        `Refusing to overwrite "${targetRoot}": it already exists and was not created by Paperclip. ` +
+          "Rename or remove the existing directory, or rename the Paperclip skill, to avoid the collision.",
+      );
+    }
     const sourceFingerprint = await hashSkillDirectory(sourceRoot);
     if (await materializedSkillFingerprintMatches(targetRoot, sourceFingerprint)) return result;
     await copyEntry(sourceRoot, tempRoot, "");


### PR DESCRIPTION
## Summary
- Fixes TRY-1021: `Skill(...)` calls for Paperclip-managed Claude skills failed with `Unknown skill: <name>` because the runtime materialized them under a content-hashed `stateDir/runtime-skills/claude/<hash>/.claude/skills` path that the Claude Code SDK's `settingSources` scan (`user`/`project`/`local`) never reads — the SDK only discovers skills under `.claude/skills` beneath one of those actual roots, not a path merely mentioned in the system prompt.
- Materializes skills straight into the session's project `cwd/.claude/skills`, mirroring how the Codex path already writes into its real `CODEX_HOME/skills`.
- Generalizes the existing Codex skill add/remove/manifest-reconciliation helpers (`reconcileManagedCodexSkills` → `reconcileManagedSkills`, etc., now taking an `agentLabel`) so both agents share the same cross-run cleanup logic.
- Only touches `.claude/skills` when a skill catalog is actually configured for the session, so runs with no Paperclip skills don't leave a stray `.paperclip-managed-skills.json` in every project checkout.

## Test plan
- [x] `vitest run packages/adapter-utils/src/acpx-engine/execute.test.ts` (155 passed) — includes an updated test asserting skills land under `cwd/.claude/skills` (not the old unreachable stateDir bundle) and a new test covering skill revocation on the Claude path
- [x] `vitest run packages/adapters/claude-local/src/server/acp.test.ts` (22 passed)
- [x] `tsc --noEmit` in `packages/adapter-utils`

🤖 Generated with [Claude Code](https://claude.com/claude-code)