### PR TITLE
fix(install): accept single-version npm array responses

### DIFF
--- a/cli/src/__tests__/install-version-resolution.test.ts
+++ b/cli/src/__tests__/install-version-resolution.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolvePublishedVersion } from "../commands/install.js";
+
+describe("resolvePublishedVersion", () => {
+  it("accepts npm's single-version JSON array response", async () => {
+    const runCommand = vi.fn(async () => ({ stdout: '["2026.824.1"]\n', stderr: "" }));
+
+    await expect(resolvePublishedVersion("latest", runCommand)).resolves.toBe("2026.824.1");
+  });
+
+  it("still accepts npm's JSON string response", async () => {
+    const runCommand = vi.fn(async () => ({ stdout: '"2026.824.1"\n', stderr: "" }));
+
+    await expect(resolvePublishedVersion("latest", runCommand)).resolves.toBe("2026.824.1");
+  });
+
+  it("rejects ambiguous multi-version arrays", async () => {
+    const runCommand = vi.fn(async () => ({ stdout: '["2026.824.1","2026.825.0"]\n', stderr: "" }));
+
+    await expect(resolvePublishedVersion("latest", runCommand)).rejects.toThrow(
+      "npm returned an unexpected version response",
+    );
+  });
+});

--- a/cli/src/commands/install.ts
+++ b/cli/src/commands/install.ts
@@ -111,6 +111,7 @@ function parseResolvedVersion(stdout: string): string {
   try {
     const parsed = JSON.parse(trimmed) as unknown;
     if (typeof parsed === "string") return parsed;
+    if (Array.isArray(parsed) && parsed.length === 1 && typeof parsed[0] === "string") return parsed[0];
   } catch {
     if (EXACT_VERSION_PATTERN.test(trimmed)) return trimmed;
   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents and their local installation flow.
> - The managed installer reads the current package version from npm.
> - npm can return one valid version inside a JSON array.
> - The current parser rejects that valid response shape.
> - This can stop an otherwise valid managed installation.
> - This pull request accepts only a single string in the array.
> - The change still rejects empty arrays and arrays with more than one version.
> - The benefit is a more robust installer without accepting ambiguous npm responses.

## Linked Issues or Issue Description

Fixes: #12226

## What Changed

- Accept an npm response that contains exactly one string version in an array.
- Keep the existing string response behavior.
- Reject empty arrays, non-string array values, and arrays with more than one version.
- Add focused regression coverage for the accepted and rejected response shapes.

## Verification

- Inspected the current parser and its existing tests.
- Compared the branch against the current upstream base.
- Searched the open PR list for duplicate work on #12226 and found no competing PR at implementation time.
- Added focused regression tests for the new accepted case and ambiguous array cases.
- Executable tests and lint were not run locally through the connected GitHub integration. Upstream CI is still required.

## Risks

Low risk. The parser only broadens acceptance for one unambiguous npm response shape. Multi-version arrays remain rejected.

## Model Used

OpenAI GPT-5.6 Sol with reasoning, GitHub tool access, and code-editing assistance.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge