### PR TITLE
feat(runner): run native Codex on remote targets

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -981,12 +981,25 @@ Remote mode requires all of the following server settings:
   run-bound `/api/runner/v1/connect/{runId}` path.
 - `PAPERCLIP_RUNNER_REMOTE_DIGEST`: the immutable `sha256:` digest of the
   `paperclip-runnerd` artifact installed in the remote image.
-- `PAPERCLIP_RUNNER_REMOTE_BINARY`: command or absolute path in the remote
-  image; defaults to `paperclip-runnerd`.
+- `PAPERCLIP_RUNNER_REMOTE_BINARY`: absolute POSIX path to the
+  `paperclip-runnerd` artifact in the remote image. The launch fails before
+  credential delivery unless the bytes at this exact path match the configured
+  digest.
 - `PAPERCLIP_RUNNER_REMOTE_RUNTIME_ROOT`: private, ephemeral remote runtime
   root; defaults to `/runner-runtime`.
+- `PAPERCLIP_RUNNER_REMOTE_CODEX_HOME`: optional absolute POSIX path to a
+  pre-provisioned Codex home in the remote image. Paperclip copies only regular,
+  non-symlink `auth.json` and `config.toml` files from it into the private
+  per-run home. When unset, those portable files are staged from the resolved
+  control-plane Codex home.
 
-The remote image owns its Codex home and runner state beneath that runtime root.
+The remote image owns its runner state beneath that runtime root. Paperclip
+creates a private, per-run Codex home there and provisions only the portable
+authentication and configuration files after verifying the runner artifact.
+The image must provide `/bin/sh`, `/proc/self/fd`, and a regular system
+`sha256sum` at `/usr/bin/sha256sum` or `/bin/sha256sum`. Host-provisioned Codex
+seeds also require a regular system `base64` at one of those prefixes. Paperclip
+removes the private runner copy, runner state, and Codex home when the run ends.
 The control plane does not copy SQLite state, caches, or sockets into the lane.
 It also does not inherit the control-plane process environment into a remote
 lane; only the resolved run environment plus the runner-owned bootstrap and

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -970,6 +970,33 @@ broker hostname is resolved once and the request is pinned to the approved
 address; IPv4 and IPv6 link-local destinations remain denied even when their
 host is allowlisted.
 
+### Remote Paperclip Runner targets
+
+The experimental `paperclip_runner` adapter may run in an already-realized
+Paperclip remote execution environment. Local execution remains the default.
+Remote mode requires all of the following server settings:
+
+- `PAPERCLIP_RUNNER_CONNECT_URL`: a runner-reachable private `ws://`
+  origin with no path, query, fragment, or credentials. The server appends the
+  run-bound `/api/runner/v1/connect/{runId}` path.
+- `PAPERCLIP_RUNNER_REMOTE_DIGEST`: the immutable `sha256:` digest of the
+  `paperclip-runnerd` artifact installed in the remote image.
+- `PAPERCLIP_RUNNER_REMOTE_BINARY`: command or absolute path in the remote
+  image; defaults to `paperclip-runnerd`.
+- `PAPERCLIP_RUNNER_REMOTE_RUNTIME_ROOT`: private, ephemeral remote runtime
+  root; defaults to `/runner-runtime`.
+
+The remote image owns its Codex home and runner state beneath that runtime root.
+The control plane does not copy SQLite state, caches, or sockets into the lane.
+It also does not inherit the control-plane process environment into a remote
+lane; only the resolved run environment plus the runner-owned bootstrap and
+Codex-home values cross that boundary.
+Only the one-use bootstrap ticket is passed in the process environment; the
+ticket is removed immediately by runnerd, is never placed in argv or the URL,
+and is exchanged for a short-lived connection lease. The remote PRP host is
+bound explicitly in runnerd's launch arguments and post-authentication PRP
+frames remain AES-256-GCM protected.
+
 ## Company Deletion Toggle
 
 Company deletion is intended as a dev/debug capability and can be disabled at runtime:

--- a/doc/SPEC-implementation.md
+++ b/doc/SPEC-implementation.md
@@ -1198,6 +1198,19 @@ Behavior:
 - non-2xx marks failed invocation
 - optional callback endpoint allows asynchronous completion updates
 
+## 11.3.1 Experimental Paperclip Runner target
+
+The explicit, default-off `paperclip_runner` adapter may launch its verified
+runner artifact in either a local environment or an already-realized remote
+execution target. Paperclip remains authoritative for the run binding,
+completion contract, semantic actions, budget and status finalization.
+
+Remote launch requirements are fail closed: an immutable runner digest, a
+private runner-reachable PRP origin, an exact non-loopback host binding, a
+one-use bootstrap ticket delivered only in the process environment, and a
+private ephemeral runner runtime root. The runner receives no broad Paperclip
+API key. Missing remote configuration must fail before provider dispatch.
+
 ## 11.4 Context Delivery
 
 - `thin`: send IDs and pointers only; agent fetches context via API

--- a/doc/architecture/paperclip-runner.md
+++ b/doc/architecture/paperclip-runner.md
@@ -49,8 +49,8 @@ paths.
 - Replace existing direct adapters.
 - Move business authorization or issue status policy into Rust.
 - Give runnerd a broad Paperclip API credential.
-- Support OpenCode, ACPX, Claude Managed, AWS AgentCore, or remote sandboxes in
-  the first production slice.
+- Support OpenCode, ACPX, Claude Managed, AWS AgentCore, or a general-purpose
+  remote-sandbox scheduler in the first production slice.
 - Expose browser SDK, React SDK, eval, lab, or scenario-explorer package entry
   points in the initial release.
 - Commit recorded screenshots, stress logs, or construction history as product
@@ -74,6 +74,13 @@ The server opens a native run and launches a verified runnerd artifact in the
 realized execution environment. Runnerd opens the outbound PRP connection. It
 then owns the provider process group and the durable transport state for that
 run.
+
+The realized environment may be local or an existing Paperclip remote execution
+target. Remote selection does not give the control plane a generic shell on a
+new host: the environment driver has already realized and leased that target,
+and the native runner uses the same bounded process interface as other adapters.
+The remote image must contain `paperclip-runnerd`; the control plane requires a
+configured immutable runner digest and a private runner-reachable PRP origin.
 
 The browser does not connect to runnerd. It reads projections from the existing
 Paperclip APIs and task-thread models.
@@ -162,6 +169,13 @@ stored. Runnerd never receives a broad Paperclip API key.
 The server rejects expired, replayed, revoked, cross-company, mismatched,
 malformed, oversized, or protocol-incompatible connections. Cancellation,
 timeout, supersession, and environment-lease loss revoke runner authority.
+
+Loopback transport remains the default. A remote runner accepts a non-loopback
+PRP destination only when its launch arguments bind the exact destination host.
+The bootstrap ticket never appears in the URL or argv. Authentication proves
+ticket possession with HMAC, then all control frames use the existing
+AES-256-GCM channel. Deployments should expose that endpoint only on a private
+runner ingress; it is not a board/API credential surface.
 
 ## Durable delivery and recovery
 

--- a/packages/adapter-utils/src/execution-target-sandbox.test.ts
+++ b/packages/adapter-utils/src/execution-target-sandbox.test.ts
@@ -352,6 +352,60 @@ describe("sandbox adapter execution targets", () => {
     });
   });
 
+  it("verifies the exact executable in the launch shell before a sandbox exec", async () => {
+    const runner = {
+      execute: vi.fn(async (_input: {
+        onSpawn?: (meta: { pid: number; startedAt: string }) => Promise<void>;
+      }) => ({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: "ok\n",
+        stderr: "",
+        pid: 42,
+        startedAt: new Date().toISOString(),
+      })),
+    };
+    const onSpawn = vi.fn(async () => {});
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "acme-sandbox",
+      remoteCwd: "/workspace",
+      runner,
+    };
+
+    await runAdapterExecutionTargetProcess(
+      "run-verified-sandbox",
+      target,
+      "/opt/paperclip/bin/paperclip-runnerd",
+      ["--run-id", "run-verified-sandbox"],
+      {
+        cwd: "/local/workspace",
+        env: { PAPERCLIP_RUNNER_BOOTSTRAP_TICKET: "one-use" },
+        timeoutSec: 5,
+        graceSec: 1,
+        onLog: async () => {},
+        onSpawn,
+        expectedExecutableSha256: `sha256:${"e".repeat(64)}`,
+      },
+    );
+
+    expect(runner.execute).toHaveBeenCalledWith(expect.objectContaining({
+      command: "/bin/sh",
+      args: ["-c", expect.stringMatching(/digest_mismatch[\s\S]+exec \/proc\/self\/fd\/9/)],
+      env: { PAPERCLIP_RUNNER_BOOTSTRAP_TICKET: "one-use" },
+      onSpawn: expect.any(Function),
+    }));
+    const passedOnSpawn = runner.execute.mock.calls[0]?.[0].onSpawn;
+    await passedOnSpawn?.({ pid: 42, startedAt: "2026-08-30T00:00:00.000Z" });
+    expect(onSpawn).toHaveBeenCalledWith({
+      pid: 42,
+      processGroupId: null,
+      startedAt: "2026-08-30T00:00:00.000Z",
+    });
+  });
+
   it("preserves stdin when wrapping sandbox adapter commands for run-log streaming", async () => {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-run-log-stdin-"));
     cleanupDirs.push(rootDir);

--- a/packages/adapter-utils/src/execution-target.test.ts
+++ b/packages/adapter-utils/src/execution-target.test.ts
@@ -3,11 +3,43 @@ import * as ssh from "./ssh.js";
 import * as serverUtils from "./server-utils.js";
 import {
   adapterExecutionTargetUsesManagedHome,
+  buildVerifiedRemoteExecutableScript,
   ensureAdapterExecutionTargetRuntimeCommandInstalled,
   resolveAdapterExecutionTargetCwd,
   runAdapterExecutionTargetProcess,
   runAdapterExecutionTargetShellCommand,
 } from "./execution-target.js";
+
+describe("buildVerifiedRemoteExecutableScript", () => {
+  it("fails closed before atomically executing the exact absolute binary", () => {
+    const script = buildVerifiedRemoteExecutableScript({
+      command: "/opt/paperclip/bin/paperclip-runnerd",
+      args: ["--run-id", "run with spaces"],
+      expectedSha256: `sha256:${"a".repeat(64)}`,
+    });
+
+    expect(script).toContain("sha256sum");
+    expect(script).toContain("shasum -a 256");
+    expect(script).toContain("/usr/bin/sha256sum");
+    expect(script).not.toContain("command -v sha256sum");
+    expect(script).toContain("paperclip_runner_remote_digest_mismatch");
+    expect(script).toContain("exec 9<\"$paperclip_runner_binary\"");
+    expect(script).toContain("exec /proc/self/fd/9 '--run-id' 'run with spaces'");
+    expect(script.indexOf("paperclip_runner_remote_digest_mismatch"))
+      .toBeLessThan(script.indexOf("exec /proc/self/fd/9"));
+  });
+
+  it("rejects PATH-resolved commands and malformed digests", () => {
+    expect(() => buildVerifiedRemoteExecutableScript({
+      command: "paperclip-runnerd",
+      expectedSha256: `sha256:${"a".repeat(64)}`,
+    })).toThrow(/absolute POSIX path/);
+    expect(() => buildVerifiedRemoteExecutableScript({
+      command: "/opt/paperclip/bin/paperclip-runnerd",
+      expectedSha256: "latest",
+    })).toThrow(/sha256 digest/);
+  });
+});
 
 describe("runAdapterExecutionTargetShellCommand", () => {
   afterEach(() => {
@@ -277,6 +309,98 @@ describe("runAdapterExecutionTargetProcess", () => {
         env: {
           SAFE_VALUE: "visible",
         },
+      }),
+    );
+  });
+
+  it("uses one verify-and-exec shell for an integrity-bound SSH launch", async () => {
+    const runChildProcessSpy = vi.spyOn(serverUtils, "runChildProcess").mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: "",
+      stderr: "",
+      pid: 123,
+      startedAt: new Date().toISOString(),
+    });
+    const onSpawn = vi.fn(async () => {});
+
+    await runAdapterExecutionTargetProcess(
+      "run-verified-ssh",
+      {
+        kind: "remote",
+        transport: "ssh",
+        remoteCwd: "/srv/paperclip/workspace",
+        spec: {
+          host: "ssh.example.test",
+          port: 22,
+          username: "ssh-user",
+          remoteCwd: "/srv/paperclip/workspace",
+          remoteWorkspacePath: "/srv/paperclip/workspace",
+          privateKey: null,
+          knownHosts: null,
+          strictHostKeyChecking: true,
+        },
+      },
+      "/opt/paperclip/bin/paperclip-runnerd",
+      ["--run-id", "run-verified-ssh"],
+      {
+        cwd: "/tmp/local",
+        env: { PAPERCLIP_RUNNER_BOOTSTRAP_TICKET: "one-use" },
+        timeoutSec: 5,
+        graceSec: 1,
+        onLog: async () => {},
+        onSpawn,
+        expectedExecutableSha256: `sha256:${"b".repeat(64)}`,
+      },
+    );
+
+    expect(runChildProcessSpy).toHaveBeenCalledWith(
+      "run-verified-ssh",
+      "/bin/sh",
+      ["-c", expect.stringMatching(/digest_mismatch[\s\S]+exec \/proc\/self\/fd\/9/)],
+      expect.objectContaining({
+        env: { PAPERCLIP_RUNNER_BOOTSTRAP_TICKET: "one-use" },
+        onSpawn,
+        remoteTrustedSystemShell: true,
+      }),
+    );
+  });
+
+  it("keeps credential stdin on the trusted SSH shell path", async () => {
+    const runSshCommandSpy = vi.spyOn(ssh, "runSshCommand").mockResolvedValue({
+      stdout: "",
+      stderr: "",
+    });
+    const target = {
+      kind: "remote" as const,
+      transport: "ssh" as const,
+      remoteCwd: "/srv/paperclip/workspace",
+      spec: {
+        host: "ssh.example.test",
+        port: 22,
+        username: "ssh-user",
+        remoteCwd: "/srv/paperclip/workspace",
+        remoteWorkspacePath: "/srv/paperclip/workspace",
+        privateKey: null,
+        knownHosts: null,
+        strictHostKeyChecking: true,
+      },
+    };
+
+    await runAdapterExecutionTargetShellCommand("run-private-seed", target, "read seed", {
+      cwd: "/tmp/local",
+      env: {},
+      stdin: "credential-bytes",
+      trustedSystemShell: true,
+    });
+
+    expect(runSshCommandSpy).toHaveBeenCalledWith(
+      target.spec,
+      "read seed",
+      expect.objectContaining({
+        stdin: "credential-bytes",
+        trustedSystemShell: true,
       }),
     );
   });

--- a/packages/adapter-utils/src/execution-target.test.ts
+++ b/packages/adapter-utils/src/execution-target.test.ts
@@ -8,6 +8,7 @@ import {
   resolveAdapterExecutionTargetCwd,
   runAdapterExecutionTargetProcess,
   runAdapterExecutionTargetShellCommand,
+  sanitizeVerifiedRemoteTransportEnv,
 } from "./execution-target.js";
 
 describe("buildVerifiedRemoteExecutableScript", () => {
@@ -19,7 +20,7 @@ describe("buildVerifiedRemoteExecutableScript", () => {
     });
 
     expect(script).toContain("sha256sum");
-    expect(script).toContain("shasum -a 256");
+    expect(script).not.toContain("shasum");
     expect(script).toContain("/usr/bin/sha256sum");
     expect(script).not.toContain("command -v sha256sum");
     expect(script).toContain("paperclip_runner_remote_digest_mismatch");
@@ -362,9 +363,197 @@ describe("runAdapterExecutionTargetProcess", () => {
       expect.objectContaining({
         env: { PAPERCLIP_RUNNER_BOOTSTRAP_TICKET: "one-use" },
         onSpawn,
+        remoteIntegrityBoundExecution: true,
         remoteTrustedSystemShell: true,
       }),
     );
+  });
+
+  it("rejects loader injection before an integrity-bound SSH launch starts", async () => {
+    const runChildProcessSpy = vi.spyOn(serverUtils, "runChildProcess").mockResolvedValue({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: "",
+      stderr: "",
+      pid: 123,
+      startedAt: new Date().toISOString(),
+    });
+
+    await expect(runAdapterExecutionTargetProcess(
+      "run-verified-ssh-rejected",
+      {
+        kind: "remote",
+        transport: "ssh",
+        remoteCwd: "/srv/paperclip/workspace",
+        spec: {
+          host: "ssh.example.test",
+          port: 22,
+          username: "ssh-user",
+          remoteCwd: "/srv/paperclip/workspace",
+          remoteWorkspacePath: "/srv/paperclip/workspace",
+          privateKey: null,
+          knownHosts: null,
+          strictHostKeyChecking: true,
+        },
+      },
+      "/opt/paperclip/bin/paperclip-runnerd",
+      ["--run-id", "run-verified-ssh-rejected"],
+      {
+        cwd: "/tmp/local",
+        env: {
+          LD_AUDIT: "/srv/paperclip/attacker-controlled.so",
+          PAPERCLIP_RUNNER_BOOTSTRAP_TICKET: "one-use",
+        },
+        timeoutSec: 5,
+        graceSec: 1,
+        onLog: async () => {},
+        expectedExecutableSha256: `sha256:${"e".repeat(64)}`,
+      },
+    )).rejects.toThrow("paperclip_verified_remote_env_unsafe:LD_AUDIT");
+    expect(runChildProcessSpy).not.toHaveBeenCalled();
+  });
+
+  it.each(["LD_PRELOAD", "BASH_ENV"])(
+    "rejects %s before an integrity-bound sandbox launch receives credentials",
+    async (unsafeKey) => {
+      const runner = {
+        execute: vi.fn(async () => ({
+          exitCode: 0,
+          signal: null,
+          timedOut: false,
+          stdout: "",
+          stderr: "",
+          pid: null,
+          startedAt: new Date().toISOString(),
+        })),
+      };
+
+      await expect(runAdapterExecutionTargetProcess(
+        "run-verified-sandbox-rejected",
+        {
+          kind: "remote",
+          transport: "sandbox",
+          providerKey: "test",
+          remoteCwd: "/srv/paperclip/workspace",
+          runner,
+        },
+        "/opt/paperclip/bin/paperclip-runnerd",
+        ["--run-id", "run-verified-sandbox-rejected"],
+        {
+          cwd: "/tmp/local",
+          env: {
+            [unsafeKey]: "/srv/paperclip/attacker-controlled",
+            PAPERCLIP_RUNNER_BOOTSTRAP_TICKET: "one-use",
+          },
+          timeoutSec: 5,
+          graceSec: 1,
+          onLog: async () => {},
+          expectedExecutableSha256: `sha256:${"c".repeat(64)}`,
+        },
+      )).rejects.toThrow(`paperclip_verified_remote_env_unsafe:${unsafeKey}`);
+      expect(runner.execute).not.toHaveBeenCalled();
+    },
+  );
+
+  it("preserves ordinary credentials for an integrity-bound sandbox launch", async () => {
+    const runner = {
+      execute: vi.fn(async () => ({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: "",
+        stderr: "",
+        pid: null,
+        startedAt: new Date().toISOString(),
+      })),
+    };
+    const env = {
+      CODEX_HOME: "/srv/paperclip/codex-home",
+      GH_TOKEN: "provider-token",
+      PAPERCLIP_RUNNER_BOOTSTRAP_TICKET: "one-use",
+      env: "production",
+      ld_token: "ordinary-lowercase-value",
+    };
+
+    await runAdapterExecutionTargetProcess(
+      "run-verified-sandbox",
+      {
+        kind: "remote",
+        transport: "sandbox",
+        providerKey: "test",
+        remoteCwd: "/srv/paperclip/workspace",
+        runner,
+      },
+      "/opt/paperclip/bin/paperclip-runnerd",
+      ["--run-id", "run-verified-sandbox"],
+      {
+        cwd: "/tmp/local",
+        env,
+        timeoutSec: 5,
+        graceSec: 1,
+        onLog: async () => {},
+        expectedExecutableSha256: `sha256:${"d".repeat(64)}`,
+      },
+    );
+
+    expect(runner.execute).toHaveBeenCalledWith(expect.objectContaining({
+      command: "/bin/sh",
+      env,
+    }));
+  });
+
+  it("removes local startup hooks while preserving SSH transport identity", () => {
+    expect(sanitizeVerifiedRemoteTransportEnv({
+      BASH_ENV: "/tmp/host-startup",
+      HOME: "/home/paperclip",
+      LD_PRELOAD: "/tmp/host-loader.so",
+      PATH: "/usr/bin:/bin",
+      SSH_AUTH_SOCK: "/tmp/ssh-agent.sock",
+    })).toEqual({
+      HOME: "/home/paperclip",
+      PATH: "/usr/bin:/bin",
+      SSH_AUTH_SOCK: "/tmp/ssh-agent.sock",
+    });
+  });
+
+  it("keeps loader variables available to ordinary non-integrity-bound sandbox launches", async () => {
+    const runner = {
+      execute: vi.fn(async () => ({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: "",
+        stderr: "",
+        pid: null,
+        startedAt: new Date().toISOString(),
+      })),
+    };
+
+    await runAdapterExecutionTargetProcess(
+      "run-ordinary-sandbox",
+      {
+        kind: "remote",
+        transport: "sandbox",
+        providerKey: "test",
+        remoteCwd: "/srv/paperclip/workspace",
+        runner,
+      },
+      "agent-cli",
+      ["--json"],
+      {
+        cwd: "/tmp/local",
+        env: { LD_LIBRARY_PATH: "/opt/agent/lib" },
+        timeoutSec: 5,
+        graceSec: 1,
+        onLog: async () => {},
+      },
+    );
+
+    expect(runner.execute).toHaveBeenCalledWith(expect.objectContaining({
+      command: "agent-cli",
+      env: { LD_LIBRARY_PATH: "/opt/agent/lib" },
+    }));
   });
 
   it("keeps credential stdin on the trusted SSH shell path", async () => {

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -71,7 +71,11 @@ import {
   type RunProcessResult,
   type TerminalResultCleanupOptions,
 } from "./server-utils.js";
-import { sanitizeRemoteExecutionEnv } from "./remote-execution-env.js";
+import {
+  sanitizeRemoteExecutionEnv,
+  sanitizeVerifiedRemoteExecutionEnv,
+  sanitizeVerifiedRemoteTransportEnv,
+} from "./remote-execution-env.js";
 import { preferredShellForSandbox, shellCommandArgs } from "./sandbox-shell.js";
 import {
   runWithRuntimeParent,
@@ -319,7 +323,11 @@ export interface AdapterExecutionTargetProcessSessionBridgeHandle {
   stop(): Promise<void>;
 }
 
-export { sanitizeRemoteExecutionEnv } from "./remote-execution-env.js";
+export {
+  sanitizeRemoteExecutionEnv,
+  sanitizeVerifiedRemoteExecutionEnv,
+  sanitizeVerifiedRemoteTransportEnv,
+} from "./remote-execution-env.js";
 
 // 4-hour wall-clock backstop for sandbox-backed adapter runs. This is a
 // last-resort kill switch, not the primary hang detector: genuinely hung runs
@@ -817,7 +825,7 @@ export function buildVerifiedRemoteExecutableScript(input: {
     'if [ ! -f "$paperclip_runner_binary" ] || [ ! -x "$paperclip_runner_binary" ] || [ -L "$paperclip_runner_binary" ]; then echo "paperclip_runner_remote_binary_unavailable" >&2; exit 71; fi',
     'exec 9<"$paperclip_runner_binary"',
     'if [ ! -e /proc/self/fd/9 ]; then echo "paperclip_runner_remote_digest_unsupported" >&2; exit 72; fi',
-    'if [ -x /usr/bin/sha256sum ] && [ ! -L /usr/bin/sha256sum ]; then paperclip_runner_actual_line=$(/usr/bin/sha256sum <&9); elif [ -x /bin/sha256sum ] && [ ! -L /bin/sha256sum ]; then paperclip_runner_actual_line=$(/bin/sha256sum <&9); elif [ -x /usr/bin/shasum ] && [ ! -L /usr/bin/shasum ]; then paperclip_runner_actual_line=$(/usr/bin/shasum -a 256 <&9); else echo "paperclip_runner_remote_digest_unsupported" >&2; exit 72; fi',
+    'if [ -x /usr/bin/sha256sum ] && [ ! -L /usr/bin/sha256sum ]; then paperclip_runner_actual_line=$(/usr/bin/sha256sum <&9); elif [ -x /bin/sha256sum ] && [ ! -L /bin/sha256sum ]; then paperclip_runner_actual_line=$(/bin/sha256sum <&9); else echo "paperclip_runner_remote_digest_unsupported" >&2; exit 72; fi',
     'paperclip_runner_actual_sha=${paperclip_runner_actual_line%% *}',
     'if [ "$paperclip_runner_actual_sha" != "$paperclip_runner_expected_sha" ]; then echo "paperclip_runner_remote_digest_mismatch" >&2; exit 73; fi',
   ];
@@ -838,7 +846,9 @@ export async function runAdapterExecutionTargetProcess(
 ): Promise<RunProcessResult> {
   if (target?.kind === "remote" && target.transport === "sandbox") {
     const runner = requireSandboxRunner(target);
-    const env = sanitizeRemoteExecutionEnv(options.env);
+    const env = options.expectedExecutableSha256
+      ? sanitizeVerifiedRemoteExecutionEnv(options.env)
+      : sanitizeRemoteExecutionEnv(options.env);
     await options.onRuntimeProgress?.({
       phase: "adapter_startup",
       message: "Starting adapter in environment",
@@ -896,7 +906,9 @@ export async function runAdapterExecutionTargetProcess(
 
   const env =
     target?.kind === "remote" && target.transport === "ssh"
-      ? sanitizeRemoteExecutionEnv(options.env)
+      ? options.expectedExecutableSha256
+        ? sanitizeVerifiedRemoteExecutionEnv(options.env)
+        : sanitizeRemoteExecutionEnv(options.env)
       : options.env;
 
   const verifiedRemoteScript = target?.kind === "remote" && options.expectedExecutableSha256
@@ -923,6 +935,7 @@ export async function runAdapterExecutionTargetProcess(
       localProcessSandbox: target?.kind === "local" || !target ? options.localProcessSandbox : null,
       remoteExecution: adapterExecutionTargetToRemoteSpec(target),
       remoteTrustedSystemShell: verifiedRemoteScript !== null,
+      remoteIntegrityBoundExecution: verifiedRemoteScript !== null,
     },
   );
 }

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -256,11 +256,21 @@ export interface AdapterExecutionTargetProcessOptions {
    */
   settleRunDisposition?: (() => DuplexBrokerRunDisposition) | null;
   localProcessSandbox?: LocalProcessSandboxOptions | null;
+  /**
+   * Remote-only executable integrity gate. When set, the execution-target
+   * launcher hashes the exact absolute executable path and execs it from the
+   * same open file descriptor only when the bytes match. The caller must first
+   * place mutable source artifacts in a private, non-writable run path.
+   */
+  expectedExecutableSha256?: string;
 }
 
 export interface AdapterExecutionTargetShellOptions {
   cwd: string;
   env: Record<string, string>;
+  stdin?: string;
+  /** Use /bin/sh without user or system profile sourcing. */
+  trustedSystemShell?: boolean;
   timeoutSec?: number;
   graceSec?: number;
   onLog?: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
@@ -779,6 +789,46 @@ function applyRunDispositionSeam(
   };
 }
 
+const SHA256_DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/;
+
+/**
+ * Build the fail-closed POSIX launcher used for credential-bearing remote
+ * commands. The configured executable must be an absolute, non-symlink path.
+ * The open descriptor prevents PATH or path replacement between hash and exec.
+ */
+export function buildVerifiedRemoteExecutableScript(input: {
+  command: string;
+  args?: string[];
+  expectedSha256: string;
+  execute?: boolean;
+}): string {
+  if (!path.posix.isAbsolute(input.command) || input.command.includes("\\")) {
+    throw new Error("verified remote executable must be an absolute POSIX path");
+  }
+  if (!SHA256_DIGEST_PATTERN.test(input.expectedSha256)) {
+    throw new Error("verified remote executable digest must be a sha256 digest");
+  }
+  const executable = shellQuote(input.command);
+  const expected = shellQuote(input.expectedSha256.slice("sha256:".length));
+  const verify = [
+    "set -eu",
+    `paperclip_runner_binary=${executable}`,
+    `paperclip_runner_expected_sha=${expected}`,
+    'if [ ! -f "$paperclip_runner_binary" ] || [ ! -x "$paperclip_runner_binary" ] || [ -L "$paperclip_runner_binary" ]; then echo "paperclip_runner_remote_binary_unavailable" >&2; exit 71; fi',
+    'exec 9<"$paperclip_runner_binary"',
+    'if [ ! -e /proc/self/fd/9 ]; then echo "paperclip_runner_remote_digest_unsupported" >&2; exit 72; fi',
+    'if [ -x /usr/bin/sha256sum ] && [ ! -L /usr/bin/sha256sum ]; then paperclip_runner_actual_line=$(/usr/bin/sha256sum <&9); elif [ -x /bin/sha256sum ] && [ ! -L /bin/sha256sum ]; then paperclip_runner_actual_line=$(/bin/sha256sum <&9); elif [ -x /usr/bin/shasum ] && [ ! -L /usr/bin/shasum ]; then paperclip_runner_actual_line=$(/usr/bin/shasum -a 256 <&9); else echo "paperclip_runner_remote_digest_unsupported" >&2; exit 72; fi',
+    'paperclip_runner_actual_sha=${paperclip_runner_actual_line%% *}',
+    'if [ "$paperclip_runner_actual_sha" != "$paperclip_runner_expected_sha" ]; then echo "paperclip_runner_remote_digest_mismatch" >&2; exit 73; fi',
+  ];
+  if (input.execute !== false) {
+    verify.push(
+      `exec /proc/self/fd/9${(input.args ?? []).map((arg) => ` ${shellQuote(arg)}`).join("")}`,
+    );
+  }
+  return verify.join("\n");
+}
+
 export async function runAdapterExecutionTargetProcess(
   runId: string,
   target: AdapterExecutionTarget | null | undefined,
@@ -796,8 +846,18 @@ export async function runAdapterExecutionTargetProcess(
     const runLogTail = options.runLogTail?.create() ?? null;
     let execCommand = command;
     let execArgs = args;
+    if (options.expectedExecutableSha256) {
+      execCommand = "/bin/sh";
+      execArgs = shellCommandArgs(
+        buildVerifiedRemoteExecutableScript({
+          command,
+          args,
+          expectedSha256: options.expectedExecutableSha256,
+        }),
+      );
+    }
     if (runLogTail) {
-      ({ command: execCommand, args: execArgs } = runLogTail.wrapCommand(command, args));
+      ({ command: execCommand, args: execArgs } = runLogTail.wrapCommand(execCommand, execArgs));
       runLogTail.start(options.onLog);
     }
     try {
@@ -839,18 +899,32 @@ export async function runAdapterExecutionTargetProcess(
       ? sanitizeRemoteExecutionEnv(options.env)
       : options.env;
 
-  return await runChildProcess(runId, command, args, {
-    cwd: options.cwd,
-    env,
-    stdin: options.stdin,
-    timeoutSec: options.timeoutSec,
-    graceSec: options.graceSec,
-    onLog: options.onLog,
-    onSpawn: options.onSpawn,
-    terminalResultCleanup: options.terminalResultCleanup,
-    localProcessSandbox: target?.kind === "local" || !target ? options.localProcessSandbox : null,
-    remoteExecution: adapterExecutionTargetToRemoteSpec(target),
-  });
+  const verifiedRemoteScript = target?.kind === "remote" && options.expectedExecutableSha256
+    ? buildVerifiedRemoteExecutableScript({
+        command,
+        args,
+        expectedSha256: options.expectedExecutableSha256,
+      })
+    : null;
+
+  return await runChildProcess(
+    runId,
+    verifiedRemoteScript ? "/bin/sh" : command,
+    verifiedRemoteScript ? ["-c", verifiedRemoteScript] : args,
+    {
+      cwd: options.cwd,
+      env,
+      stdin: options.stdin,
+      timeoutSec: options.timeoutSec,
+      graceSec: options.graceSec,
+      onLog: options.onLog,
+      onSpawn: options.onSpawn,
+      terminalResultCleanup: options.terminalResultCleanup,
+      localProcessSandbox: target?.kind === "local" || !target ? options.localProcessSandbox : null,
+      remoteExecution: adapterExecutionTargetToRemoteSpec(target),
+      remoteTrustedSystemShell: verifiedRemoteScript !== null,
+    },
+  );
 }
 
 export async function runAdapterExecutionTargetShellCommand(
@@ -872,6 +946,8 @@ export async function runAdapterExecutionTargetShellCommand(
         // identity var (NVM_DIR / PATH / etc.) that a profile re-exports.
         const result = await runSshCommand(target.spec, command, {
           env,
+          stdin: options.stdin,
+          trustedSystemShell: options.trustedSystemShell,
           timeoutMs: (options.timeoutSec ?? 15) * 1000,
         });
         if (result.stdout) await onLog("stdout", result.stdout);
@@ -923,12 +999,13 @@ export async function runAdapterExecutionTargetShellCommand(
       }
     }
 
-    const shellCommand = preferredSandboxShell(target);
+    const shellCommand = options.trustedSystemShell ? "/bin/sh" : preferredSandboxShell(target);
     return await requireSandboxRunner(target).execute({
       command: shellCommand,
       args: shellCommandArgs(command),
       cwd: target.remoteCwd,
       env,
+      stdin: options.stdin,
       timeoutMs: (options.timeoutSec ?? 15) * 1000,
       onLog,
     });
@@ -942,6 +1019,7 @@ export async function runAdapterExecutionTargetShellCommand(
     {
       cwd: options.cwd,
       env: options.env,
+      stdin: options.stdin,
       timeoutSec: options.timeoutSec ?? 15,
       graceSec: options.graceSec ?? 5,
       onLog,

--- a/packages/adapter-utils/src/remote-execution-env.ts
+++ b/packages/adapter-utils/src/remote-execution-env.ts
@@ -16,6 +16,23 @@ const REMOTE_EXECUTION_ENV_IDENTITY_KEYS = new Set([
   "XDG_RUNTIME_DIR",
 ]);
 
+const VERIFIED_REMOTE_EXECUTION_ENV_STARTUP_KEYS = new Set([
+  "BASHOPTS",
+  "BASH_ENV",
+  "ENV",
+  "GCONV_PATH",
+  "KSH_ENV",
+  "PS4",
+  "SHELLOPTS",
+  "ZDOTDIR",
+]);
+
+function isUnsafeVerifiedRemoteExecutionEnvKey(key: string): boolean {
+  return key.startsWith("LD_") ||
+    key.startsWith("DYLD_") ||
+    VERIFIED_REMOTE_EXECUTION_ENV_STARTUP_KEYS.has(key);
+}
+
 function readEnvValueCaseInsensitive(env: NodeJS.ProcessEnv, key: string): string | undefined {
   const direct = env[key];
   if (typeof direct === "string") return direct;
@@ -46,4 +63,36 @@ export function sanitizeRemoteExecutionEnv(
     sanitized[key] = value;
   }
   return sanitized;
+}
+
+/**
+ * Reject environment controls that can execute or load target-controlled code
+ * before an integrity-bound remote executable has been verified. This is
+ * deliberately narrower than the general remote sanitizer: ordinary adapter
+ * launches retain their existing environment contract.
+ */
+export function sanitizeVerifiedRemoteExecutionEnv(
+  env: Record<string, string>,
+  inheritedEnv: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  const sanitized = sanitizeRemoteExecutionEnv(env, inheritedEnv);
+  for (const key of Object.keys(sanitized)) {
+    if (isUnsafeVerifiedRemoteExecutionEnvKey(key)) {
+      throw new Error(`paperclip_verified_remote_env_unsafe:${key}`);
+    }
+  }
+  return sanitized;
+}
+
+/**
+ * Build the local SSH-client environment for an integrity-bound remote start.
+ * Remote runtime credentials travel only in the encoded remote command, while
+ * local loader/startup hooks are removed before the transport process starts.
+ */
+export function sanitizeVerifiedRemoteTransportEnv(
+  env: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  return Object.fromEntries(
+    Object.entries(env).filter(([key]) => !isUnsafeVerifiedRemoteExecutionEnvKey(key)),
+  );
 }

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -2469,6 +2469,7 @@ async function resolveSpawnTarget(
   options: {
     remoteExecution?: RemoteExecutionSpec | null;
     remoteEnv?: Record<string, string> | null;
+    remoteTrustedSystemShell?: boolean;
     localProcessSandbox?: LocalProcessSandboxOptions | null;
   } = {},
 ): Promise<SpawnTarget> {
@@ -2485,6 +2486,7 @@ async function resolveSpawnTarget(
       env: Object.fromEntries(
         Object.entries(options.remoteEnv ?? {}).filter((entry): entry is [string, string] => typeof entry[1] === "string"),
       ),
+      trustedSystemShell: options.remoteTrustedSystemShell,
     });
     return {
       command: sshResolved,
@@ -3359,6 +3361,7 @@ export async function runChildProcess(
     terminalResultCleanup?: TerminalResultCleanupOptions;
     stdin?: string;
     remoteExecution?: RemoteExecutionSpec | null;
+    remoteTrustedSystemShell?: boolean;
     localProcessSandbox?: LocalProcessSandboxOptions | null;
   },
 ): Promise<RunProcessResult> {
@@ -3391,6 +3394,7 @@ export async function runChildProcess(
     void resolveSpawnTarget(command, args, opts.cwd, mergedEnv, {
       remoteExecution: opts.remoteExecution ?? null,
       remoteEnv: opts.remoteExecution ? opts.env : null,
+      remoteTrustedSystemShell: opts.remoteTrustedSystemShell,
       localProcessSandbox: opts.localProcessSandbox ?? null,
     })
       .then((target) => {

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -4,7 +4,10 @@ import { constants as fsConstants, promises as fs, type Dirent } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { CONNECTION_INTENT_AGENT_GUIDANCE } from "@paperclipai/shared";
-import { sanitizeRemoteExecutionEnv } from "./remote-execution-env.js";
+import {
+  sanitizeRemoteExecutionEnv,
+  sanitizeVerifiedRemoteTransportEnv,
+} from "./remote-execution-env.js";
 import {
   buildLocalProcessSandboxSpawnTarget,
   type LocalProcessSandboxOptions,
@@ -3362,15 +3365,16 @@ export async function runChildProcess(
     stdin?: string;
     remoteExecution?: RemoteExecutionSpec | null;
     remoteTrustedSystemShell?: boolean;
+    remoteIntegrityBoundExecution?: boolean;
     localProcessSandbox?: LocalProcessSandboxOptions | null;
   },
 ): Promise<RunProcessResult> {
   const onLogError = opts.onLogError ?? ((err, id, msg) => console.warn({ err, runId: id }, msg));
   return new Promise<RunProcessResult>((resolve, reject) => {
-    const rawMerged: NodeJS.ProcessEnv = {
-      ...sanitizeInheritedPaperclipEnv(process.env),
-      ...opts.env,
-    };
+    const inheritedEnv = sanitizeInheritedPaperclipEnv(process.env);
+    const rawMerged: NodeJS.ProcessEnv = opts.remoteExecution && opts.remoteIntegrityBoundExecution
+      ? sanitizeVerifiedRemoteTransportEnv(inheritedEnv)
+      : { ...inheritedEnv, ...opts.env };
 
     // Strip Claude Code nesting-guard env vars so spawned `claude` processes
     // don't refuse to start with "cannot be launched inside another session".

--- a/packages/adapter-utils/src/ssh-fixture.test.ts
+++ b/packages/adapter-utils/src/ssh-fixture.test.ts
@@ -490,6 +490,32 @@ describe("ssh env-lab fixture", () => {
     await target.cleanup();
   });
 
+  it("uses the fixed system shell without profiles for an integrity-bound launch", async () => {
+    const target = await buildSshSpawnTarget({
+      spec: {
+        host: "ssh.example.test",
+        port: 22,
+        username: "ssh-user",
+        remoteCwd: "/srv/paperclip/workspace",
+        remoteWorkspacePath: "/srv/paperclip/workspace",
+        privateKey: null,
+        knownHosts: null,
+        strictHostKeyChecking: true,
+      },
+      command: "/bin/sh",
+      args: ["-c", "exec /proc/self/fd/9"],
+      env: { PAPERCLIP_RUNNER_BOOTSTRAP_TICKET: "one-use" },
+      trustedSystemShell: true,
+    });
+
+    const remoteScript = String(target.args.at(-1) ?? "");
+    expect(remoteScript).toContain("/bin/sh");
+    expect(remoteScript).not.toContain("/etc/profile");
+    expect(remoteScript).not.toContain(".bashrc");
+    expect(remoteScript).toContain("PAPERCLIP_RUNNER_BOOTSTRAP_TICKET");
+    await target.cleanup();
+  });
+
   it("rejects invalid environment variable keys when constructing SSH spawn targets", async () => {
     await expect(
       buildSshSpawnTarget({

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -1197,6 +1197,7 @@ export async function runSshCommand(
     stdin?: string;
     timeoutMs?: number;
     maxBuffer?: number;
+    trustedSystemShell?: boolean;
   } = {},
 ): Promise<SshCommandResult> {
   let cleanup: () => Promise<void> = () => Promise.resolve();
@@ -1224,21 +1225,24 @@ export async function runSshCommand(
     // directly when no .bash_profile exists, so a host that adds nvm in
     // .bashrc still resolves node without a double-run of the setup.
     const envArgs = envEntries.map(([key, value]) => `${key}=${shellQuote(value)}`);
+    const remoteShell = options.trustedSystemShell ? "/bin/sh" : "sh";
     const remoteScript = [
-      'if [ -f /etc/profile ]; then . /etc/profile >/dev/null 2>&1 || true; fi',
-      'if [ -f "$HOME/.profile" ]; then . "$HOME/.profile" >/dev/null 2>&1 || true; fi',
-      'if [ -f "$HOME/.bash_profile" ]; then . "$HOME/.bash_profile" >/dev/null 2>&1 || true; elif [ -f "$HOME/.bashrc" ]; then . "$HOME/.bashrc" >/dev/null 2>&1 || true; fi',
-      'if [ -f "$HOME/.zprofile" ]; then . "$HOME/.zprofile" >/dev/null 2>&1 || true; fi',
+      ...(options.trustedSystemShell ? [] : [
+        'if [ -f /etc/profile ]; then . /etc/profile >/dev/null 2>&1 || true; fi',
+        'if [ -f "$HOME/.profile" ]; then . "$HOME/.profile" >/dev/null 2>&1 || true; fi',
+        'if [ -f "$HOME/.bash_profile" ]; then . "$HOME/.bash_profile" >/dev/null 2>&1 || true; elif [ -f "$HOME/.bashrc" ]; then . "$HOME/.bashrc" >/dev/null 2>&1 || true; fi',
+        'if [ -f "$HOME/.zprofile" ]; then . "$HOME/.zprofile" >/dev/null 2>&1 || true; fi',
+      ]),
       envArgs.length > 0
-        ? `exec env ${envArgs.join(" ")} sh -c ${shellQuote(remoteCommand)}`
-        : `exec sh -c ${shellQuote(remoteCommand)}`,
+        ? `exec env ${envArgs.join(" ")} ${shellQuote(remoteShell)} -c ${shellQuote(remoteCommand)}`
+        : `exec ${shellQuote(remoteShell)} -c ${shellQuote(remoteCommand)}`,
     ].join(" && ");
 
     sshArgs.push(
       "-p",
       String(config.port),
       `${config.username}@${config.host}`,
-      `sh -c ${shellQuote(remoteScript)}`,
+      `${shellQuote(remoteShell)} -c ${shellQuote(remoteScript)}`,
     );
 
     return options.stdin != null
@@ -1261,6 +1265,7 @@ export async function buildSshSpawnTarget(input: {
   command: string;
   args: string[];
   env: Record<string, string>;
+  trustedSystemShell?: boolean;
 }): Promise<{
   command: string;
   args: string[];
@@ -1288,11 +1293,14 @@ export async function buildSshSpawnTarget(input: {
   // .bash_profile typically sources .bashrc itself; only source .bashrc
   // directly when no .bash_profile exists, so a host that adds nvm in
   // .bashrc still resolves node without a double-run of the setup.
+  const remoteShell = input.trustedSystemShell ? "/bin/sh" : "sh";
   const remoteScript = [
-    'if [ -f /etc/profile ]; then . /etc/profile >/dev/null 2>&1 || true; fi',
-    'if [ -f "$HOME/.profile" ]; then . "$HOME/.profile" >/dev/null 2>&1 || true; fi',
-    'if [ -f "$HOME/.bash_profile" ]; then . "$HOME/.bash_profile" >/dev/null 2>&1 || true; elif [ -f "$HOME/.bashrc" ]; then . "$HOME/.bashrc" >/dev/null 2>&1 || true; fi',
-    'if [ -f "$HOME/.zprofile" ]; then . "$HOME/.zprofile" >/dev/null 2>&1 || true; fi',
+    ...(input.trustedSystemShell ? [] : [
+      'if [ -f /etc/profile ]; then . /etc/profile >/dev/null 2>&1 || true; fi',
+      'if [ -f "$HOME/.profile" ]; then . "$HOME/.profile" >/dev/null 2>&1 || true; fi',
+      'if [ -f "$HOME/.bash_profile" ]; then . "$HOME/.bash_profile" >/dev/null 2>&1 || true; elif [ -f "$HOME/.bashrc" ]; then . "$HOME/.bashrc" >/dev/null 2>&1 || true; fi',
+      'if [ -f "$HOME/.zprofile" ]; then . "$HOME/.zprofile" >/dev/null 2>&1 || true; fi',
+    ]),
     `cd ${shellQuote(input.spec.remoteCwd)}`,
     envArgs.length > 0
       ? `exec env ${envArgs.join(" ")} ${remoteCommandParts}`
@@ -1303,7 +1311,7 @@ export async function buildSshSpawnTarget(input: {
     "-p",
     String(input.spec.port),
     `${input.spec.username}@${input.spec.host}`,
-    `sh -c ${shellQuote(remoteScript)}`,
+    `${shellQuote(remoteShell)} -c ${shellQuote(remoteScript)}`,
   );
 
   return {

--- a/packages/paperclip-runner/runner/DURABLE_TRANSPORT.md
+++ b/packages/paperclip-runner/runner/DURABLE_TRANSPORT.md
@@ -7,8 +7,13 @@ only installed provider; other providers remain unavailable.
 
 ## Trust boundary
 
-- The runner accepts only `ws://` destinations whose complete DNS result is
-  loopback. Resolution happens once and reconnects reuse the pinned addresses.
+- The runner accepts only `ws://` destinations. Loopback remains the default.
+  A non-loopback destination is accepted only when the trusted launcher also
+  supplies the exact host through `--allow-remote-host`; the URL host and
+  launch binding must match case-insensitively. Resolution happens once and
+  reconnects reuse the pinned addresses. The private ingress is only a carrier:
+  bootstrap proof and every post-authentication control frame remain protected
+  by the PRP cryptographic channel.
 - A bootstrap ticket is read from `PAPERCLIP_RUNNER_BOOTSTRAP_TICKET`, removed
   from the environment immediately, and never sent over the socket. Both peers
   prove possession through HMAC-SHA-256.
@@ -70,6 +75,11 @@ Durable mode is selected only when `paperclip-runnerd` receives
 completion contract through `run.prepare`, owns the provider process group,
 resumes the persisted Codex thread after runner restart, and translates
 provider notifications to PRP events. The server supplies the bootstrap ticket
-only through the child environment, stores the process identity for bounded
-cancellation, and waits for the durable result and terminal pair. The existing
-local fake-runner mode remains unchanged.
+only through the child environment and waits for the durable result and
+terminal pair. A local launch stores local process identity for bounded
+cancellation. The existing local fake-runner mode remains unchanged.
+
+For a remote execution target, the control plane passes the one-use ticket only
+in the target process environment, requires an immutable `sha256:` runner
+digest, and keeps coordinator state on the control-plane side. The remote
+runtime stores runner and Codex state under its own private runtime root.

--- a/packages/paperclip-runner/runner/crates/runner-core/src/bin/paperclip-runnerd.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/bin/paperclip-runnerd.rs
@@ -53,6 +53,15 @@ fn run_durable(args: &[String]) -> Result<(), LocalRunnerError> {
     run_durable_runner(
         DurableRunnerConfig {
             connect_url: value(args, "--connect-url")?,
+            allowed_remote_host: args
+                .iter()
+                .position(|argument| argument == "--allow-remote-host")
+                .map(|index| {
+                    args.get(index + 1).cloned().ok_or_else(|| {
+                        LocalRunnerError::invalid("missing value for --allow-remote-host")
+                    })
+                })
+                .transpose()?,
             state_dir: state_dir.clone(),
             runner_instance_id: value(args, "--runner-id")?,
             environment_lease_id: value(args, "--environment-lease-id")?,

--- a/packages/paperclip-runner/runner/crates/runner-core/src/durable/mod.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/durable/mod.rs
@@ -94,6 +94,9 @@ pub fn capture_bootstrap_ticket() -> Result<Option<BootstrapTicket>, DurableRunn
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DurableRunnerConfig {
     pub connect_url: String,
+    /// Exact non-loopback URL host authorized by the trusted launcher.
+    /// `None` preserves the local-only default.
+    pub allowed_remote_host: Option<String>,
     pub state_dir: PathBuf,
     pub runner_instance_id: String,
     pub environment_lease_id: String,
@@ -127,6 +130,20 @@ impl DurableRunnerConfig {
                 return Err(DurableRunnerError::invalid(format!(
                     "{name} must be a non-empty bounded string without control characters"
                 )));
+            }
+        }
+        if let Some(host) = self.allowed_remote_host.as_deref() {
+            if host.is_empty()
+                || host.len() > 253
+                || host.chars().any(|character| {
+                    character.is_control()
+                        || character.is_whitespace()
+                        || matches!(character, '/' | '\\' | '@' | ':' | '%' | '?' | '#')
+                })
+            {
+                return Err(DurableRunnerError::invalid(
+                    "allowed remote host must be an exact bounded URL host",
+                ));
             }
         }
         if self.max_outbox_bytes == 0

--- a/packages/paperclip-runner/runner/crates/runner-core/src/durable/runner.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/durable/runner.rs
@@ -81,10 +81,8 @@ pub fn run_durable_runner<E: CommandExecutor>(
     }
     // Resolve once. Every reconnect uses the same validated concrete addresses,
     // so DNS cannot redirect a retry after the trust decision.
-    let target = ResolvedWsTarget::resolve(
-        &config.connect_url,
-        config.allowed_remote_host.as_deref(),
-    )?;
+    let target =
+        ResolvedWsTarget::resolve(&config.connect_url, config.allowed_remote_host.as_deref())?;
     let started = Instant::now();
     let mut bootstrap_ticket = Some(bootstrap_ticket);
     let mut lease: Option<LeaseCredential> = None;

--- a/packages/paperclip-runner/runner/crates/runner-core/src/durable/runner.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/durable/runner.rs
@@ -81,7 +81,10 @@ pub fn run_durable_runner<E: CommandExecutor>(
     }
     // Resolve once. Every reconnect uses the same validated concrete addresses,
     // so DNS cannot redirect a retry after the trust decision.
-    let target = ResolvedWsTarget::resolve(&config.connect_url)?;
+    let target = ResolvedWsTarget::resolve(
+        &config.connect_url,
+        config.allowed_remote_host.as_deref(),
+    )?;
     let started = Instant::now();
     let mut bootstrap_ticket = Some(bootstrap_ticket);
     let mut lease: Option<LeaseCredential> = None;
@@ -475,6 +478,7 @@ mod tests {
     fn config(directory: PathBuf) -> DurableRunnerConfig {
         DurableRunnerConfig {
             connect_url: "ws://127.0.0.1:3000/path".to_owned(),
+            allowed_remote_host: None,
             state_dir: directory,
             runner_instance_id: "runner_1".to_owned(),
             environment_lease_id: "environment_1".to_owned(),

--- a/packages/paperclip-runner/runner/crates/runner-core/src/durable/state.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/durable/state.rs
@@ -1179,6 +1179,7 @@ mod tests {
     fn config(state_dir: PathBuf) -> DurableRunnerConfig {
         DurableRunnerConfig {
             connect_url: "ws://127.0.0.1:3000/api/runner/v1/connect/run_1".to_owned(),
+            allowed_remote_host: None,
             state_dir,
             runner_instance_id: "runner_1".to_owned(),
             environment_lease_id: "environment_1".to_owned(),

--- a/packages/paperclip-runner/runner/crates/runner-core/src/durable/transport.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/durable/transport.rs
@@ -1260,19 +1260,20 @@ mod tests {
     #[test]
     fn url_resolution_rejects_non_loopback_and_ambiguous_inputs() {
         let public = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)), 80);
-        assert!(
-            resolve_ws_target_with("ws://example.test:80/path", None, |_, _| Ok(vec![public])).is_err()
-        );
+        assert!(resolve_ws_target_with("ws://example.test:80/path", None, |_, _| Ok(vec![public]))
+            .is_err());
         assert!(resolve_ws_target_with(
             "ws://example.test:80/path",
             Some("example.test"),
             |_, _| Ok(vec![public]),
-        ).is_ok());
+        )
+        .is_ok());
         assert!(resolve_ws_target_with(
             "ws://example.test:80/path",
             Some("other.test"),
             |_, _| Ok(vec![public]),
-        ).is_err());
+        )
+        .is_err());
         for input in [
             "wss://127.0.0.1:80/path",
             "ws://user@127.0.0.1:80/path",
@@ -1436,10 +1437,9 @@ mod tests {
             send_plain(&mut socket, &encrypted, server_config.max_frame_bytes).unwrap();
         });
 
-        let target = ResolvedWsTarget::resolve(
-            &config.connect_url,
-            config.allowed_remote_host.as_deref(),
-        ).unwrap();
+        let target =
+            ResolvedWsTarget::resolve(&config.connect_url, config.allowed_remote_host.as_deref())
+                .unwrap();
         let ticket = BootstrapTicket::new("bootstrap-secret".to_owned()).unwrap();
         let (_, welcome) =
             AuthenticatedTransport::connect(&target, &config, &state, Some(&ticket), None).unwrap();

--- a/packages/paperclip-runner/runner/crates/runner-core/src/durable/transport.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/durable/transport.rs
@@ -1260,8 +1260,10 @@ mod tests {
     #[test]
     fn url_resolution_rejects_non_loopback_and_ambiguous_inputs() {
         let public = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)), 80);
-        assert!(resolve_ws_target_with("ws://example.test:80/path", None, |_, _| Ok(vec![public]))
-            .is_err());
+        assert!(
+            resolve_ws_target_with("ws://example.test:80/path", None, |_, _| Ok(vec![public]))
+                .is_err()
+        );
         assert!(resolve_ws_target_with(
             "ws://example.test:80/path",
             Some("example.test"),

--- a/packages/paperclip-runner/runner/crates/runner-core/src/durable/transport.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/durable/transport.rs
@@ -38,8 +38,11 @@ pub(crate) struct ResolvedWsTarget {
 }
 
 impl ResolvedWsTarget {
-    pub(crate) fn resolve(input: &str) -> Result<Self, DurableRunnerError> {
-        resolve_ws_target_with(input, |host, port| {
+    pub(crate) fn resolve(
+        input: &str,
+        allowed_remote_host: Option<&str>,
+    ) -> Result<Self, DurableRunnerError> {
+        resolve_ws_target_with(input, allowed_remote_host, |host, port| {
             (host, port)
                 .to_socket_addrs()
                 .map(|addresses| addresses.collect())
@@ -115,6 +118,7 @@ fn parse_ws_url(input: &str) -> Result<ParsedWsUrl, DurableRunnerError> {
 
 fn resolve_ws_target_with<F>(
     input: &str,
+    allowed_remote_host: Option<&str>,
     resolver: F,
 ) -> Result<ResolvedWsTarget, DurableRunnerError>
 where
@@ -131,9 +135,11 @@ where
             "WebSocket destination resolved to no addresses",
         ));
     }
-    if addresses.iter().any(|address| !address.ip().is_loopback()) {
+    if addresses.iter().any(|address| !address.ip().is_loopback())
+        && !allowed_remote_host.is_some_and(|allowed| allowed.eq_ignore_ascii_case(&parsed.host))
+    {
         return Err(DurableRunnerError::invalid(
-            "every WebSocket destination must resolve to loopback",
+            "non-loopback WebSocket destination is not bound to the trusted launch host",
         ));
     }
     Ok(ResolvedWsTarget {
@@ -1063,6 +1069,7 @@ mod tests {
     fn config(port: u16) -> DurableRunnerConfig {
         DurableRunnerConfig {
             connect_url: format!("ws://127.0.0.1:{port}/api/runner/v1/connect/run_1"),
+            allowed_remote_host: None,
             state_dir: PathBuf::from("unused"),
             runner_instance_id: "runner_1".to_owned(),
             environment_lease_id: "environment_1".to_owned(),
@@ -1254,8 +1261,18 @@ mod tests {
     fn url_resolution_rejects_non_loopback_and_ambiguous_inputs() {
         let public = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1)), 80);
         assert!(
-            resolve_ws_target_with("ws://example.test:80/path", |_, _| Ok(vec![public])).is_err()
+            resolve_ws_target_with("ws://example.test:80/path", None, |_, _| Ok(vec![public])).is_err()
         );
+        assert!(resolve_ws_target_with(
+            "ws://example.test:80/path",
+            Some("example.test"),
+            |_, _| Ok(vec![public]),
+        ).is_ok());
+        assert!(resolve_ws_target_with(
+            "ws://example.test:80/path",
+            Some("other.test"),
+            |_, _| Ok(vec![public]),
+        ).is_err());
         for input in [
             "wss://127.0.0.1:80/path",
             "ws://user@127.0.0.1:80/path",
@@ -1263,7 +1280,7 @@ mod tests {
             "ws://127.0.0.1:80/path?ticket=secret",
         ] {
             assert!(
-                resolve_ws_target_with(input, |_, _| Ok(vec![])).is_err(),
+                resolve_ws_target_with(input, None, |_, _| Ok(vec![])).is_err(),
                 "{input}"
             );
         }
@@ -1419,7 +1436,10 @@ mod tests {
             send_plain(&mut socket, &encrypted, server_config.max_frame_bytes).unwrap();
         });
 
-        let target = ResolvedWsTarget::resolve(&config.connect_url).unwrap();
+        let target = ResolvedWsTarget::resolve(
+            &config.connect_url,
+            config.allowed_remote_host.as_deref(),
+        ).unwrap();
         let ticket = BootstrapTicket::new("bootstrap-secret".to_owned()).unwrap();
         let (_, welcome) =
             AuthenticatedTransport::connect(&target, &config, &state, Some(&ticket), None).unwrap();

--- a/packages/paperclip-runner/runner/crates/runner-core/tests/codex_provider.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/tests/codex_provider.rs
@@ -80,6 +80,7 @@ fn task_context_tool_set() -> AuthorizedToolSet {
 fn durable_config(directory: &Path) -> DurableRunnerConfig {
     DurableRunnerConfig {
         connect_url: "ws://127.0.0.1:3000/runner".to_owned(),
+        allowed_remote_host: None,
         state_dir: directory.to_path_buf(),
         runner_instance_id: "runner-1".to_owned(),
         environment_lease_id: "lease-1".to_owned(),

--- a/packages/paperclip-runner/runner/crates/runner-core/tests/durable_recovery.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/tests/durable_recovery.rs
@@ -13,6 +13,7 @@ static NEXT_TEMPORARY_DIRECTORY: AtomicU64 = AtomicU64::new(0);
 fn config(state_dir: PathBuf) -> DurableRunnerConfig {
     DurableRunnerConfig {
         connect_url: "ws://127.0.0.1:3000/api/runner/v1/connect/run_1".to_owned(),
+        allowed_remote_host: None,
         state_dir,
         runner_instance_id: "runner_1".to_owned(),
         environment_lease_id: "environment_1".to_owned(),

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -580,12 +580,19 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
 
       await heartbeat.resumeQueuedRuns();
       await waitForCondition(async () => {
-        const run = await db
-          .select({ status: heartbeatRuns.status })
-          .from(heartbeatRuns)
-          .where(eq(heartbeatRuns.id, runId))
-          .then((rows) => rows[0] ?? null);
-        return run?.status === "cancelled";
+        const [run, wakeup] = await Promise.all([
+          db
+            .select({ status: heartbeatRuns.status })
+            .from(heartbeatRuns)
+            .where(eq(heartbeatRuns.id, runId))
+            .then((rows) => rows[0] ?? null),
+          db
+            .select({ status: agentWakeupRequests.status })
+            .from(agentWakeupRequests)
+            .where(eq(agentWakeupRequests.id, wakeupRequestId))
+            .then((rows) => rows[0] ?? null),
+        ]);
+        return run?.status === "cancelled" && wakeup?.status === "skipped";
       });
 
       const [run, wakeup, issue] = await Promise.all([

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -862,7 +862,10 @@ export async function startServer(): Promise<StartedServer> {
   process.env.PAPERCLIP_RUNTIME_API_CANDIDATES_JSON = JSON.stringify(runtimeApiCandidates);
   process.env.PAPERCLIP_API_URL = configuredApiUrl;
   
-  setupRunnerPrpWebSocketServer(server, { apiUrl: configuredApiUrl });
+  setupRunnerPrpWebSocketServer(server, {
+    apiUrl: configuredApiUrl,
+    connectUrl: process.env.PAPERCLIP_RUNNER_CONNECT_URL?.trim() || undefined,
+  });
   setupEnvironmentCustomImageTerminalWebSocketServer(server, db as any, {
     pluginWorkerManager,
   });

--- a/server/src/realtime/runner-prp-ws.test.ts
+++ b/server/src/realtime/runner-prp-ws.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   registerRunnerPrpAuthority,
+  resolveRunnerPrpConnectOrigin,
   runnerPrpWebSocketInternals,
   setupRunnerPrpWebSocketServer,
 } from "./runner-prp-ws.js";
@@ -52,6 +53,40 @@ describe("runner PRP websocket route", () => {
         runId,
       }),
     ).toBe(false);
+    server.close();
+  });
+
+  it("uses an explicit runner-reachable origin without accepting URL credentials or paths", () => {
+    expect(resolveRunnerPrpConnectOrigin("http://paperclip.internal:3100")).toBe(
+      "ws://paperclip.internal:3100",
+    );
+    expect(resolveRunnerPrpConnectOrigin("https://paperclip.example")).toBe(
+      "wss://paperclip.example",
+    );
+    expect(() => resolveRunnerPrpConnectOrigin("https://user@paperclip.example")).toThrow(
+      "runner_prp_websocket_origin_invalid",
+    );
+    expect(() => resolveRunnerPrpConnectOrigin("https://paperclip.example/nested")).toThrow(
+      "runner_prp_websocket_origin_invalid",
+    );
+  });
+
+  it("publishes the configured private runner origin", async () => {
+    const server = createServer();
+    setupRunnerPrpWebSocketServer(server, {
+      apiUrl: "http://127.0.0.1:3214",
+      connectUrl: "http://paperclip.internal:3100",
+    });
+    const runId = "00000000-0000-4000-8000-000000000780";
+    const registration = await registerRunnerPrpAuthority({
+      companyId: "company-1",
+      runId,
+      authority: { handleUpgrade: vi.fn() } as unknown as DurablePrpControlPlane,
+    });
+    expect(registration.connectUrl).toBe(
+      `ws://paperclip.internal:3100/api/runner/v1/connect/${runId}`,
+    );
+    await registration.release();
     server.close();
   });
 

--- a/server/src/realtime/runner-prp-ws.ts
+++ b/server/src/realtime/runner-prp-ws.ts
@@ -20,7 +20,24 @@ interface RunnerPrpUpgradeRequest extends IncomingMessage {
 }
 
 const registrations = new Map<string, RegisteredAuthority>();
-let loopbackOrigin: string | null = null;
+let connectOrigin: string | null = null;
+
+export function resolveRunnerPrpConnectOrigin(input: string): string {
+  const url = new URL(input);
+  if (!["http:", "https:", "ws:", "wss:"].includes(url.protocol)) {
+    throw new Error("runner_prp_websocket_api_url_invalid");
+  }
+  if (url.username || url.password || (url.pathname !== "/" && url.pathname !== "") || url.search || url.hash) {
+    throw new Error("runner_prp_websocket_origin_invalid");
+  }
+  url.protocol = url.protocol === "https:" || url.protocol === "wss:" ? "wss:" : "ws:";
+  url.username = "";
+  url.password = "";
+  url.pathname = "";
+  url.search = "";
+  url.hash = "";
+  return url.toString().replace(/\/$/, "");
+}
 
 function rejectUpgrade(
   socket: Duplex,
@@ -42,19 +59,16 @@ function rejectUpgrade(
 
 export function setupRunnerPrpWebSocketServer(
   server: Server,
-  options: { readonly apiUrl: string },
+  options: {
+    readonly apiUrl: string;
+    /**
+     * Optional runner-reachable origin. This is intentionally separate from
+     * the board/API URL so a remote execution lane can use a private ingress.
+     */
+    readonly connectUrl?: string;
+  },
 ): void {
-  const apiUrl = new URL(options.apiUrl);
-  if (!["http:", "https:"].includes(apiUrl.protocol)) {
-    throw new Error("runner_prp_websocket_api_url_invalid");
-  }
-  apiUrl.protocol = apiUrl.protocol === "https:" ? "wss:" : "ws:";
-  apiUrl.username = "";
-  apiUrl.password = "";
-  apiUrl.pathname = "";
-  apiUrl.search = "";
-  apiUrl.hash = "";
-  loopbackOrigin = apiUrl.toString().replace(/\/$/, "");
+  connectOrigin = resolveRunnerPrpConnectOrigin(options.connectUrl ?? options.apiUrl);
   server.on(
     "upgrade",
     (request: IncomingMessage, socket: Duplex, head: Buffer) => {
@@ -91,7 +105,7 @@ export async function registerRunnerPrpAuthority(input: {
   readonly runId: string;
   readonly authority: DurablePrpControlPlane;
 }): Promise<{ readonly connectUrl: string; release(): Promise<void> }> {
-  if (loopbackOrigin === null) {
+  if (connectOrigin === null) {
     throw new Error("runner_prp_websocket_server_not_configured");
   }
   if (!UUID_PATTERN.test(input.runId) || input.companyId.length === 0) {
@@ -107,7 +121,7 @@ export async function registerRunnerPrpAuthority(input: {
     generation,
   });
   return {
-    connectUrl: `${loopbackOrigin}${CONNECT_PATH_PREFIX}${input.runId}`,
+    connectUrl: `${connectOrigin}${CONNECT_PATH_PREFIX}${input.runId}`,
     release: async () => {
       if (registrations.get(input.runId)?.generation === generation) {
         registrations.delete(input.runId);
@@ -126,6 +140,6 @@ export const runnerPrpWebSocketInternals = {
   },
   resetForTests(): void {
     registrations.clear();
-    loopbackOrigin = null;
+    connectOrigin = null;
   },
 };

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -340,7 +340,10 @@ import {
 } from "./effective-run-config-fingerprints.js";
 import type { PluginWorkerManager } from "./plugin-worker-manager.js";
 import { serverVersion } from "../version.js";
-import { executeNativeCodexRunner } from "./native-runtime/native-codex-runner.js";
+import {
+  executeNativeCodexRunner,
+  requestRemoteNativeRunnerCancellation,
+} from "./native-runtime/native-codex-runner.js";
 import { prepareNativeHeartbeatRun } from "./native-runtime/prepare-native-run.js";
 import {
   NativeRunnerSelectionError,
@@ -16699,6 +16702,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             completionContract: native.completionContract,
             timeoutMs,
             environment,
+            executionTarget,
             onLog,
             onSpawn: async (meta) => {
               markDispatchStarted();
@@ -19785,8 +19789,13 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       : options.resultJson;
 
     const running = runningProcesses.get(run.id);
+    const remoteNativeCancellationRequested = run.runtimeMode === "native"
+      && requestRemoteNativeRunnerCancellation(run.id, reason);
     try {
-      if (running) {
+      if (remoteNativeCancellationRequested) {
+        // The run-bound PRP shutdown command owns remote cancellation. Never
+        // interpret a remote runner PID as a local operating-system process.
+      } else if (running) {
         await terminateHeartbeatRunProcess({
           pid: running.child.pid ?? run.processPid,
           processGroupId: running.processGroupId ?? run.processGroupId,
@@ -19860,7 +19869,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       });
 
       const running = runningProcesses.get(run.id);
-      if (running) {
+      const remoteNativeCancellationRequested = run.runtimeMode === "native"
+        && requestRemoteNativeRunnerCancellation(run.id, reason);
+      if (remoteNativeCancellationRequested) {
+        // Remote cancellation is delivered through the authenticated PRP
+        // authority; there is no local process handle to terminate.
+      } else if (running) {
         await terminateHeartbeatRunProcess({
           pid: running.child.pid ?? run.processPid,
           processGroupId: running.processGroupId ?? run.processGroupId,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -16704,6 +16704,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             environment,
             executionTarget,
             onLog,
+            onDispatch: markDispatchStarted,
             onSpawn: async (meta) => {
               markDispatchStarted();
               await onSpawn(meta);

--- a/server/src/services/native-runtime/native-codex-runner-paths.test.ts
+++ b/server/src/services/native-runtime/native-codex-runner-paths.test.ts
@@ -1,0 +1,44 @@
+import { lstatSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  resolveNativeRunnerRuntimeRoot,
+  seedNativeCodexHome,
+} from "./native-codex-runner.js";
+
+const cleanup = new Set<string>();
+
+afterEach(async () => {
+  await Promise.all([...cleanup].map((path) => rm(path, { recursive: true, force: true })));
+  cleanup.clear();
+});
+
+describe("native Codex runner paths", () => {
+  it("accepts only an absolute configured runtime root", () => {
+    const absolute = resolve(tmpdir(), "paperclip-runner-runtime");
+    expect(resolveNativeRunnerRuntimeRoot(absolute)).toBe(absolute);
+    expect(() => resolveNativeRunnerRuntimeRoot("relative/runtime")).toThrow(
+      "PAPERCLIP_RUNNER_RUNTIME_ROOT must be an absolute path",
+    );
+  });
+
+  it("copies only portable Codex seed files into the local runtime home", async () => {
+    const root = await mkdtemp(resolve(tmpdir(), "paperclip-native-codex-home-"));
+    cleanup.add(root);
+    const source = resolve(root, "remote-source");
+    const target = resolve(root, "local-target");
+    seedNativeCodexHome(null, source);
+    writeFileSync(resolve(source, "auth.json"), "{\"auth\":true}\n", "utf8");
+    writeFileSync(resolve(source, "config.toml"), "model = \"gpt-5.6-sol\"\n", "utf8");
+    writeFileSync(resolve(source, "state.sqlite"), "remote sqlite", "utf8");
+
+    seedNativeCodexHome(source, target);
+
+    expect(readFileSync(resolve(target, "auth.json"), "utf8")).toContain("auth");
+    expect(readFileSync(resolve(target, "config.toml"), "utf8")).toContain("gpt-5.6-sol");
+    expect(() => lstatSync(resolve(target, "state.sqlite"))).toThrow();
+  });
+});

--- a/server/src/services/native-runtime/native-codex-runner.integration.test.ts
+++ b/server/src/services/native-runtime/native-codex-runner.integration.test.ts
@@ -207,6 +207,7 @@ describeEmbeddedPostgres("native Codex server vertical slice", () => {
       onLog: async (_stream, chunk) => {
         logs.push(chunk);
       },
+      onDispatch: () => undefined,
       onSpawn: async () => undefined,
     });
     const result = await execute.catch((error) => {
@@ -320,6 +321,7 @@ describeEmbeddedPostgres("native Codex server vertical slice", () => {
       onLog: async (_stream, chunk) => {
         logs.push(chunk);
       },
+      onDispatch: () => undefined,
       onSpawn: async () => undefined,
     });
     expect(resumed).toMatchObject({

--- a/server/src/services/native-runtime/native-codex-runner.test.ts
+++ b/server/src/services/native-runtime/native-codex-runner.test.ts
@@ -120,6 +120,7 @@ describe("remote native runner preparation", () => {
     });
     expect(script).toContain("cp -- /proc/self/fd/9");
     expect(script).toContain("chmod 500");
+    expect(script).toContain("chmod 700 '/runner-runtime/runs/abc'");
     expect(script.match(/paperclip_runner_expected_sha=/g)).toHaveLength(2);
     expect(script).not.toContain("bootstrap");
   });
@@ -135,9 +136,29 @@ describe("remote native runner preparation", () => {
     );
     expect(prepareScript).toContain("IFS= read -r paperclip_codex_auth");
     expect(prepareScript).toContain("chmod 600");
+    expect(prepareScript).toContain("chmod 700 '/runner-runtime/runs/abc/codex-home'");
     expect(prepareScript).toContain("codex-home.prepare");
     expect(prepareScript).not.toContain("auth-secret");
     expect(cleanupScript).toContain("rm -rf -- '/runner-runtime/runs/abc'");
+  });
+
+  it("never exports an agent-selected local Codex home to a remote target", () => {
+    const resolveSeedHome = nativeCodexRunnerRemoteInternals.resolveNativeCodexSeedHome;
+    expect(resolveSeedHome({
+      remote: true,
+      runtimeEnvironment: { CODEX_HOME: "C:/sensitive/agent-selected" },
+      hostEnvironment: { CODEX_HOME: "C:/trusted/operator-home" },
+    })).toBe("C:/trusted/operator-home");
+    expect(resolveSeedHome({
+      remote: true,
+      runtimeEnvironment: { CODEX_HOME: "C:/sensitive/agent-selected" },
+      hostEnvironment: {},
+    })).toBeNull();
+    expect(resolveSeedHome({
+      remote: false,
+      runtimeEnvironment: { CODEX_HOME: "C:/local-agent-home" },
+      hostEnvironment: { CODEX_HOME: "C:/trusted/operator-home" },
+    })).toBe("C:/local-agent-home");
   });
 });
 

--- a/server/src/services/native-runtime/native-codex-runner.test.ts
+++ b/server/src/services/native-runtime/native-codex-runner.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { buildNativeRunnerArguments } from "./native-codex-runner.js";
+import {
+  buildNativeRunnerArguments,
+  buildNativeRunnerEnvironment,
+  queueNativeRunnerTermination,
+  requestRemoteNativeRunnerCancellation,
+  resolveRemoteNativeRunnerConfig,
+} from "./native-codex-runner.js";
 
 describe("buildNativeRunnerArguments", () => {
   it("binds every durable identity without exposing the bootstrap ticket", () => {
@@ -19,5 +25,96 @@ describe("buildNativeRunnerArguments", () => {
     expect(args).toContain("--connect-url");
     expect(args).toContain("--runner-digest");
     expect(args.join(" ")).not.toContain("bootstrap");
+  });
+
+  it("binds a remote host without placing the bootstrap ticket in argv", () => {
+    const args = buildNativeRunnerArguments({
+      connectUrl: "ws://paperclip.internal:3100/api/runner/v1/connect/run-1",
+      stateDirectory: "/runner-runtime/runner/run-1",
+      runnerInstanceId: "runner-1",
+      environmentLeaseId: "lease-1",
+      runId: "run-1",
+      normalizedSessionId: "session-1",
+      turnId: "turn-1",
+      itemId: "item-1",
+      runnerDigest: `sha256:${"b".repeat(64)}`,
+      maxRuntimeMs: 60_000,
+      allowRemoteHost: "paperclip.internal",
+    });
+    expect(args).toContain("--allow-remote-host");
+    expect(args).toContain("paperclip.internal");
+    expect(args.join(" ")).not.toContain("bootstrap");
+  });
+});
+
+describe("resolveRemoteNativeRunnerConfig", () => {
+  it("requires an immutable runner digest and an absolute remote runtime root", () => {
+    expect(resolveRemoteNativeRunnerConfig({
+      PAPERCLIP_RUNNER_REMOTE_DIGEST: `sha256:${"c".repeat(64)}`,
+      PAPERCLIP_RUNNER_REMOTE_RUNTIME_ROOT: "/runner-runtime",
+      PAPERCLIP_RUNNER_REMOTE_BINARY: "paperclip-runnerd",
+    })).toEqual({
+      binary: "paperclip-runnerd",
+      digest: `sha256:${"c".repeat(64)}`,
+      runtimeRoot: "/runner-runtime",
+    });
+    expect(() => resolveRemoteNativeRunnerConfig({
+      PAPERCLIP_RUNNER_REMOTE_DIGEST: "latest",
+    })).toThrow(/must be a sha256 digest/);
+    expect(() => resolveRemoteNativeRunnerConfig({
+      PAPERCLIP_RUNNER_REMOTE_DIGEST: `sha256:${"c".repeat(64)}`,
+      PAPERCLIP_RUNNER_REMOTE_RUNTIME_ROOT: "runner-runtime",
+    })).toThrow(/absolute POSIX path/);
+  });
+});
+
+describe("buildNativeRunnerEnvironment", () => {
+  it("does not inherit control-plane secrets for a remote launch", () => {
+    expect(buildNativeRunnerEnvironment({
+      runtimeEnvironment: { GH_TOKEN: "short-lived" },
+      codexHome: "/runner-runtime/codex/run-1",
+      bootstrapTicket: "one-use-ticket",
+    })).toEqual({
+      GH_TOKEN: "short-lived",
+      CODEX_HOME: "/runner-runtime/codex/run-1",
+      PAPERCLIP_RUNNER_BOOTSTRAP_TICKET: "one-use-ticket",
+    });
+    expect(buildNativeRunnerEnvironment({
+      runtimeEnvironment: {},
+      codexHome: "/runner-runtime/codex/run-1",
+      bootstrapTicket: "one-use-ticket",
+      hostEnvironment: { DATABASE_URL: "must-stay-local" },
+    })).toMatchObject({ DATABASE_URL: "must-stay-local" });
+  });
+});
+
+describe("remote native runner cancellation", () => {
+  it("queues a bound cancellation and orderly runner shutdown", () => {
+    const queued: Array<{ type: string; payload: Record<string, unknown>; commandId?: string }> = [];
+    queueNativeRunnerTermination({
+      prepared: {
+        queueCommand(type, payload = {}, commandId) {
+          queued.push({ type, payload, commandId });
+          return { commandId: commandId ?? "generated", controllerSeq: queued.length };
+        },
+      },
+      runId: "run-1",
+      cancel: true,
+      reason: "Cancelled by control plane",
+    });
+
+    expect(queued).toEqual([
+      {
+        type: "run.cancel",
+        payload: { reason: "Cancelled by control plane" },
+        commandId: "cancel_run-1",
+      },
+      { type: "session.close", payload: {}, commandId: "close_run-1" },
+      { type: "runner.shutdown", payload: {}, commandId: "shutdown_run-1" },
+    ]);
+  });
+
+  it("does not claim an inactive remote run", () => {
+    expect(requestRemoteNativeRunnerCancellation("inactive-run", "cancel")).toBe(false);
   });
 });

--- a/server/src/services/native-runtime/native-codex-runner.test.ts
+++ b/server/src/services/native-runtime/native-codex-runner.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildNativeRunnerArguments,
   buildNativeRunnerEnvironment,
+  nativeCodexRunnerRemoteInternals,
   queueNativeRunnerTermination,
   requestRemoteNativeRunnerCancellation,
   resolveRemoteNativeRunnerConfig,
@@ -52,19 +53,38 @@ describe("resolveRemoteNativeRunnerConfig", () => {
     expect(resolveRemoteNativeRunnerConfig({
       PAPERCLIP_RUNNER_REMOTE_DIGEST: `sha256:${"c".repeat(64)}`,
       PAPERCLIP_RUNNER_REMOTE_RUNTIME_ROOT: "/runner-runtime",
-      PAPERCLIP_RUNNER_REMOTE_BINARY: "paperclip-runnerd",
+      PAPERCLIP_RUNNER_REMOTE_BINARY: "/opt/paperclip/bin/paperclip-runnerd",
     })).toEqual({
-      binary: "paperclip-runnerd",
+      binary: "/opt/paperclip/bin/paperclip-runnerd",
       digest: `sha256:${"c".repeat(64)}`,
       runtimeRoot: "/runner-runtime",
+      codexHome: null,
     });
     expect(() => resolveRemoteNativeRunnerConfig({
       PAPERCLIP_RUNNER_REMOTE_DIGEST: "latest",
     })).toThrow(/must be a sha256 digest/);
     expect(() => resolveRemoteNativeRunnerConfig({
       PAPERCLIP_RUNNER_REMOTE_DIGEST: `sha256:${"c".repeat(64)}`,
+      PAPERCLIP_RUNNER_REMOTE_BINARY: "/opt/paperclip/bin/paperclip-runnerd",
       PAPERCLIP_RUNNER_REMOTE_RUNTIME_ROOT: "runner-runtime",
     })).toThrow(/absolute POSIX path/);
+    expect(() => resolveRemoteNativeRunnerConfig({
+      PAPERCLIP_RUNNER_REMOTE_DIGEST: `sha256:${"c".repeat(64)}`,
+      PAPERCLIP_RUNNER_REMOTE_BINARY: "paperclip-runnerd",
+    })).toThrow(/REMOTE_BINARY.*absolute POSIX path/);
+  });
+
+  it("accepts an optional pre-provisioned remote Codex home", () => {
+    expect(resolveRemoteNativeRunnerConfig({
+      PAPERCLIP_RUNNER_REMOTE_DIGEST: `sha256:${"d".repeat(64)}`,
+      PAPERCLIP_RUNNER_REMOTE_BINARY: "/opt/paperclip/bin/paperclip-runnerd",
+      PAPERCLIP_RUNNER_REMOTE_CODEX_HOME: "/opt/paperclip/codex-home",
+    }).codexHome).toBe("/opt/paperclip/codex-home");
+    expect(() => resolveRemoteNativeRunnerConfig({
+      PAPERCLIP_RUNNER_REMOTE_DIGEST: `sha256:${"d".repeat(64)}`,
+      PAPERCLIP_RUNNER_REMOTE_BINARY: "/opt/paperclip/bin/paperclip-runnerd",
+      PAPERCLIP_RUNNER_REMOTE_CODEX_HOME: "relative/codex-home",
+    })).toThrow(/REMOTE_CODEX_HOME.*absolute POSIX path/);
   });
 });
 
@@ -85,6 +105,39 @@ describe("buildNativeRunnerEnvironment", () => {
       bootstrapTicket: "one-use-ticket",
       hostEnvironment: { DATABASE_URL: "must-stay-local" },
     })).toMatchObject({ DATABASE_URL: "must-stay-local" });
+  });
+});
+
+describe("remote native runner preparation", () => {
+  it("copies verified bytes into a private run path and verifies that copy", () => {
+    const script = nativeCodexRunnerRemoteInternals.buildRemoteRunnerInstallScript({
+      sourceBinary: "/opt/paperclip/bin/paperclip-runnerd",
+      digest: `sha256:${"e".repeat(64)}`,
+      runtimeRoot: "/runner-runtime",
+      runRoot: "/runner-runtime/runs/abc",
+      stateDirectory: "/runner-runtime/runs/abc/state",
+      verifiedBinary: "/runner-runtime/runs/abc/bin/paperclip-runnerd",
+    });
+    expect(script).toContain("cp -- /proc/self/fd/9");
+    expect(script).toContain("chmod 500");
+    expect(script.match(/paperclip_runner_expected_sha=/g)).toHaveLength(2);
+    expect(script).not.toContain("bootstrap");
+  });
+
+  it("stages Codex seeds through stdin into an atomic private home and removes the run root", () => {
+    const prepareScript = nativeCodexRunnerRemoteInternals.buildPrivateRemoteCodexHomeScript({
+      runRoot: "/runner-runtime/runs/abc",
+      codexHome: "/runner-runtime/runs/abc/codex-home",
+      sourceCodexHome: null,
+    });
+    const cleanupScript = nativeCodexRunnerRemoteInternals.buildRemoteRuntimeCleanupScript(
+      "/runner-runtime/runs/abc",
+    );
+    expect(prepareScript).toContain("IFS= read -r paperclip_codex_auth");
+    expect(prepareScript).toContain("chmod 600");
+    expect(prepareScript).toContain("codex-home.prepare");
+    expect(prepareScript).not.toContain("auth-secret");
+    expect(cleanupScript).toContain("rm -rf -- '/runner-runtime/runs/abc'");
   });
 });
 

--- a/server/src/services/native-runtime/native-codex-runner.ts
+++ b/server/src/services/native-runtime/native-codex-runner.ts
@@ -1,6 +1,17 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
-import { accessSync, chmodSync, constants, copyFileSync, lstatSync, mkdirSync, readFileSync } from "node:fs";
+import {
+  accessSync,
+  chmodSync,
+  closeSync,
+  constants,
+  copyFileSync,
+  fstatSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+} from "node:fs";
 import { dirname, isAbsolute, posix, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -192,15 +203,32 @@ function trustedRemotePathScript(): string {
   return "PATH=/usr/bin:/bin; export PATH";
 }
 
+function resolveNativeCodexSeedHome(input: {
+  remote: boolean;
+  runtimeEnvironment: Record<string, string>;
+  hostEnvironment: NodeJS.ProcessEnv;
+}): string | null {
+  if (input.remote) return input.hostEnvironment.CODEX_HOME?.trim() || null;
+  return input.runtimeEnvironment.CODEX_HOME?.trim()
+    || input.hostEnvironment.CODEX_HOME?.trim()
+    || null;
+}
+
 function readNativeCodexSeedPayload(sourceHome: string | null): string {
   return `${NATIVE_CODEX_SEED_FILES.map((fileName) => {
     if (!sourceHome) return "";
+    let descriptor: number | null = null;
     try {
       const source = resolve(sourceHome, fileName);
       if (!lstatSync(source).isFile()) return "";
-      return readFileSync(source).toString("base64");
+      const noFollow = typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0;
+      descriptor = openSync(source, constants.O_RDONLY | noFollow);
+      if (!fstatSync(descriptor).isFile()) return "";
+      return readFileSync(descriptor).toString("base64");
     } catch {
       return "";
+    } finally {
+      if (descriptor !== null) closeSync(descriptor);
     }
   }).join("\n")}\n`;
 }
@@ -234,6 +262,7 @@ function buildRemoteRunnerInstallScript(input: {
     `chmod 500 ${shellQuote(tempVerifiedBinary)}`,
     `rm -rf -- ${shellQuote(input.runRoot)}`,
     `mv -- ${shellQuote(tempRunRoot)} ${shellQuote(input.runRoot)}`,
+    `chmod 700 ${shellQuote(input.runRoot)} ${shellQuote(posix.dirname(input.verifiedBinary))} ${shellQuote(input.stateDirectory)}`,
     buildVerifiedRemoteExecutableScript({
       command: input.verifiedBinary,
       expectedSha256: input.digest,
@@ -261,7 +290,7 @@ function buildPrivateRemoteCodexHomeScript(input: {
     const sourceHome = shellQuote(input.sourceCodexHome);
     const targetHome = shellQuote(temporaryHome);
     commands.push(
-      `for paperclip_codex_seed in auth.json config.toml; do paperclip_codex_source=${sourceHome}/$paperclip_codex_seed; if [ -f "$paperclip_codex_source" ] && [ ! -L "$paperclip_codex_source" ]; then cp -- "$paperclip_codex_source" ${targetHome}/$paperclip_codex_seed; chmod 600 ${targetHome}/$paperclip_codex_seed; fi; done`,
+      `for paperclip_codex_seed in auth.json config.toml; do paperclip_codex_source=${sourceHome}/$paperclip_codex_seed; if [ -f "$paperclip_codex_source" ] && [ ! -L "$paperclip_codex_source" ]; then exec 8<"$paperclip_codex_source"; if [ ! -e /proc/self/fd/8 ]; then echo "paperclip_runner_remote_codex_seed_unsupported" >&2; exit 77; fi; cp -- /proc/self/fd/8 ${targetHome}/$paperclip_codex_seed; exec 8<&-; chmod 600 ${targetHome}/$paperclip_codex_seed; fi; done`,
     );
   } else {
     commands.push(
@@ -275,6 +304,7 @@ function buildPrivateRemoteCodexHomeScript(input: {
   commands.push(
     `rm -rf -- ${shellQuote(input.codexHome)}`,
     `mv -- ${shellQuote(temporaryHome)} ${shellQuote(input.codexHome)}`,
+    `chmod 700 ${shellQuote(input.codexHome)}`,
   );
   return commands.join("\n");
 }
@@ -293,6 +323,7 @@ export const nativeCodexRunnerRemoteInternals = {
   buildRemoteRunnerInstallScript,
   buildRemoteRuntimeCleanupScript,
   readNativeCodexSeedPayload,
+  resolveNativeCodexSeedHome,
 };
 
 function assertRemoteRunnerConnectUrl(connectUrl: string): string {
@@ -447,9 +478,14 @@ export async function executeNativeCodexRunner(input: {
     ?? `sha256:${createHash("sha256").update(readFileSync(binary)).digest("hex")}`;
   const runnerRuntimeRoot = remoteConfig?.runtimeRoot ?? localRuntimeRoot;
   let runnerStateDirectory = resolve(runnerRuntimeRoot, "runner", input.runId);
-  const sourceCodexHome = input.environment.CODEX_HOME?.trim()
-    || process.env.CODEX_HOME?.trim()
-    || null;
+  // Remote staging crosses a trust boundary. Only the control-plane operator's
+  // own CODEX_HOME may seed it; an agent-controlled runtime env must never turn
+  // this path into an arbitrary host-file export primitive.
+  const sourceCodexHome = resolveNativeCodexSeedHome({
+    remote: remoteTarget !== null,
+    runtimeEnvironment: input.environment,
+    hostEnvironment: process.env,
+  });
   let codexHome = remoteConfig ? "" : resolve(runnerRuntimeRoot, "codex", input.runId);
   let cleanupRemoteRuntime: (() => Promise<void>) | null = null;
   privateDirectory(localRuntimeRoot);
@@ -618,7 +654,6 @@ export async function executeNativeCodexRunner(input: {
       }
       throw new Error("paperclip_runner_remote_cancellation_already_registered");
     }
-    input.onDispatch();
     const remoteProcess = runAdapterExecutionTargetProcess(
       input.runId,
       remoteTarget,
@@ -649,6 +684,15 @@ export async function executeNativeCodexRunner(input: {
     };
     activeRemoteNativeRunnerCancellations.set(input.runId, cancelRemoteRunner);
     try {
+      await Promise.race([
+        prepared.waitForConnection(Math.min(Math.max(input.timeoutMs, 1_000), 30_000)),
+        remoteProcess.then((result) => {
+          throw new Error(
+            `paperclip_runner_process_exited_before_connection: code=${result.exitCode ?? "null"} signal=${result.signal ?? "null"}`,
+          );
+        }),
+      ]);
+      input.onDispatch();
       const completed = await Promise.race([
         prepared.waitForTerminal(input.timeoutMs),
         remoteProcess.then(async (result) => {

--- a/server/src/services/native-runtime/native-codex-runner.ts
+++ b/server/src/services/native-runtime/native-codex-runner.ts
@@ -1,17 +1,68 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { createHash } from "node:crypto";
-import { accessSync, chmodSync, constants, mkdirSync, readFileSync } from "node:fs";
-import { dirname, isAbsolute, resolve } from "node:path";
+import { accessSync, chmodSync, constants, copyFileSync, lstatSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, isAbsolute, posix, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import type { AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  runAdapterExecutionTargetProcess,
+  type AdapterExecutionTarget,
+} from "@paperclipai/adapter-utils/execution-target";
 import type { Db } from "@paperclipai/db";
 
 import { resolvePaperclipInstanceRoot } from "../../home-paths.js";
-import { runnerPrpCoordinator } from "./runner-prp-coordinator.js";
+import {
+  runnerPrpCoordinator,
+  type PreparedRunnerPrpSession,
+} from "./runner-prp-coordinator.js";
 
 const moduleDirectory = dirname(fileURLToPath(import.meta.url));
 const RUNNER_VERSION = "paperclip-runner-v1";
+const NATIVE_RUNNER_RUNTIME_ROOT_ENV = "PAPERCLIP_RUNNER_RUNTIME_ROOT";
+const REMOTE_RUNNER_BINARY_ENV = "PAPERCLIP_RUNNER_REMOTE_BINARY";
+const REMOTE_RUNNER_DIGEST_ENV = "PAPERCLIP_RUNNER_REMOTE_DIGEST";
+const REMOTE_RUNNER_RUNTIME_ROOT_ENV = "PAPERCLIP_RUNNER_REMOTE_RUNTIME_ROOT";
+const NATIVE_CODEX_SEED_FILES = ["auth.json", "config.toml"] as const;
+const RUNNER_DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/;
+type NativeRunnerCancellation = (reason: string) => void;
+const activeRemoteNativeRunnerCancellations = new Map<string, NativeRunnerCancellation>();
+
+/**
+ * Requests cancellation through the run-bound PRP authority. Remote runner
+ * process identifiers are intentionally not treated as local operating-system
+ * PIDs by the heartbeat service.
+ */
+export function requestRemoteNativeRunnerCancellation(runId: string, reason: string): boolean {
+  const cancel = activeRemoteNativeRunnerCancellations.get(runId);
+  if (!cancel) return false;
+  try {
+    cancel(reason);
+    return true;
+  } catch {
+    if (activeRemoteNativeRunnerCancellations.get(runId) === cancel) {
+      activeRemoteNativeRunnerCancellations.delete(runId);
+    }
+    return false;
+  }
+}
+
+export function queueNativeRunnerTermination(input: {
+  prepared: Pick<PreparedRunnerPrpSession, "queueCommand">;
+  runId: string;
+  cancel: boolean;
+  reason?: string;
+}): void {
+  if (input.cancel) {
+    input.prepared.queueCommand(
+      "run.cancel",
+      input.reason ? { reason: input.reason } : {},
+      `cancel_${input.runId}`,
+    );
+  }
+  input.prepared.queueCommand("session.close", {}, `close_${input.runId}`);
+  input.prepared.queueCommand("runner.shutdown", {}, `shutdown_${input.runId}`);
+}
 
 function executableName(): string {
   return process.platform === "win32" ? "paperclip-runnerd.exe" : "paperclip-runnerd";
@@ -57,8 +108,9 @@ export function buildNativeRunnerArguments(input: {
   itemId: string;
   runnerDigest: string;
   maxRuntimeMs: number;
+  allowRemoteHost?: string;
 }): string[] {
-  return [
+  const args = [
     "--connect-url", input.connectUrl,
     "--state-dir", input.stateDirectory,
     "--runner-id", input.runnerInstanceId,
@@ -71,11 +123,95 @@ export function buildNativeRunnerArguments(input: {
     "--runner-digest", input.runnerDigest,
     "--max-runtime-ms", String(input.maxRuntimeMs),
   ];
+  if (input.allowRemoteHost) {
+    args.push("--allow-remote-host", input.allowRemoteHost);
+  }
+  return args;
 }
 
 function privateDirectory(path: string): void {
   mkdirSync(path, { recursive: true, mode: 0o700 });
   if (process.platform !== "win32") chmodSync(path, 0o700);
+}
+
+export function resolveNativeRunnerRuntimeRoot(
+  configuredRoot = process.env[NATIVE_RUNNER_RUNTIME_ROOT_ENV],
+): string {
+  const configured = configuredRoot?.trim();
+  if (configured) {
+    if (!isAbsolute(configured)) {
+      throw new Error(`${NATIVE_RUNNER_RUNTIME_ROOT_ENV} must be an absolute path`);
+    }
+    return resolve(configured);
+  }
+  return resolve(resolvePaperclipInstanceRoot(), "runtime", "paperclip-runner");
+}
+
+export function resolveRemoteNativeRunnerConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): { binary: string; digest: string; runtimeRoot: string } {
+  const binary = env[REMOTE_RUNNER_BINARY_ENV]?.trim() || "paperclip-runnerd";
+  const digest = env[REMOTE_RUNNER_DIGEST_ENV]?.trim() ?? "";
+  const runtimeRoot = env[REMOTE_RUNNER_RUNTIME_ROOT_ENV]?.trim() || "/runner-runtime";
+  if (!RUNNER_DIGEST_PATTERN.test(digest)) {
+    throw new Error(`${REMOTE_RUNNER_DIGEST_ENV} must be a sha256 digest`);
+  }
+  if (!runtimeRoot.startsWith("/") || runtimeRoot.includes("\\")) {
+    throw new Error(`${REMOTE_RUNNER_RUNTIME_ROOT_ENV} must be an absolute POSIX path`);
+  }
+  if (binary.includes("\0") || binary.trim().length === 0) {
+    throw new Error(`${REMOTE_RUNNER_BINARY_ENV} is invalid`);
+  }
+  return { binary, digest, runtimeRoot: posix.resolve(runtimeRoot) };
+}
+
+function assertRemoteRunnerConnectUrl(connectUrl: string): string {
+  const url = new URL(connectUrl);
+  const hostname = url.hostname.toLowerCase();
+  if (url.protocol !== "ws:") {
+    throw new Error("paperclip_runner_remote_connect_protocol_unsupported");
+  }
+  if (["localhost", "127.0.0.1", "::1"].includes(hostname)) {
+    throw new Error("paperclip_runner_remote_connect_url_required");
+  }
+  return hostname;
+}
+
+/**
+ * Seed only Codex's portable authentication/configuration inputs into the
+ * replica-local home. SQLite state, caches, sockets, and symlinks deliberately
+ * stay behind so a network filesystem can never become Codex's runtime store.
+ */
+export function seedNativeCodexHome(sourceHome: string | null, targetHome: string): void {
+  privateDirectory(targetHome);
+  if (!sourceHome || resolve(sourceHome) === resolve(targetHome)) return;
+  for (const fileName of NATIVE_CODEX_SEED_FILES) {
+    try {
+      const source = resolve(sourceHome, fileName);
+      if (!lstatSync(source).isFile()) continue;
+      const target = resolve(targetHome, fileName);
+      copyFileSync(source, target);
+      if (process.platform !== "win32") chmodSync(target, 0o600);
+    } catch {
+      // A missing or unreadable optional seed file is handled by Codex's normal
+      // authentication failure path; never fall back to the remote home.
+    }
+  }
+}
+
+export function buildNativeRunnerEnvironment(input: {
+  runtimeEnvironment: Record<string, string>;
+  codexHome: string;
+  bootstrapTicket: string;
+  /** Local launches inherit the server process. Remote launches must omit it. */
+  hostEnvironment?: NodeJS.ProcessEnv;
+}): Record<string, string> {
+  return Object.fromEntries(Object.entries({
+    ...(input.hostEnvironment ?? {}),
+    ...input.runtimeEnvironment,
+    CODEX_HOME: input.codexHome,
+    PAPERCLIP_RUNNER_BOOTSTRAP_TICKET: input.bootstrapTicket,
+  }).filter((entry): entry is [string, string] => typeof entry[1] === "string"));
 }
 
 function waitForExit(child: ChildProcess): Promise<{
@@ -101,6 +237,10 @@ async function waitForChildExit(exit: Promise<unknown>, timeoutMs: number): Prom
   } finally {
     if (timer) clearTimeout(timer);
   }
+}
+
+async function waitForPromiseSettlement(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
+  return await waitForChildExit(promise.then(() => undefined, () => undefined), timeoutMs);
 }
 
 function signalRunnerProcessGroup(child: ChildProcess, signal: NodeJS.Signals): void {
@@ -147,6 +287,7 @@ export async function executeNativeCodexRunner(input: {
   completionContract: { revision: string; criterionIds: string[] };
   timeoutMs: number;
   environment: Record<string, string>;
+  executionTarget?: AdapterExecutionTarget | null;
   /** Internal test seam; production always resolves the packaged binary. */
   runnerBinary?: string;
   /** Internal test seam; production always uses the instance runtime root. */
@@ -164,19 +305,35 @@ export async function executeNativeCodexRunner(input: {
     startedAt: string;
   }) => Promise<void>;
 }): Promise<AdapterExecutionResult> {
-  const binary = input.runnerBinary ?? resolvePaperclipRunnerBinary();
-  const runnerDigest = `sha256:${createHash("sha256").update(readFileSync(binary)).digest("hex")}`;
-  const runtimeRoot = input.runtimeRoot
+  const remoteTarget = input.executionTarget?.kind === "remote" ? input.executionTarget : null;
+  const localRuntimeRoot = input.runtimeRoot
     ? resolve(input.runtimeRoot)
-    : resolve(resolvePaperclipInstanceRoot(), "runtime", "paperclip-runner");
-  const runnerStateDirectory = resolve(runtimeRoot, "runner", input.runId);
-  privateDirectory(runtimeRoot);
-  privateDirectory(resolve(runtimeRoot, "control-plane"));
-  privateDirectory(resolve(runtimeRoot, "runner"));
-  privateDirectory(runnerStateDirectory);
+    : resolveNativeRunnerRuntimeRoot();
+  const remoteConfig = remoteTarget ? resolveRemoteNativeRunnerConfig() : null;
+  const binary = remoteConfig?.binary ?? input.runnerBinary ?? resolvePaperclipRunnerBinary();
+  const runnerDigest = remoteConfig?.digest
+    ?? `sha256:${createHash("sha256").update(readFileSync(binary)).digest("hex")}`;
+  const runnerRuntimeRoot = remoteConfig?.runtimeRoot ?? localRuntimeRoot;
+  const runnerStateDirectory = remoteConfig
+    ? posix.resolve(runnerRuntimeRoot, "runner", input.runId)
+    : resolve(runnerRuntimeRoot, "runner", input.runId);
+  const sourceCodexHome = input.environment.CODEX_HOME?.trim()
+    || process.env.CODEX_HOME?.trim()
+    || null;
+  const codexHome = remoteConfig
+    ? posix.resolve(runnerRuntimeRoot, "codex", input.runId)
+    : resolve(runnerRuntimeRoot, "codex", input.runId);
+  privateDirectory(localRuntimeRoot);
+  privateDirectory(resolve(localRuntimeRoot, "control-plane"));
+  if (!remoteTarget) {
+    privateDirectory(resolve(runnerRuntimeRoot, "runner"));
+    privateDirectory(runnerStateDirectory);
+    seedNativeCodexHome(sourceCodexHome, codexHome);
+  }
+  const runnerCwd = remoteTarget?.remoteCwd ?? input.cwd;
 
   const prepared = await runnerPrpCoordinator(input.db, {
-    stateRoot: resolve(runtimeRoot, "control-plane"),
+    stateRoot: resolve(localRuntimeRoot, "control-plane"),
   }).prepare({
     companyId: input.companyId,
     issueId: input.issueId,
@@ -198,7 +355,7 @@ export async function executeNativeCodexRunner(input: {
       providerVersion: input.providerLaunch?.providerVersion ?? "codex-app-server-v1",
       command: input.providerLaunch?.command ?? "codex",
       args: input.providerLaunch?.args ?? ["app-server"],
-      cwd: input.cwd,
+      cwd: runnerCwd,
       ...(input.model ? { model: input.model } : {}),
       ...(input.resumeProviderSessionId
         ? { providerSessionId: input.resumeProviderSessionId }
@@ -211,7 +368,16 @@ export async function executeNativeCodexRunner(input: {
   prepared.queueCommand("session.open", {}, `open_${input.runId}`);
   prepared.queueCommand("turn.start", { text: input.prompt }, `turn_${input.runId}`);
 
-  const child = spawn(binary, buildNativeRunnerArguments({
+  let allowRemoteHost: string | undefined;
+  try {
+    allowRemoteHost = remoteTarget
+      ? assertRemoteRunnerConnectUrl(prepared.connectUrl)
+      : undefined;
+  } catch (error) {
+    await prepared.release();
+    throw error;
+  }
+  const runnerArguments = buildNativeRunnerArguments({
     connectUrl: prepared.connectUrl,
     stateDirectory: runnerStateDirectory,
     runnerInstanceId: input.runnerInstanceId,
@@ -222,13 +388,102 @@ export async function executeNativeCodexRunner(input: {
     itemId: input.itemId,
     runnerDigest,
     maxRuntimeMs: input.timeoutMs,
-  }), {
+    allowRemoteHost,
+  });
+  const runnerEnvironment = buildNativeRunnerEnvironment({
+    runtimeEnvironment: input.environment,
+    codexHome,
+    bootstrapTicket: prepared.bootstrapTicket,
+    ...(remoteTarget ? {} : { hostEnvironment: process.env }),
+  });
+
+  if (remoteTarget) {
+    if (activeRemoteNativeRunnerCancellations.has(input.runId)) {
+      await prepared.release();
+      throw new Error("paperclip_runner_remote_cancellation_already_registered");
+    }
+    const remoteProcess = runAdapterExecutionTargetProcess(
+      input.runId,
+      remoteTarget,
+      binary,
+      runnerArguments,
+      {
+        cwd: runnerCwd,
+        env: runnerEnvironment,
+        timeoutSec: Math.max(1, Math.ceil(input.timeoutMs / 1_000)),
+        graceSec: 5,
+        onLog: input.onLog,
+      },
+    );
+    let terminationQueued = false;
+    const queueTermination = (cancel: boolean, reason?: string) => {
+      if (terminationQueued) return;
+      terminationQueued = true;
+      queueNativeRunnerTermination({
+        prepared,
+        runId: input.runId,
+        cancel,
+        reason,
+      });
+    };
+    const cancelRemoteRunner: NativeRunnerCancellation = (reason) => {
+      queueTermination(true, reason);
+    };
+    activeRemoteNativeRunnerCancellations.set(input.runId, cancelRemoteRunner);
+    try {
+      const completed = await Promise.race([
+        prepared.waitForTerminal(input.timeoutMs),
+        remoteProcess.then(async (result) => {
+          const recovered = await prepared.waitForTerminal(2_000).catch(() => null);
+          if (recovered) return recovered;
+          throw new Error(
+            `paperclip_runner_process_exited: code=${result.exitCode ?? "null"} signal=${result.signal ?? "null"}`,
+          );
+        }),
+      ]);
+      queueTermination(false);
+      if (!await waitForPromiseSettlement(remoteProcess, 5_000)) {
+        throw new Error("paperclip_runner_remote_shutdown_timeout");
+      }
+      await remoteProcess;
+      const succeeded = completed.terminal.runTerminalState === "succeeded";
+      return {
+        exitCode: succeeded ? 0 : 1,
+        signal: null,
+        timedOut: false,
+        ...(succeeded ? {} : {
+          errorCode: "paperclip_runner_provider_failed",
+          errorMessage: completed.result.summary,
+        }),
+        provider: "codex",
+        model: input.model,
+        sessionParams: {
+          sessionId: completed.providerSessionId ?? input.normalizedSessionId,
+        },
+        sessionDisplayId: completed.providerSessionId ?? input.normalizedSessionId,
+        resultJson: {
+          nativeRunner: {
+            result: completed.result,
+            terminal: completed.terminal,
+          },
+        },
+        summary: completed.result.summary,
+      };
+    } finally {
+      if (activeRemoteNativeRunnerCancellations.get(input.runId) === cancelRemoteRunner) {
+        activeRemoteNativeRunnerCancellations.delete(input.runId);
+      }
+      queueTermination(false);
+      await waitForPromiseSettlement(remoteProcess, 5_000).catch(() => false);
+      await prepared.release();
+    }
+  }
+
+  const child = spawn(binary, runnerArguments, {
     cwd: input.cwd,
     detached: process.platform !== "win32",
     env: {
-      ...process.env,
-      ...input.environment,
-      PAPERCLIP_RUNNER_BOOTSTRAP_TICKET: prepared.bootstrapTicket,
+      ...runnerEnvironment,
     },
     stdio: ["ignore", "pipe", "pipe"],
   });

--- a/server/src/services/native-runtime/native-codex-runner.ts
+++ b/server/src/services/native-runtime/native-codex-runner.ts
@@ -6,7 +6,9 @@ import { fileURLToPath } from "node:url";
 
 import type { AdapterExecutionResult } from "@paperclipai/adapter-utils";
 import {
+  buildVerifiedRemoteExecutableScript,
   runAdapterExecutionTargetProcess,
+  runAdapterExecutionTargetShellCommand,
   type AdapterExecutionTarget,
 } from "@paperclipai/adapter-utils/execution-target";
 import type { Db } from "@paperclipai/db";
@@ -23,6 +25,7 @@ const NATIVE_RUNNER_RUNTIME_ROOT_ENV = "PAPERCLIP_RUNNER_RUNTIME_ROOT";
 const REMOTE_RUNNER_BINARY_ENV = "PAPERCLIP_RUNNER_REMOTE_BINARY";
 const REMOTE_RUNNER_DIGEST_ENV = "PAPERCLIP_RUNNER_REMOTE_DIGEST";
 const REMOTE_RUNNER_RUNTIME_ROOT_ENV = "PAPERCLIP_RUNNER_REMOTE_RUNTIME_ROOT";
+const REMOTE_CODEX_HOME_ENV = "PAPERCLIP_RUNNER_REMOTE_CODEX_HOME";
 const NATIVE_CODEX_SEED_FILES = ["auth.json", "config.toml"] as const;
 const RUNNER_DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/;
 type NativeRunnerCancellation = (reason: string) => void;
@@ -149,21 +152,148 @@ export function resolveNativeRunnerRuntimeRoot(
 
 export function resolveRemoteNativeRunnerConfig(
   env: NodeJS.ProcessEnv = process.env,
-): { binary: string; digest: string; runtimeRoot: string } {
-  const binary = env[REMOTE_RUNNER_BINARY_ENV]?.trim() || "paperclip-runnerd";
+): { binary: string; digest: string; runtimeRoot: string; codexHome: string | null } {
+  const binary = env[REMOTE_RUNNER_BINARY_ENV]?.trim() ?? "";
   const digest = env[REMOTE_RUNNER_DIGEST_ENV]?.trim() ?? "";
   const runtimeRoot = env[REMOTE_RUNNER_RUNTIME_ROOT_ENV]?.trim() || "/runner-runtime";
+  const codexHome = env[REMOTE_CODEX_HOME_ENV]?.trim() || null;
   if (!RUNNER_DIGEST_PATTERN.test(digest)) {
     throw new Error(`${REMOTE_RUNNER_DIGEST_ENV} must be a sha256 digest`);
   }
   if (!runtimeRoot.startsWith("/") || runtimeRoot.includes("\\")) {
     throw new Error(`${REMOTE_RUNNER_RUNTIME_ROOT_ENV} must be an absolute POSIX path`);
   }
-  if (binary.includes("\0") || binary.trim().length === 0) {
-    throw new Error(`${REMOTE_RUNNER_BINARY_ENV} is invalid`);
+  if (!binary.startsWith("/") || binary.includes("\\") || binary.includes("\0")) {
+    throw new Error(`${REMOTE_RUNNER_BINARY_ENV} must be an absolute POSIX path`);
   }
-  return { binary, digest, runtimeRoot: posix.resolve(runtimeRoot) };
+  if (
+    codexHome &&
+    (!codexHome.startsWith("/") || codexHome.includes("\\") || codexHome.includes("\0"))
+  ) {
+    throw new Error(`${REMOTE_CODEX_HOME_ENV} must be an absolute POSIX path`);
+  }
+  return {
+    binary: posix.resolve(binary),
+    digest,
+    runtimeRoot: posix.resolve(runtimeRoot),
+    codexHome: codexHome ? posix.resolve(codexHome) : null,
+  };
 }
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+function remoteRuntimeKey(runId: string): string {
+  return createHash("sha256").update(runId).digest("hex").slice(0, 24);
+}
+
+function trustedRemotePathScript(): string {
+  return "PATH=/usr/bin:/bin; export PATH";
+}
+
+function readNativeCodexSeedPayload(sourceHome: string | null): string {
+  return `${NATIVE_CODEX_SEED_FILES.map((fileName) => {
+    if (!sourceHome) return "";
+    try {
+      const source = resolve(sourceHome, fileName);
+      if (!lstatSync(source).isFile()) return "";
+      return readFileSync(source).toString("base64");
+    } catch {
+      return "";
+    }
+  }).join("\n")}\n`;
+}
+
+function buildRemoteRunnerInstallScript(input: {
+  sourceBinary: string;
+  digest: string;
+  runtimeRoot: string;
+  runRoot: string;
+  stateDirectory: string;
+  verifiedBinary: string;
+}): string {
+  const tempRunRoot = `${input.runRoot}.prepare`;
+  const tempVerifiedBinary = posix.join(tempRunRoot, "bin", posix.basename(input.verifiedBinary));
+  const tempStateDirectory = posix.join(tempRunRoot, posix.relative(input.runRoot, input.stateDirectory));
+  return [
+    buildVerifiedRemoteExecutableScript({
+      command: input.sourceBinary,
+      expectedSha256: input.digest,
+      execute: false,
+    }),
+    trustedRemotePathScript(),
+    "umask 077",
+    `if [ -L ${shellQuote(input.runtimeRoot)} ]; then echo "paperclip_runner_remote_runtime_symlink" >&2; exit 74; fi`,
+    `mkdir -p ${shellQuote(input.runtimeRoot)} ${shellQuote(posix.dirname(input.runRoot))}`,
+    `chmod 700 ${shellQuote(input.runtimeRoot)} ${shellQuote(posix.dirname(input.runRoot))}`,
+    `rm -rf -- ${shellQuote(tempRunRoot)}`,
+    `mkdir -p ${shellQuote(posix.dirname(tempVerifiedBinary))} ${shellQuote(tempStateDirectory)}`,
+    `chmod 700 ${shellQuote(tempRunRoot)} ${shellQuote(posix.dirname(tempVerifiedBinary))} ${shellQuote(tempStateDirectory)}`,
+    `cp -- /proc/self/fd/9 ${shellQuote(tempVerifiedBinary)}`,
+    `chmod 500 ${shellQuote(tempVerifiedBinary)}`,
+    `rm -rf -- ${shellQuote(input.runRoot)}`,
+    `mv -- ${shellQuote(tempRunRoot)} ${shellQuote(input.runRoot)}`,
+    buildVerifiedRemoteExecutableScript({
+      command: input.verifiedBinary,
+      expectedSha256: input.digest,
+      execute: false,
+    }),
+  ].join("\n");
+}
+
+function buildPrivateRemoteCodexHomeScript(input: {
+  runRoot: string;
+  codexHome: string;
+  sourceCodexHome: string | null;
+}): string {
+  const temporaryHome = `${input.codexHome}.prepare`;
+  const commands = [
+    "set -eu",
+    trustedRemotePathScript(),
+    "umask 077",
+    `if [ -L ${shellQuote(input.runRoot)} ] || [ ! -d ${shellQuote(input.runRoot)} ]; then echo "paperclip_runner_remote_runtime_untrusted" >&2; exit 75; fi`,
+    `rm -rf -- ${shellQuote(temporaryHome)}`,
+    `mkdir -p ${shellQuote(temporaryHome)}`,
+    `chmod 700 ${shellQuote(temporaryHome)}`,
+  ];
+  if (input.sourceCodexHome) {
+    const sourceHome = shellQuote(input.sourceCodexHome);
+    const targetHome = shellQuote(temporaryHome);
+    commands.push(
+      `for paperclip_codex_seed in auth.json config.toml; do paperclip_codex_source=${sourceHome}/$paperclip_codex_seed; if [ -f "$paperclip_codex_source" ] && [ ! -L "$paperclip_codex_source" ]; then cp -- "$paperclip_codex_source" ${targetHome}/$paperclip_codex_seed; chmod 600 ${targetHome}/$paperclip_codex_seed; fi; done`,
+    );
+  } else {
+    commands.push(
+      'if [ -x /usr/bin/base64 ] && [ ! -L /usr/bin/base64 ]; then paperclip_base64=/usr/bin/base64; elif [ -x /bin/base64 ] && [ ! -L /bin/base64 ]; then paperclip_base64=/bin/base64; else echo "paperclip_runner_remote_base64_unsupported" >&2; exit 76; fi',
+      "IFS= read -r paperclip_codex_auth || true",
+      "IFS= read -r paperclip_codex_config || true",
+      `if [ -n "$paperclip_codex_auth" ]; then printf %s "$paperclip_codex_auth" | "$paperclip_base64" -d > ${shellQuote(posix.join(temporaryHome, "auth.json"))}; chmod 600 ${shellQuote(posix.join(temporaryHome, "auth.json"))}; fi`,
+      `if [ -n "$paperclip_codex_config" ]; then printf %s "$paperclip_codex_config" | "$paperclip_base64" -d > ${shellQuote(posix.join(temporaryHome, "config.toml"))}; chmod 600 ${shellQuote(posix.join(temporaryHome, "config.toml"))}; fi`,
+    );
+  }
+  commands.push(
+    `rm -rf -- ${shellQuote(input.codexHome)}`,
+    `mv -- ${shellQuote(temporaryHome)} ${shellQuote(input.codexHome)}`,
+  );
+  return commands.join("\n");
+}
+
+function buildRemoteRuntimeCleanupScript(runRoot: string): string {
+  return [
+    "set -eu",
+    trustedRemotePathScript(),
+    `if [ -L ${shellQuote(runRoot)} ]; then rm -f -- ${shellQuote(runRoot)}; else rm -rf -- ${shellQuote(runRoot)}; fi`,
+    `rm -rf -- ${shellQuote(`${runRoot}.prepare`)}`,
+  ].join("\n");
+}
+
+export const nativeCodexRunnerRemoteInternals = {
+  buildPrivateRemoteCodexHomeScript,
+  buildRemoteRunnerInstallScript,
+  buildRemoteRuntimeCleanupScript,
+  readNativeCodexSeedPayload,
+};
 
 function assertRemoteRunnerConnectUrl(connectUrl: string): string {
   const url = new URL(connectUrl);
@@ -299,6 +429,8 @@ export async function executeNativeCodexRunner(input: {
     providerVersion?: string;
   };
   onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+  /** Release the atomic issue gate immediately before remote provider dispatch. */
+  onDispatch: () => void;
   onSpawn: (meta: {
     pid: number;
     processGroupId: number | null;
@@ -310,43 +442,119 @@ export async function executeNativeCodexRunner(input: {
     ? resolve(input.runtimeRoot)
     : resolveNativeRunnerRuntimeRoot();
   const remoteConfig = remoteTarget ? resolveRemoteNativeRunnerConfig() : null;
-  const binary = remoteConfig?.binary ?? input.runnerBinary ?? resolvePaperclipRunnerBinary();
+  let binary = remoteConfig?.binary ?? input.runnerBinary ?? resolvePaperclipRunnerBinary();
   const runnerDigest = remoteConfig?.digest
     ?? `sha256:${createHash("sha256").update(readFileSync(binary)).digest("hex")}`;
   const runnerRuntimeRoot = remoteConfig?.runtimeRoot ?? localRuntimeRoot;
-  const runnerStateDirectory = remoteConfig
-    ? posix.resolve(runnerRuntimeRoot, "runner", input.runId)
-    : resolve(runnerRuntimeRoot, "runner", input.runId);
+  let runnerStateDirectory = resolve(runnerRuntimeRoot, "runner", input.runId);
   const sourceCodexHome = input.environment.CODEX_HOME?.trim()
     || process.env.CODEX_HOME?.trim()
     || null;
-  const codexHome = remoteConfig
-    ? posix.resolve(runnerRuntimeRoot, "codex", input.runId)
-    : resolve(runnerRuntimeRoot, "codex", input.runId);
+  let codexHome = remoteConfig ? "" : resolve(runnerRuntimeRoot, "codex", input.runId);
+  let cleanupRemoteRuntime: (() => Promise<void>) | null = null;
   privateDirectory(localRuntimeRoot);
   privateDirectory(resolve(localRuntimeRoot, "control-plane"));
-  if (!remoteTarget) {
+  if (remoteTarget && remoteConfig) {
+    const runRoot = posix.join(runnerRuntimeRoot, "runs", remoteRuntimeKey(input.runId));
+    const verifiedBinary = posix.join(runRoot, "bin", "paperclip-runnerd");
+    runnerStateDirectory = posix.join(runRoot, "state");
+    codexHome = posix.join(runRoot, "codex-home");
+    cleanupRemoteRuntime = async () => {
+      await runAdapterExecutionTargetShellCommand(
+        input.runId,
+        remoteTarget,
+        buildRemoteRuntimeCleanupScript(runRoot),
+        {
+          cwd: remoteTarget.remoteCwd,
+          env: {},
+          trustedSystemShell: true,
+          timeoutSec: 30,
+          graceSec: 5,
+        },
+      ).catch(() => undefined);
+    };
+    try {
+      const installedRunner = await runAdapterExecutionTargetShellCommand(
+        input.runId,
+        remoteTarget,
+        buildRemoteRunnerInstallScript({
+          sourceBinary: binary,
+          digest: runnerDigest,
+          runtimeRoot: runnerRuntimeRoot,
+          runRoot,
+          stateDirectory: runnerStateDirectory,
+          verifiedBinary,
+        }),
+        {
+          cwd: remoteTarget.remoteCwd,
+          env: {},
+          trustedSystemShell: true,
+          timeoutSec: 30,
+          graceSec: 5,
+        },
+      );
+      if (installedRunner.timedOut || installedRunner.exitCode !== 0) {
+        const typedFailure = installedRunner.stderr.match(
+          /paperclip_runner_remote_[a-z0-9_]+/,
+        )?.[0];
+        throw new Error(typedFailure ?? "paperclip_runner_remote_runtime_prepare_failed");
+      }
+      binary = verifiedBinary;
+
+      const preparedHome = await runAdapterExecutionTargetShellCommand(
+        input.runId,
+        remoteTarget,
+        buildPrivateRemoteCodexHomeScript({
+          runRoot,
+          codexHome,
+          sourceCodexHome: remoteConfig.codexHome,
+        }),
+        {
+          cwd: remoteTarget.remoteCwd,
+          env: {},
+          trustedSystemShell: true,
+          ...(remoteConfig.codexHome
+            ? {}
+            : { stdin: readNativeCodexSeedPayload(sourceCodexHome) }),
+          timeoutSec: 30,
+          graceSec: 5,
+        },
+      );
+      if (preparedHome.timedOut || preparedHome.exitCode !== 0) {
+        throw new Error("paperclip_runner_remote_codex_home_prepare_failed");
+      }
+    } catch (error) {
+      await cleanupRemoteRuntime();
+      throw error;
+    }
+  } else {
     privateDirectory(resolve(runnerRuntimeRoot, "runner"));
     privateDirectory(runnerStateDirectory);
     seedNativeCodexHome(sourceCodexHome, codexHome);
   }
   const runnerCwd = remoteTarget?.remoteCwd ?? input.cwd;
 
-  const prepared = await runnerPrpCoordinator(input.db, {
-    stateRoot: resolve(localRuntimeRoot, "control-plane"),
-  }).prepare({
-    companyId: input.companyId,
-    issueId: input.issueId,
-    runId: input.runId,
-    agentId: input.agentId,
-    runnerInstanceId: input.runnerInstanceId,
-    environmentLeaseId: input.environmentLeaseId,
-    normalizedSessionId: input.normalizedSessionId,
-    turnId: input.turnId,
-    itemId: input.itemId,
-    runnerVersion: RUNNER_VERSION,
-    runnerDigest,
-  });
+  let prepared: PreparedRunnerPrpSession;
+  try {
+    prepared = await runnerPrpCoordinator(input.db, {
+      stateRoot: resolve(localRuntimeRoot, "control-plane"),
+    }).prepare({
+      companyId: input.companyId,
+      issueId: input.issueId,
+      runId: input.runId,
+      agentId: input.agentId,
+      runnerInstanceId: input.runnerInstanceId,
+      environmentLeaseId: input.environmentLeaseId,
+      normalizedSessionId: input.normalizedSessionId,
+      turnId: input.turnId,
+      itemId: input.itemId,
+      runnerVersion: RUNNER_VERSION,
+      runnerDigest,
+    });
+  } catch (error) {
+    await cleanupRemoteRuntime?.();
+    throw error;
+  }
 
   prepared.queueCommand("run.prepare", {
     provider: {
@@ -374,7 +582,11 @@ export async function executeNativeCodexRunner(input: {
       ? assertRemoteRunnerConnectUrl(prepared.connectUrl)
       : undefined;
   } catch (error) {
-    await prepared.release();
+    try {
+      await prepared.release();
+    } finally {
+      await cleanupRemoteRuntime?.();
+    }
     throw error;
   }
   const runnerArguments = buildNativeRunnerArguments({
@@ -399,9 +611,14 @@ export async function executeNativeCodexRunner(input: {
 
   if (remoteTarget) {
     if (activeRemoteNativeRunnerCancellations.has(input.runId)) {
-      await prepared.release();
+      try {
+        await prepared.release();
+      } finally {
+        await cleanupRemoteRuntime?.();
+      }
       throw new Error("paperclip_runner_remote_cancellation_already_registered");
     }
+    input.onDispatch();
     const remoteProcess = runAdapterExecutionTargetProcess(
       input.runId,
       remoteTarget,
@@ -413,6 +630,7 @@ export async function executeNativeCodexRunner(input: {
         timeoutSec: Math.max(1, Math.ceil(input.timeoutMs / 1_000)),
         graceSec: 5,
         onLog: input.onLog,
+        expectedExecutableSha256: runnerDigest,
       },
     );
     let terminationQueued = false;
@@ -475,7 +693,11 @@ export async function executeNativeCodexRunner(input: {
       }
       queueTermination(false);
       await waitForPromiseSettlement(remoteProcess, 5_000).catch(() => false);
-      await prepared.release();
+      try {
+        await prepared.release();
+      } finally {
+        await cleanupRemoteRuntime?.();
+      }
     }
   }
 

--- a/server/src/services/native-runtime/runner-prp-coordinator.test.ts
+++ b/server/src/services/native-runtime/runner-prp-coordinator.test.ts
@@ -264,6 +264,9 @@ describeEmbeddedPostgres("hidden runner PRP coordinator", () => {
       `ws://127.0.0.1:3213/api/runner/v1/connect/${seed.runId}`,
     );
     expect(prepared.bootstrapTicket).toMatch(/^bootstrap_/);
+    await expect(prepared.waitForConnection(999)).rejects.toThrow(
+      "runner_prp_connection_timeout_invalid",
+    );
     expect(prepared.semanticTools.map((tool) => tool.name)).toEqual([
       "get_task_context",
       "get_task_history",

--- a/server/src/services/native-runtime/runner-prp-coordinator.ts
+++ b/server/src/services/native-runtime/runner-prp-coordinator.ts
@@ -61,6 +61,8 @@ export interface PreparedRunnerPrpSession {
     readonly disposition: "committed" | "duplicate";
     readonly resultId: string;
   }>;
+  /** Wait until a runner has completed PRP authentication for this bound run. */
+  waitForConnection(timeoutMs?: number): Promise<void>;
   waitForTerminal(timeoutMs?: number): Promise<{
     readonly result: PrpStructuredRunResult;
     readonly terminal: PrpTerminalState;
@@ -340,6 +342,18 @@ export function runnerPrpCoordinator(
         completeRun: (completeInput) => {
           if (released) throw new Error("runner_prp_session_released");
           return nativeStore.completeRun(completeInput);
+        },
+        waitForConnection: async (timeoutMs = 30_000) => {
+          if (released) throw new Error("runner_prp_session_released");
+          if (!Number.isInteger(timeoutMs) || timeoutMs < 1_000 || timeoutMs > 60_000) {
+            throw new Error("runner_prp_connection_timeout_invalid");
+          }
+          const deadline = Date.now() + timeoutMs;
+          while (!released && authority.activeRunnerConnectionCount() === 0) {
+            if (Date.now() >= deadline) throw new Error("runner_prp_connection_timeout");
+            await new Promise<void>((resolveWait) => setTimeout(resolveWait, 10));
+          }
+          if (released) throw new Error("runner_prp_session_released");
         },
         waitForTerminal: async (timeoutMs = 60 * 60 * 1_000) => {
           if (released) throw new Error("runner_prp_session_released");

--- a/server/src/services/native-runtime/runtime-mode.test.ts
+++ b/server/src/services/native-runtime/runtime-mode.test.ts
@@ -37,7 +37,7 @@ describe("resolveHeartbeatRuntimeMode", () => {
     }) as NativeRunnerSelectionError);
   });
 
-  it("selects only Codex on a local target", () => {
+  it("selects only Codex on a realized local or remote target", () => {
     expect(resolveHeartbeatRuntimeMode({
       ...base,
       adapterType: "paperclip_runner",
@@ -47,11 +47,16 @@ describe("resolveHeartbeatRuntimeMode", () => {
       adapterType: "paperclip_runner",
       adapterConfig: { provider: "opencode" },
     })).toThrow(/only the Codex provider/);
-    expect(() => resolveHeartbeatRuntimeMode({
+    expect(resolveHeartbeatRuntimeMode({
       ...base,
       adapterType: "paperclip_runner",
       executionTarget: { kind: "remote" },
-    })).toThrow(/local execution environment/);
+    })).toMatchObject({ kind: "native", provider: "codex" });
+    expect(() => resolveHeartbeatRuntimeMode({
+      ...base,
+      adapterType: "paperclip_runner",
+      executionTarget: { kind: "cloud" },
+    })).toThrow(/realized local or remote execution environment/);
   });
 
   it("recovers a persisted native run after the flag changes", () => {

--- a/server/src/services/native-runtime/runtime-mode.ts
+++ b/server/src/services/native-runtime/runtime-mode.ts
@@ -81,10 +81,10 @@ export function resolveHeartbeatRuntimeMode(input: {
       "Paperclip Runner requires a standard, planning, or ask task.",
     );
   }
-  if (!input.executionTarget || input.executionTarget.kind !== "local") {
+  if (!input.executionTarget || !["local", "remote"].includes(input.executionTarget.kind ?? "")) {
     throw new NativeRunnerSelectionError(
       "paperclip_runner_environment_unsupported",
-      "Paperclip Runner currently requires a local execution environment.",
+      "Paperclip Runner requires a realized local or remote execution environment.",
     );
   }
   if (!["active", "running"].includes(input.agentStatus)) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The control plane can place agent work in local or remote execution environments.
> - The explicit `paperclip_runner` adapter previously required a local target.
> - A remote native runner must keep the same run identity, authority, cancellation, and completion rules.
> - A remote launch must also verify runner bytes before it supplies run credentials.
> - This pull request adds a fail-closed remote path and keeps local execution as the default.
> - The benefit is durable native Codex execution on realized remote targets without a broad Paperclip API key.

## Linked Issues or Issue Description

**Subsystem affected**

Cross-cutting. This change affects server orchestration, execution-target utilities, and the Rust runner transport.

**Problem or motivation**

The native `paperclip_runner` can run Codex only on the control-plane host. It cannot use an already-realized SSH or sandbox target. A direct remote launch also needs an immutable artifact check, private credentials, and a runner-reachable PRP origin.

**Proposed solution**

Permit realized remote targets for the explicit, default-off adapter. Bind the private PRP host in the launch arguments. Verify the exact remote runner bytes before credential staging and again at exec. Stage only portable Codex files in a private per-run home. Use PRP commands for remote cancellation and cleanup.

**Alternatives considered**

The change does not give runnerd a broad API key. It does not copy Codex SQLite state, caches, sockets, or symlinks. It does not use an unverified PATH command or a mutable image tag as proof of runner identity.

**Roadmap alignment**

The roadmap marks Cloud / Sandbox agents as shipped. This change extends that existing execution model to the explicit native runner. Related work: Refs #12250.

## What Changed

- Allow `paperclip_runner` to use realized SSH and sandbox execution targets.
- Add a private runner-reachable WebSocket origin and bind the exact remote host in runnerd.
- Pin DNS resolution for PRP reconnects and keep non-loopback access fail-closed.
- Require an absolute remote runner path and an immutable SHA-256 digest.
- Copy verified runner bytes into a private per-run path and verify the open file again at exec.
- Stage `auth.json` and `config.toml` through stdin or from an optional image Codex home.
- Apply 0700 directory modes and 0600 credential modes, and remove the remote run root at termination.
- Release the atomic issue gate through the native `onDispatch` contract before remote dispatch.
- Route remote cancellation through the run-bound PRP authority instead of local PID signals.
- Reject loader and shell-startup injection before credential-bearing verified sandbox or SSH launches.
- Keep the local SSH transport process free of remote credentials and unsafe inherited startup hooks.
- Add TypeScript and Rust tests, and update operator and architecture documentation.

## Verification

- `node_modules/.bin/vitest.CMD run packages/adapter-utils/src/execution-target.test.ts server/src/services/native-runtime/native-codex-runner.test.ts server/src/services/native-runtime/native-codex-runner-paths.test.ts server/src/services/native-runtime/runtime-mode.test.ts`
- `node_modules/.bin/vitest.CMD run packages/adapter-utils/src/execution-target-sandbox.test.ts -t "verifies the exact executable"`
- `node_modules/.bin/vitest.CMD run packages/adapter-utils/src/ssh-fixture.test.ts -t "uses the fixed system shell"`
- `node_modules/.bin/vitest.CMD run packages/adapter-utils/src/execution-target.test.ts packages/adapter-utils/src/server-utils.test.ts server/src/services/native-runtime/native-codex-runner.test.ts`: 126 passed, 6 platform skips.
- `node_modules/.bin/tsc.CMD --noEmit` in `packages/adapter-utils`.
- `node_modules/.bin/tsc.CMD --noEmit` in `server`.
- The full GitHub PR workflow passed at `7a63d6d1a`, including Build, Typecheck + Release Registry, all server/workspace/E2E shards, Canary Dry Run, and the final `ci / verify` gate.
- Current-head Superagent Security, Snyk, commitperclip, and Greptile checks pass; Greptile reports 5/5 with no blocking finding.
- The full sandbox fixture needs a POSIX shell and cannot run in this Windows host. Its focused test passes.
- Rust is not installed on this host. GitHub CI passed rustfmt, Rust tests, the full typecheck, and the build.

## Risks

- Remote native execution is experimental and remains behind the existing rollout gate.
- Remote images must provide `/bin/sh`, `/proc/self/fd`, a fixed system `sha256sum`, and `base64` for host seed transfer.
- `PAPERCLIP_RUNNER_REMOTE_BINARY` now requires an absolute POSIX path. A PATH-only value fails closed.
- Integrity-bound launches reject dynamic-loader and shell-startup environment controls before credentials are dispatched.
- A remote cleanup command can fail if the environment disappears. The environment lifecycle must still remove an expired lease.
- Local native execution keeps its existing behavior.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex based on GPT-5. The exact deployment ID and context-window size are not exposed to this task. The model used reasoning, repository tools, code execution, GitHub inspection, and read-only security review agents.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
