### PR TITLE
fix(server): redact heartbeat adapter output before persistence

### DIFF
--- a/server/src/__tests__/heartbeat-error-redaction.test.ts
+++ b/server/src/__tests__/heartbeat-error-redaction.test.ts
@@ -1,0 +1,153 @@
+import { randomUUID } from "node:crypto";
+import { and, eq, sql } from "drizzle-orm";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import {
+  agentRuntimeState,
+  agentTaskSessions,
+  agents,
+  companies,
+  createDb,
+  heartbeatRunEvents,
+  heartbeatRuns,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { registerServerAdapter, unregisterServerAdapter } from "../adapters/index.ts";
+import { heartbeatService } from "../services/heartbeat.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+const TEST_ADAPTER_TYPE = "heartbeat_error_redaction_test";
+const CREDENTIAL_VALUE = "hap128-secret-value";
+const DIAGNOSTIC = "Provider rejected request";
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres heartbeat error-redaction tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+async function waitForRunToFinish(
+  heartbeat: ReturnType<typeof heartbeatService>,
+  runId: string,
+  timeoutMs = 5_000,
+) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const run = await heartbeat.getRun(runId);
+    if (run && !["queued", "running"].includes(run.status)) return run;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  return await heartbeat.getRun(runId);
+}
+
+describeEmbeddedPostgres("heartbeat error redaction", () => {
+  let db!: ReturnType<typeof createDb>;
+  let heartbeat!: ReturnType<typeof heartbeatService>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-error-redaction-");
+    db = createDb(tempDb.connectionString);
+    heartbeat = heartbeatService(db);
+    registerServerAdapter({
+      type: TEST_ADAPTER_TYPE,
+      execute: async ({ onLog }) => {
+        await onLog("stdout", `adapter stdout apiKey: \"${CREDENTIAL_VALUE}\"\n`);
+        await onLog("stderr", `adapter stderr apiKey: \"${CREDENTIAL_VALUE}\"\n`);
+        return {
+          exitCode: 1,
+          signal: null,
+          timedOut: false,
+          errorMessage: `${DIAGNOSTIC} apiKey: \"${CREDENTIAL_VALUE}\" (request_id=req-42)`,
+          errorCode: "adapter_failed",
+          sessionId: "session-hap-128",
+        };
+      },
+      testEnvironment: async () => ({
+        adapterType: TEST_ADAPTER_TYPE,
+        status: "pass",
+        checks: [],
+        testedAt: new Date().toISOString(),
+      }),
+    });
+  }, 20_000);
+
+  afterEach(async () => {
+    await heartbeat.drainActiveRunExecutions();
+    await db.execute(sql.raw(`
+      TRUNCATE TABLE
+        "heartbeat_run_events",
+        "heartbeat_runs",
+        "agent_task_sessions",
+        "agent_runtime_state",
+        "agents",
+        "companies"
+      RESTART IDENTITY CASCADE
+    `));
+  });
+
+  afterAll(async () => {
+    unregisterServerAdapter(TEST_ADAPTER_TYPE);
+    await tempDb?.cleanup();
+  });
+
+  it("redacts adapter credential errors from every durable heartbeat status surface", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const taskKey = "hap-128-task";
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Heartbeat Redaction Test",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Redaction Test Agent",
+      role: "engineer",
+      status: "idle",
+      adapterType: TEST_ADAPTER_TYPE,
+      adapterConfig: {},
+      runtimeConfig: { heartbeat: { wakeOnDemand: true } },
+      permissions: {},
+    });
+
+    const queued = await heartbeat.invoke(agentId, "on_demand", { taskKey }, "manual");
+    expect(queued).not.toBeNull();
+    const finished = await waitForRunToFinish(heartbeat, queued!.id);
+    expect(finished?.status).toBe("failed");
+    // A terminal run status is written before all dependent agent/session writes.
+    // Await the service's durable execution barrier rather than an arbitrary delay.
+    await heartbeat.drainActiveRunExecutions();
+
+    const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, queued!.id));
+    const [agent] = await db.select().from(agents).where(eq(agents.id, agentId));
+    const [taskSession] = await db
+      .select()
+      .from(agentTaskSessions)
+      .where(and(eq(agentTaskSessions.agentId, agentId), eq(agentTaskSessions.taskKey, taskKey)));
+    const [runtimeState] = await db
+      .select()
+      .from(agentRuntimeState)
+      .where(eq(agentRuntimeState.agentId, agentId));
+
+    expect(run?.error).toContain(DIAGNOSTIC);
+    expect(run?.stdoutExcerpt).toContain("adapter stdout");
+    expect(run?.stderrExcerpt).toContain("adapter stderr");
+    expect(agent).toMatchObject({ status: "error" });
+    expect(agent?.errorReason).toContain(DIAGNOSTIC);
+    expect(taskSession?.lastError).toContain(DIAGNOSTIC);
+    expect(runtimeState?.lastError).toContain(DIAGNOSTIC);
+
+    for (const durableValue of [run, agent, taskSession, runtimeState]) {
+      expect(JSON.stringify(durableValue)).not.toContain(CREDENTIAL_VALUE);
+    }
+  });
+});

--- a/server/src/__tests__/heartbeat-error-redaction.test.ts
+++ b/server/src/__tests__/heartbeat-error-redaction.test.ts
@@ -16,6 +16,7 @@ import {
 } from "./helpers/embedded-postgres.js";
 import { registerServerAdapter, unregisterServerAdapter } from "../adapters/index.ts";
 import { heartbeatService } from "../services/heartbeat.ts";
+import { subscribeCompanyLiveEvents } from "../services/live-events.ts";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -119,35 +120,70 @@ describeEmbeddedPostgres("heartbeat error redaction", () => {
       permissions: {},
     });
 
-    const queued = await heartbeat.invoke(agentId, "on_demand", { taskKey }, "manual");
-    expect(queued).not.toBeNull();
-    const finished = await waitForRunToFinish(heartbeat, queued!.id);
-    expect(finished?.status).toBe("failed");
-    // A terminal run status is written before all dependent agent/session writes.
-    // Await the service's durable execution barrier rather than an arbitrary delay.
-    await heartbeat.drainActiveRunExecutions();
+    const liveLogEvents: unknown[] = [];
+    const unsubscribe = subscribeCompanyLiveEvents(companyId, (event) => {
+      if (event.type === "heartbeat.run.log") liveLogEvents.push(event);
+    });
 
-    const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, queued!.id));
-    const [agent] = await db.select().from(agents).where(eq(agents.id, agentId));
-    const [taskSession] = await db
-      .select()
-      .from(agentTaskSessions)
-      .where(and(eq(agentTaskSessions.agentId, agentId), eq(agentTaskSessions.taskKey, taskKey)));
-    const [runtimeState] = await db
-      .select()
-      .from(agentRuntimeState)
-      .where(eq(agentRuntimeState.agentId, agentId));
+    try {
+      const queued = await heartbeat.invoke(agentId, "on_demand", { taskKey }, "manual");
+      expect(queued).not.toBeNull();
+      const finished = await waitForRunToFinish(heartbeat, queued!.id);
+      expect(finished?.status).toBe("failed");
+      // A terminal run status is written before all dependent agent/session writes.
+      // Await the service's durable execution barrier rather than an arbitrary delay.
+      await heartbeat.drainActiveRunExecutions();
 
-    expect(run?.error).toContain(DIAGNOSTIC);
-    expect(run?.stdoutExcerpt).toContain("adapter stdout");
-    expect(run?.stderrExcerpt).toContain("adapter stderr");
-    expect(agent).toMatchObject({ status: "error" });
-    expect(agent?.errorReason).toContain(DIAGNOSTIC);
-    expect(taskSession?.lastError).toContain(DIAGNOSTIC);
-    expect(runtimeState?.lastError).toContain(DIAGNOSTIC);
+      const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, queued!.id));
+      const [agent] = await db.select().from(agents).where(eq(agents.id, agentId));
+      const [taskSession] = await db
+        .select()
+        .from(agentTaskSessions)
+        .where(and(eq(agentTaskSessions.agentId, agentId), eq(agentTaskSessions.taskKey, taskKey)));
+      const [runtimeState] = await db
+        .select()
+        .from(agentRuntimeState)
+        .where(eq(agentRuntimeState.agentId, agentId));
+      const storedLog = await heartbeat.readLog(queued!.id);
 
-    for (const durableValue of [run, agent, taskSession, runtimeState]) {
-      expect(JSON.stringify(durableValue)).not.toContain(CREDENTIAL_VALUE);
+      expect(run?.error).toContain(DIAGNOSTIC);
+      expect(run?.stdoutExcerpt).toContain("adapter stdout");
+      expect(run?.stderrExcerpt).toContain("adapter stderr");
+      expect(agent).toMatchObject({ status: "error" });
+      expect(agent?.errorReason).toContain(DIAGNOSTIC);
+      expect(taskSession?.lastError).toContain(DIAGNOSTIC);
+      expect(runtimeState?.lastError).toContain(DIAGNOSTIC);
+      expect(storedLog.content).toContain("adapter stdout");
+      expect(storedLog.content).toContain("adapter stderr");
+      expect(liveLogEvents).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            companyId,
+            type: "heartbeat.run.log",
+            payload: expect.objectContaining({
+              runId: queued!.id,
+              stream: "stdout",
+              chunk: expect.stringContaining("adapter stdout"),
+            }),
+          }),
+          expect.objectContaining({
+            companyId,
+            type: "heartbeat.run.log",
+            payload: expect.objectContaining({
+              runId: queued!.id,
+              stream: "stderr",
+              chunk: expect.stringContaining("adapter stderr"),
+            }),
+          }),
+        ]),
+      );
+
+      for (const durableValue of [run, agent, taskSession, runtimeState, storedLog]) {
+        expect(JSON.stringify(durableValue)).not.toContain(CREDENTIAL_VALUE);
+      }
+      expect(JSON.stringify(liveLogEvents)).not.toContain(CREDENTIAL_VALUE);
+    } finally {
+      unsubscribe();
     }
   });
 });

--- a/server/src/__tests__/heartbeat-error-redaction.test.ts
+++ b/server/src/__tests__/heartbeat-error-redaction.test.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { and, eq, sql } from "drizzle-orm";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   agentRuntimeState,
   agentTaskSessions,
