### PR TITLE
Prevent checkout from reopening terminal issues

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -146,7 +146,7 @@ Stale-lock recovery is crash recovery, not a retry loop. Paperclip must not clea
 
 Checkout never reopens a terminal issue (`done` or `cancelled`), even if a caller includes that terminal value in `expectedStatuses`. Resuming completed work is a separate, explicit action: first reopen the issue with an authenticated `PATCH /api/issues/{issueId}` status update, then let the new run checkout the resulting non-terminal issue.
 
-For a row affected by the former checkout defect, the signature is an issue that should be complete but is `in_progress` while `checkoutRunId` and `executionRunId` are both null. A board operator restores it with `PATCH /api/issues/{issueId}` and body `{ "status": "done" }`. The status update also clears execution lock fields. Confirm the response and a following `GET /api/issues/{issueId}` both report `status: "done"` before treating recovery as complete.
+For a row affected by the former checkout defect, the strongest signature is an issue that should be complete but is `in_progress` while its prior `completedAt` or `cancelledAt` timestamp remains set; checkout and execution run IDs may be null, stale, or non-null. After confirming the intended terminal state from audit history, a board operator restores it with `PATCH /api/issues/{issueId}` and body `{ "status": "done" }` (or `{ "status": "cancelled" }`). The explicit transition clears execution lock fields and writes a fresh terminal timestamp rather than preserving the old one. Confirm the response and a following `GET /api/issues/{issueId}` both report the intended terminal status before treating recovery as complete.
 
 ### Pre-dispatch configuration validation
 

--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -144,6 +144,10 @@ The active-lock lifecycle is part of the checkout contract:
 
 Stale-lock recovery is crash recovery, not a retry loop. Paperclip must not clear or adopt locks held by non-terminal runs. After stale cleanup, a checkout `409` should mean a real live owner, status/assignee mismatch, unresolved blocker, or active gate still prevents checkout. Agents must treat that `409` as an ownership conflict and stop rather than retrying the same checkout.
 
+Checkout never reopens a terminal issue (`done` or `cancelled`), even if a caller includes that terminal value in `expectedStatuses`. Resuming completed work is a separate, explicit action: first reopen the issue with an authenticated `PATCH /api/issues/{issueId}` status update, then let the new run checkout the resulting non-terminal issue.
+
+For a row affected by the former checkout defect, the signature is an issue that should be complete but is `in_progress` while `checkoutRunId` and `executionRunId` are both null. A board operator restores it with `PATCH /api/issues/{issueId}` and body `{ "status": "done" }`. The status update also clears execution lock fields. Confirm the response and a following `GET /api/issues/{issueId}` both report `status: "done"` before treating recovery as complete.
+
 ### Pre-dispatch configuration validation
 
 Pre-dispatch configuration validation is a distinct gate that runs after ownership and checkout are resolved but before the control plane actually dispatches a run.

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5973,6 +5973,73 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
     });
   });
 
+  it("checkout refuses terminal issues even when the caller includes 'cancelled' in expectedStatuses", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+    const cancelledAt = new Date("2026-08-30T20:00:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "manual",
+      startedAt: new Date("2026-08-30T20:01:00.000Z"),
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Cancelled issue with no run ownership",
+      status: "cancelled",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      cancelledAt,
+    });
+
+    await expect(svc.checkout(issueId, agentId, ["cancelled"], runId))
+      .rejects.toMatchObject({ status: 409 });
+
+    const row = await db
+      .select({
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        cancelledAt: issues.cancelledAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toMatchObject({
+      status: "cancelled",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      cancelledAt,
+    });
+  });
+
   it("checkout adoption of a stale checkoutRunId preserves the issue's assigneeUserId", async () => {
     // Regression for PR #2482 checkout-adoption review finding: any adoption
     // helper that re-locks an existing in_progress issue (e.g. when the prior

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5906,6 +5906,73 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
     });
   });
 
+  it("checkout refuses terminal issues even when the caller includes 'done' in expectedStatuses", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+    const completedAt = new Date("2026-08-30T20:00:00.000Z");
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "manual",
+      startedAt: new Date("2026-08-30T20:01:00.000Z"),
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Completed issue with no run ownership",
+      status: "done",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      completedAt,
+    });
+
+    await expect(svc.checkout(issueId, agentId, ["done"], runId))
+      .rejects.toMatchObject({ status: 409 });
+
+    const row = await db
+      .select({
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        completedAt: issues.completedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toMatchObject({
+      status: "done",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      completedAt,
+    });
+  });
+
   it("checkout adoption of a stale checkoutRunId preserves the issue's assigneeUserId", async () => {
     // Regression for PR #2482 checkout-adoption review finding: any adoption
     // helper that re-locks an existing in_progress issue (e.g. when the prior

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -8294,6 +8294,7 @@ export function issueService(db: Db) {
           and(
             eq(issues.id, id),
             inArray(issues.status, expectedStatuses),
+            notInArray(issues.status, ["done", "cancelled"]),
             or(isNull(issues.assigneeAgentId), sameRunAssigneeCondition),
             executionLockCondition,
           ),
@@ -8400,6 +8401,7 @@ export function issueService(db: Db) {
               and(
                 eq(issues.id, id),
                 inArray(issues.status, expectedStatuses),
+                notInArray(issues.status, ["done", "cancelled"]),
                 eq(issues.executionRunId, current.executionRunId),
                 or(isNull(issues.assigneeAgentId), eq(issues.assigneeAgentId, agentId)),
               ),


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Issue checkout atomically assigns a run and moves ready work into progress.
> - The caller supplies the list of statuses that it expects to claim.
> - A caller could include a terminal status and reopen completed work without run ownership.
> - This pull request makes terminal status protection a service invariant.
> - The benefit is that completed work stays complete until an explicit status update reopens it.

## Linked Issues or Issue Description

**What happened?**

Checkout can accept an issue with status `done` when the caller includes `done` in `expectedStatuses`.

**Expected behavior**

Checkout returns HTTP 409. The issue remains `done` with its completion timestamp and null run ownership.

**Steps to reproduce**

1. Create a completed issue with null checkout and execution run IDs.
2. Call checkout with `expectedStatuses: ["done"]`.
3. Observe that the issue changes to `in_progress` before this fix.

**Paperclip version or commit**

Reproduced on `master` before commit `efbf02285`.

**Deployment mode**

Self-hosted server.

**Additional context**

An explicit status update remains the supported way to reopen completed work. The recovery procedure for previously affected rows is now documented.

## What Changed

- Excluded `done` and `cancelled` from both atomic checkout update paths.
- Added a regression test that passes `done` in the caller status list.
- Documented explicit resume and recovery for previously reopened rows.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issues-service.test.ts` passed all 123 tests.
- `pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && pnpm --filter @paperclipai/server exec tsc --noEmit` passed.

## Risks

- Low risk. The change only rejects terminal states during checkout.
- Callers that intentionally resume terminal work must first use the explicit issue status update.

## Model Used

- OpenAI Codex, GPT-5, with reasoning, tool use, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
