### PR TITLE
fix(issues): stop silently dropping run-scoped workspace inheritance

### DIFF
--- a/server/src/__tests__/issue-create-run-workspace-inheritance.test.ts
+++ b/server/src/__tests__/issue-create-run-workspace-inheritance.test.ts
@@ -1,0 +1,260 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { expect, it } from "vitest";
+import {
+  activityLog,
+  agents,
+  createDb,
+  heartbeatRuns,
+  issues,
+  projectWorkspaces,
+  projects,
+} from "@paperclipai/db";
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+import {
+  describeEmbeddedPostgres,
+  resetCompanyIssueFixtures,
+  seedCompanyWithBoardAccess,
+  useEmbeddedPostgres,
+} from "./helpers/route-test-harness.js";
+
+type Db = ReturnType<typeof createDb>;
+
+/**
+ * A shared_workspace-mode project's serialize gate
+ * (`heartbeat.ts`'s `findSharedWorkspaceHolder` call) only runs for an issue
+ * that carries `projectWorkspaceId`. An issue an agent creates for itself
+ * mid-run — a self-raised follow-up or independent check, with no `parentId`
+ * naming an already-bound issue — has to get that binding from somewhere.
+ * `resolveRunIssueWorkspaceInheritanceSource` in `routes/issues.ts` is the
+ * mechanism: it looks at the *creating run's own issue* and, if that issue is
+ * itself project-bound, carries the binding onto the new issue.
+ *
+ * These tests exercise the real HTTP route end to end (embedded Postgres, no
+ * mocks) and cover the two ways that mechanism went silently inert:
+ *
+ *   1. `hasExplicitIssueWorkspaceCreateSelection` treated an explicit
+ *      `parentId: null` — an ordinary way for a JSON client to say "no
+ *      parent" — the same as a caller naming a real parent, and skipped
+ *      run-based inheritance entirely.
+ *   2. The same function additionally required the run's context snapshot to
+ *      already carry `executionWorkspaceId`, a field that is not the one the
+ *      shared-workspace serialize gate reads and is not guaranteed to be
+ *      present yet when an agent's very first turn creates an issue.
+ */
+function agentActorApp(db: Db) {
+  const app = express();
+  app.use(express.json());
+  app.use((req, _res, next) => {
+    (req as any).actor = {
+      type: "agent",
+      agentId: (req.headers["x-test-agent-id"] as string) ?? undefined,
+      companyId: (req.headers["x-test-company-id"] as string) ?? undefined,
+      runId: (req.headers["x-test-run-id"] as string) ?? undefined,
+      keyId: randomUUID(),
+      source: "agent_key",
+    };
+    next();
+  });
+  app.use("/api", issueRoutes(db, {} as never));
+  app.use(errorHandler);
+  return app;
+}
+
+describeEmbeddedPostgres("issue create inherits the creating run's project workspace", () => {
+  const ctx = useEmbeddedPostgres("paperclip-issue-run-workspace-inheritance-", {
+    resetEach: async (db) => {
+      await db.delete(activityLog);
+      await db.delete(heartbeatRuns);
+      await db.delete(issues);
+      await db.delete(agents);
+      await db.delete(projectWorkspaces);
+      await db.delete(projects);
+      await resetCompanyIssueFixtures(db);
+    },
+  });
+
+  async function seed() {
+    const company = await seedCompanyWithBoardAccess(ctx.db, "Run workspace inheritance");
+    const companyId = company.companyId;
+
+    const projectId = randomUUID();
+    await ctx.db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Bound project",
+      executionWorkspacePolicy: {
+        enabled: true,
+        sharedWorkspaceConcurrency: "serialize",
+        defaultMode: "shared_workspace",
+        allowIssueOverride: false,
+      },
+    });
+
+    const projectWorkspaceId = randomUUID();
+    await ctx.db.insert(projectWorkspaces).values({
+      id: projectWorkspaceId,
+      companyId,
+      projectId,
+      name: "primary",
+      sourceType: "local_path",
+      isPrimary: true,
+    });
+
+    const agentId = randomUUID();
+    await ctx.db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Self-check agent",
+      role: "engineer",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    // The run's OWN issue: already bound, exactly as an agent's assigned
+    // work-package issue would be after the project's shared workspace has
+    // been established for it.
+    const currentIssueId = randomUUID();
+    await ctx.db.insert(issues).values({
+      id: currentIssueId,
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      title: "Assigned work package",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+
+    // A second, unrelated bound issue, to prove an explicit parentId still
+    // wins over run-based inheritance rather than being ignored.
+    const otherBoundIssueId = randomUUID();
+    const otherProjectWorkspaceId = randomUUID();
+    await ctx.db.insert(projectWorkspaces).values({
+      id: otherProjectWorkspaceId,
+      companyId,
+      projectId,
+      name: "other",
+      sourceType: "local_path",
+      isPrimary: false,
+    });
+    await ctx.db.insert(issues).values({
+      id: otherBoundIssueId,
+      companyId,
+      projectId,
+      projectWorkspaceId: otherProjectWorkspaceId,
+      title: "Other bound issue",
+      status: "todo",
+      priority: "medium",
+    });
+
+    return {
+      companyId,
+      projectId,
+      projectWorkspaceId,
+      agentId,
+      currentIssueId,
+      otherBoundIssueId,
+      otherProjectWorkspaceId,
+    };
+  }
+
+  type Seeded = Awaited<ReturnType<typeof seed>>;
+
+  /**
+   * `contextSnapshot` intentionally carries only `issueId` — no
+   * `executionWorkspaceId` — mirroring a run early in its lifecycle, before
+   * (or without) whatever later step in the dispatch flow might populate
+   * that field. This is the shape `resolveRunIssueWorkspaceInheritanceSource`
+   * silently refused to act on before this fix.
+   */
+  async function seedRun(seeded: Seeded, contextSnapshot: Record<string, unknown>) {
+    const runId = randomUUID();
+    await ctx.db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId: seeded.companyId,
+      agentId: seeded.agentId,
+      status: "running",
+      contextSnapshot,
+    });
+    return runId;
+  }
+
+  function postIssue(seeded: Seeded, runId: string, body: Record<string, unknown>) {
+    return request(agentActorApp(ctx.db))
+      .post(`/api/companies/${seeded.companyId}/issues`)
+      .set("x-test-agent-id", seeded.agentId)
+      .set("x-test-company-id", seeded.companyId)
+      .set("x-test-run-id", runId)
+      .send({ title: "Self-raised independent check", status: "todo", priority: "medium", ...body });
+  }
+
+  it("inherits projectId/projectWorkspaceId from the run's own issue when parentId is omitted", async () => {
+    const seeded = await seed();
+    const runId = await seedRun(seeded, { issueId: seeded.currentIssueId });
+
+    const res = await postIssue(seeded, runId, {});
+
+    expect(res.status).toBe(201);
+    expect(res.body.projectId).toBe(seeded.projectId);
+    expect(res.body.projectWorkspaceId).toBe(seeded.projectWorkspaceId);
+  });
+
+  it("inherits projectId/projectWorkspaceId when the caller sends an explicit parentId: null", async () => {
+    const seeded = await seed();
+    const runId = await seedRun(seeded, { issueId: seeded.currentIssueId });
+
+    const res = await postIssue(seeded, runId, { parentId: null });
+
+    expect(res.status).toBe(201);
+    expect(res.body.projectId).toBe(seeded.projectId);
+    expect(res.body.projectWorkspaceId).toBe(seeded.projectWorkspaceId);
+  });
+
+  it("still inherits when the run's context snapshot has no executionWorkspaceId at all", async () => {
+    const seeded = await seed();
+    // No `executionWorkspaceId` key whatsoever — the exact shape that made
+    // the old `!readNonEmptyString(context.executionWorkspaceId)` gate return
+    // null unconditionally.
+    const runId = await seedRun(seeded, { issueId: seeded.currentIssueId, taskId: "some-task" });
+
+    const res = await postIssue(seeded, runId, {});
+
+    expect(res.status).toBe(201);
+    expect(res.body.projectWorkspaceId).toBe(seeded.projectWorkspaceId);
+  });
+
+  it("does not fabricate a binding when the run's own issue has no project", async () => {
+    const seeded = await seed();
+    const unboundIssueId = randomUUID();
+    await ctx.db.insert(issues).values({
+      id: unboundIssueId,
+      companyId: seeded.companyId,
+      title: "Unbound current issue",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: seeded.agentId,
+    });
+    const runId = await seedRun(seeded, { issueId: unboundIssueId });
+
+    const res = await postIssue(seeded, runId, {});
+
+    expect(res.status).toBe(201);
+    expect(res.body.projectId).toBeNull();
+    expect(res.body.projectWorkspaceId).toBeNull();
+  });
+
+  it("still prefers an explicit parentId naming a different issue over the run's own binding", async () => {
+    const seeded = await seed();
+    const runId = await seedRun(seeded, { issueId: seeded.currentIssueId });
+
+    const res = await postIssue(seeded, runId, { parentId: seeded.otherBoundIssueId });
+
+    expect(res.status).toBe(201);
+    expect(res.body.projectWorkspaceId).toBe(seeded.otherProjectWorkspaceId);
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -3058,12 +3058,19 @@ export function issueRoutes(
   }
 
   function hasExplicitIssueWorkspaceCreateSelection(input: Record<string, unknown>) {
-    return input.parentId !== undefined ||
-      input.inheritExecutionWorkspaceFromIssueId !== undefined ||
-      input.projectWorkspaceId !== undefined ||
-      input.executionWorkspaceId !== undefined ||
-      input.executionWorkspacePreference !== undefined ||
-      input.executionWorkspaceSettings !== undefined;
+    // `!= null` (not `!== undefined`) on purpose: a caller that explicitly sends
+    // `parentId: null` — a normal, idiomatic way for a JSON API client to say
+    // "no parent" — must not be treated the same as a caller who actually named
+    // a parent or workspace. Treating an explicit null the same as an explicit
+    // value used to skip run-scoped workspace inheritance below even though the
+    // request carried no real workspace selection at all, silently leaving the
+    // created issue unbound from the creating run's project workspace.
+    return input.parentId != null ||
+      input.inheritExecutionWorkspaceFromIssueId != null ||
+      input.projectWorkspaceId != null ||
+      input.executionWorkspaceId != null ||
+      input.executionWorkspacePreference != null ||
+      input.executionWorkspaceSettings != null;
   }
 
   async function resolveRunIssueWorkspaceInheritanceSource(
@@ -3086,7 +3093,21 @@ export function issueRoutes(
     const context = run.contextSnapshot && typeof run.contextSnapshot === "object"
       ? run.contextSnapshot as Record<string, unknown>
       : null;
-    if (!context || !readNonEmptyString(context.executionWorkspaceId)) return null;
+    // Previously this also required `context.executionWorkspaceId` to be a
+    // non-empty string before treating the run as having a workspace to
+    // inherit. That field is written onto the run's context snapshot by the
+    // heartbeat dispatch's own workspace-provisioning step, at a point in the
+    // run lifecycle downstream of where this route can be called (an agent
+    // can create an issue from its very first turn, before that step has
+    // run), and it is not the field the shared-workspace serialize gate
+    // itself reads (that gate keys off the issue's own `projectWorkspaceId`,
+    // set separately). Gating run-scoped inheritance on it made this whole
+    // path silently inert for exactly the run shapes it exists to cover.
+    // The run's own current issue (`context.issueId`) is the correct and
+    // sufficient signal: if that issue has no project association either,
+    // `getWorkspaceInheritanceIssue` below simply finds nothing to inherit,
+    // which is the same safe no-op as returning null here.
+    if (!context) return null;
     const paperclipIssue = context.paperclipIssue && typeof context.paperclipIssue === "object"
       ? context.paperclipIssue as Record<string, unknown>
       : null;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -18258,6 +18258,36 @@ export function heartbeatService(
             "Dispatching alongside a live shared-workspace holder",
           );
         }
+      } else if (
+        effectiveExecutionWorkspaceMode === "shared_workspace" &&
+        issueRef?.projectId &&
+        !issueRef?.projectWorkspaceId
+      ) {
+        // Same shared_workspace dispatch, but the holder check above never ran:
+        // `findSharedWorkspaceHolder` is only called when `issueRef.projectWorkspaceId`
+        // is set, so an issue that belongs to a project but was never bound to
+        // that project's workspace row gets no holder lookup, no
+        // `WorkspaceBusyDeferral`, and no collision detection at all — it is
+        // dispatched into the project's shared cwd exactly as if no other run
+        // could be there. This is the "silent" failure mode: nothing above
+        // this branch would otherwise say so. Log it loudly so an operator can
+        // find and fix the missing binding before two runs collide in the same
+        // working directory.
+        logger.warn(
+          {
+            event: "shared_workspace_dispatch_missing_project_workspace_binding",
+            runId: run.id,
+            issueId: issueRef.id,
+            issueIdentifier: issueRef.identifier,
+            projectId: issueRef.projectId,
+          },
+          "Dispatching a shared_workspace-mode run whose issue has a project but no " +
+            "projectWorkspaceId bound to it; the shared-workspace holder check is " +
+            "skipped entirely for this run and it can collide with any other run " +
+            "that IS bound to this project's shared workspace, with no deferral " +
+            "and no warning until this line. Bind the issue to its project's " +
+            "workspace before dispatch to get holder tracking back.",
+        );
       }
       const workspaceManagedConfig = buildExecutionWorkspaceAdapterConfig({
         agentConfig: config,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - A project can set `executionWorkspacePolicy.sharedWorkspaceConcurrency: "serialize"` so that concurrent runs in the same shared git checkout defer to each other instead of colliding.
> - That gate only runs when the dispatching run's issue carries `projectWorkspaceId`. An agent creating an issue for itself mid-run (a follow-up or an independent check, with no `parentId` naming an already-bound issue) is supposed to inherit that binding from its own current issue through `resolveRunIssueWorkspaceInheritanceSource`.
> - Two bugs made that inheritance path silently inert for exactly the run shapes it exists to cover, so self-created issues came out unbound and later dispatched with no serialize gate at all — no deferral, no log line, no warning.
> - It needs fixing because an unbound run in a serialize-policy project can write into the same working directory as a properly-bound concurrent run, corrupting both.
> - This pull request fixes both silent-inheritance gaps and adds a warning log at the dispatch site itself for the same root cause, so the failure is diagnosable instead of silent.
> - The benefit is that self-raised agent issues get their project workspace binding back, and any issue that still ends up unbound now says so loudly at dispatch time instead of silently skipping the holder check.

## Linked Issues or Issue Description

Fixes: #12413

Related: #7384 (closed, fixed by #7970 — that PR introduced the exact two functions this PR fixes a regression in) and #3459 / #3922 (child-issue `projectId` inheritance) — both of those already appear resolved on current `master`; `issueService.create()`'s workspace-inheritance block already copies `projectId` from the inheritance source (`server/src/services/issues.ts`, the `if (issueData.projectId == null && workspaceSource.projectId)` branch), so no change needed there. Flagging in case those two are stale and can be closed, not claiming this PR fixes them.

## What Changed

- `server/src/routes/issues.ts` — `hasExplicitIssueWorkspaceCreateSelection` used `!== undefined`, which treats an explicit `parentId: null` (an ordinary way for a JSON client to say "no parent") the same as a caller naming a real parent or workspace, and skipped run-based inheritance entirely. Changed every check in that function to `!= null`.
- `server/src/routes/issues.ts` — `resolveRunIssueWorkspaceInheritanceSource` additionally required the run's `contextSnapshot.executionWorkspaceId` to already be a non-empty string. That field is written later in the dispatch flow than this route can be called from (an agent can create an issue on its very first turn), and it is not the field the shared-workspace serialize gate itself reads (that gate keys off the issue's own `projectWorkspaceId`). Removed that requirement; the run's own current issue id is the correct and sufficient signal, and `getWorkspaceInheritanceIssue` downstream already no-ops safely if that issue has no project either.
- `server/src/services/heartbeat.ts` — added the second suggested fix from #12413: a `logger.warn` at the exact dispatch site, firing when a `shared_workspace`-mode run's issue has a project but no `projectWorkspaceId`, naming the run/issue/project so an operator can find and fix the missing binding instead of it being invisible.
- Added `server/src/__tests__/issue-create-run-workspace-inheritance.test.ts` — HTTP-level regression tests (embedded Postgres, no mocks) covering both gaps plus two guard cases (no fabricated binding when the run's own issue has no project; an explicit `parentId` to a different issue still wins over run-based inheritance).

I did not change #12413's suggested fix (1) (bypassing or refusing dispatch when `projectWorkspaceId` is missing but the resolved cwd is a project workspace) — that changes runtime dispatch behavior for an existing gap this PR does not create, and is a separate, larger decision (fail dispatch vs. degrade vs. always apply the holder check) than the silent-inheritance bug and the warning this PR adds. Left it as a follow-up rather than bundling a behavior change into a bug-fix PR.

## Verification

- New test file, run in isolation: `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-create-run-workspace-inheritance.test.ts` → 5 passed.
- Confirmed the tests actually catch the regression: reverted only the two fixed functions (`git stash` on the two source files, test file kept) and reran — 3 of 5 cases fail exactly as expected (the two guard cases still pass, confirming they test the correct baseline behavior rather than the fix).
- Related suites, unmodified, still green after the fix: `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issues-parent-id-alias.test.ts src/__tests__/issues-service.test.ts src/__tests__/cross-issue-influence-limit-postgres.test.ts src/__tests__/issues-user-context.test.ts src/__tests__/issue-create-deduplication-routes.test.ts src/__tests__/issue-onboarding-first-task-routes.test.ts src/__tests__/issue-execution-policy-routes.test.ts src/__tests__/environment-selection-route-guards.test.ts src/__tests__/issue-existing-branch-validation-status.test.ts src/__tests__/issue-agent-mutation-ownership-routes.test.ts` → 141 passed, 0 failed.
- `pnpm --filter @paperclipai/server exec tsc --noEmit -p tsconfig.json` — no new errors in either touched file or the new test file (the run reports pre-existing errors in `plugin-host-services.ts` / `plugin-loader.ts` / `vendor/paperclip-runner` from a `@paperclipai/plugin-sdk` / `acpx@0.13.1` build artifact this sandbox does not have installed — present before this change, unrelated to it, confirmed with `git stash`).
- **Not run, disclosed as such:** `pnpm -r typecheck` (repo-wide; blocked by the same missing vendor build artifacts above), `pnpm test:run` (full suite), `pnpm build`, `pnpm test:e2e`. This is a two-function change plus one added log branch in a third file, with no schema or dependency changes, which bounds but does not eliminate the risk of not running the full gate locally — CI should confirm.

## Risks

- Low risk for the two `routes/issues.ts` changes: both are pure loosenings of an over-broad gate (treating `null` the same as "not present" for a set of optional fields, and dropping a requirement that isn't the actual signal needed), covered by new regression tests, with a guard test proving an explicit `parentId` to a different issue still wins over run-based inheritance (no behavior change for callers who *do* name a parent or workspace).
- The `heartbeat.ts` change is additive (a new `else if` branch that only logs); it does not alter control flow, dispatch decisions, or existing log lines in the `if` branch it sits beside.
- Widest blast radius: `hasExplicitIssueWorkspaceCreateSelection` gates the general issue-create route (`POST /companies/:companyId/issues`), which is high-traffic. The change only affects requests that send one of its fields as an explicit `null` — a narrow, previously-mishandled case — not the common "field omitted entirely" or "field set to a real value" paths, both of which are unchanged and covered by the existing `issues-parent-id-alias` and `issues-service` suites (still green).

## Model Used

Claude (Anthropic), model id `claude-sonnet-5`, standard reasoning mode (no extended/chain-of-thought toggle exposed to this session), used for the full investigation (root-cause tracing through `routes/issues.ts` and `heartbeat.ts`), the fix, and the regression test.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (no user-facing docs describe this internal inheritance mechanism; none found to update)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (not yet run — awaiting CI; repo-wide typecheck/build blocked locally by a pre-existing vendor build gap, disclosed above)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (awaiting automated review)
- [x] I will address all Greptile and reviewer comments before requesting merge