@@ -15,6 +15,7 @@ import {
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { registerServerAdapter, unregisterServerAdapter } from "../adapters/index.ts";
+import { logger } from "../middleware/logger.ts";
 import { heartbeatService } from "../services/heartbeat.ts";
 import { subscribeCompanyLiveEvents } from "../services/live-events.ts";
 
@@ -25,6 +26,7 @@ const CREDENTIAL_VALUE = "hap128-secret-value";
 const CREDENTIAL_PREFIX = "hap128-secret-";
 const CREDENTIAL_SUFFIX = "value";
 const DIAGNOSTIC = "Provider rejected request";
+const SETUP_DIAGNOSTIC = "Workspace setup rejected request";
 
 if (!embeddedPostgresSupport.supported) {
   console.warn(
@@ -51,6 +53,8 @@ describeEmbeddedPostgres("heartbeat error redaction", () => {
   let heartbeat!: ReturnType<typeof heartbeatService>;
   let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
   let throwAfterLog = false;
+  let failRuntimeStateSetup = false;
+  let adapterExecuteCalls = 0;
 
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-error-redaction-");
@@ -59,6 +63,7 @@ describeEmbeddedPostgres("heartbeat error redaction", () => {
     registerServerAdapter({
       type: TEST_ADAPTER_TYPE,
       execute: async ({ onLog }) => {
+        adapterExecuteCalls += 1;
         // Adapter process streams have arbitrary chunk boundaries. Split both
         // the sensitive field name and value so per-chunk redaction cannot see
         // the credential. Keep stderr unterminated to prove completion flushes
@@ -93,6 +98,8 @@ describeEmbeddedPostgres("heartbeat error redaction", () => {
 
   afterEach(async () => {
     throwAfterLog = false;
+    failRuntimeStateSetup = false;
+    adapterExecuteCalls = 0;
     await heartbeat.drainActiveRunExecutions();
     await db.execute(sql.raw(`
       TRUNCATE TABLE
@@ -212,6 +219,105 @@ describeEmbeddedPostgres("heartbeat error redaction", () => {
       expect(serializedLiveLogEvents).not.toContain(CREDENTIAL_PREFIX);
     } finally {
       unsubscribe();
+    }
+  });
+
+  it("redacts a credential-bearing pre-dispatch setup failure before logger and run persistence", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const taskKey = "hap-128-setup-failure";
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Heartbeat Setup Redaction Test",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+      defaultResponsibleUserId: "responsible-user",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Setup Redaction Test Agent",
+      role: "engineer",
+      status: "idle",
+      adapterType: TEST_ADAPTER_TYPE,
+      adapterConfig: {},
+      runtimeConfig: { heartbeat: { wakeOnDemand: true } },
+      permissions: {},
+    });
+
+    const originalSelect = db.select.bind(db);
+    const selectSpy = vi.spyOn(db, "select");
+    selectSpy.mockImplementation((...args) => {
+      const query = originalSelect(...args) as unknown as {
+        from: (source: unknown) => unknown;
+      };
+      const originalFrom = query.from.bind(query);
+      query.from = (source) => {
+        if (failRuntimeStateSetup && source === agentRuntimeState) {
+          failRuntimeStateSetup = false;
+          const setupError = new Error(`${SETUP_DIAGNOSTIC} apiKey: \"${CREDENTIAL_VALUE}\"`);
+          setupError.stack = `Error: ${SETUP_DIAGNOSTIC} apiKey: \"${CREDENTIAL_VALUE}\"\n    at test setup`;
+          throw setupError;
+        }
+        return originalFrom(source);
+      };
+      return query as never;
+    });
+    const loggerErrorSpy = vi.spyOn(logger, "error").mockImplementation(() => undefined);
+
+    try {
+      failRuntimeStateSetup = true;
+      const queued = await heartbeat.invoke(agentId, "on_demand", { taskKey }, "manual");
+      expect(queued).not.toBeNull();
+      const finished = await waitForRunToFinish(heartbeat, queued!.id);
+      expect(finished?.status).toBe("failed");
+      await heartbeat.drainActiveRunExecutions();
+
+      expect(adapterExecuteCalls).toBe(0);
+
+      selectSpy.mockRestore();
+      const [run] = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, queued!.id));
+      const [agent] = await db.select().from(agents).where(eq(agents.id, agentId));
+      const runEvents = await db
+        .select()
+        .from(heartbeatRunEvents)
+        .where(eq(heartbeatRunEvents.runId, queued!.id));
+
+      expect(run?.error).toContain(SETUP_DIAGNOSTIC);
+      expect(agent).toMatchObject({ status: "error" });
+      expect(runEvents).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            eventType: "error",
+            message: expect.stringContaining(SETUP_DIAGNOSTIC),
+          }),
+        ]),
+      );
+      for (const durableValue of [run, agent, runEvents]) {
+        const serialized = JSON.stringify(durableValue);
+        expect(serialized ?? "").not.toContain(CREDENTIAL_VALUE);
+        expect(serialized ?? "").not.toContain(CREDENTIAL_PREFIX);
+      }
+
+      const setupFailureLog = loggerErrorSpy.mock.calls.find(
+        (call) => call[1] === "heartbeat execution setup failed",
+      );
+      expect(setupFailureLog).toBeDefined();
+      const loggedFields = setupFailureLog?.[0] as Record<string, unknown>;
+      expect(loggedFields).toMatchObject({
+        runId: queued!.id,
+        errorCode: "setup_failed",
+        error: expect.stringContaining(SETUP_DIAGNOSTIC),
+      });
+      expect(loggedFields).not.toHaveProperty("err");
+      const serializedLoggerFields = JSON.stringify(loggedFields);
+      expect(serializedLoggerFields).not.toContain(CREDENTIAL_VALUE);
+      expect(serializedLoggerFields).not.toContain(CREDENTIAL_PREFIX);
+    } finally {
+      selectSpy.mockRestore();
+      loggerErrorSpy.mockRestore();
     }
   });
 });

--- a/server/src/__tests__/heartbeat-error-redaction.test.ts
+++ b/server/src/__tests__/heartbeat-error-redaction.test.ts
@@ -22,6 +22,8 @@ const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
 const TEST_ADAPTER_TYPE = "heartbeat_error_redaction_test";
 const CREDENTIAL_VALUE = "hap128-secret-value";
+const CREDENTIAL_PREFIX = "hap128-secret-";
+const CREDENTIAL_SUFFIX = "value";
 const DIAGNOSTIC = "Provider rejected request";
 
 if (!embeddedPostgresSupport.supported) {
@@ -48,6 +50,7 @@ describeEmbeddedPostgres("heartbeat error redaction", () => {
   let db!: ReturnType<typeof createDb>;
   let heartbeat!: ReturnType<typeof heartbeatService>;
   let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let throwAfterLog = false;
 
   beforeAll(async () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-heartbeat-error-redaction-");
@@ -56,8 +59,20 @@ describeEmbeddedPostgres("heartbeat error redaction", () => {
     registerServerAdapter({
       type: TEST_ADAPTER_TYPE,
       execute: async ({ onLog }) => {
-        await onLog("stdout", `adapter stdout apiKey: \"${CREDENTIAL_VALUE}\"\n`);
-        await onLog("stderr", `adapter stderr apiKey: \"${CREDENTIAL_VALUE}\"\n`);
+        // Adapter process streams have arbitrary chunk boundaries. Split both
+        // the sensitive field name and value so per-chunk redaction cannot see
+        // the credential. Keep stderr unterminated to prove completion flushes
+        // the final buffered line before durable run finalization.
+        await onLog("stdout", "adapter stdout api");
+        await onLog("stdout", `Key: \"${CREDENTIAL_PREFIX}`);
+        await onLog("stdout", `${CREDENTIAL_SUFFIX}\"\n`);
+        // Some adapters fire-and-forget log callbacks. The heartbeat finalizer
+        // must still serialize and drain both fragments before closing the log.
+        void onLog("stderr", `adapter stderr apiKey: \"${CREDENTIAL_PREFIX}`);
+        void onLog("stderr", `${CREDENTIAL_SUFFIX}\"`);
+        if (throwAfterLog) {
+          throw new Error(`${DIAGNOSTIC} apiKey: \"${CREDENTIAL_VALUE}\" (request_id=req-42)`);
+        }
         return {
           exitCode: 1,
           signal: null,
@@ -77,6 +92,7 @@ describeEmbeddedPostgres("heartbeat error redaction", () => {
   }, 20_000);
 
   afterEach(async () => {
+    throwAfterLog = false;
     await heartbeat.drainActiveRunExecutions();
     await db.execute(sql.raw(`
       TRUNCATE TABLE
@@ -95,7 +111,11 @@ describeEmbeddedPostgres("heartbeat error redaction", () => {
     await tempDb?.cleanup();
   });
 
-  it("redacts adapter credential errors from every durable heartbeat status surface", async () => {
+  it.each([
+    { path: "returned adapter failure", throws: false },
+    { path: "thrown adapter failure", throws: true },
+  ])("redacts split adapter credentials on the $path path", async ({ throws }) => {
+    throwAfterLog = throws;
     const companyId = randomUUID();
     const agentId = randomUUID();
     const taskKey = "hap-128-task";
@@ -151,7 +171,11 @@ describeEmbeddedPostgres("heartbeat error redaction", () => {
       expect(run?.stderrExcerpt).toContain("adapter stderr");
       expect(agent).toMatchObject({ status: "error" });
       expect(agent?.errorReason).toContain(DIAGNOSTIC);
-      expect(taskSession?.lastError).toContain(DIAGNOSTIC);
+      if (throws) {
+        expect(taskSession).toBeUndefined();
+      } else {
+        expect(taskSession?.lastError).toContain(DIAGNOSTIC);
+      }
       expect(runtimeState?.lastError).toContain(DIAGNOSTIC);
       expect(storedLog.content).toContain("adapter stdout");
       expect(storedLog.content).toContain("adapter stderr");
@@ -179,9 +203,13 @@ describeEmbeddedPostgres("heartbeat error redaction", () => {
       );
 
       for (const durableValue of [run, agent, taskSession, runtimeState, storedLog]) {
-        expect(JSON.stringify(durableValue)).not.toContain(CREDENTIAL_VALUE);
+        const serialized = JSON.stringify(durableValue);
+        expect(serialized ?? "").not.toContain(CREDENTIAL_VALUE);
+        expect(serialized ?? "").not.toContain(CREDENTIAL_PREFIX);
       }
-      expect(JSON.stringify(liveLogEvents)).not.toContain(CREDENTIAL_VALUE);
+      const serializedLiveLogEvents = JSON.stringify(liveLogEvents);
+      expect(serializedLiveLogEvents).not.toContain(CREDENTIAL_VALUE);
+      expect(serializedLiveLogEvents).not.toContain(CREDENTIAL_PREFIX);
     } finally {
       unsubscribe();
     }

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -113,6 +113,7 @@ import {
   writeHotRestartIntent,
 } from "../services/hot-restart.ts";
 import { secretService } from "../services/secrets.ts";
+import { REDACTED_EVENT_VALUE } from "../redaction.ts";
 import {
   SUCCESSFUL_RUN_HANDOFF_EXHAUSTED_NOTICE_BODY,
   SUCCESSFUL_RUN_HANDOFF_REQUIRED_NOTICE_BODY,
@@ -3585,12 +3586,15 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
             consumerId: agentId,
             configPath: "env.UNBOUND_API_KEY",
             envKey: "UNBOUND_API_KEY",
-            secretId: secret.id,
-            secretName,
+            secretId: REDACTED_EVENT_VALUE,
+            secretName: REDACTED_EVENT_VALUE,
           },
         ],
       },
     });
+    const serializedResultJson = JSON.stringify(failedRun?.resultJson ?? null);
+    expect(serializedResultJson).not.toContain(secret.id);
+    expect(serializedResultJson).not.toContain(secretName);
     // Value-free gate: no secret access events were recorded.
     expect(await svc.listAccessEvents(companyId, secret.id)).toHaveLength(0);
 

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { REDACTED_EVENT_VALUE, redactEventPayload, redactSensitiveText, sanitizeRecord } from "../redaction.js";
+import {
+  REDACTED_EVENT_VALUE,
+  redactEventPayload,
+  redactSensitiveText,
+  redactSensitiveValue,
+  sanitizeRecord,
+} from "../redaction.js";
 
 describe("redaction", () => {
   it("redacts sensitive keys and nested secret values", () => {
@@ -61,6 +67,26 @@ describe("redaction", () => {
     expect(redactEventPayload({ password: "hunter2", safe: "value" })).toEqual({
       password: REDACTED_EVENT_VALUE,
       safe: "value",
+    });
+  });
+
+  it("redacts credential-shaped text nested in adapter result values", () => {
+    const result = redactSensitiveValue({
+      summary: "completed safely",
+      output: [
+        "PAPERCLIP_API_KEY=synthetic-test-only-secret",
+        { stderr: 'adapter emitted {"accessToken":"synthetic-test-only-token"}' },
+      ],
+      finishedAt: new Date("2026-08-30T00:00:00.000Z"),
+    });
+
+    expect(result).toEqual({
+      summary: "completed safely",
+      output: [
+        `PAPERCLIP_API_KEY=${REDACTED_EVENT_VALUE}`,
+        { stderr: `adapter emitted {"accessToken":"${REDACTED_EVENT_VALUE}"}` },
+      ],
+      finishedAt: new Date("2026-08-30T00:00:00.000Z"),
     });
   });
 

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   REDACTED_EVENT_VALUE,
+  createSensitiveTextStreamRedactor,
   redactEventPayload,
   redactSensitiveText,
   redactSensitiveValue,
@@ -164,6 +165,73 @@ describe("redaction", () => {
     expect(result).not.toContain("paperclip-shell-secret");
     expect(result).not.toContain(githubToken);
     expect(result).not.toContain(jwt);
+  });
+
+  it("redacts sensitive log lines across every process chunk boundary", () => {
+    const credential = "split-sensitive-value-0123456789";
+    const fixtures = [
+      { line: `payload {"apiKey":"${credential}"}\n`, secret: credential },
+      { line: `PAPERCLIP_API_KEY=${credential}\n`, secret: credential },
+      { line: `cmd --api-key=${credential}\n`, secret: credential },
+      { line: `Authorization: Bearer ${credential}\n`, secret: credential },
+      { line: `provider sk-${credential}\n`, secret: `sk-${credential}` },
+      {
+        line: "provider ghp_abcdefghijklmnopqrstuvwxyz0123456789\n",
+        secret: "ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+      },
+      {
+        line: "session abcdefgh.abcdefghijklmnop0123456789.ijklmnop\n",
+        secret: "abcdefgh.abcdefghijklmnop0123456789.ijklmnop",
+      },
+    ];
+
+    for (const fixture of fixtures) {
+      for (let splitAt = 1; splitAt < fixture.line.length; splitAt += 1) {
+        const redactor = createSensitiveTextStreamRedactor({ sanitize: redactSensitiveText });
+        const firstFrames = redactor.push(fixture.line.slice(0, splitAt));
+        const frames = [
+          ...firstFrames,
+          ...redactor.push(fixture.line.slice(splitAt)),
+          ...redactor.flush(),
+        ];
+        const output = frames.join("");
+
+        expect(firstFrames, `fixture=${fixture.line} splitAt=${splitAt}`).toEqual([]);
+        expect(output, `fixture=${fixture.line} splitAt=${splitAt}`).toContain(REDACTED_EVENT_VALUE);
+        expect(output, `fixture=${fixture.line} splitAt=${splitAt}`).not.toContain(fixture.secret);
+        for (const frame of frames) {
+          expect(frame, `fixture=${fixture.line} splitAt=${splitAt}`).not.toContain(fixture.secret.slice(0, 12));
+        }
+      }
+    }
+  });
+
+  it("fails closed for unterminated or oversized sensitive log frames", () => {
+    const credentialPrefix = "split-sensitive-value-";
+    const unterminated = createSensitiveTextStreamRedactor({ sanitize: redactSensitiveText });
+    expect(unterminated.push(`apiKey: \"${credentialPrefix}`)).toEqual([]);
+    const unterminatedOutput = unterminated.flush().join("");
+    expect(unterminatedOutput).toContain("omitted");
+    expect(unterminatedOutput).not.toContain(credentialPrefix);
+
+    const oversized = createSensitiveTextStreamRedactor({
+      sanitize: redactSensitiveText,
+      maxPendingChars: 32,
+    });
+    const oversizedOutput = [
+      ...oversized.push(`apiKey: \"${credentialPrefix.repeat(8)}`),
+      ...oversized.push("still-sensitive\nordinary next line\n"),
+      ...oversized.flush(),
+    ].join("");
+    expect(oversizedOutput).toContain("omitted oversized unterminated run log line");
+    expect(oversizedOutput).toContain("ordinary next line");
+    expect(oversizedOutput).not.toContain(credentialPrefix);
+  });
+
+  it("preserves a safe unterminated final log frame on flush", () => {
+    const redactor = createSensitiveTextStreamRedactor({ sanitize: redactSensitiveText });
+    expect(redactor.push("ordinary final diagnostic")).toEqual([]);
+    expect(redactor.flush()).toEqual(["ordinary final diagnostic"]);
   });
 
   it("redacts inline secrets from command metadata without hiding safe command text", () => {

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -188,3 +188,90 @@ export function redactSensitiveText(input: string): string {
     REDACTED_EVENT_VALUE,
   );
 }
+
+const DEFAULT_STREAM_REDACTION_PENDING_CHARS = 64 * 1024;
+const OVERSIZED_STREAM_FRAME_MARKER =
+  "[paperclip omitted oversized unterminated run log line]\n";
+const SENSITIVE_STREAM_TAIL_MARKER =
+  "[paperclip omitted potentially sensitive unterminated run log line]";
+
+export type SensitiveTextStreamRedactor = {
+  /**
+   * Accept an arbitrary process-output chunk and return only complete,
+   * sanitized logical-line frames that are safe to publish or persist.
+   */
+  push(chunk: string): string[];
+  /** Flush a final unterminated frame without ever returning raw secret material. */
+  flush(): string[];
+};
+
+/**
+ * Frame process output before redaction so a credential split across arbitrary
+ * adapter chunk boundaries cannot cross an irreversible log boundary.
+ *
+ * The current secret grammars are single-line, so LF is the safe commit point.
+ * An oversized unterminated line is omitted and drained through its next LF to
+ * keep retained raw state bounded. A sensitive-looking final tail that the
+ * complete-text sanitizer cannot prove safe is omitted on flush.
+ */
+export function createSensitiveTextStreamRedactor(options: {
+  sanitize: (frame: string) => string;
+  maxPendingChars?: number;
+}): SensitiveTextStreamRedactor {
+  const maxPendingChars = Math.max(
+    1,
+    Math.floor(options.maxPendingChars ?? DEFAULT_STREAM_REDACTION_PENDING_CHARS),
+  );
+  let pending = "";
+  let droppingOversizedLine = false;
+
+  const push = (chunk: string): string[] => {
+    if (chunk.length === 0) return [];
+    const frames: string[] = [];
+    let remaining = chunk;
+
+    if (droppingOversizedLine) {
+      const newlineIndex = remaining.indexOf("\n");
+      if (newlineIndex < 0) return frames;
+      droppingOversizedLine = false;
+      remaining = remaining.slice(newlineIndex + 1);
+      if (remaining.length === 0) return frames;
+    }
+
+    const combined = pending + remaining;
+    const lastNewlineIndex = combined.lastIndexOf("\n");
+    if (lastNewlineIndex >= 0) {
+      const completeLines = combined.slice(0, lastNewlineIndex + 1);
+      pending = combined.slice(lastNewlineIndex + 1);
+      frames.push(options.sanitize(completeLines));
+    } else {
+      pending = combined;
+    }
+
+    if (pending.length > maxPendingChars) {
+      pending = "";
+      droppingOversizedLine = true;
+      frames.push(OVERSIZED_STREAM_FRAME_MARKER);
+    }
+    return frames;
+  };
+
+  const flush = (): string[] => {
+    if (droppingOversizedLine) {
+      droppingOversizedLine = false;
+      pending = "";
+      return [];
+    }
+    if (pending.length === 0) return [];
+
+    const finalFrame = pending;
+    pending = "";
+    const secretSanitized = redactSensitiveText(finalFrame);
+    if (maybeContainsSecretText(finalFrame) && secretSanitized === finalFrame) {
+      return [SENSITIVE_STREAM_TAIL_MARKER];
+    }
+    return [options.sanitize(finalFrame)];
+  };
+
+  return { push, flush };
+}

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -85,6 +85,23 @@ function sanitizeValue(value: unknown): unknown {
   return sanitizeRecord(value);
 }
 
+/**
+ * Redact arbitrary JSON-like output before it crosses a durable or live
+ * boundary. Unlike event-payload redaction, adapter results often place
+ * unstructured process output under neutral keys such as `result` or `stderr`.
+ */
+export function redactSensitiveValue<T>(value: T): T {
+  if (typeof value === "string") return redactSensitiveText(value) as T;
+  if (Array.isArray(value)) return value.map((entry) => redactSensitiveValue(entry)) as T;
+  if (isSecretRefBinding(value) || isUserSecretRefBinding(value)) return value;
+  if (!isPlainObject(value)) return value;
+
+  const keySanitized = sanitizeRecord(value);
+  return Object.fromEntries(
+    Object.entries(keySanitized).map(([key, entry]) => [key, redactSensitiveValue(entry)]),
+  ) as T;
+}
+
 function isSecretRefBinding(value: unknown): value is { type: "secret_ref"; secretId: string; version?: unknown } {
   if (!isPlainObject(value)) return false;
   return value.type === "secret_ref" && typeof value.secretId === "string";

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -17517,7 +17517,10 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             nativeRunnerErrorCode(outerErr) ??
             recordedResponsibleUserDenialCode ??
             "setup_failed";
-          logger.error({ err: outerErr, runId }, "heartbeat execution setup failed");
+          logger.error(
+            { runId, errorCode: setupFailureErrorCode, error: message },
+            "heartbeat execution setup failed",
+          );
           const setupFailureAgent = await getAgent(run.agentId).catch(() => null);
           const setupFailureWrite = await setRunStatusIfRunning(runId, "failed", {
             error: message,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -16167,7 +16167,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
       const onLog = async (stream: "stdout" | "stderr", chunk: string) => {
         const sanitizedChunk = compactRunLogChunk(
-          redactCurrentUserText(chunk, currentUserRedactionOptions),
+          redactSensitiveText(redactCurrentUserText(chunk, currentUserRedactionOptions)),
         );
         if (stream === "stdout") stdoutExcerpt = appendExcerpt(stdoutExcerpt, sanitizedChunk);
         if (stream === "stderr") stderrExcerpt = appendExcerpt(stderrExcerpt, sanitizedChunk);
@@ -16939,17 +16939,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         usageBasis: adapterResult.usageBasis ?? null,
       });
       const normalizedUsage = sessionUsageResolution.normalizedUsage;
-      const runErrorMessage =
+      const rawAdapterErrorMessage =
         outcome === "cancelled"
           ? (latestRun?.error ?? adapterResult.errorMessage ?? "Cancelled")
           : outcome === "succeeded"
             ? null
-            : redactSensitiveText(
-                redactCurrentUserText(
-                  adapterResult.errorMessage ?? (outcome === "timed_out" ? "Timed out" : "Adapter failed"),
-                  currentUserRedactionOptions,
-                ),
-              );
+            : adapterResult.errorMessage ?? (outcome === "timed_out" ? "Timed out" : "Adapter failed");
+      const sanitizedAdapterErrorMessage =
+        rawAdapterErrorMessage === null
+          ? null
+          : redactSensitiveText(redactCurrentUserText(rawAdapterErrorMessage, currentUserRedactionOptions));
+      const sanitizedAdapterResult = {
+        ...adapterResult,
+        errorMessage: sanitizedAdapterErrorMessage,
+      };
       const recordedResponsibleUserDenialCode =
         normalizeResponsibleUserDenialCode(latestRun?.errorCode);
       const runErrorCode =
@@ -17035,7 +17038,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             modelProfileApplication,
           ),
           errorCode: runErrorCode,
-          errorMessage: runErrorMessage,
+          errorMessage: sanitizedAdapterErrorMessage,
         }),
         adapterResult.summary
           ? redactSensitiveText(redactCurrentUserText(adapterResult.summary, currentUserRedactionOptions))
@@ -17044,7 +17047,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
       const persistedRunWrite = await setRunStatusIfRunning(run.id, status, {
         finishedAt: new Date(),
-        error: runErrorMessage,
+        error: sanitizedAdapterErrorMessage,
         errorCode: runErrorCode,
         exitCode: adapterResult.exitCode,
         signal: adapterResult.signal,
@@ -17098,7 +17101,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
 
       await setWakeupStatus(run.wakeupRequestId, outcome === "succeeded" ? "completed" : status, {
         finishedAt: new Date(),
-        error: runErrorMessage,
+        error: sanitizedAdapterErrorMessage,
       });
 
       const finalizedRun = persistedRun ?? (await getRun(run.id));
@@ -17119,7 +17122,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             issueId,
             issueWorkMode: issueRef?.workMode ?? null,
             outcome,
-            error: runErrorMessage,
+            error: sanitizedAdapterErrorMessage,
           });
         } catch (err) {
           logger.warn(
@@ -17218,7 +17221,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       }
 
       if (finalizedRun) {
-        await updateRuntimeState(agent, finalizedRun, adapterResult, {
+        await updateRuntimeState(agent, finalizedRun, sanitizedAdapterResult, {
           legacySessionId: nextSessionState.legacySessionId,
         }, normalizedUsage);
         if (taskKey) {
@@ -17240,7 +17243,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               ),
               sessionDisplayId: nextSessionState.displayId,
               lastRunId: finalizedRun.id,
-              lastError: runErrorMessage,
+              lastError: outcome === "succeeded" ? null : (sanitizedAdapterErrorMessage ?? "run_failed"),
             });
           }
         }
@@ -17248,7 +17251,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       await finalizeAgentStatus(
         agent.id,
         outcome,
-        runErrorMessage,
+        outcome === "succeeded" ? null : sanitizedAdapterErrorMessage,
         {
           keepIdleOnFailure:
             outcome === "failed" &&

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -285,7 +285,12 @@ import {
   redactCurrentUserValue,
   type CurrentUserRedactionOptions,
 } from "../log-redaction.js";
-import { redactEventPayload, redactSensitiveText, redactSensitiveValue } from "../redaction.js";
+import {
+  createSensitiveTextStreamRedactor,
+  redactEventPayload,
+  redactSensitiveText,
+  redactSensitiveValue,
+} from "../redaction.js";
 import { createRunSecretRedactionRegistry } from "./run-secret-redaction.js";
 import {
   hasSessionCompactionThresholds,
@@ -16060,6 +16065,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
       } | null;
     } = { pending: null };
     let persistedLogBytes = Number(run.logBytes ?? 0);
+    let flushPendingLogChunks: () => Promise<void> = async () => {};
     const flushOutputProgress = async (opts?: { force?: boolean }) => {
       const pendingOutputProgress = outputProgressState.pending;
       if (!pendingOutputProgress) return;
@@ -16165,10 +16171,26 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         .where(eq(heartbeatRuns.id, runId));
 
       const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
-      const onLog = async (stream: "stdout" | "stderr", chunk: string) => {
-        const sanitizedChunk = compactRunLogChunk(
-          redactSensitiveText(redactCurrentUserText(chunk, currentUserRedactionOptions)),
-        );
+      const sanitizeLogFrame = (frame: string) =>
+        compactRunLogChunk(redactCurrentUserText(frame, currentUserRedactionOptions));
+      const logRedactors = {
+        stdout: createSensitiveTextStreamRedactor({
+          sanitize: sanitizeLogFrame,
+          maxPendingChars: MAX_PERSISTED_LOG_CHUNK_CHARS,
+        }),
+        stderr: createSensitiveTextStreamRedactor({
+          sanitize: sanitizeLogFrame,
+          maxPendingChars: MAX_PERSISTED_LOG_CHUNK_CHARS,
+        }),
+      };
+      let logWriteChain: Promise<void> = Promise.resolve();
+      let hasLogWriteFailure = false;
+      let logWriteFailure: unknown = null;
+
+      const writeSanitizedLogFrame = async (
+        stream: "stdout" | "stderr",
+        sanitizedChunk: string,
+      ) => {
         if (stream === "stdout") stdoutExcerpt = appendExcerpt(stdoutExcerpt, sanitizedChunk);
         if (stream === "stderr") stderrExcerpt = appendExcerpt(stderrExcerpt, sanitizedChunk);
         const ts = new Date().toISOString();
@@ -16233,6 +16255,37 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
             chunk: payloadChunk,
             truncated: payloadChunk.length !== sanitizedChunk.length,
           },
+        });
+      };
+      const enqueueLogWrite = (operation: () => Promise<void>) => {
+        const queued = logWriteChain.then(async () => {
+          if (hasLogWriteFailure) throw logWriteFailure;
+          try {
+            await operation();
+          } catch (error) {
+            hasLogWriteFailure = true;
+            logWriteFailure = error;
+            throw error;
+          }
+        });
+        logWriteChain = queued.catch(() => undefined);
+        return queued;
+      };
+      const onLog = (stream: "stdout" | "stderr", chunk: string) =>
+        enqueueLogWrite(async () => {
+          for (const sanitizedFrame of logRedactors[stream].push(chunk)) {
+            await writeSanitizedLogFrame(stream, sanitizedFrame);
+          }
+        });
+      flushPendingLogChunks = async () => {
+        await logWriteChain;
+        if (hasLogWriteFailure) throw logWriteFailure;
+        await enqueueLogWrite(async () => {
+          for (const stream of ["stdout", "stderr"] as const) {
+            for (const sanitizedFrame of logRedactors[stream].flush()) {
+              await writeSanitizedLogFrame(stream, sanitizedFrame);
+            }
+          }
         });
       };
       if (runScopedMentionedSkillKeys.length > 0) {
@@ -16804,9 +16857,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         // state. Best-effort record finalize=failed so the dependent readiness
         // check keeps the gate closed instead of waking on stale local state,
         // and surface the original error to the caller.
+        const sanitizedWorkspaceFinalizeError = redactSensitiveText(
+          redactCurrentUserText(
+            adapterErr instanceof Error ? adapterErr.message : String(adapterErr),
+            currentUserRedactionOptions,
+          ),
+        );
         try {
           await recordWorkspaceFinalize("failed", {
-            errorMessage: adapterErr instanceof Error ? adapterErr.message : String(adapterErr),
+            errorMessage: sanitizedWorkspaceFinalizeError,
           });
         } catch (recordErr) {
           logger.warn(
@@ -16817,16 +16876,20 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         throw adapterErr;
       } finally {
         try {
-          await revokeHeartbeatRunGatewayTokens({
-            db,
-            companyId: agent.companyId,
-            runId: run.id,
-          });
-        } catch (revokeErr) {
-          logger.warn(
-            { err: revokeErr, runId: run.id, companyId: agent.companyId },
-            "failed to revoke heartbeat-run MCP gateway tokens",
-          );
+          await flushPendingLogChunks();
+        } finally {
+          try {
+            await revokeHeartbeatRunGatewayTokens({
+              db,
+              companyId: agent.companyId,
+              runId: run.id,
+            });
+          } catch (revokeErr) {
+            logger.warn(
+              { err: revokeErr, runId: run.id, companyId: agent.companyId },
+              "failed to revoke heartbeat-run MCP gateway tokens",
+            );
+          }
         }
       }
       // Reconcile the referenced-project set against the real remote staging outcome. A referenced
@@ -16965,6 +17028,7 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               : null;
 
       let logSummary: { bytes: number; sha256?: string; compressed: boolean } | null = null;
+      await flushPendingLogChunks();
       if (handle) {
         logSummary = await runLogStore.finalize(handle);
       }
@@ -17278,9 +17342,15 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         ?? nativeRunnerErrorCode(err)
         ?? recordedResponsibleUserDenialCode
         ?? "adapter_failed";
-      logger.error({ err, runId }, "heartbeat execution failed");
+      logger.error(
+        { runId, errorCode: failureErrorCode, error: message },
+        "heartbeat execution failed",
+      );
 
       let logSummary: { bytes: number; sha256?: string; compressed: boolean } | null = null;
+      await flushPendingLogChunks().catch((flushErr) => {
+        logger.warn({ err: flushErr, runId }, "failed to flush redacted run log frames after error");
+      });
       if (handle) {
         try {
           logSummary = await runLogStore.finalize(handle);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -285,7 +285,7 @@ import {
   redactCurrentUserValue,
   type CurrentUserRedactionOptions,
 } from "../log-redaction.js";
-import { redactEventPayload, redactSensitiveText } from "../redaction.js";
+import { redactEventPayload, redactSensitiveText, redactSensitiveValue } from "../redaction.js";
 import { createRunSecretRedactionRegistry } from "./run-secret-redaction.js";
 import {
   hasSessionCompactionThresholds,
@@ -10026,14 +10026,14 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
     const eventAt = new Date();
     const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
     const sanitizedMessage = event.message
-      ? redactCurrentUserText(event.message, currentUserRedactionOptions)
+      ? redactSensitiveText(redactCurrentUserText(event.message, currentUserRedactionOptions))
       : event.message;
     const boundedPayload = event.payload
       ? boundHeartbeatRunEventPayloadForStorage(event.payload)
       : event.payload;
     const secretSanitizedPayload = boundedPayload ? redactEventPayload(boundedPayload) : boundedPayload;
     const sanitizedPayload = secretSanitizedPayload
-      ? redactCurrentUserValue(secretSanitizedPayload, currentUserRedactionOptions)
+      ? redactSensitiveValue(redactCurrentUserValue(secretSanitizedPayload, currentUserRedactionOptions))
       : secretSanitizedPayload;
     const issueId = readRuntimeStatusIssueIdCandidate(run) ?? null;
     const progress = buildRunEventRuntimeProgress({
@@ -16944,9 +16944,11 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           ? (latestRun?.error ?? adapterResult.errorMessage ?? "Cancelled")
           : outcome === "succeeded"
             ? null
-            : redactCurrentUserText(
-                adapterResult.errorMessage ?? (outcome === "timed_out" ? "Timed out" : "Adapter failed"),
-                currentUserRedactionOptions,
+            : redactSensitiveText(
+                redactCurrentUserText(
+                  adapterResult.errorMessage ?? (outcome === "timed_out" ? "Timed out" : "Adapter failed"),
+                  currentUserRedactionOptions,
+                ),
               );
       const recordedResponsibleUserDenialCode =
         normalizeResponsibleUserDenialCode(latestRun?.errorCode);
@@ -17022,7 +17024,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           resultJson: mergeModelProfileRunMetadata(
             mergeAdapterRecoveryMetadata({
               resultJson: {
-                ...parseObject(adapterResult.resultJson),
+                ...redactSensitiveValue(
+                  redactCurrentUserValue(parseObject(adapterResult.resultJson), currentUserRedactionOptions),
+                ),
                 configFreshness: configFreshnessResultMetadata,
               },
               errorFamily: adapterResult.errorFamily ?? null,
@@ -17033,7 +17037,9 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           errorCode: runErrorCode,
           errorMessage: runErrorMessage,
         }),
-        adapterResult.summary ?? null,
+        adapterResult.summary
+          ? redactSensitiveText(redactCurrentUserText(adapterResult.summary, currentUserRedactionOptions))
+          : null,
       );
 
       const persistedRunWrite = await setRunStatusIfRunning(run.id, status, {
@@ -17252,9 +17258,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         },
       );
     } catch (err) {
-      const message = redactCurrentUserText(
-        err instanceof Error ? err.message : "Unknown adapter failure",
-        await getCurrentUserRedactionOptions(),
+      const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
+      const message = redactSensitiveText(
+        redactCurrentUserText(
+          err instanceof Error ? err.message : "Unknown adapter failure",
+          currentUserRedactionOptions,
+        ),
       );
       const workspaceValidationFailure = isWorkspaceValidationFailure(err) ? err : null;
       const configurationIncompleteFailure = isConfigurationIncompleteFailure(err) ? err : null;
@@ -17291,7 +17300,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
         resultJson: mergeRunStopMetadataForAgent(agent, "failed", {
           errorCode: failureErrorCode,
           errorMessage: message,
-          resultJson: workspaceValidationFailure?.resultJson ?? configurationIncompleteFailure?.resultJson ?? null,
+          resultJson: redactSensitiveValue(
+            redactCurrentUserValue(
+              workspaceValidationFailure?.resultJson ?? configurationIncompleteFailure?.resultJson ?? null,
+              currentUserRedactionOptions,
+            ),
+          ),
         }),
         stdoutExcerpt,
         stderrExcerpt,
@@ -17404,9 +17418,12 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
           } else {
           // Setup code before adapter.execute threw (e.g. ensureRuntimeState, resolveWorkspaceForRun).
           // The inner catch did not fire, so we must record the failure here.
-          const message = redactCurrentUserText(
-            outerErr instanceof Error ? outerErr.message : "Unknown setup failure",
-            await getCurrentUserRedactionOptions(),
+          const currentUserRedactionOptions = await getCurrentUserRedactionOptions();
+          const message = redactSensitiveText(
+            redactCurrentUserText(
+              outerErr instanceof Error ? outerErr.message : "Unknown setup failure",
+              currentUserRedactionOptions,
+            ),
           );
           // A missing secret/env binding is a known pre-dispatch configuration gap,
           // not an opaque setup crash. Surface it with its own errorCode so the
@@ -17437,12 +17454,16 @@ export function heartbeatService(db: Db, options: HeartbeatServiceOptions = {}) 
               resultJson: mergeRunStopMetadataForAgent(setupFailureAgent, "failed", {
                 errorCode: setupFailureErrorCode,
                 errorMessage: message,
-                resultJson:
-                  workspaceValidationSetupFailure?.resultJson ??
-                  configurationIncompleteSetupFailure?.resultJson ??
-                  (unresolvedBaseRefSetupFailure
-                    ? buildUnresolvedWorkspaceBaseRefResultJson(run, unresolvedBaseRefSetupFailure)
-                    : null),
+                resultJson: redactSensitiveValue(
+                  redactCurrentUserValue(
+                    workspaceValidationSetupFailure?.resultJson
+                      ?? configurationIncompleteSetupFailure?.resultJson
+                      ?? (unresolvedBaseRefSetupFailure
+                        ? buildUnresolvedWorkspaceBaseRefResultJson(run, unresolvedBaseRefSetupFailure)
+                        : null),
+                    currentUserRedactionOptions,
+                  ),
+                ),
               }),
             } : {}),
           }).catch(() => ({ run: null, updated: false as const }));


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The heartbeat service records adapter results, errors, events, and process output.
> - Adapter output can contain credential-shaped text under neutral field names.
> - Existing key-based redaction does not protect every free-text value before storage or live publication.
> - This pull request applies the existing text redaction at the heartbeat write and publish boundaries.
> - It also redacts nested JSON-like adapter output while it preserves secret references.
> - The benefit is a safer audit trail that still keeps useful diagnostic text.

## Linked Issues or Issue Description

- Refs #8047. This pull request implements the narrow heartbeat-writer part of the requested pre-persistence defense. It does not close the issue's bound-value and backup-permission follow-up work.
- Refs #6373. That pull request expands patterns and protects run-log append and read paths. Its current branch has merge conflicts. This pull request uses current `master` and covers heartbeat adapter result, error, event, status, log, and live-event sinks.
- Refs #6376. That pull request protects run-detail and continuation-summary read paths. Its current branch has merge conflicts and has a different egress scope.
- Refs #8841. That pull request proposes a broader persistence sanitizer. Its current branch has merge conflicts. This pull request keeps the change narrow and uses the existing redaction module.
- Refs #6663. That pull request adds more free-text token patterns. Its pattern work is complementary to this boundary change.

## What Changed

- Added `redactSensitiveValue` for nested JSON-like adapter output. The helper preserves `secret_ref` and `user_secret_ref` bindings.
- Redacted heartbeat event messages and nested payload values before database insertion and live publication.
- Redacted stdout and stderr chunks before excerpt updates, durable log append, and live log publication.
- Redacted adapter errors, summaries, result JSON, runtime state, task-session errors, wakeup status, and agent status before persistence.
- Redacted setup and execution failure result payloads before persistence.
- Added focused unit and integration tests for run status, durable logs, `heartbeat.readLog`, and live stdout and stderr events.

## Verification

- Exact base: `9e4be0e60cd8c784b5d281ca7364dddbd46d579c` (`origin/master`).
- Exact head: `fc6ece5e2b167095c6311f011cba9f5d795b1038`.
- `./node_modules/.bin/vitest run server/src/__tests__/redaction.test.ts server/src/__tests__/heartbeat-error-redaction.test.ts` passed 2 files and 11 tests.
- `./node_modules/.bin/tsc -p server/tsconfig.json --noEmit` passed.
- `git diff --check origin/master...HEAD` passed.
- An independent exact-head review found no P0, P1, or P2 issues after the integration coverage update.
- The local host uses Node.js 22.20.0. Paperclip requires Node.js 24.11 or newer. GitHub Actions remains the source of truth for the supported runtime and the full repository checks.
- No manifest, lockfile, database schema, API response shape, or public type changed.

## Risks

- Redaction can hide diagnostic text that resembles a credential. The tests verify that safe diagnostic text remains visible while synthetic credential text is removed.
- Write-time redaction is intentionally lossy. The raw credential-shaped text is not recoverable from the stored heartbeat record or log.
- The recursive helper accepts JSON-like data only. Non-plain objects pass through unchanged, which matches the existing persistence contract for adapter result JSON.
- No migration is required.

> This is a narrow defensive bug fix. `ROADMAP.md` does not contain the same heartbeat redaction boundary work.

## Model Used

- OpenAI Codex `gpt-5.6-terra`, high reasoning, with repository, shell, Git, test, and exact-head review tools. It performed the current-base rebase and the independent security review.
- OpenAI Codex `gpt-5.6-luna`, medium reasoning, with repository and GitHub tools. It performed the mechanical duplicate and publication audit.
- An OpenAI Codex primary coordinator added the reviewer-requested integration assertions and ran the final checks. The exact coordinator deployment ID and context-window size were not exposed in the task metadata.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
