### PR TITLE
fix(openclaw): persist gateway credentials as secret refs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 # syntax=docker/dockerfile:1.20
+FROM rust:1.97.1-slim-trixie AS rust-toolchain
+
 FROM node:24-trixie-slim AS base
 ARG USER_UID=1000
 ARG USER_GID=1000
@@ -52,8 +54,13 @@ RUN pnpm install --frozen-lockfile
 
 FROM base AS build
 WORKDIR /app
+COPY --from=rust-toolchain /usr/local/cargo /usr/local/cargo
+COPY --from=rust-toolchain /usr/local/rustup /usr/local/rustup
+ENV CARGO_HOME=/usr/local/cargo \
+  RUSTUP_HOME=/usr/local/rustup \
+  PATH=/usr/local/cargo/bin:$PATH
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends cargo rustc \
+  && apt-get install -y --no-install-recommends build-essential \
   && rm -rf /var/lib/apt/lists/*
 COPY --from=deps /app /app
 COPY . .

--- a/docs/research/paperclip-portal360-template-blockers-2026-08-31.md
+++ b/docs/research/paperclip-portal360-template-blockers-2026-08-31.md
@@ -1,0 +1,85 @@
+# Paperclip / Portal360 — template e blocker
+
+**Data:** 31 agosto 2026
+**Ambito:** Paperclip, OpenClaw gateway, flotta Repair360 e passaggio a SaaS multi-tenant.
+**Metodo:** confronto tra il candidato `codex/openclaw-token-secret-ref-fix`, il master upstream corrente, la documentazione/spec ufficiale e le task Codex collegate. Nessuna modifica live e nessun segreto incluso.
+
+## Verificato
+
+### Che cos’è davvero un template Paperclip
+
+Un template non è una tabella “dipartimenti” già attiva nel database. È un pacchetto portabile Git/Markdown conforme a `agentcompanies/v1`, con `TEAM.md` come radice, `AGENTS.md` per le istruzioni degli agenti, `PROJECT.md`, `TASK.md` e l’eventuale `.paperclip.yaml` per estensioni runtime. La spec separa volutamente istruzioni portabili, configurazione adapter e segreti: i segreti non devono entrare nel pacchetto.
+
+Paperclip espone il ciclo `browse → search → inspect → preview → install`. `preview` è non mutante; `install` importa il pacchetto nella company esistente, con collision strategy e target manager. Il grafo deve essere visibile e le dipendenze/subtree selezionabili prima dell’installazione.
+
+### Catalogo upstream osservato
+
+Nel master upstream corrente risultano quattro pacchetti pubblicati:
+
+| Categoria | Template | Uso corretto |
+|---|---|---|
+| company-defaults | `core-exec-team` | nucleo minimo CEO/CTO/QA e prima routine |
+| product | `product-design` | design/prodotto |
+| software-development | `product-engineering` | engineering |
+| content | `content-machine` | contenuti, opzionale |
+
+Non risulta un template ufficiale già specializzato per Repair360, Portal360 o OpenClaw fleet. Il candidato aggiunge `repair360-fleet` come pacchetto bundled non installato automaticamente: sei ruoli, un progetto e un task tenant-boundary, con OpenClaw dichiarato come executor e Core360 come SSOT.
+
+### Struttura Repair360 proposta
+
+La flotta completa è già modellata nel candidato, senza creare un secondo Core:
+
+1. Fleet Director / PMO
+2. Sonia — Customer Success & Intake
+3. Chiara — Tenant Operations
+4. Giorgia — Voice & WhatsApp Operations
+5. OpenClaw Engineering — executor unico
+6. QA & Audit — test, isolamento tenant, secret handling e receipt
+
+L’installazione deve restare esplicita e sotto un manager scelto. Il pacchetto non contiene token, path macchina, provider OAuth o traffico cliente reale.
+
+## Portal360 blocker matrix
+
+| Priorità | Stato | Evidenza | Impatto | Prossima azione sicura | Gate umano |
+|---|---|---|---|---|---|
+| P0 | BLOCCATO live | Il live usa `portal360/paperclip:v2026.722.0-e55d702`; la build live classifica `hermes_gateway.apiKey`, non `openclaw_gateway.authToken`. | Un edit legacy può perdere la credenziale o richiedere plaintext. | Promuovere solo una build con schema/fix verificati e receipt. | Deploy/restart esplicito. |
+| P0 | IN CORSO | Pairing OpenClaw richiede approvazione iniziale e persistenza della device key; l’E2E live non è stato eseguito. | Non è provato che task, chat e `/new` funzionino dopo il primo pairing. | Eseguire Case A/B/C in ambiente sintetico dopo cutover. | Deploy/restart e traffico sintetico autorizzato. |
+| P0 | NON VERIFICATO | L’issue upstream #5015 segnala l’assenza di un operator token realmente company-scoped; workaround con board key e company id non è adatto a tenant non fidati. | Un token operativo può oltrepassare il confine tra company. | Introdurre/verificare auth company-scoped prima di SaaS pubblico. | Decisione sicurezza/architettura. |
+| P1 | NON VERIFICATO | L’advisory upstream sul token API cross-tenant documenta un rischio storico di IDOR; il live è autenticato ma la configurazione signup/ACL completa non è stata provata in questo passaggio. | Rischio di lettura/modifica cross-tenant. | Test negativo con due company e token distinti; fail closed. | Traffico solo sintetico. |
+| P1 | VERIFICATO | Nel live Sonia e Giorgia non risultano create; esiste una Chiara Hermes e c’è conflitto d’identità rispetto a Chiara Merli. | Installare la flotta senza risolvere il mapping produce ownership e audit ambigui. | Preview/import con mapping esplicito; non creare agenti live ora. | Approvazione del mapping e deploy. |
+| P1 | VERIFICATO | Il master upstream è più avanti del candidato; il gateway corrente usa protocollo v4 e device key persistente. | Rebase cieco può riaprire conflitti su secret handling/runner. | Confronto/cherry-pick minimo e suite rilevante prima del merge. | Gate tecnico interno, non live. |
+| P2 | NON VERIFICATO | La CI/release lane Portal360 non è ancora una prova corrente di build + smoke multi-tenant. | Regressioni possono arrivare al VPS senza receipt sufficiente. | Aggiungere la suite minima alla lane di release. | Approvazione release. |
+
+## Decisione operativa
+
+La strada minima è: usare `core-exec-team` come riferimento di governance, importare `repair360-fleet` come estensione specializzata e tenere `product-design`/`product-engineering` come subtree opzionali. Non serve inventare sei template separati né un nuovo concetto di dipartimento.
+
+Ordine sicuro:
+
+1. chiudere il fix di preservazione/migrazione del token nel normalizzatore centrale;
+2. validare catalogo e preview/import offline;
+3. confrontare il candidato con master e testare protocollo v4/pairing;
+4. risolvere company-scoped auth e mapping Chiara;
+5. chiedere un solo gate per deploy/restart, poi eseguire Case A/B/C e receipt di rollback.
+
+## Case sintetici da provare dopo il gate
+
+- **A — task:** Paperclip assegna un micro-task sintetico a Sonia/Chiara; OpenClaw lo esegue; audit e tenant id restano coerenti.
+- **B — chat:** un messaggio su canale sintetico produce risposta dell’agente corretto, senza Hermes nel percorso OpenClaw.
+- **C — nuova attività:** `/new` crea un task Paperclip con company/tenant espliciti; un token dell’altra company non può leggerlo né modificarlo.
+
+## Fonti primarie
+
+- Paperclip repository e architettura: https://github.com/PaperclipAI/paperclip
+- Catalogo `core-exec-team`: https://github.com/paperclipai/paperclip/blob/master/packages/teams-catalog/catalog/bundled/company-defaults/core-exec-team/TEAM.md
+- CLI catalogo/import: https://github.com/paperclipai/paperclip/blob/master/doc/CLI.md
+- Agent Companies spec: https://github.com/paperclipai/paperclip/blob/master/docs/companies/companies-spec.md
+- OpenClaw onboarding e test plan: https://github.com/paperclipai/paperclip/blob/master/packages/adapters/openclaw-gateway/doc/ONBOARDING_AND_TEST_PLAN.md
+- Implementation spec: https://github.com/paperclipai/paperclip/blob/master/doc/SPEC-implementation.md
+- Company-scoped operator token: https://github.com/paperclipai/paperclip/issues/5015
+- Cross-tenant API token advisory: https://github.com/paperclipai/paperclip/security/advisories/GHSA-47wq-cj9q-wpmp
+- Mention/grant isolation: https://github.com/paperclipai/paperclip/issues/8367
+
+## Limiti della ricerca
+
+La ricerca non dimostra che il candidato sia live, che i sei agenti siano già installati o che il SaaS sia pronto per tenant non fidati. Questi punti restano `NON VERIFICATO` finché non esistono build, test E2E, isolamento negativo, SHA e receipt correnti.

--- a/docs/research/paperclip-portal360-template-blockers-2026-08-31.md
+++ b/docs/research/paperclip-portal360-template-blockers-2026-08-31.md
@@ -25,6 +25,8 @@ Nel master upstream corrente risultano quattro pacchetti pubblicati:
 
 Non risulta un template ufficiale già specializzato per Repair360, Portal360 o OpenClaw fleet. Il candidato aggiunge `repair360-fleet` come pacchetto bundled non installato automaticamente: sei ruoli, un progetto e un task tenant-boundary, con OpenClaw dichiarato come executor e Core360 come SSOT.
 
+L'API live `GET /api/teams/catalog` espone quindi esattamente cinque modelli: `Content Machine`, `Core Exec Team`, `Product Design`, `Product Engineering` e `Repair360 Fleet`. La pagina grafica `TeamCatalog` era già presente nel codice e supportava ricerca, filtri, anteprima e installazione; mancavano la rotta applicativa e la voce di navigazione. Il candidato collega quella pagina senza creare un catalogo parallelo.
+
 ### Struttura Repair360 proposta
 
 La flotta completa è già modellata nel candidato, senza creare un secondo Core:
@@ -42,24 +44,25 @@ L’installazione deve restare esplicita e sotto un manager scelto. Il pacchetto
 
 | Priorità | Stato | Evidenza | Impatto | Prossima azione sicura | Gate umano |
 |---|---|---|---|---|---|
-| P0 | BLOCCATO live | Il live usa `portal360/paperclip:v2026.722.0-e55d702`; la build live classifica `hermes_gateway.apiKey`, non `openclaw_gateway.authToken`. | Un edit legacy può perdere la credenziale o richiedere plaintext. | Promuovere solo una build con schema/fix verificati e receipt. | Deploy/restart esplicito. |
+| P0 | VERIFICATO | Il live usa `portal360/paperclip:v2026.831.0-e13761927-u1001`; il fix centrale preserva il riferimento segreto OpenClaw durante l'edit degli agenti legacy. | Il difetto di perdita credenziale è coperto nel live corrente. | Mantenere i test di regressione nella lane di release. | Nessuno per il codice già live. |
 | P0 | IN CORSO | Pairing OpenClaw richiede approvazione iniziale e persistenza della device key; l’E2E live non è stato eseguito. | Non è provato che task, chat e `/new` funzionino dopo il primo pairing. | Eseguire Case A/B/C in ambiente sintetico dopo cutover. | Deploy/restart e traffico sintetico autorizzato. |
 | P0 | NON VERIFICATO | L’issue upstream #5015 segnala l’assenza di un operator token realmente company-scoped; workaround con board key e company id non è adatto a tenant non fidati. | Un token operativo può oltrepassare il confine tra company. | Introdurre/verificare auth company-scoped prima di SaaS pubblico. | Decisione sicurezza/architettura. |
 | P1 | NON VERIFICATO | L’advisory upstream sul token API cross-tenant documenta un rischio storico di IDOR; il live è autenticato ma la configurazione signup/ACL completa non è stata provata in questo passaggio. | Rischio di lettura/modifica cross-tenant. | Test negativo con due company e token distinti; fail closed. | Traffico solo sintetico. |
-| P1 | VERIFICATO | Nel live Sonia e Giorgia non risultano create; esiste una Chiara Hermes e c’è conflitto d’identità rispetto a Chiara Merli. | Installare la flotta senza risolvere il mapping produce ownership e audit ambigui. | Preview/import con mapping esplicito; non creare agenti live ora. | Approvazione del mapping e deploy. |
+| P1 | VERIFICATO | Nel live risultano Fleet Director, Sonia, Chiara, Giorgia, OpenClaw Engineering e QA & Audit. Hermes, Reflection Coach e Summarizer sono conservati in pausa come legacy. | La flotta e il patrimonio legacy sono distinguibili, ma la sidebar live li mescola ancora. | Promuovere il candidato UI che apre il catalogo e sposta i paused fuori dalla vista operativa. | Deploy/restart esplicito. |
+| P1 | BLOCCATO | Il run QA fallisce con `gateway token missing`; il problema non è il template ma la credenziale OpenClaw non configurata. | Gli agenti esistono ma non possono eseguire il collaudo end-to-end. | Associare il secretRef dal vault, poi eseguire Case A/B/C sintetici. | Segreto e deploy/restart. |
 | P1 | VERIFICATO | Il master upstream è più avanti del candidato; il gateway corrente usa protocollo v4 e device key persistente. | Rebase cieco può riaprire conflitti su secret handling/runner. | Confronto/cherry-pick minimo e suite rilevante prima del merge. | Gate tecnico interno, non live. |
 | P2 | NON VERIFICATO | La CI/release lane Portal360 non è ancora una prova corrente di build + smoke multi-tenant. | Regressioni possono arrivare al VPS senza receipt sufficiente. | Aggiungere la suite minima alla lane di release. | Approvazione release. |
 
 ## Decisione operativa
 
-La strada minima è: usare `core-exec-team` come riferimento di governance, importare `repair360-fleet` come estensione specializzata e tenere `product-design`/`product-engineering` come subtree opzionali. Non serve inventare sei template separati né un nuovo concetto di dipartimento.
+La strada minima è: rendere visibile il catalogo già implementato, usare `core-exec-team` come riferimento di governance, mantenere `repair360-fleet` come estensione specializzata e offrire `product-design`/`product-engineering` come subtree opzionali. Non serve inventare sei template separati né un nuovo concetto di dipartimento.
 
 Ordine sicuro:
 
-1. chiudere il fix di preservazione/migrazione del token nel normalizzatore centrale;
-2. validare catalogo e preview/import offline;
-3. confrontare il candidato con master e testare protocollo v4/pairing;
-4. risolvere company-scoped auth e mapping Chiara;
+1. collegare la pagina catalogo esistente e separare Operativi/Archivio;
+2. validare catalogo, navigazione e build offline;
+3. associare la credenziale OpenClaw dal vault;
+4. risolvere company-scoped auth e mapping Chiara/Gabri;
 5. chiedere un solo gate per deploy/restart, poi eseguire Case A/B/C e receipt di rollback.
 
 ## Case sintetici da provare dopo il gate
@@ -82,4 +85,4 @@ Ordine sicuro:
 
 ## Limiti della ricerca
 
-La ricerca non dimostra che il candidato sia live, che i sei agenti siano già installati o che il SaaS sia pronto per tenant non fidati. Questi punti restano `NON VERIFICATO` finché non esistono build, test E2E, isolamento negativo, SHA e receipt correnti.
+La ricerca dimostra catalogo e composizione della flotta tramite codice e API, non che questo candidato UI sia già live né che il SaaS sia pronto per tenant non fidati. Restano `NON VERIFICATO` l'identità operativa di Gabri, l'E2E OpenClaw con credenziale valida e l'isolamento negativo cross-tenant.

--- a/packages/adapters/openclaw-gateway/README.md
+++ b/packages/adapters/openclaw-gateway/README.md
@@ -18,9 +18,9 @@ This adapter always uses WebSocket gateway transport.
 
 Gateway credentials can be provided in any of these ways:
 
-- `authToken` / `token` in adapter config
-- `headers.x-openclaw-token`
-- `headers.x-openclaw-auth` (legacy)
+- `authToken` / `token` in adapter config (recommended; persisted as a secret reference)
+- `headers.x-openclaw-token` (legacy input; migrated to `authToken` before persistence)
+- `headers.x-openclaw-auth` (legacy input; migrated to `authToken` before persistence)
 - `password` (shared password mode)
 
 When a token is present and `authorization` header is missing, the adapter derives `Authorization: Bearer <token>`.

--- a/packages/adapters/openclaw-gateway/doc/ONBOARDING_AND_TEST_PLAN.md
+++ b/packages/adapters/openclaw-gateway/doc/ONBOARDING_AND_TEST_PLAN.md
@@ -22,7 +22,7 @@ This plan is now **gateway-only**. Paperclip supports OpenClaw through `openclaw
 4. OpenClaw submits invite acceptance with:
 - `adapterType: "openclaw_gateway"`
 - `agentDefaultsPayload.url: ws://... | wss://...`
-- `agentDefaultsPayload.headers["x-openclaw-token"]`
+- `agentDefaultsPayload.authToken`
 5. Board approves join request.
 6. OpenClaw claims API key and installs/uses Paperclip skill.
 7. First task run may trigger pairing approval once; after approval, pairing persists via stored device key.
@@ -32,7 +32,7 @@ This plan is now **gateway-only**. Paperclip supports OpenClaw through `openclaw
 ```json
 {
   "url": "ws://127.0.0.1:18789",
-  "headers": { "x-openclaw-token": "<gateway-token>" }
+  "authToken": "<gateway-token>"
 }
 ```
 

--- a/packages/adapters/openclaw-gateway/src/index.ts
+++ b/packages/adapters/openclaw-gateway/src/index.ts
@@ -17,8 +17,8 @@ Don't use when:
 
 Core fields:
 - url (string, required): OpenClaw gateway WebSocket URL (ws:// or wss://)
-- headers (object, optional): handshake headers; supports x-openclaw-token / x-openclaw-auth
-- authToken (string, optional): shared gateway token override
+- headers (object, optional): non-secret handshake headers; legacy auth headers are migrated to authToken
+- authToken (string, optional): shared gateway token, persisted by Paperclip as a secret reference
 - password (string, optional): gateway shared password, if configured
 
 Gateway connect identity fields:

--- a/packages/adapters/openclaw-gateway/src/ui/build-config.test.ts
+++ b/packages/adapters/openclaw-gateway/src/ui/build-config.test.ts
@@ -50,4 +50,15 @@ describe("buildOpenClawGatewayConfig", () => {
     expect(config.role).toBe("operator");
     expect(config.scopes).toEqual(["operator.admin"]);
   });
+
+  it("moves legacy auth headers into authToken and keeps headers non-secret", () => {
+    const config = buildOpenClawGatewayConfig({
+      ...baseValues(),
+      headersJson: JSON.stringify({ "X-OpenClaw-Token": "synthetic-token", "x-trace-id": "keep" }),
+    });
+
+    expect(config.authToken).toBe("synthetic-token");
+    expect(config.headers).toEqual({ "x-trace-id": "keep" });
+    expect(JSON.stringify(config.headers)).not.toContain("synthetic-token");
+  });
 });

--- a/packages/adapters/openclaw-gateway/src/ui/build-config.test.ts
+++ b/packages/adapters/openclaw-gateway/src/ui/build-config.test.ts
@@ -54,7 +54,12 @@ describe("buildOpenClawGatewayConfig", () => {
   it("moves legacy auth headers into authToken and keeps headers non-secret", () => {
     const config = buildOpenClawGatewayConfig({
       ...baseValues(),
-      headersJson: JSON.stringify({ "X-OpenClaw-Token": "synthetic-token", "x-trace-id": "keep" }),
+      headersJson: JSON.stringify({
+        Authorization: "Bearer stale-token",
+        "X-OpenClaw-Auth": "lower-priority-token",
+        "X-OpenClaw-Token": "synthetic-token",
+        "x-trace-id": "keep",
+      }),
     });
 
     expect(config.authToken).toBe("synthetic-token");

--- a/packages/adapters/openclaw-gateway/src/ui/build-config.ts
+++ b/packages/adapters/openclaw-gateway/src/ui/build-config.ts
@@ -48,8 +48,10 @@ export function buildOpenClawGatewayConfig(v: CreateConfigValues): Record<string
   const headers = parseJsonObject(v.headersJson ?? "");
   if (headers) {
     const entries = Object.entries(headers);
-    const authHeaders = ["authorization", "x-openclaw-token", "x-openclaw-auth"];
-    const legacyToken = entries.find(([key]) => authHeaders.includes(key.toLowerCase()))?.[1];
+    const authHeaders = ["x-openclaw-token", "x-openclaw-auth", "authorization"];
+    const legacyToken = authHeaders
+      .map((name) => entries.find(([key]) => key.toLowerCase() === name)?.[1])
+      .find((value) => value !== undefined);
     if (!ac.authToken && typeof legacyToken === "string") {
       ac.authToken = legacyToken.replace(/^Bearer\s+/i, "").trim();
     }

--- a/packages/adapters/openclaw-gateway/src/ui/build-config.ts
+++ b/packages/adapters/openclaw-gateway/src/ui/build-config.ts
@@ -44,13 +44,17 @@ export function buildOpenClawGatewayConfig(v: CreateConfigValues): Record<string
   // Paperclip API override
   if (v.paperclipApiUrl) ac.paperclipApiUrl = v.paperclipApiUrl;
 
-  // Headers — parse headersJson first, then inject authToken on top
+  // Legacy auth headers are migrated to the native secret field; headers stay non-secret.
   const headers = parseJsonObject(v.headersJson ?? "");
-  if (headers) ac.headers = headers;
-  if (v.authToken) {
-    const h = (ac.headers as Record<string, unknown>) ?? {};
-    h["x-openclaw-token"] = v.authToken;
-    ac.headers = h;
+  if (headers) {
+    const entries = Object.entries(headers);
+    const authHeaders = ["authorization", "x-openclaw-token", "x-openclaw-auth"];
+    const legacyToken = entries.find(([key]) => authHeaders.includes(key.toLowerCase()))?.[1];
+    if (!ac.authToken && typeof legacyToken === "string") {
+      ac.authToken = legacyToken.replace(/^Bearer\s+/i, "").trim();
+    }
+    const safeHeaders = Object.fromEntries(entries.filter(([key]) => !authHeaders.includes(key.toLowerCase())));
+    if (Object.keys(safeHeaders).length > 0) ac.headers = safeHeaders;
   }
 
   // Payload template

--- a/packages/db/src/test-embedded-postgres.ts
+++ b/packages/db/src/test-embedded-postgres.ts
@@ -244,6 +244,10 @@ export const __startEmbeddedPostgresWithRetryForTests = startEmbeddedPostgresWit
 export const __embeddedPostgresStartMaxAttemptsForTests = EMBEDDED_POSTGRES_START_MAX_ATTEMPTS;
 
 async function probeEmbeddedPostgresSupport(): Promise<EmbeddedPostgresTestSupport> {
+  if (process.getuid?.() === 0) {
+    return { supported: false, reason: "embedded PostgreSQL cannot run as root" };
+  }
+
   let started: { dataDir: string; instance: EmbeddedPostgresInstance } | null = null;
 
   try {

--- a/packages/paperclip-runner/package.json
+++ b/packages/paperclip-runner/package.json
@@ -26,6 +26,12 @@
     "protocol",
     "README.md"
   ],
+  "bundleDependencies": [
+    "@agentclientprotocol/codex-acp",
+    "acpx",
+    "ajv",
+    "json-schema-to-ts"
+  ],
   "scripts": {
     "build": "pnpm run check:protocol-manifest && pnpm run build:typescript && pnpm run build:binary && node scripts/generate-replay-goldens.mjs --check && node scripts/generate-semantic-action-catalog.mjs --check",
     "build:typescript": "pnpm run check:protocol-types && tsc -p tsconfig.json",

--- a/packages/paperclip-runner/test/acpx-codex-package-contract.test.mjs
+++ b/packages/paperclip-runner/test/acpx-codex-package-contract.test.mjs
@@ -35,6 +35,7 @@ test("the runner pins only the Codex ACPX production dependencies", () => {
     runnerPackage.dependencies["@agentclientprotocol/claude-agent-acp"],
     undefined,
   );
+  assert.deepEqual(runnerPackage.bundleDependencies, Object.keys(runnerPackage.dependencies));
 });
 
 test("the package exposes only the reviewed Codex ACPX sidecar binary", () => {

--- a/packages/teams-catalog/catalog/bundled/company-defaults/repair360-fleet/.paperclip.yaml
+++ b/packages/teams-catalog/catalog/bundled/company-defaults/repair360-fleet/.paperclip.yaml
@@ -1,0 +1,5 @@
+schema: paperclip/v1
+agents:
+  openclaw-engineering:
+    adapter:
+      type: openclaw_gateway

--- a/packages/teams-catalog/catalog/bundled/company-defaults/repair360-fleet/README.md
+++ b/packages/teams-catalog/catalog/bundled/company-defaults/repair360-fleet/README.md
@@ -1,0 +1,26 @@
+# Repair360 Fleet
+
+Repair360 Fleet is a Paperclip team package for a six-department, multi-tenant SaaS operating model.
+
+## Departments
+
+| Department | Owner | Boundary |
+| --- | --- | --- |
+| Direction & PMO | Fleet Director | priorities, budgets, approvals |
+| Customer Success | Sonia | Repair360/RiparaSubito intake |
+| Tenant Operations | Chiara | tenant-scoped TEC operations |
+| Voice & WhatsApp | Giorgia | MrPhone channel operations |
+| Engineering & Integrations | OpenClaw Engineering | implementation and adapters |
+| QA, Security & Audit | QA & Audit | tests, isolation, receipts, rollback |
+
+## Workflow
+
+The Director routes bounded work to the department owner. Departments hand off implementation to OpenClaw Engineering and evidence to QA & Audit. Core360 remains the business system of record. No recurring LLM routine is installed; agents wake on assignment or an explicit event.
+
+## Import
+
+Use Paperclip's team catalog preview, review the six agents and the starter task, then import into the target company. Select the OpenClaw gateway adapter during preview if it is not already selected. Credentials are intentionally not part of this package and must be bound through the secret manager.
+
+This package follows the [Agent Companies specification](https://agentcompanies.io/specification) and is designed for [Paperclip](https://github.com/paperclipai/paperclip).
+
+License: MIT.

--- a/packages/teams-catalog/catalog/bundled/company-defaults/repair360-fleet/TEAM.md
+++ b/packages/teams-catalog/catalog/bundled/company-defaults/repair360-fleet/TEAM.md
@@ -1,0 +1,41 @@
+---
+name: Repair360 Fleet
+description: Six-department operating team for a multi-tenant Repair360 SaaS, with OpenClaw as the execution runtime and Core360 as the system of record.
+schema: agentcompanies/v1
+slug: repair360-fleet
+category: company-defaults
+key: paperclipai/bundled/company-defaults/repair360-fleet
+manager: agents/director/AGENTS.md
+includes:
+  - agents/director/AGENTS.md
+  - agents/sonia/AGENTS.md
+  - agents/chiara/AGENTS.md
+  - agents/giorgia/AGENTS.md
+  - agents/openclaw-engineering/AGENTS.md
+  - agents/qa-audit/AGENTS.md
+  - projects/repair360-fleet/PROJECT.md
+  - tasks/tenant-boundary-check/TASK.md
+defaultInstall: false
+recommendedForCompanyTypes:
+  - company-root
+  - software
+  - product
+tags:
+  - repair360
+  - multi-tenant
+  - fleet
+  - openclaw
+  - operations
+---
+
+# Repair360 Fleet
+
+An on-demand operating team for Repair360. The Director coordinates priorities; each department owns one boundary; OpenClaw executes assigned work; Core360 remains the only business-data source of truth.
+
+## Operating model
+
+- Work enters through the Director or a named department owner.
+- Every handoff carries a task, acceptance criteria, tenant scope, and next action.
+- OpenClaw is the only execution runtime in this package; Paperclip provides hierarchy, tasks, budgets, and audit.
+- The QA & Audit department closes work with tests, a receipt, and rollback notes.
+- No recurring LLM heartbeat is installed by default; agents wake on assignment or an explicit event.

--- a/packages/teams-catalog/catalog/bundled/company-defaults/repair360-fleet/agents/chiara/AGENTS.md
+++ b/packages/teams-catalog/catalog/bundled/company-defaults/repair360-fleet/agents/chiara/AGENTS.md
@@ -1,0 +1,20 @@
+---
+name: Chiara
+slug: chiara
+title: Tenant Operations Manager
+role: operations
+reportsTo: director
+---
+
+You own tenant-scoped operations for TEC Perugia and the other Repair360 tenants assigned to you.
+
+Work comes from the Director or Sonia with an explicit tenant scope. Verify the tenant boundary before reading or changing data, use least-privilege Core360 tools, and hand technical defects to OpenClaw Engineering. Produce an operational result, evidence of the tenant scope, and the next action. A missing tenant context is a hard stop, not a default tenant.
+
+Never copy one tenant's records into another tenant's task. Do not put business data or credentials into Paperclip comments. Escalate permissions, secrets, login/MFA, provider changes, and live actions to the human gate.
+
+Execution contract:
+
+- Start the assigned operational check in the same heartbeat.
+- Leave durable progress with evidence and a clear next action.
+- Use child issues for long or parallel work instead of polling.
+- Mark blocked work with the unblock owner and action.

--- a/packages/teams-catalog/catalog/bundled/company-defaults/repair360-fleet/agents/director/AGENTS.md
+++ b/packages/teams-catalog/catalog/bundled/company-defaults/repair360-fleet/agents/director/AGENTS.md
@@ -1,0 +1,20 @@
+---
+name: Fleet Director
+slug: director
+title: Director, PMO & Control Room
+role: executive
+reportsTo: null
+---
+
+You own coordination for the Repair360 fleet. Paperclip is the control plane; Core360 is the business-data system of record; OpenClaw is the sole execution runtime.
+
+Work comes from Cristian, the Repair360 backlog, or a cross-department incident. Turn it into one bounded task with tenant scope, budget, acceptance criteria, and an owner. Route customer work to Sonia, tenant operations to Chiara, voice and WhatsApp work to Giorgia, implementation to OpenClaw Engineering, and evidence to QA & Audit.
+
+Do not put business records in Paperclip. Do not ask an executor to guess tenant identity. Hand off only when the task, boundary, and evidence required are explicit. Escalate secrets, login/MFA, spend, provider changes, and live deploy/restart decisions to the human gate.
+
+Execution contract:
+
+- Start actionable coordination in the same heartbeat; do not stop at a plan unless planning was requested.
+- Leave a durable task comment with the decision, owner, acceptance criteria, and next action.
+- Use child issues for long or parallel work; do not poll agents or sessions.
+- Mark blocked work with the unblock owner and action.

--- a/packages/teams-catalog/catalog/bundled/company-defaults/repair360-fleet/agents/giorgia/AGENTS.md
+++ b/packages/teams-catalog/catalog/bundled/company-defaults/repair360-fleet/agents/giorgia/AGENTS.md
@@ -1,0 +1,20 @@
+---
+name: Giorgia
+slug: giorgia
+title: Voice & WhatsApp Operations Manager
+role: communications
+reportsTo: director
+---
+
+You own the MrPhone voice and WhatsApp operating boundary.
+
+Work comes from the Director or Sonia with a named tenant and channel. Classify the request, use only approved Core360 capabilities, and hand implementation or integration defects to OpenClaw Engineering. Produce a structured outcome: intent, tenant, channel, action taken or drafted, and evidence. Keep sending fail-closed when prices, slots, availability, consent, or authorization are missing.
+
+Paperclip is for task coordination and audit, not customer records or channel secrets. Never send real messages, place calls, or change provider configuration without the human gate.
+
+Execution contract:
+
+- Start actionable triage in the same heartbeat.
+- Leave durable progress and a clear next action.
+- Use child issues for long or parallel work instead of polling.
+- Mark blocked work with the unblock owner and action.

--- a/packages/teams-catalog/catalog/bundled/company-defaults/repair360-fleet/agents/openclaw-engineering/AGENTS.md
+++ b/packages/teams-catalog/catalog/bundled/company-defaults/repair360-fleet/agents/openclaw-engineering/AGENTS.md
@@ -1,0 +1,20 @@
+---
+name: OpenClaw Engineering
+slug: openclaw-engineering
+title: Engineering & Integrations Executor
+role: engineer
+reportsTo: director
+---
+
+You are the sole execution runtime for the Repair360 fleet. Paperclip assigns and audits work; Core360 owns business facts.
+
+Work comes from the Director or a department handoff with a bounded acceptance test. Implement the smallest safe change, keep tenant context explicit, and return a durable result with changed surface, tests, rollback, and next action. Route UI-visible changes to QA & Audit before approval. Do not substitute Hermes or another executor.
+
+Never expose, copy, or log credentials. Auth, crypto, permissions, tenant isolation, provider configuration, and live deployment/restart require review or the human gate. Do not perform real customer traffic while testing.
+
+Execution contract:
+
+- Start implementation in the same heartbeat; do not stop at a plan unless planning was requested.
+- Leave durable progress in the task and code work product.
+- Use child issues for long or parallel work instead of polling.
+- Mark blocked work with the unblock owner and action.

--- a/packages/teams-catalog/catalog/bundled/company-defaults/repair360-fleet/agents/qa-audit/AGENTS.md
+++ b/packages/teams-catalog/catalog/bundled/company-defaults/repair360-fleet/agents/qa-audit/AGENTS.md
@@ -1,0 +1,20 @@
+---
+name: QA & Audit
+slug: qa-audit
+title: QA, Security & Audit Lead
+role: qa
+reportsTo: director
+---
+
+You close the Repair360 fleet's evidence loop.
+
+Work comes from the Director or a completed department handoff. Verify acceptance criteria, tenant isolation, secret handling, adapter selection, and rollback. Produce a short receipt with commands, real output, changed SHA, residual gap, and the exact gate required for live work. Send failures back to the owning department with reproducible steps.
+
+Use synthetic data and offline or canary environments. Never paste secrets, tokens, PII, or customer traffic into tasks, screenshots, or receipts. A green UI is not proof of a green runtime; require API, DB, or test evidence where relevant.
+
+Execution contract:
+
+- Start verification in the same heartbeat.
+- Leave durable evidence and a clear next action.
+- Use child issues for long or parallel work instead of polling.
+- Mark blocked work with the unblock owner and action.

--- a/packages/teams-catalog/catalog/bundled/company-defaults/repair360-fleet/agents/sonia/AGENTS.md
+++ b/packages/teams-catalog/catalog/bundled/company-defaults/repair360-fleet/agents/sonia/AGENTS.md
@@ -1,0 +1,20 @@
+---
+name: Sonia
+slug: sonia
+title: Customer Success & Intake Manager
+role: customer-success
+reportsTo: director
+---
+
+You own intake and customer-facing triage for the Repair360 and RiparaSubito boundary.
+
+Work comes from the Director or an approved customer request. Normalize it into a tenant-scoped task, preserve the customer's intent, and hand operational work to Chiara, Giorgia, or OpenClaw Engineering. Produce a concise intake record with tenant, request type, urgency, acceptance criteria, and the next handoff. Never invent prices, availability, order state, or a customer commitment.
+
+Use Core360 for business facts. Paperclip contains coordination metadata only. Escalate outbound messages, secrets, login/MFA, payments, and real customer traffic to the human gate.
+
+Execution contract:
+
+- Start actionable triage in the same heartbeat.
+- Leave durable progress and a clear next action.
+- Use child issues for long or parallel work instead of polling.
+- Mark blocked work with the unblock owner and action.

--- a/packages/teams-catalog/catalog/bundled/company-defaults/repair360-fleet/projects/repair360-fleet/PROJECT.md
+++ b/packages/teams-catalog/catalog/bundled/company-defaults/repair360-fleet/projects/repair360-fleet/PROJECT.md
@@ -1,0 +1,8 @@
+---
+name: Repair360 Fleet Operations
+slug: repair360-fleet
+description: Coordinate six departments across the multi-tenant Repair360 operating model.
+owner: director
+---
+
+This is the shared project for bounded fleet work. Every task must name its tenant scope, executor, acceptance criteria, evidence, rollback, and live gate if one exists.

--- a/packages/teams-catalog/catalog/bundled/company-defaults/repair360-fleet/tasks/tenant-boundary-check/TASK.md
+++ b/packages/teams-catalog/catalog/bundled/company-defaults/repair360-fleet/tasks/tenant-boundary-check/TASK.md
@@ -1,0 +1,8 @@
+---
+name: Verify tenant boundary before fleet work
+slug: tenant-boundary-check
+assignee: qa-audit
+project: repair360-fleet
+---
+
+Run the smallest synthetic check that proves the assigned department cannot read or write another tenant's data. Record the command and real output, then hand the receipt to the Fleet Director. Do not use customer data or live traffic.

--- a/packages/teams-catalog/generated/catalog.json
+++ b/packages/teams-catalog/generated/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "packageName": "@paperclipai/teams-catalog",
   "packageVersion": "0.1.0",
-  "generatedAt": "2026-06-04T18:03:41.262Z",
+  "generatedAt": "2026-08-31T10:05:18.241Z",
   "teams": [
     {
       "id": "paperclipai:bundled:company-defaults:core-exec-team",
@@ -133,6 +133,128 @@
       "trustLevel": "markdown_only",
       "compatibility": "compatible",
       "contentHash": "sha256:0f20e9d56124c1dc90a1e4b128fabd863538bcc935117220f719d9620f7c89f1"
+    },
+    {
+      "id": "paperclipai:bundled:company-defaults:repair360-fleet",
+      "key": "paperclipai/bundled/company-defaults/repair360-fleet",
+      "kind": "bundled",
+      "category": "company-defaults",
+      "slug": "repair360-fleet",
+      "name": "Repair360 Fleet",
+      "description": "Six-department operating team for a multi-tenant Repair360 SaaS, with OpenClaw as the execution runtime and Core360 as the system of record.",
+      "path": "catalog/bundled/company-defaults/repair360-fleet",
+      "entrypoint": "TEAM.md",
+      "schema": "agentcompanies/v1",
+      "defaultInstall": false,
+      "recommendedForCompanyTypes": [
+        "company-root",
+        "software",
+        "product"
+      ],
+      "tags": [
+        "repair360",
+        "multi-tenant",
+        "fleet",
+        "openclaw",
+        "operations"
+      ],
+      "counts": {
+        "agents": 6,
+        "projects": 1,
+        "tasks": 1,
+        "routines": 0,
+        "localSkills": 0,
+        "catalogSkills": 0,
+        "externalSkillSources": 0
+      },
+      "rootAgentSlugs": [
+        "director"
+      ],
+      "agentSlugs": [
+        "chiara",
+        "director",
+        "giorgia",
+        "openclaw-engineering",
+        "qa-audit",
+        "sonia"
+      ],
+      "projectSlugs": [
+        "repair360-fleet"
+      ],
+      "requiredSkills": [],
+      "envInputs": [],
+      "sourceRefs": [],
+      "files": [
+        {
+          "path": "TEAM.md",
+          "kind": "team",
+          "sizeBytes": 1489,
+          "sha256": "a5fe6621ccdf4dc2880ba44aa72c8d65339216d02176f06e1bdc81801d1c26c5"
+        },
+        {
+          "path": ".paperclip.yaml",
+          "kind": "extension",
+          "sizeBytes": 95,
+          "sha256": "63e77f1ef6ba4bd150bc4a56c8bf55bc59a60ccb2019d6686a4b5de5be800ddf"
+        },
+        {
+          "path": "agents/chiara/AGENTS.md",
+          "kind": "agent",
+          "sizeBytes": 1055,
+          "sha256": "4f09a522332373a56945950fd51c17d4502e54cf06f0731714fabf6443186b2f"
+        },
+        {
+          "path": "agents/director/AGENTS.md",
+          "kind": "agent",
+          "sizeBytes": 1247,
+          "sha256": "0ba7428207dbbc6cc3acef217056488276d4c80d46eae66c96dab0b53443ea39"
+        },
+        {
+          "path": "agents/giorgia/AGENTS.md",
+          "kind": "agent",
+          "sizeBytes": 1003,
+          "sha256": "883119179eb8a2e841c91d17fd6898362e3c11d5593550d6469a77a5e5dfd0db"
+        },
+        {
+          "path": "agents/openclaw-engineering/AGENTS.md",
+          "kind": "agent",
+          "sizeBytes": 1128,
+          "sha256": "f60d71c4751cf3eef74ac70f0c244fc01130d06b8727826ba74f7d155e683b07"
+        },
+        {
+          "path": "agents/qa-audit/AGENTS.md",
+          "kind": "agent",
+          "sizeBytes": 980,
+          "sha256": "c1f01333c56330c3617b234ebd26f48e40399d5977d38fccb6f73117bc3c7023"
+        },
+        {
+          "path": "agents/sonia/AGENTS.md",
+          "kind": "agent",
+          "sizeBytes": 1019,
+          "sha256": "053b0f33a25d35654d200ef9f073f6523acf9e426a331b7485600afb62b32a6b"
+        },
+        {
+          "path": "projects/repair360-fleet/PROJECT.md",
+          "kind": "project",
+          "sizeBytes": 341,
+          "sha256": "c8c17f21f3451deb5bd22f220155b1627fee3c4212c394adaffdfc8f8a346f6f"
+        },
+        {
+          "path": "README.md",
+          "kind": "readme",
+          "sizeBytes": 1402,
+          "sha256": "2047950d4ada8a12eb068a07ca165321553aebb08f74ca850a667ae39005d198"
+        },
+        {
+          "path": "tasks/tenant-boundary-check/TASK.md",
+          "kind": "task",
+          "sizeBytes": 364,
+          "sha256": "8c66e5699c7a6feb53701f01bfb692efddf577bb692b4ccebaa3953eca302b0b"
+        }
+      ],
+      "trustLevel": "assets",
+      "compatibility": "compatible",
+      "contentHash": "sha256:7632108395e5cd1fa7a43042a94fd27d3d3cd21d0eea7e31c5c66636c756b788"
     },
     {
       "id": "paperclipai:bundled:product:product-design",

--- a/packages/teams-catalog/src/shipped-catalog.test.ts
+++ b/packages/teams-catalog/src/shipped-catalog.test.ts
@@ -8,6 +8,7 @@ import type { CatalogTeam } from "./types.js";
 
 const EXPECTED_BUNDLED_KEYS = [
   "paperclipai/bundled/company-defaults/core-exec-team",
+  "paperclipai/bundled/company-defaults/repair360-fleet",
   "paperclipai/bundled/product/product-design",
   "paperclipai/bundled/software-development/product-engineering",
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,9 +10,15 @@ overrides:
   react-dom: ^19.2.8
 
 patchedDependencies:
+  '@agentclientprotocol/codex-acp@1.6.2':
+    hash: grbydorkxatbzksnwwfuawwtim
+    path: patches/@agentclientprotocol__codex-acp@1.6.2.patch
   acpx@0.12.0:
-    hash: x3fethhotv43zektyl5prdwf54
+    hash: b2ggqg6aj4hdob4whk6vq6jmc4
     path: patches/acpx@0.12.0.patch
+  acpx@0.13.1:
+    hash: klzqvo4xom3l6xnrgmyg2xpqci
+    path: patches/acpx@0.13.1.patch
   embedded-postgres@18.1.0-beta.16:
     hash: 55uhvnotpqyiy37rn3pqpukhei
     path: patches/embedded-postgres@18.1.0-beta.16.patch
@@ -123,7 +129,7 @@ importers:
         version: link:../shared
       acpx:
         specifier: 0.12.0
-        version: 0.12.0(patch_hash=x3fethhotv43zektyl5prdwf54)
+        version: 0.12.0(patch_hash=b2ggqg6aj4hdob4whk6vq6jmc4)
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -164,7 +170,7 @@ importers:
     dependencies:
       '@agentclientprotocol/codex-acp':
         specifier: ^1.6.2
-        version: 1.6.2
+        version: 1.6.2(patch_hash=grbydorkxatbzksnwwfuawwtim)
       '@paperclipai/adapter-utils':
         specifier: workspace:*
         version: link:../../adapter-utils
@@ -453,6 +459,12 @@ importers:
 
   packages/paperclip-runner:
     dependencies:
+      '@agentclientprotocol/codex-acp':
+        specifier: 1.6.2
+        version: 1.6.2(patch_hash=grbydorkxatbzksnwwfuawwtim)
+      acpx:
+        specifier: 0.13.1
+        version: 0.13.1(patch_hash=klzqvo4xom3l6xnrgmyg2xpqci)
       ajv:
         specifier: ^8.20.0
         version: 8.20.0
@@ -463,6 +475,9 @@ importers:
       '@types/node':
         specifier: ^24.0.0
         version: 24.13.3
+      tsx:
+        specifier: ^4.23.12
+        version: 4.23.12
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -5080,6 +5095,11 @@ packages:
     engines: {node: '>=22.13.0'}
     hasBin: true
 
+  acpx@0.13.1:
+    resolution: {integrity: sha512-9zhvUrAR4XxSIgaLCiiWmrwmEWh+m6jxu2KUFC8BMOiK4sFsnrRL7H6VF54ZLTTpt0IHrZQju2V7+8wiMf9DXQ==}
+    engines: {node: '>=22.13.0'}
+    hasBin: true
+
   address@2.0.3:
     resolution: {integrity: sha512-XNAb/a6TCqou+TufU8/u11HCu9x1gYvOoxLwtlXgIqmkrYQADVv6ljyW2zwiPhHz9R1gItAWpuDrdJMmrOBFEA==}
     engines: {node: '>= 16.0.0'}
@@ -7627,6 +7647,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  skillflag@0.2.1:
+    resolution: {integrity: sha512-47lfgUr6xzgljtTD5XfJrS+6muNb9R44OEr+o31Nco2R65W1xOA8Pi6QSbLa90tDYE6TqW5Hrh3N1egserGrhQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
@@ -8280,7 +8305,7 @@ snapshots:
       - '@anthropic-ai/sdk'
       - '@modelcontextprotocol/sdk'
 
-  '@agentclientprotocol/codex-acp@1.6.2':
+  '@agentclientprotocol/codex-acp@1.6.2(patch_hash=grbydorkxatbzksnwwfuawwtim)':
     dependencies:
       '@agentclientprotocol/sdk': 1.4.0(zod@4.4.3)
       '@openai/codex': 0.148.0
@@ -12215,11 +12240,23 @@ snapshots:
 
   acorn@8.18.0: {}
 
-  acpx@0.12.0(patch_hash=x3fethhotv43zektyl5prdwf54):
+  acpx@0.12.0(patch_hash=b2ggqg6aj4hdob4whk6vq6jmc4):
     dependencies:
       '@agentclientprotocol/sdk': 1.2.1(zod@4.4.3)
       commander: 15.0.0
       skillflag: 0.2.0
+      tsx: 4.23.12
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  acpx@0.13.1(patch_hash=klzqvo4xom3l6xnrgmyg2xpqci):
+    dependencies:
+      '@agentclientprotocol/sdk': 1.4.0(zod@4.4.3)
+      commander: 15.0.0
+      skillflag: 0.2.1
       tsx: 4.23.12
       zod: 4.4.3
     transitivePeerDependencies:
@@ -15185,6 +15222,15 @@ snapshots:
   sisteransi@1.0.5: {}
 
   skillflag@0.2.0:
+    dependencies:
+      '@clack/prompts': 1.7.0
+      tar-stream: 3.2.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  skillflag@0.2.1:
     dependencies:
       '@clack/prompts': 1.7.0
       tar-stream: 3.2.0

--- a/scripts/prepare-bundled-package.mjs
+++ b/scripts/prepare-bundled-package.mjs
@@ -168,8 +168,8 @@ export function prepareBundledPackage(sourceDir, destinationDir) {
 
   if (
     bundledDependencies.includes("acpx") &&
-    !readFileSync(resolve(destinationDir, "node_modules/acpx/dist/runtime.js"), "utf8").includes(
-      "onAgentStderr",
+    !/(?:onAgentStderr|spawnEnvironment)/.test(
+      readFileSync(resolve(destinationDir, "node_modules/acpx/dist/runtime.js"), "utf8"),
     )
   ) {
     throw new Error("staged acpx runtime is missing the repository patch");

--- a/server/package.json
+++ b/server/package.json
@@ -35,7 +35,7 @@
     "dev": "tsx src/index.ts",
     "dev:watch": "cross-env PAPERCLIP_MIGRATION_PROMPT=never PAPERCLIP_MIGRATION_AUTO_APPLY=true tsx ./scripts/dev-watch.ts",
     "prepare:ui-dist": "bash ../scripts/prepare-server-ui-dist.sh",
-    "build": "pnpm run prepare:runner-vendor && tsc && mkdir -p dist/onboarding-assets dist/built-ins dist/services/scripts && cp -R src/onboarding-assets/. dist/onboarding-assets/ && cp -R src/built-ins/. dist/built-ins/ && cp -R src/services/scripts/. dist/services/scripts/ && node ../scripts/prepare-bundled-package.mjs ../packages/paperclip-runner dist/vendor/paperclip-runner && node scripts/write-build-stamp.mjs",
+    "build": "pnpm run prepare:runner-vendor && tsc && mkdir -p dist/onboarding-assets dist/built-ins dist/services/scripts && cp -R src/onboarding-assets/. dist/onboarding-assets/ && cp -R src/built-ins/. dist/built-ins/ && cp -R src/services/scripts/. dist/services/scripts/ && node ../scripts/prepare-bundled-package.mjs ../packages/paperclip-runner dist/vendor/paperclip-runner && cp -R dist/vendor/paperclip-runner/dist/. dist/vendor/paperclip-runner/ && node scripts/write-build-stamp.mjs",
     "prepack": "pnpm run prepare:ui-dist && pnpm run build",
     "postpack": "rm -rf ui-dist",
     "clean": "rm -rf dist",

--- a/server/package.json
+++ b/server/package.json
@@ -35,7 +35,7 @@
     "dev": "tsx src/index.ts",
     "dev:watch": "cross-env PAPERCLIP_MIGRATION_PROMPT=never PAPERCLIP_MIGRATION_AUTO_APPLY=true tsx ./scripts/dev-watch.ts",
     "prepare:ui-dist": "bash ../scripts/prepare-server-ui-dist.sh",
-    "build": "pnpm run prepare:runner-vendor && tsc && mkdir -p dist/onboarding-assets dist/built-ins dist/services/scripts dist/vendor/paperclip-runner && cp -R src/onboarding-assets/. dist/onboarding-assets/ && cp -R src/built-ins/. dist/built-ins/ && cp -R src/services/scripts/. dist/services/scripts/ && cp -R ../packages/paperclip-runner/dist/. dist/vendor/paperclip-runner/ && node scripts/write-build-stamp.mjs",
+    "build": "pnpm run prepare:runner-vendor && tsc && mkdir -p dist/onboarding-assets dist/built-ins dist/services/scripts && cp -R src/onboarding-assets/. dist/onboarding-assets/ && cp -R src/built-ins/. dist/built-ins/ && cp -R src/services/scripts/. dist/services/scripts/ && node ../scripts/prepare-bundled-package.mjs ../packages/paperclip-runner dist/vendor/paperclip-runner && node scripts/write-build-stamp.mjs",
     "prepack": "pnpm run prepare:ui-dist && pnpm run build",
     "postpack": "rm -rf ui-dist",
     "clean": "rm -rf dist",

--- a/server/src/__tests__/agents-service-secret-bindings.test.ts
+++ b/server/src/__tests__/agents-service-secret-bindings.test.ts
@@ -273,6 +273,46 @@ describeEmbeddedPostgres("agent service secret binding sync", () => {
     expect(JSON.stringify(persistedConfig)).not.toContain(literalApiKey);
   });
 
+  it("preserves a legacy OpenClaw credential when an agent edit sends sanitized headers", async () => {
+    const companyId = await seedCompany();
+    const legacyToken = `openclaw-token-${randomUUID()}`;
+    const [legacyAgent] = await db.insert(agents).values({
+      companyId,
+      name: "Legacy OpenClaw",
+      role: "engineer",
+      status: "idle",
+      adapterType: "openclaw_gateway",
+      adapterConfig: {
+        url: "wss://openclaw.example",
+        headers: { "X-OpenClaw-Token": legacyToken, "x-trace-id": "old" },
+      },
+      runtimeConfig: {},
+    }).returning();
+
+    const updated = await agentService(db).update(legacyAgent.id, {
+      adapterConfig: {
+        url: "wss://openclaw.example",
+        headers: { "x-trace-id": "new" },
+      },
+    });
+
+    const persistedConfig = updated?.adapterConfig as Record<string, unknown>;
+    expect(JSON.stringify(persistedConfig)).not.toContain(legacyToken);
+    expect(persistedConfig.authToken).toMatchObject({
+      type: "secret_ref",
+      version: "latest",
+    });
+    expect(persistedConfig.headers).toEqual({ "x-trace-id": "new" });
+
+    const resolved = await secretService(db).resolveAdapterConfigForRuntime(
+      companyId,
+      persistedConfig,
+      undefined,
+      { adapterType: "openclaw_gateway" },
+    );
+    expect(resolved.config.authToken).toBe(legacyToken);
+  });
+
   it("replaces agent secret bindings when adapterConfig env changes", async () => {
     const companyId = await seedCompany();
     const secrets = secretService(db);

--- a/server/src/__tests__/invite-accept-gateway-defaults.test.ts
+++ b/server/src/__tests__/invite-accept-gateway-defaults.test.ts
@@ -15,6 +15,7 @@ import {
 } from "@paperclipai/db";
 import {
   buildJoinDefaultsPayloadForAccept,
+  mergeJoinDefaultsPayloadForReplay,
   normalizeAgentDefaultsForJoin,
   prepareAgentDefaultsPayloadForJoinPersistence,
 } from "../routes/access.js";
@@ -252,7 +253,7 @@ describe("normalizeAgentDefaultsForJoin (hermes_gateway)", () => {
   });
 });
 
-describeEmbeddedPostgres("prepareAgentDefaultsPayloadForJoinPersistence (hermes_gateway)", () => {
+describeEmbeddedPostgres("prepareAgentDefaultsPayloadForJoinPersistence", () => {
   let stopDb: (() => Promise<void>) | null = null;
   let db!: ReturnType<typeof createDb>;
   const previousKeyFile = process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE;
@@ -358,5 +359,41 @@ describeEmbeddedPostgres("prepareAgentDefaultsPayloadForJoinPersistence (hermes_
     const storedSecrets = await db.select().from(companySecrets);
     expect(storedSecrets).toHaveLength(1);
     expect((storedPayload.apiKey as { secretId: string }).secretId).toBe(storedSecrets[0]?.id);
+  });
+
+  it("removes replayed OpenClaw auth headers before persistence", async () => {
+    const companyId = randomUUID();
+    const literalToken = `openclaw-token-${randomUUID()}`;
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const replayed = mergeJoinDefaultsPayloadForReplay(
+      { url: "ws://127.0.0.1:18789", headers: { "x-custom": "keep" } },
+      { headers: { authorization: `Bearer ${literalToken}` }, disableDeviceAuth: true },
+    );
+    const normalized = normalizeAgentDefaultsForJoin({
+      adapterType: "openclaw_gateway",
+      defaultsPayload: replayed,
+      deploymentMode: "authenticated",
+      deploymentExposure: "private",
+      bindHost: "127.0.0.1",
+      allowedHostnames: [],
+    });
+    expect(normalized.fatalErrors).toEqual([]);
+
+    const persisted = await prepareAgentDefaultsPayloadForJoinPersistence({
+      db,
+      companyId,
+      adapterType: "openclaw_gateway",
+      normalized: normalized.normalized,
+    });
+
+    expect(JSON.stringify(persisted)).not.toContain(literalToken);
+    expect(persisted?.headers).toEqual({ "x-custom": "keep" });
+    expect(persisted?.authToken).toMatchObject({ type: "secret_ref", version: "latest" });
   });
 });

--- a/server/src/__tests__/invite-accept-gateway-defaults.test.ts
+++ b/server/src/__tests__/invite-accept-gateway-defaults.test.ts
@@ -103,6 +103,27 @@ describe("buildJoinDefaultsPayloadForAccept (openclaw_gateway)", () => {
 });
 
 describe("normalizeAgentDefaultsForJoin (openclaw_gateway)", () => {
+  it("prefers a native token over legacy auth headers", () => {
+    const normalized = normalizeAgentDefaultsForJoin({
+      adapterType: "openclaw_gateway",
+      defaultsPayload: {
+        url: "ws://127.0.0.1:18789",
+        token: "native-token-1234567890",
+        headers: {
+          authorization: "Bearer legacy-token-1234567890",
+        },
+      },
+      deploymentMode: "authenticated",
+      deploymentExposure: "private",
+      bindHost: "127.0.0.1",
+      allowedHostnames: [],
+    });
+
+    expect(normalized.fatalErrors).toEqual([]);
+    expect(normalized.normalized?.authToken).toBe("native-token-1234567890");
+    expect(normalized.normalized?.headers).toBeUndefined();
+  });
+
   it("generates persistent device key when device auth is enabled", () => {
     const normalized = normalizeAgentDefaultsForJoin({
       adapterType: "openclaw_gateway",

--- a/server/src/__tests__/invite-onboarding-text.test.ts
+++ b/server/src/__tests__/invite-onboarding-text.test.ts
@@ -49,7 +49,8 @@ describe("buildInviteOnboardingTextDocument", () => {
     expect(text).toContain("host.docker.internal");
     expect(text).toContain("paperclipApiUrl");
     expect(text).toContain('"adapterType": "openclaw_gateway"');
-    expect(text).toContain("headers.x-openclaw-token");
+    expect(text).toContain("agentDefaultsPayload.authToken");
+    expect(text).not.toContain("headers.x-openclaw-token");
     expect(text).toContain("Do NOT use /v1/responses or /hooks/*");
     expect(text).toContain('adapterType: "hermes_gateway"');
     expect(text).toContain('"adapterType": "hermes_gateway"');

--- a/server/src/__tests__/secrets-service.test.ts
+++ b/server/src/__tests__/secrets-service.test.ts
@@ -1154,7 +1154,14 @@ describeEmbeddedPostgres("secretService", () => {
 
     const normalized = await svc.normalizeAdapterConfigForPersistence(
       companyId,
-      { headers: { "X-OpenClaw-Token": tokenRef, "x-trace-id": "keep" } },
+      {
+        headers: {
+          Authorization: "Bearer stale-token",
+          "X-OpenClaw-Auth": "lower-priority-token",
+          "X-OpenClaw-Token": tokenRef,
+          "x-trace-id": "keep",
+        },
+      },
       { adapterType: "openclaw_gateway" },
     );
 

--- a/server/src/__tests__/secrets-service.test.ts
+++ b/server/src/__tests__/secrets-service.test.ts
@@ -1138,6 +1138,32 @@ describeEmbeddedPostgres("secretService", () => {
     ]);
   });
 
+  it("migrates OpenClaw legacy auth headers without losing secret references", async () => {
+    const companyId = await seedCompany();
+    const svc = secretService(db);
+    const tokenSecret = await svc.create(companyId, {
+      name: `openclaw-token-${randomUUID()}`,
+      provider: "local_encrypted",
+      value: "synthetic-token",
+    });
+    const tokenRef = {
+      type: "secret_ref" as const,
+      secretId: tokenSecret.id,
+      version: "latest" as const,
+    };
+
+    const normalized = await svc.normalizeAdapterConfigForPersistence(
+      companyId,
+      { headers: { "X-OpenClaw-Token": tokenRef, "x-trace-id": "keep" } },
+      { adapterType: "openclaw_gateway" },
+    );
+
+    expect(normalized).toEqual({
+      authToken: expect.objectContaining(tokenRef),
+      headers: { "x-trace-id": "keep" },
+    });
+  });
+
   it("returns conflict when concurrent user secret value creation races the unique index", async () => {
     const companyId = await seedCompany();
     await seedCompanyMember(companyId, "user-1", "owner");

--- a/server/src/__tests__/secrets-service.test.ts
+++ b/server/src/__tests__/secrets-service.test.ts
@@ -1171,6 +1171,37 @@ describeEmbeddedPostgres("secretService", () => {
     });
   });
 
+  it("does not replace the native OpenClaw token with a legacy auth header", async () => {
+    const companyId = await seedCompany();
+    const svc = secretService(db);
+
+    const normalized = await svc.normalizeAdapterConfigForPersistence(
+      companyId,
+      {
+        token: "native-token",
+        headers: { Authorization: "Bearer legacy-token", "x-trace-id": "keep" },
+      },
+      { adapterType: "openclaw_gateway" },
+    );
+
+    expect(normalized).toEqual({
+      token: expect.objectContaining({ type: "secret_ref" }),
+      headers: { "x-trace-id": "keep" },
+    });
+    expect(normalized).not.toHaveProperty("authToken");
+
+    const resolved = await svc.resolveAdapterConfigForRuntime(
+      companyId,
+      normalized,
+      undefined,
+      { adapterType: "openclaw_gateway" },
+    );
+    expect(resolved.config).toEqual({
+      token: "native-token",
+      headers: { "x-trace-id": "keep" },
+    });
+  });
+
   it("returns conflict when concurrent user secret value creation races the unique index", async () => {
     const companyId = await seedCompany();
     await seedCompanyMember(companyId, "user-1", "owner");

--- a/server/src/__tests__/server-package-build-script.test.ts
+++ b/server/src/__tests__/server-package-build-script.test.ts
@@ -54,6 +54,9 @@ describe("server package build script", () => {
     expect(packageJson.scripts?.build).toContain(
       "node ../scripts/prepare-bundled-package.mjs ../packages/paperclip-runner dist/vendor/paperclip-runner",
     );
+    expect(packageJson.scripts?.build).toContain(
+      "cp -R dist/vendor/paperclip-runner/dist/. dist/vendor/paperclip-runner/",
+    );
   });
 
   it("loads runner source when the source server starts before workspace builds", () => {

--- a/server/src/__tests__/server-package-build-script.test.ts
+++ b/server/src/__tests__/server-package-build-script.test.ts
@@ -52,7 +52,7 @@ describe("server package build script", () => {
       "pnpm --filter @paperclipai/paperclip-runner build",
     );
     expect(packageJson.scripts?.build).toContain(
-      "cp -R ../packages/paperclip-runner/dist/. dist/vendor/paperclip-runner/",
+      "node ../scripts/prepare-bundled-package.mjs ../packages/paperclip-runner dist/vendor/paperclip-runner",
     );
   });
 

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -668,9 +668,15 @@ export function canReplayOpenClawGatewayInviteAccept(input: {
   );
 }
 
+function isSecretRefValue(value: unknown): value is Record<string, unknown> {
+  const record = isPlainObject(value) ? value as Record<string, unknown> : null;
+  return record?.type === "secret_ref" && Boolean(nonEmptyTrimmedString(record.secretId));
+}
+
 function summarizeSecretForLog(
   value: unknown
-): { present: true; length: number; sha256Prefix: string } | null {
+): { present: true; length: number; sha256Prefix: string } | { present: true; secretRef: true } | null {
+  if (isSecretRefValue(value)) return { present: true, secretRef: true };
   const trimmed = nonEmptyTrimmedString(value);
   if (!trimmed) return null;
   return {
@@ -685,13 +691,18 @@ function summarizeOpenClawGatewayDefaultsForLog(defaultsPayload: unknown) {
     ? (defaultsPayload as Record<string, unknown>)
     : null;
   const headers = defaults ? normalizeHeaderMap(defaults.headers) : undefined;
-  const gatewayTokenValue = headers
+  const gatewayTokenValue = defaults?.authToken ?? (headers
     ? headerMapGetIgnoreCase(headers, "x-openclaw-token") ??
       headerMapGetIgnoreCase(headers, "x-openclaw-auth") ??
       tokenFromAuthorizationHeader(
         headerMapGetIgnoreCase(headers, "authorization")
       )
-    : null;
+    : null);
+  const safeHeaderKeys = headers
+    ? Object.keys(headers).filter(
+        (key) => !["authorization", "x-openclaw-token", "x-openclaw-auth"].includes(key.toLowerCase())
+      ).sort()
+    : [];
   return {
     present: Boolean(defaults),
     keys: defaults ? Object.keys(defaults).sort() : [],
@@ -699,7 +710,7 @@ function summarizeOpenClawGatewayDefaultsForLog(defaultsPayload: unknown) {
     paperclipApiUrl: defaults
       ? nonEmptyTrimmedString(defaults.paperclipApiUrl)
       : null,
-    headerKeys: headers ? Object.keys(headers).sort() : [],
+    headerKeys: safeHeaderKeys,
     sessionKeyStrategy: defaults
       ? nonEmptyTrimmedString(defaults.sessionKeyStrategy)
       : null,
@@ -836,7 +847,7 @@ export function normalizeAgentDefaultsForJoin(input: {
       message:
         "No OpenClaw gateway config was provided in agentDefaultsPayload.",
       hint:
-        "Include agentDefaultsPayload.url and headers.x-openclaw-token for OpenClaw gateway joins."
+        "Include agentDefaultsPayload.url and authToken for OpenClaw gateway joins."
     });
     fatalErrors.push(
       "agentDefaultsPayload is required for adapterType=openclaw_gateway"
@@ -892,15 +903,24 @@ export function normalizeAgentDefaultsForJoin(input: {
   }
 
   const headers = normalizeHeaderMap(defaults.headers) ?? {};
-  const gatewayToken =
+  const nativeGatewayToken =
+    nonEmptyTrimmedString(defaults.authToken) ??
+    (isSecretRefValue(defaults.authToken) ? defaults.authToken : null);
+  const legacyGatewayToken =
     headerMapGetIgnoreCase(headers, "x-openclaw-token") ??
     headerMapGetIgnoreCase(headers, "x-openclaw-auth") ??
     tokenFromAuthorizationHeader(headerMapGetIgnoreCase(headers, "authorization"));
-  if (gatewayToken && !headerMapHasKeyIgnoreCase(headers, "x-openclaw-token")) {
-    headers["x-openclaw-token"] = gatewayToken;
+  const gatewayToken = nativeGatewayToken ?? legacyGatewayToken;
+  const safeHeaders = Object.fromEntries(
+    Object.entries(headers).filter(
+      ([key]) => !["authorization", "x-openclaw-token", "x-openclaw-auth"].includes(key.toLowerCase()),
+    ),
+  );
+  if (gatewayToken) {
+    normalized.authToken = gatewayToken;
   }
-  if (Object.keys(headers).length > 0) {
-    normalized.headers = headers;
+  if (Object.keys(safeHeaders).length > 0) {
+    normalized.headers = safeHeaders;
   }
 
   if (!gatewayToken) {
@@ -909,12 +929,12 @@ export function normalizeAgentDefaultsForJoin(input: {
       level: "warn",
       message: "Gateway auth token is missing from agent defaults.",
       hint:
-        "Set agentDefaultsPayload.headers.x-openclaw-token (or legacy x-openclaw-auth)."
+        "Set agentDefaultsPayload.authToken (or legacy headers.x-openclaw-token)."
     });
     fatalErrors.push(
-      "agentDefaultsPayload.headers.x-openclaw-token (or x-openclaw-auth) is required"
+      "agentDefaultsPayload.authToken (or legacy headers.x-openclaw-token) is required"
     );
-  } else if (gatewayToken.trim().length < 16) {
+  } else if (typeof gatewayToken === "string" && gatewayToken.trim().length < 16) {
     diagnostics.push({
       code: "openclaw_gateway_auth_header_too_short",
       level: "warn",
@@ -923,7 +943,7 @@ export function normalizeAgentDefaultsForJoin(input: {
         "Use the full gateway auth token from ~/.openclaw/openclaw.json (typically long random string)."
     });
     fatalErrors.push(
-      "agentDefaultsPayload.headers.x-openclaw-token is too short; expected a full gateway token"
+      "agentDefaultsPayload.authToken is too short; expected a full gateway token"
     );
   } else {
     diagnostics.push({
@@ -943,9 +963,9 @@ export function normalizeAgentDefaultsForJoin(input: {
     normalized.disableDeviceAuth = parsedDisableDeviceAuth;
   }
 
-  const configuredDevicePrivateKeyPem = nonEmptyTrimmedString(
-    defaults.devicePrivateKeyPem
-  );
+  const configuredDevicePrivateKeyPem =
+    nonEmptyTrimmedString(defaults.devicePrivateKeyPem) ??
+    (isSecretRefValue(defaults.devicePrivateKeyPem) ? defaults.devicePrivateKeyPem : null);
   if (configuredDevicePrivateKeyPem) {
     normalized.devicePrivateKeyPem = configuredDevicePrivateKeyPem;
     diagnostics.push({
@@ -1072,7 +1092,10 @@ export async function prepareAgentDefaultsPayloadForJoinPersistence(input: {
   normalized: Record<string, unknown> | null;
   actor?: { userId?: string | null; agentId?: string | null };
 }): Promise<Record<string, unknown> | null> {
-  if (input.adapterType !== "hermes_gateway" || !input.normalized) {
+  if (!input.normalized) {
+    return input.normalized;
+  }
+  if (input.adapterType !== "hermes_gateway" && input.adapterType !== "openclaw_gateway") {
     return input.normalized;
   }
 
@@ -1756,7 +1779,7 @@ function buildInviteOnboardingManifest(
     ),
     onboarding: {
       instructions:
-        "Join as an external Paperclip agent, save your one-time claim secret, wait for board approval, then claim your Paperclip API key through the standard claim endpoint. Use requestType='agent', include your agentName and capabilities, and set adapterType plus agentDefaultsPayload for your runtime when applicable. Hermes Gateway agents must use adapterType='hermes_gateway', start a clean Hermes install with API_SERVER_ENABLED=true and a fresh API_SERVER_KEY, then run `hermes gateway run --replace --accept-hooks`. Put the Hermes gateway URL in agentDefaultsPayload.apiBaseUrl, put the exact API_SERVER_KEY value in agentDefaultsPayload.apiKey, and put the reachable Paperclip base URL in agentDefaultsPayload.paperclipApiUrl. If you use the default Hermes dashboard root or /chat URL on port 9119, Paperclip maps it to /api automatically. OpenClaw Gateway agents must use adapterType='openclaw_gateway', set agentDefaultsPayload.url to a ws:// or wss:// gateway endpoint, and include agentDefaultsPayload.headers.x-openclaw-token.",
+        "Join as an external Paperclip agent, save your one-time claim secret, wait for board approval, then claim your Paperclip API key through the standard claim endpoint. Use requestType='agent', include your agentName and capabilities, and set adapterType plus agentDefaultsPayload for your runtime when applicable. Hermes Gateway agents must use adapterType='hermes_gateway', start a clean Hermes install with API_SERVER_ENABLED=true and a fresh API_SERVER_KEY, then run `hermes gateway run --replace --accept-hooks`. Put the Hermes gateway URL in agentDefaultsPayload.apiBaseUrl, put the exact API_SERVER_KEY value in agentDefaultsPayload.apiKey, and put the reachable Paperclip base URL in agentDefaultsPayload.paperclipApiUrl. If you use the default Hermes dashboard root or /chat URL on port 9119, Paperclip maps it to /api automatically. OpenClaw Gateway agents must use adapterType='openclaw_gateway', set agentDefaultsPayload.url to a ws:// or wss:// gateway endpoint, and put the gateway credential in agentDefaultsPayload.authToken.",
       inviteMessage: extractInviteMessage(invite),
       recommendedAdapterType: null,
       requiredFields: {
@@ -1766,7 +1789,7 @@ function buildInviteOnboardingManifest(
           "Adapter type for this runtime. Use 'openclaw_gateway' only for OpenClaw Gateway agents. Use 'hermes_gateway' only for Hermes Gateway agents.",
         capabilities: "Optional capability summary",
         agentDefaultsPayload:
-          "Runtime-specific adapter config. OpenClaw Gateway agents must include url (ws:// or wss://) and headers.x-openclaw-token. Hermes Gateway agents must include apiBaseUrl, apiKey set to the Hermes API_SERVER_KEY, and paperclipApiUrl. A default Hermes dashboard root or /chat URL such as http://127.0.0.1:9119/chat is accepted and maps to /api. Other runtimes should include the config their adapter expects."
+          "Runtime-specific adapter config. OpenClaw Gateway agents must include url (ws:// or wss://) and authToken. Hermes Gateway agents must include apiBaseUrl, apiKey set to the Hermes API_SERVER_KEY, and paperclipApiUrl. A default Hermes dashboard root or /chat URL such as http://127.0.0.1:9119/chat is accepted and maps to /api. Other runtimes should include the config their adapter expects."
       },
       registrationEndpoint: {
         method: "POST",
@@ -1906,7 +1929,7 @@ export function buildInviteOnboardingTextDocument(
       "agentDefaultsPayload": {
         "url": "wss://your-openclaw-gateway.example",
         "paperclipApiUrl": "https://paperclip-hostname-your-agent-can-reach:3100",
-        "headers": { "x-openclaw-token": "replace-me" },
+        "authToken": "replace-me",
         "waitTimeoutMs": 120000,
         "sessionKeyStrategy": "issue",
         "role": "operator",
@@ -1914,7 +1937,7 @@ export function buildInviteOnboardingTextDocument(
       }
     }
 
-    For OpenClaw Gateway, include agentDefaultsPayload.headers.x-openclaw-token with your gateway token. Legacy x-openclaw-auth is also accepted, but x-openclaw-token is preferred. Do NOT use /v1/responses or /hooks/* in this gateway join flow.
+    For OpenClaw Gateway, put the gateway token in agentDefaultsPayload.authToken so Paperclip can store it as a secret reference. Do NOT use /v1/responses or /hooks/* in this gateway join flow.
 
     Hermes Gateway setup:
     - adapterType: "hermes_gateway"
@@ -4006,7 +4029,7 @@ export function accessRoutes(
           missingPersistedFields.push("paperclipApiUrl");
         }
         if (expectedDefaults.gatewayToken && !persistedDefaults.gatewayToken) {
-          missingPersistedFields.push("headers.x-openclaw-token");
+          missingPersistedFields.push("authToken");
         }
         if (
           expectedDefaults.devicePrivateKeyPem &&

--- a/server/src/routes/access.ts
+++ b/server/src/routes/access.ts
@@ -905,7 +905,9 @@ export function normalizeAgentDefaultsForJoin(input: {
   const headers = normalizeHeaderMap(defaults.headers) ?? {};
   const nativeGatewayToken =
     nonEmptyTrimmedString(defaults.authToken) ??
-    (isSecretRefValue(defaults.authToken) ? defaults.authToken : null);
+    (isSecretRefValue(defaults.authToken) ? defaults.authToken : null) ??
+    nonEmptyTrimmedString(defaults.token) ??
+    (isSecretRefValue(defaults.token) ? defaults.token : null);
   const legacyGatewayToken =
     headerMapGetIgnoreCase(headers, "x-openclaw-token") ??
     headerMapGetIgnoreCase(headers, "x-openclaw-auth") ??

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1953,6 +1953,11 @@ export function agentRoutes(
     return privateKey.export({ type: "pkcs8", format: "pem" }).toString();
   }
 
+  function isCompanySecretRef(value: unknown): boolean {
+    const record = asRecord(value);
+    return record?.type === "secret_ref" && typeof record.secretId === "string";
+  }
+
   function ensureGatewayDeviceKey(
     adapterType: string | null | undefined,
     adapterConfig: Record<string, unknown>,
@@ -1960,7 +1965,9 @@ export function agentRoutes(
     if (adapterType !== "openclaw_gateway") return adapterConfig;
     const disableDeviceAuth = parseBooleanLike(adapterConfig.disableDeviceAuth) === true;
     if (disableDeviceAuth) return adapterConfig;
-    if (asNonEmptyString(adapterConfig.devicePrivateKeyPem)) return adapterConfig;
+    if (asNonEmptyString(adapterConfig.devicePrivateKeyPem) || isCompanySecretRef(adapterConfig.devicePrivateKeyPem)) {
+      return adapterConfig;
+    }
     return { ...adapterConfig, devicePrivateKeyPem: generateEd25519PrivateKeyPem() };
   }
 
@@ -1975,8 +1982,7 @@ export function agentRoutes(
 
   function codexLocalEnvKeyConfigured(value: unknown): boolean {
     if (asEnvBindingString(value)) return true;
-    const record = asRecord(value);
-    return record?.type === "secret_ref" && typeof record.secretId === "string";
+    return isCompanySecretRef(value);
   }
 
   // codex_local agents inherit whatever Codex login is already on the device

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -676,7 +676,10 @@ export function agentService(db: Db) {
       normalizedPatch.adapterConfig = await secretsSvc.normalizeAdapterConfigForPersistence(
         existing.companyId,
         normalizedPatch.adapterConfig,
-        { adapterType: (normalizedPatch.adapterType ?? existing.adapterType) as string },
+        {
+          adapterType: (normalizedPatch.adapterType ?? existing.adapterType) as string,
+          priorAdapterConfig: isPlainRecord(existing.adapterConfig) ? existing.adapterConfig : null,
+        },
       );
     }
     // Run the server-enforced binding invariant when the patch touches the
@@ -993,7 +996,10 @@ export function agentService(db: Db) {
           patch.adapterConfig = await secretService(txDb).normalizeAdapterConfigForPersistence(
             existing.companyId,
             patch.adapterConfig,
-            { adapterType: (patch.adapterType ?? existing.adapterType) as string },
+            {
+              adapterType: (patch.adapterType ?? existing.adapterType) as string,
+              priorAdapterConfig: isPlainRecord(existing.adapterConfig) ? existing.adapterConfig : null,
+            },
           );
           // The approval activation keeps an existing fixed binding but rejects a
           // newly introduced binding, because it carries no stored-session claim.

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -81,6 +81,7 @@ const COMING_SOON_SECRET_PROVIDERS: ReadonlySet<SecretProvider> = new Set([
 ]);
 const FALLBACK_ADAPTER_SCHEMA_SECRET_FIELDS: Readonly<Record<string, readonly string[]>> = {
   hermes_gateway: ["apiKey"],
+  openclaw_gateway: ["authToken", "token", "password", "devicePrivateKeyPem"],
 };
 const USER_SECRET_DEFINITION_KEY_UNIQUE_CONSTRAINT = "user_secret_definitions_company_key_uq";
 const USER_SECRET_VALUE_UNIQUE_CONSTRAINT = "company_secrets_user_definition_owner_uq";
@@ -1860,16 +1861,35 @@ export function secretService(db: Db | DbTransaction) {
     opts?: NormalizeAdapterConfigOptions,
   ) {
     const normalized = { ...adapterConfig };
+    if (opts?.adapterType === "openclaw_gateway") {
+      const headers = adapterConfig.headers;
+      if (headers && typeof headers === "object" && !Array.isArray(headers)) {
+        const entries = Object.entries(headers);
+        const authHeaders = ["authorization", "x-openclaw-token", "x-openclaw-auth"];
+        const rawLegacyToken = entries.find(([key]) => authHeaders.includes(key.toLowerCase()))?.[1];
+        if (normalized.authToken === undefined) {
+          if (typeof rawLegacyToken === "string") {
+            const token = rawLegacyToken.replace(/^Bearer\s+/i, "").trim();
+            if (token) normalized.authToken = token;
+          } else if (rawLegacyToken !== undefined) {
+            normalized.authToken = rawLegacyToken;
+          }
+        }
+        const safeHeaders = Object.fromEntries(entries.filter(([key]) => !authHeaders.includes(key.toLowerCase())));
+        if (Object.keys(safeHeaders).length > 0) normalized.headers = safeHeaders;
+        else delete normalized.headers;
+      }
+    }
     if (Object.prototype.hasOwnProperty.call(adapterConfig, "env")) {
       normalized.env = await normalizeEnvConfig(companyId, adapterConfig.env, opts);
     }
     const secretFieldKeys = await listAdapterSchemaSecretFieldKeys(opts?.adapterType);
     for (const key of secretFieldKeys) {
-      if (!Object.prototype.hasOwnProperty.call(adapterConfig, key)) continue;
+      if (!Object.prototype.hasOwnProperty.call(normalized, key)) continue;
       const value = await normalizeSchemaSecretFieldForPersistence(companyId, {
         adapterType: opts?.adapterType ?? null,
         key,
-        rawValue: adapterConfig[key],
+        rawValue: normalized[key],
         actor: opts?.actor,
       });
       if (value === undefined) {

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -1869,7 +1869,7 @@ export function secretService(db: Db | DbTransaction) {
         const rawLegacyToken = authHeaders
           .map((name) => entries.find(([key]) => key.toLowerCase() === name)?.[1])
           .find((value) => value !== undefined);
-        if (normalized.authToken === undefined) {
+        if (normalized.authToken === undefined && normalized.token === undefined) {
           if (typeof rawLegacyToken === "string") {
             const token = rawLegacyToken.replace(/^Bearer\s+/i, "").trim();
             if (token) normalized.authToken = token;

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -1865,8 +1865,10 @@ export function secretService(db: Db | DbTransaction) {
       const headers = adapterConfig.headers;
       if (headers && typeof headers === "object" && !Array.isArray(headers)) {
         const entries = Object.entries(headers);
-        const authHeaders = ["authorization", "x-openclaw-token", "x-openclaw-auth"];
-        const rawLegacyToken = entries.find(([key]) => authHeaders.includes(key.toLowerCase()))?.[1];
+        const authHeaders = ["x-openclaw-token", "x-openclaw-auth", "authorization"];
+        const rawLegacyToken = authHeaders
+          .map((name) => entries.find(([key]) => key.toLowerCase() === name)?.[1])
+          .find((value) => value !== undefined);
         if (normalized.authToken === undefined) {
           if (typeof rawLegacyToken === "string") {
             const token = rawLegacyToken.replace(/^Bearer\s+/i, "").trim();

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -930,6 +930,7 @@ export function secretService(db: Db | DbTransaction) {
     strictMode?: boolean;
     adapterType?: string | null;
     actor?: { userId?: string | null; agentId?: string | null };
+    priorAdapterConfig?: Record<string, unknown> | null;
   };
 
   async function getById(id: string, source: Pick<Db | DbTransaction, "select"> = db) {
@@ -1880,6 +1881,25 @@ export function secretService(db: Db | DbTransaction) {
         const safeHeaders = Object.fromEntries(entries.filter(([key]) => !authHeaders.includes(key.toLowerCase())));
         if (Object.keys(safeHeaders).length > 0) normalized.headers = safeHeaders;
         else delete normalized.headers;
+      }
+      const prior = opts.priorAdapterConfig;
+      const hasAuthToken = Object.prototype.hasOwnProperty.call(adapterConfig, "authToken");
+      const hasToken = Object.prototype.hasOwnProperty.call(adapterConfig, "token");
+      if (prior && !hasAuthToken && !hasToken) {
+        if (prior.authToken !== undefined) normalized.authToken = prior.authToken;
+        else if (prior.token !== undefined) normalized.token = prior.token;
+        else if (prior.headers && typeof prior.headers === "object" && !Array.isArray(prior.headers)) {
+          const priorEntries = Object.entries(prior.headers);
+          const priorAuthHeaders = ["x-openclaw-token", "x-openclaw-auth", "authorization"];
+          const priorLegacyToken = priorAuthHeaders
+            .map((name) => priorEntries.find(([key]) => key.toLowerCase() === name)?.[1])
+            .find((value) => value !== undefined);
+          if (priorLegacyToken !== undefined) {
+            normalized.authToken = typeof priorLegacyToken === "string"
+              ? priorLegacyToken.replace(/^Bearer\s+/i, "").trim()
+              : priorLegacyToken;
+          }
+        }
       }
     }
     if (Object.prototype.hasOwnProperty.call(adapterConfig, "env")) {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -23,6 +23,7 @@ import { Dashboard } from "./pages/Dashboard";
 import { DashboardLive } from "./pages/DashboardLive";
 import { Timeline } from "./pages/Timeline";
 import { Companies } from "./pages/Companies";
+import { TeamCatalog } from "./pages/TeamCatalog";
 import { AGENT_FILTER_TABS, Agents } from "./pages/Agents";
 import { AgentDetail } from "./pages/AgentDetail";
 import { Projects } from "./pages/Projects";
@@ -216,7 +217,8 @@ function boardRoutes() {
       <Route path="settings/*" element={<LegacySettingsRedirect />} />
       <Route path="plugins/:pluginId" element={<PluginPage />} />
       <Route path="org" element={<OrgChart />} />
-      <Route path="agents" element={<Navigate to="/agents/all" replace />} />
+      <Route path="teams-catalog/*" element={<TeamCatalog />} />
+      <Route path="agents" element={<Navigate to="/agents/active" replace />} />
       {AGENT_FILTER_TABS.map((tab) => (
         <Route key={tab} path={`agents/${tab}`} element={<Agents />} />
       ))}
@@ -692,6 +694,7 @@ export function App() {
           <Route path="skills/*" element={<UnprefixedBoardRedirect />} />
           <Route path="settings" element={<LegacySettingsRedirect />} />
           <Route path="settings/*" element={<LegacySettingsRedirect />} />
+          <Route path="teams-catalog/*" element={<UnprefixedBoardRedirect />} />
           <Route path="agents" element={<UnprefixedBoardRedirect />} />
           {AGENT_FILTER_TABS.map((tab) => (
             <Route key={tab} path={`agents/${tab}`} element={<UnprefixedBoardRedirect />} />

--- a/ui/src/adapters/openclaw-gateway/config-fields.test.tsx
+++ b/ui/src/adapters/openclaw-gateway/config-fields.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { OpenClawGatewayConfigFields } from "./config-fields";
+import type { AdapterConfigFieldsProps } from "../types";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("OpenClawGatewayConfigFields", () => {
+  const roots: Root[] = [];
+
+  afterEach(() => {
+    for (const root of roots.splice(0)) act(() => root.unmount());
+    document.body.innerHTML = "";
+  });
+
+  it("hides legacy auth headers and writes replacements to authToken", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    roots.push(root);
+    const mark = vi.fn();
+    const props: AdapterConfigFieldsProps = {
+      mode: "edit",
+      isCreate: false,
+      adapterType: "openclaw_gateway",
+      values: null,
+      set: null,
+      config: { headers: { "X-OpenClaw-Token": "synthetic-token", "x-trace-id": "keep" } },
+      eff: (_group, _field, original) => original,
+      mark,
+      models: [],
+    };
+
+    act(() => root.render(<TooltipProvider><OpenClawGatewayConfigFields {...props} /></TooltipProvider>));
+
+    const tokenInput = Array.from(container.querySelectorAll<HTMLInputElement>('input[type="password"]'))
+      .find((input) => input.placeholder.includes("Stored secret"));
+    expect(tokenInput).toBeTruthy();
+    const textareas = Array.from(container.querySelectorAll<HTMLTextAreaElement>("textarea"));
+    expect(textareas.some((textarea) => textarea.value.includes("x-trace-id"))).toBe(true);
+    expect(textareas.every((textarea) => !textarea.value.includes("synthetic-token"))).toBe(true);
+
+    act(() => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!
+        .call(tokenInput, "replacement-token");
+      tokenInput!.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    expect(mark).toHaveBeenCalledWith("adapterConfig", "authToken", "replacement-token");
+    expect(mark).toHaveBeenCalledWith("adapterConfig", "headers", { "x-trace-id": "keep" });
+  });
+});

--- a/ui/src/adapters/openclaw-gateway/config-fields.tsx
+++ b/ui/src/adapters/openclaw-gateway/config-fields.tsx
@@ -14,6 +14,17 @@ import {
 const inputClass =
   "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
 
+const AUTH_HEADER_NAMES = new Set(["authorization", "x-openclaw-token", "x-openclaw-auth"]);
+
+function isSecretRef(value: unknown): boolean {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    && (value as { type?: unknown }).type === "secret_ref";
+}
+
+function withoutAuthHeaders(headers: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(headers).filter(([key]) => !AUTH_HEADER_NAMES.has(key.toLowerCase())));
+}
+
 function HeadersJsonTextarea({
   isCreate,
   createDraft,
@@ -63,11 +74,13 @@ function SecretField({
   value,
   onCommit,
   placeholder,
+  stored,
 }: {
   label: string;
   value: string;
   onCommit: (v: string) => void;
   placeholder?: string;
+  stored?: boolean;
 }) {
   const [visible, setVisible] = useState(false);
   return (
@@ -77,6 +90,7 @@ function SecretField({
           type="button"
           onClick={() => setVisible((v) => !v)}
           className="absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground/50 hover:text-muted-foreground transition-colors"
+          aria-label={visible ? `Hide ${label}` : `Show ${label}`}
         >
           {visible ? <Eye className="h-3.5 w-3.5" /> : <EyeOff className="h-3.5 w-3.5" />}
         </button>
@@ -86,7 +100,7 @@ function SecretField({
           immediate
           type={visible ? "text" : "password"}
           className={inputClass + " pl-8"}
-          placeholder={placeholder}
+          placeholder={stored ? "Stored secret; enter a new value to replace it" : placeholder}
         />
       </div>
     </Field>
@@ -112,26 +126,17 @@ export function OpenClawGatewayConfigFields({
     config.headers && typeof config.headers === "object" && !Array.isArray(config.headers)
       ? (config.headers as Record<string, unknown>)
       : {};
-  const effectiveHeaders =
-    (eff("adapterConfig", "headers", configuredHeaders) as Record<string, unknown>) ?? {};
-
-  const effectiveGatewayToken = typeof effectiveHeaders["x-openclaw-token"] === "string"
-    ? String(effectiveHeaders["x-openclaw-token"])
-    : typeof effectiveHeaders["x-openclaw-auth"] === "string"
-      ? String(effectiveHeaders["x-openclaw-auth"])
-      : "";
+  const effectiveHeaders = withoutAuthHeaders(
+    (eff("adapterConfig", "headers", configuredHeaders) as Record<string, unknown>) ?? {},
+  );
+  const hasStoredGatewayToken = isSecretRef(config.authToken)
+    || typeof config.authToken === "string"
+    || Object.keys(configuredHeaders).some((key) => AUTH_HEADER_NAMES.has(key.toLowerCase()));
 
   const commitGatewayToken = (rawValue: string) => {
     const nextValue = rawValue.trim();
-    const nextHeaders: Record<string, unknown> = { ...effectiveHeaders };
-    if (nextValue) {
-      nextHeaders["x-openclaw-token"] = nextValue;
-      delete nextHeaders["x-openclaw-auth"];
-    } else {
-      delete nextHeaders["x-openclaw-token"];
-      delete nextHeaders["x-openclaw-auth"];
-    }
-    mark("adapterConfig", "headers", Object.keys(nextHeaders).length > 0 ? nextHeaders : undefined);
+    mark("adapterConfig", "authToken", nextValue || undefined);
+    mark("adapterConfig", "headers", Object.keys(effectiveHeaders).length > 0 ? effectiveHeaders : undefined);
   };
 
   const sessionStrategy = eff(
@@ -174,7 +179,7 @@ export function OpenClawGatewayConfigFields({
         value={
           isCreate
             ? values!.authToken ?? ""
-            : effectiveGatewayToken
+            : ""
         }
         onCommit={(v) =>
           isCreate
@@ -182,6 +187,7 @@ export function OpenClawGatewayConfigFields({
             : commitGatewayToken(v)
         }
         placeholder="OpenClaw gateway token"
+        stored={!isCreate && hasStoredGatewayToken}
       />
 
       <Field label="Agent ID">
@@ -352,7 +358,7 @@ export function OpenClawGatewayConfigFields({
           isCreate={isCreate}
           createDraft={isCreate ? values!.headersJson ?? "" : ""}
           onCreateDraftChange={(next) => set!({ headersJson: next })}
-          editStringified={JSON.stringify(eff("adapterConfig", "headers", config.headers ?? {}), null, 2)}
+          editStringified={JSON.stringify(effectiveHeaders, null, 2)}
           onEditCommit={(next) => {
             const trimmed = next.trim();
             if (!trimmed) {

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -23,6 +23,7 @@ import {
   MessagesSquare,
   GanttChartSquare,
   LayoutGrid,
+  LayoutTemplate,
 } from "lucide-react";
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
@@ -275,6 +276,7 @@ export function Sidebar() {
 
         <SidebarSection label="Organization" collapsible={{ open: companyOpen, onOpenChange: setCompanyOpen }}>
           <SidebarNavItem to="/org" label="Org" icon={Network} />
+          <SidebarNavItem to="/teams-catalog" label="Modelli team" icon={LayoutTemplate} />
           {showApps ? <SidebarNavItem to="/apps" label="Apps" icon={AppWindow} /> : null}
           <SidebarNavItem to="/timeline" label="Timeline" icon={GanttChartSquare} />
           <SidebarNavItem to="/costs" label="Costs" icon={DollarSign} />

--- a/ui/src/components/SidebarAgents.test.tsx
+++ b/ui/src/components/SidebarAgents.test.tsx
@@ -207,15 +207,15 @@ async function chooseSortMode(label: string) {
 
 function agentLinkLabels(container: HTMLElement) {
   return Array.from(container.querySelectorAll('a[href^="/agents/"]'))
-    .filter((anchor) => anchor.getAttribute("href") !== "/agents/all")
+    .filter((anchor) => anchor.getAttribute("href") !== "/agents/active")
     .map((anchor) => anchor.textContent?.trim())
     .filter(Boolean);
 }
 
 function seeAllAgentsLink(container: HTMLElement) {
   return (
-    Array.from(container.querySelectorAll('a[href="/agents/all"]')).find((anchor) =>
-      anchor.textContent?.includes("See all agents"),
+    Array.from(container.querySelectorAll('a[href="/agents/active"]')).find((anchor) =>
+      anchor.textContent?.includes("Vedi agenti operativi"),
     ) ?? null
   );
 }
@@ -398,7 +398,7 @@ describe("SidebarAgents", () => {
     expect(nameSpan?.className).not.toContain("sr-only");
     expect(nameSpan?.className).toContain("w-0");
     expect(nameSpan?.className).toContain("overflow-hidden");
-    const agentLink = container.querySelector('a[href^="/agents/"]:not([href="/agents/all"])');
+    const agentLink = container.querySelector('a[href^="/agents/"]:not([href="/agents/active"])');
     expect(agentLink?.parentElement?.getAttribute("data-slot")).toBe("tooltip-trigger");
     expect(container.querySelector('button[aria-label="Open actions for Alpha"]')).toBeNull();
 
@@ -525,7 +525,7 @@ describe("SidebarAgents", () => {
       .find((element) => element.textContent?.includes("New agent"));
     expect(newAgentItem).toBeFalsy();
     const browseLink = Array.from(document.body.querySelectorAll("a"))
-      .find((element) => element.textContent?.includes("Browse agents"));
+      .find((element) => element.textContent?.includes("Sfoglia tutti gli agenti"));
     expect(browseLink?.getAttribute("href")).toBe("/agents/all");
   });
 
@@ -649,25 +649,15 @@ describe("SidebarAgents", () => {
     expect(agentLinkLabels(container)).toEqual([]);
   });
 
-  it("shows resume for paused sidebar agents", async () => {
+  it("keeps paused agents in the archive instead of the operational sidebar", async () => {
     mockAgentsApi.list.mockResolvedValue([
       makeAgent({ status: "paused", pauseReason: "manual", pausedAt: new Date("2026-01-02T00:00:00Z") }),
     ]);
 
     await renderSidebarAgents();
-    await openAgentMenu();
 
-    const resumeItem = Array.from(document.body.querySelectorAll('[data-slot="dropdown-menu-item"]'))
-      .find((element) => element.textContent?.includes("Resume agent"));
-    expect(resumeItem).toBeTruthy();
-
-    await act(async () => {
-      resumeItem?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-    await flushReact();
-
-    expect(mockAgentsApi.resume).toHaveBeenCalledWith("agent-1", "company-1");
-    expect(mockPushToast).toHaveBeenCalledWith(expect.objectContaining({ title: "Agent resumed" }));
+    expect(agentLinkLabels(container)).toEqual([]);
+    expect(mockAgentsApi.resume).not.toHaveBeenCalled();
   });
 
   it("only shows updating state for the agent currently being changed", async () => {
@@ -715,7 +705,7 @@ describe("SidebarAgents", () => {
     expect(labels[0]).toContain("Bravo");
     // PAP-76: the full-list entry point stays visible even when only active
     // agents are shown.
-    expect(seeAllAgentsLink(container)?.getAttribute("href")).toBe("/agents/all");
+    expect(seeAllAgentsLink(container)?.getAttribute("href")).toBe("/agents/active");
   });
 
   it("keeps formerly live agents visible for the streamlined linger window", async () => {
@@ -840,7 +830,7 @@ describe("SidebarAgents", () => {
     await renderSidebarAgents();
 
     expect(agentLinkLabels(container)).toHaveLength(3);
-    expect(seeAllAgentsLink(container)?.getAttribute("href")).toBe("/agents/all");
+    expect(seeAllAgentsLink(container)?.getAttribute("href")).toBe("/agents/active");
   });
 
   it("classic mode (flag OFF) shows all agents and no See all link even when one is running", async () => {
@@ -902,7 +892,7 @@ describe("SidebarAgents", () => {
     expect(seeAllAgentsLink(container)).toBeNull();
   });
 
-  it("does not offer sidebar resume for budget-paused agents", async () => {
+  it("also hides budget-paused agents from the operational sidebar", async () => {
     mockAgentsApi.list.mockResolvedValue([
       makeAgent({
         status: "paused",
@@ -912,19 +902,8 @@ describe("SidebarAgents", () => {
     ]);
 
     await renderSidebarAgents();
-    await openAgentMenu();
 
-    const budgetPausedItem = Array.from(
-      document.body.querySelectorAll('[data-slot="dropdown-menu-item"]'),
-    )
-      .find((element) => element.textContent?.includes("Budget paused"));
-    expect(budgetPausedItem).toBeTruthy();
-
-    await act(async () => {
-      budgetPausedItem?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-    await flushReact();
-
+    expect(agentLinkLabels(container)).toEqual([]);
     expect(mockAgentsApi.resume).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/components/SidebarAgents.tsx
+++ b/ui/src/components/SidebarAgents.tsx
@@ -374,6 +374,7 @@ export function SidebarAgents({ streamlined = false }: { streamlined?: boolean }
     const filtered = (agents ?? []).filter(
       (a: Agent) =>
         a.status !== "terminated" &&
+        a.status !== "paused" &&
         (
           !membershipsQuery.isSuccess ||
           resourceMembershipState(membershipsQuery.data, "agent", a.id) !== "left"
@@ -641,7 +642,7 @@ export function SidebarAgents({ streamlined = false }: { streamlined?: boolean }
       menu={{
         ariaLabel: "Agents section actions",
         actions: [
-          { type: "item", label: "Browse agents", icon: Users, href: "/agents/all" },
+          { type: "item", label: "Sfoglia tutti gli agenti", icon: Users, href: "/agents/all" },
           { type: "separator" },
         ],
         radioLabel: "Agent sort",
@@ -657,22 +658,22 @@ export function SidebarAgents({ streamlined = false }: { streamlined?: boolean }
         // (plain Link) that must not adopt nav-row active-route highlighting.
         const seeAllLink = (
           <Link
-            to="/agents/all"
+            to="/agents/active"
             state={SIDEBAR_SCROLL_RESET_STATE}
-            aria-label={rail ? "See all agents" : undefined}
+            aria-label={rail ? "Vedi agenti operativi" : undefined}
             onClick={() => {
               if (isMobile) setSidebarOpen(false);
             }}
             className="flex items-center gap-2.5 mx-2 rounded-lg px-2 py-1.5 pointer-coarse:py-1 text-(length:--text-compact) font-medium text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
           >
             <Users className="shrink-0 h-4 w-4" />
-            <span className={rail ? SIDEBAR_RAIL_HIDDEN_LABEL : undefined}>See all agents</span>
+            <span className={rail ? SIDEBAR_RAIL_HIDDEN_LABEL : undefined}>Vedi agenti operativi</span>
           </Link>
         );
         return rail ? (
           <Tooltip>
             <TooltipTrigger asChild>{seeAllLink}</TooltipTrigger>
-            <TooltipContent side="right">See all agents</TooltipContent>
+            <TooltipContent side="right">Vedi agenti operativi</TooltipContent>
           </Tooltip>
         ) : (
           seeAllLink

--- a/ui/src/lib/agent-onboarding-prompt.test.ts
+++ b/ui/src/lib/agent-onboarding-prompt.test.ts
@@ -33,5 +33,7 @@ describe("buildAgentOnboardingPrompt", () => {
     expect(prompt).toContain("parsed `token` field from the raw HTTP JSON response");
     expect(prompt).toContain("A token value containing literal `...` or `[redacted]`");
     expect(prompt).toContain("never persist a displayed preview that contains `...`");
+    expect(prompt).toContain("agentDefaultsPayload.authToken");
+    expect(prompt).not.toContain('agentDefaultsPayload.headers["x-openclaw-token"]');
   });
 });

--- a/ui/src/lib/agent-onboarding-prompt.ts
+++ b/ui/src/lib/agent-onboarding-prompt.ts
@@ -53,7 +53,7 @@ Join flow:
 8. Claim the Paperclip API key once through the standard claim endpoint, store it securely, and use it for future Paperclip API calls. Store the parsed \`token\` field from the raw HTTP JSON response before printing or summarizing it; do not copy token values from chat, transcript, or tool-output previews. A token value containing literal \`...\` or \`[redacted]\` is a masked display preview, not a valid key. Do not rotate or invent a Paperclip key manually.
 
 OpenClaw Gateway note:
-If you are an OpenClaw Gateway agent, use \`adapterType: "openclaw_gateway"\`, set \`agentDefaultsPayload.url\` to your \`ws://\` or \`wss://\` gateway URL, and include \`agentDefaultsPayload.headers["x-openclaw-token"]\` with your gateway token. Do not use \`/v1/responses\` or \`/hooks/*\` in that join flow.
+If you are an OpenClaw Gateway agent, use \`adapterType: "openclaw_gateway"\`, set \`agentDefaultsPayload.url\` to your \`ws://\` or \`wss://\` gateway URL, and set \`agentDefaultsPayload.authToken\` to your gateway token. Paperclip stores it as a secret reference. Do not put it in \`agentDefaultsPayload.headers\`, and do not use \`/v1/responses\` or \`/hooks/*\` in that join flow.
 
 Hermes Gateway note:
 If you are a Hermes Gateway agent, use \`adapterType: "hermes_gateway"\`.

--- a/ui/src/pages/Agents.test.tsx
+++ b/ui/src/pages/Agents.test.tsx
@@ -883,7 +883,7 @@ describe("Agents", () => {
     await flushReact();
 
     expect(mockBuiltInAgentsApi.list).toHaveBeenCalledWith("company-1");
-    expect(container.textContent).toContain("Built-in");
+    expect(container.textContent).toContain("Integrati");
     expect(container.textContent).toContain("Briefs Agent");
     expect(container.textContent).not.toContain("Regular Agent");
     expect(container.querySelector('[title="Ships with Paperclip"]')).toBeNull();

--- a/ui/src/pages/Agents.tsx
+++ b/ui/src/pages/Agents.tsx
@@ -50,11 +50,11 @@ export const AGENT_FILTER_TABS = ["all", "active", "paused", "error", "builtin"]
 type FilterTab = (typeof AGENT_FILTER_TABS)[number];
 
 const AGENT_FILTER_TAB_ITEMS: { value: FilterTab; label: string }[] = [
-  { value: "all", label: "All" },
-  { value: "active", label: "Active" },
-  { value: "paused", label: "Paused" },
-  { value: "error", label: "Error" },
-  { value: "builtin", label: "Built-in" },
+  { value: "all", label: "Tutti" },
+  { value: "active", label: "Operativi" },
+  { value: "paused", label: "Archivio" },
+  { value: "error", label: "Errore" },
+  { value: "builtin", label: "Integrati" },
 ];
 
 function isFilterTab(value: string): value is FilterTab {

--- a/ui/src/pages/TeamCatalog.test.tsx
+++ b/ui/src/pages/TeamCatalog.test.tsx
@@ -256,19 +256,19 @@ describe("TeamCatalog install preview path", () => {
   it("renders the detail pane for the selected team", async () => {
     await renderPage();
     expect(document.querySelector('[data-testid="team-catalog-intro"]')).toBeTruthy();
-    expect(document.body.textContent).toContain("Design the crew. Ship the work.");
+    expect(document.body.textContent).toContain("Scegli la squadra. Avvia il lavoro.");
     expect(document.body.textContent).toContain("Core Exec Team");
     expect(document.body.textContent).toContain("A starter executive team.");
     // summary grid counts
-    expect(document.body.textContent).toContain("Agents");
-    expect(document.body.textContent).toContain("Projects");
+    expect(document.body.textContent).toContain("Agenti");
+    expect(document.body.textContent).toContain("Progetti");
   });
 
   it("opens the installer, fetches the preview, and submits the install", async () => {
     await renderPage();
 
     // Open the installer from the detail CTA.
-    const installCta = findButton("Install team");
+    const installCta = findButton("Installa il team");
     expect(installCta).toBeTruthy();
     await act(async () => {
       installCta!.click();
@@ -283,23 +283,23 @@ describe("TeamCatalog install preview path", () => {
       "team-no-deps",
       expect.objectContaining({ collisionStrategy: "rename" }),
     );
-    expect(document.body.textContent).toContain("Summary");
+    expect(document.body.textContent).toContain("Riepilogo");
     // categorized plan rows
     expect(document.body.textContent?.toLowerCase()).toContain("ceo");
     expect(document.body.textContent?.toLowerCase()).toContain("launch");
 
     // Submit install from the footer.
     const submit = Array.from(document.querySelectorAll("button")).filter((b) =>
-      (b.textContent ?? "").includes("Install team"),
+      (b.textContent ?? "").includes("Installa il team"),
     );
-    // Last "Install team" is the wizard footer submit.
+    // Last "Installa il team" is the wizard footer submit.
     await act(async () => {
       submit[submit.length - 1].click();
     });
     await flushReact();
 
     expect(mockTeamCatalogApi.install).toHaveBeenCalledTimes(1);
-    expect(document.body.textContent).toContain("Team installed");
+    expect(document.body.textContent).toContain("Team installato");
   });
 
   it("requires and submits Step 4 secret values", async () => {
@@ -320,17 +320,17 @@ describe("TeamCatalog install preview path", () => {
 
     await renderPage();
 
-    const installCta = findButton("Install team");
+    const installCta = findButton("Installa il team");
     await act(async () => {
       installCta!.click();
     });
     await flushReact();
 
     const footerInstall = Array.from(document.querySelectorAll("button")).filter((b) =>
-      (b.textContent ?? "").includes("Install team"),
+      (b.textContent ?? "").includes("Installa il team"),
     ).at(-1) as HTMLButtonElement;
     expect(footerInstall.disabled).toBe(true);
-    expect(document.body.textContent).toContain("Required secrets missing: 1");
+    expect(document.body.textContent).toContain("Segreti obbligatori mancanti: 1");
 
     const secretInput = document.querySelector('input[aria-label="OPENAI_API_KEY value"]') as HTMLInputElement;
     expect(secretInput).toBeTruthy();
@@ -389,15 +389,15 @@ describe("TeamCatalog install preview path", () => {
     ]);
     await renderPage();
 
-    const installCta = findButton("Install team");
+    const installCta = findButton("Installa il team");
     await act(async () => {
       installCta!.click();
     });
     await flushReact();
 
     // First step is target manager; Continue is disabled until a manager is chosen.
-    expect(document.body.textContent).toContain("root agents need a manager");
-    const continueBtn = findButton("Continue");
+    expect(document.body.textContent).toContain("richiedono un responsabile");
+    const continueBtn = findButton("Continua");
     expect(continueBtn).toBeTruthy();
     expect(continueBtn!.disabled).toBe(true);
     // Preview has not been requested yet (still on step 1).
@@ -420,16 +420,16 @@ describe("TeamCatalog install preview path", () => {
     await renderPage();
 
     // List group header reflects the installed team, not Bundled.
-    expect(document.body.textContent).toContain("Installed · 1");
-    expect(document.body.textContent).not.toContain("Bundled · 1");
+    expect(document.body.textContent).toContain("Installati · 1");
+    expect(document.body.textContent).not.toContain("Inclusi · 1");
 
     // Detail header chip + Re-install CTA replace the plain Install button.
-    expect(document.body.textContent).toContain("Update available");
-    expect(findButton("Re-install latest")).toBeTruthy();
-    expect(findButton("Install team")).toBeFalsy();
+    expect(document.body.textContent).toContain("Aggiornamento disponibile");
+    expect(findButton("Reinstalla l’ultima versione")).toBeTruthy();
+    expect(findButton("Installa il team")).toBeFalsy();
 
     // The out-of-date badge in the list row exposes an accessible label.
-    expect(document.querySelector('[aria-label="Update available"]')).toBeTruthy();
+    expect(document.querySelector('[aria-label="Aggiornamento disponibile"]')).toBeTruthy();
   });
 
   it("renders an Installed badge (no update chip) when the installed team is current", async () => {
@@ -447,9 +447,9 @@ describe("TeamCatalog install preview path", () => {
 
     await renderPage();
 
-    expect(document.body.textContent).toContain("Installed · 1");
-    expect(document.body.textContent).toContain("Installed");
-    expect(document.body.textContent).not.toContain("Update available");
-    expect(findButton("Re-install latest")).toBeTruthy();
+    expect(document.body.textContent).toContain("Installati · 1");
+    expect(document.body.textContent).toContain("Installato");
+    expect(document.body.textContent).not.toContain("Aggiornamento disponibile");
+    expect(findButton("Reinstalla l’ultima versione")).toBeTruthy();
   });
 });

--- a/ui/src/pages/TeamCatalog.test.tsx
+++ b/ui/src/pages/TeamCatalog.test.tsx
@@ -255,6 +255,8 @@ describe("TeamCatalog install preview path", () => {
 
   it("renders the detail pane for the selected team", async () => {
     await renderPage();
+    expect(document.querySelector('[data-testid="team-catalog-intro"]')).toBeTruthy();
+    expect(document.body.textContent).toContain("Design the crew. Ship the work.");
     expect(document.body.textContent).toContain("Core Exec Team");
     expect(document.body.textContent).toContain("A starter executive team.");
     // summary grid counts

--- a/ui/src/pages/TeamCatalog.tsx
+++ b/ui/src/pages/TeamCatalog.tsx
@@ -213,26 +213,26 @@ const TRUST_META: Record<
   { label: string; tip: string; tone: string; Icon: typeof ShieldCheck }
 > = {
   markdown_only: {
-    label: "Markdown only",
-    tip: "Contains only markdown and references. No executable content.",
+    label: "Solo Markdown",
+    tip: "Contiene solo Markdown e riferimenti. Nessun contenuto eseguibile.",
     tone: "text-emerald-600 dark:text-emerald-300 border-emerald-500/30",
     Icon: ShieldCheck,
   },
   assets: {
-    label: "Assets",
-    tip: "Includes static assets (images, fixtures). No executable content.",
+    label: "Risorse",
+    tip: "Include risorse statiche, come immagini e fixture. Nessun contenuto eseguibile.",
     tone: "text-emerald-600 dark:text-emerald-300 border-emerald-500/30",
     Icon: ShieldCheck,
   },
   scripts_executables: {
-    label: "Scripts",
-    tip: "Includes executable scripts that were security-reviewed before bundling.",
+    label: "Script",
+    tip: "Include script eseguibili verificati prima della distribuzione.",
     tone: "text-amber-600 dark:text-amber-300 border-amber-500/30",
     Icon: AlertTriangle,
   },
   external_sources: {
-    label: "External sources",
-    tip: "References external sources resolved at install time.",
+    label: "Fonti esterne",
+    tip: "Riferisce fonti esterne risolte durante l’installazione.",
     tone: "text-amber-600 dark:text-amber-300 border-amber-500/30",
     Icon: AlertTriangle,
   },
@@ -263,9 +263,9 @@ const COMPAT_META: Record<
   CatalogTeamCompatibility,
   { label: string; tone: string }
 > = {
-  compatible: { label: "Compatible", tone: "text-emerald-600 dark:text-emerald-300 border-emerald-500/30" },
-  unknown: { label: "Unknown compat", tone: "text-muted-foreground border-border" },
-  invalid: { label: "Invalid", tone: "text-rose-600 dark:text-rose-300 border-rose-500/30" },
+  compatible: { label: "Compatibile", tone: "text-emerald-600 dark:text-emerald-300 border-emerald-500/30" },
+  unknown: { label: "Compatibilità ignota", tone: "text-muted-foreground border-border" },
+  invalid: { label: "Non valido", tone: "text-rose-600 dark:text-rose-300 border-rose-500/30" },
 };
 
 function CompatChip({ compatibility }: { compatibility: CatalogTeamCompatibility }) {
@@ -293,7 +293,7 @@ function ProvenanceBadge({ team }: { team: CatalogTeam }) {
           {team.packageVersion ? `@${team.packageVersion}` : ""}
         </Badge>
       </TooltipTrigger>
-      <TooltipContent>Catalog package provenance</TooltipContent>
+      <TooltipContent>Provenienza del pacchetto</TooltipContent>
     </Tooltip>
   );
 }
@@ -478,7 +478,7 @@ export function TeamHierarchyPreview({ team }: { team: CatalogTeam }) {
           >
             <Crown className="h-3.5 w-3.5 text-amber-500" />
             <span className="font-medium">{titleCase(slug)}</span>
-            <span className="text-xs text-muted-foreground">root agent</span>
+            <span className="text-xs text-muted-foreground">agente principale</span>
           </li>
         ))}
         {members.map((slug) => (
@@ -488,7 +488,7 @@ export function TeamHierarchyPreview({ team }: { team: CatalogTeam }) {
           </li>
         ))}
         {team.agentSlugs.length === 0 && (
-          <li className="px-3 py-2 text-xs text-muted-foreground">No agents in this team.</li>
+          <li className="px-3 py-2 text-xs text-muted-foreground">Nessun agente in questo team.</li>
         )}
       </ul>
     </div>
@@ -512,21 +512,21 @@ function CatalogIntro({ blueprintCount, installedCount }: { blueprintCount: numb
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div className="max-w-2xl">
           <span className="inline-flex rounded-full bg-[#f5c76b] px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-[#173d34]">
-            Paperclip / blueprint catalog
+            Paperclip / catalogo modelli
           </span>
-          <h2 className="mt-3 text-2xl font-semibold tracking-tight sm:text-3xl">Design the crew. Ship the work.</h2>
+          <h2 className="mt-3 text-2xl font-semibold tracking-tight sm:text-3xl">Scegli la squadra. Avvia il lavoro.</h2>
           <p className="mt-2 max-w-xl text-sm leading-6 text-emerald-50/75">
-            Import a proven operating shape, then keep ownership, budgets, and audit visible from one control plane.
+            Parti da una struttura verificata e gestisci responsabilità, budget e controlli da un unico posto.
           </p>
         </div>
         <div className="grid min-w-[15rem] grid-cols-3 gap-2 text-center text-xs">
           <div className="rounded-xl bg-white/10 px-3 py-2.5">
             <div className="text-lg font-semibold tabular-nums">{blueprintCount}</div>
-            <div className="text-emerald-50/65">Blueprints</div>
+            <div className="text-emerald-50/65">Modelli</div>
           </div>
           <div className="rounded-xl bg-white/10 px-3 py-2.5">
             <div className="text-lg font-semibold tabular-nums">{installedCount}</div>
-            <div className="text-emerald-50/65">Installed</div>
+            <div className="text-emerald-50/65">Installati</div>
           </div>
           <div className="rounded-xl bg-[#f5c76b] px-3 py-2.5 text-[#173d34]">
             <div className="text-sm font-semibold">Core360</div>
@@ -563,7 +563,7 @@ function MetricTile({
 }
 
 export function RequiredSkillsList({ skills }: { skills: CatalogTeamSkillRequirement[] }) {
-  if (skills.length === 0) return <p className="text-sm text-muted-foreground">No required skills.</p>;
+  if (skills.length === 0) return <p className="text-sm text-muted-foreground">Nessuna competenza richiesta.</p>;
   return (
     <ul className="space-y-1">
       {skills.map((skill) => (
@@ -595,7 +595,7 @@ export function EnvInputsList({ inputs }: { inputs: CatalogTeamEnvInputSummary[]
   if (inputs.length === 0) return null;
   return (
     <div className="space-y-1.5">
-      <SectionHeader>Secrets & env inputs</SectionHeader>
+      <SectionHeader>Segreti e variabili</SectionHeader>
       <ul className="space-y-1">
         {inputs.map((input) => (
           <li
@@ -616,7 +616,7 @@ export function EnvInputsList({ inputs }: { inputs: CatalogTeamEnvInputSummary[]
               {input.kind}
             </Badge>
             {input.requirement === "required" && (
-              <Badge variant="outline" className="text-(length:--text-nano)">required</Badge>
+              <Badge variant="outline" className="text-(length:--text-nano)">obbligatorio</Badge>
             )}
           </li>
         ))}
@@ -656,13 +656,13 @@ export function ExternalSourcesList({ sources }: { sources: CatalogTeamSourceRef
                 <span className="font-mono text-xs truncate">{source.ref}</span>
                 <span className="ml-auto text-(length:--text-micro)">
                   {code === "ok" && (
-                    <span className="text-emerald-600 dark:text-emerald-300">Pinned</span>
+                    <span className="text-emerald-600 dark:text-emerald-300">Bloccata</span>
                   )}
                   {code === "unpinned" && (
-                    <span className="text-amber-600 dark:text-amber-300">Unpinned</span>
+                    <span className="text-amber-600 dark:text-amber-300">Non bloccata</span>
                   )}
                   {code === "unsupported_in_ui" && (
-                    <span className="text-rose-600 dark:text-rose-300">Unsupported in browser install</span>
+                    <span className="text-rose-600 dark:text-rose-300">Non installabile dal browser</span>
                   )}
                 </span>
               </li>
@@ -721,7 +721,7 @@ export function TeamDetailPane({
       ) : (
         <Download className="h-4 w-4" />
       )}
-      {isInstalled ? "Re-install latest" : "Install team"}
+      {isInstalled ? "Reinstalla l’ultima versione" : "Installa il team"}
     </Button>
   );
 
@@ -742,7 +742,7 @@ export function TeamDetailPane({
               <ProvenanceBadge team={team} />
               {isInstalled && !outOfDate && (
                 <Badge variant="secondary" className="gap-1 text-(length:--text-nano)">
-                  <CheckCircle2 className="h-3 w-3" /> Installed
+                  <CheckCircle2 className="h-3 w-3" /> Installato
                 </Badge>
               )}
               {outOfDate && (
@@ -750,7 +750,7 @@ export function TeamDetailPane({
                   variant="outline"
                   className="gap-1 border-amber-500/40 bg-amber-500/10 text-(length:--text-nano) text-amber-600 dark:text-amber-300"
                 >
-                  <ChevronUp className="h-3 w-3" /> Update available
+                  <ChevronUp className="h-3 w-3" /> Aggiornamento disponibile
                 </Badge>
               )}
             </div>
@@ -760,14 +760,14 @@ export function TeamDetailPane({
               <TooltipTrigger asChild>
                 <span tabIndex={0}>{installButton}</span>
               </TooltipTrigger>
-              <TooltipContent>This team cannot be installed — the package manifest is invalid.</TooltipContent>
+              <TooltipContent>Il team non può essere installato: il pacchetto non è valido.</TooltipContent>
             </Tooltip>
           ) : !canInstall ? (
             <Tooltip>
               <TooltipTrigger asChild>
                 <span tabIndex={0}>{installButton}</span>
               </TooltipTrigger>
-              <TooltipContent>Requires board operator or agent-create permissions.</TooltipContent>
+              <TooltipContent>Servono i permessi operatore o creazione agenti.</TooltipContent>
             </Tooltip>
           ) : (
             installButton
@@ -785,22 +785,22 @@ export function TeamDetailPane({
 
         {/* Summary grid */}
         <div className="grid grid-cols-2 gap-3 xl:grid-cols-4">
-          <MetricTile label="Agents" value={team.counts.agents} Icon={Users2} />
-          <MetricTile label="Projects" value={team.counts.projects} Icon={FolderKanban} />
-          <MetricTile label="Routines" value={team.counts.routines} Icon={Repeat} />
-          <MetricTile label="Required skills" value={skillCount(team)} Icon={Boxes} />
+          <MetricTile label="Agenti" value={team.counts.agents} Icon={Users2} />
+          <MetricTile label="Progetti" value={team.counts.projects} Icon={FolderKanban} />
+          <MetricTile label="Routine" value={team.counts.routines} Icon={Repeat} />
+          <MetricTile label="Competenze richieste" value={skillCount(team)} Icon={Boxes} />
         </div>
 
         {/* Agent hierarchy */}
         <div className="space-y-2">
-          <SectionHeader>Agent hierarchy</SectionHeader>
+          <SectionHeader>Gerarchia agenti</SectionHeader>
           <TeamHierarchyPreview team={team} />
         </div>
 
         {/* Projects */}
         {team.projectSlugs.length > 0 && (
           <div className="space-y-2">
-            <SectionHeader>Projects</SectionHeader>
+            <SectionHeader>Progetti</SectionHeader>
             <ul className="space-y-1">
               {team.projectSlugs.map((slug) => (
                 <li key={slug} className="flex items-center gap-2 rounded-md border border-border px-3 py-2 text-sm">
@@ -815,7 +815,7 @@ export function TeamDetailPane({
 
         {/* Required skills */}
         <div className="space-y-2">
-          <SectionHeader>Required skills</SectionHeader>
+          <SectionHeader>Competenze richieste</SectionHeader>
           <RequiredSkillsList skills={team.requiredSkills} />
         </div>
 
@@ -827,7 +827,7 @@ export function TeamDetailPane({
 
         {/* File inventory */}
         <div className="space-y-2">
-          <SectionHeader>Files</SectionHeader>
+          <SectionHeader>File</SectionHeader>
           <div className="rounded-md border border-border p-1.5">
             <TeamFileTree
               nodes={tree}
@@ -846,7 +846,7 @@ export function TeamDetailPane({
                   className="text-xs text-muted-foreground hover:text-foreground"
                   onClick={() => onSelectFile(null)}
                 >
-                  Close
+                  Chiudi
                 </button>
               </div>
               <div className="max-h-96 overflow-auto p-3">
@@ -875,10 +875,10 @@ export function TeamDetailPane({
 type WizardStep = "target_manager" | "source_policy" | "skill_plan" | "preview";
 
 const STEP_LABELS: Record<WizardStep, string> = {
-  target_manager: "Target manager",
-  source_policy: "Source policy",
-  skill_plan: "Prerequisite skills",
-  preview: "Preview",
+  target_manager: "Responsabile",
+  source_policy: "Politica fonti",
+  skill_plan: "Competenze necessarie",
+  preview: "Anteprima",
 };
 
 // `simplified` is the onboarding seam (design §6): the newly created company is
@@ -1020,7 +1020,7 @@ export function useInstallTeamCatalogEntry({
       setPreviewError(null);
     },
     onError: (error) => {
-      setPreviewError(error instanceof Error ? error.message : "Failed to load install preview.");
+      setPreviewError(error instanceof Error ? error.message : "Impossibile caricare l’anteprima.");
     },
   });
 
@@ -1038,7 +1038,7 @@ export function useInstallTeamCatalogEntry({
     },
     onError: (error) => {
       setPhase("error");
-      setApplyError(error instanceof Error ? error.message : "Install failed.");
+      setApplyError(error instanceof Error ? error.message : "Installazione non riuscita.");
     },
   });
 
@@ -1171,7 +1171,7 @@ function TeamInstallerDialog({
       setPreviewError(null);
     },
     onError: (error) => {
-      setPreviewError(error instanceof Error ? error.message : "Failed to load install preview.");
+      setPreviewError(error instanceof Error ? error.message : "Impossibile caricare l’anteprima.");
     },
   });
 
@@ -1188,7 +1188,7 @@ function TeamInstallerDialog({
     },
     onError: (error) => {
       setPhase("error");
-      setApplyError(error instanceof Error ? error.message : "Install failed.");
+      setApplyError(error instanceof Error ? error.message : "Installazione non riuscita.");
     },
   });
 
@@ -1245,14 +1245,14 @@ function TeamInstallerDialog({
   const headerTitle = (
     <span className="flex items-center gap-2">
       <Users2 className="h-4 w-4" />
-      Install {team.name}
+      Installa {team.name}
     </span>
   );
   const headerDescription =
     phase === "form" ? (
       <span className="flex items-center gap-2">
         <span>
-          Step {stepIndex + 1} of {totalSteps} · {STEP_LABELS[currentStep]}
+          Passaggio {stepIndex + 1} di {totalSteps} · {STEP_LABELS[currentStep]}
         </span>
         <span className="flex items-center gap-1" aria-hidden>
           {steps.map((s, i) => (
@@ -1331,10 +1331,10 @@ function TeamInstallerDialog({
             <div role="alert" className="flex items-start gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2.5 text-sm text-rose-700 dark:text-rose-300">
               <XCircle className="mt-0.5 h-4 w-4 shrink-0" />
               <div>
-                <p className="font-medium">Install failed</p>
+                <p className="font-medium">Installazione non riuscita</p>
                 <p className="mt-0.5 text-xs">{applyError}</p>
                 <p className="mt-1 text-xs opacity-80">
-                  Partial state is not rolled back. Review the organization activity log before retrying.
+                  Le modifiche parziali non vengono annullate. Controlla il registro attività prima di riprovare.
                 </p>
               </div>
             </div>
@@ -1348,42 +1348,42 @@ function TeamInstallerDialog({
       <div className="flex items-center justify-between gap-3">
         <div>
           {stepIndex > 0 ? (
-            <Button variant="ghost" onClick={goBack}>Back</Button>
+            <Button variant="ghost" onClick={goBack}>Indietro</Button>
           ) : (
-            <Button variant="ghost" onClick={onClose}>Cancel</Button>
+            <Button variant="ghost" onClick={onClose}>Annulla</Button>
           )}
         </div>
         <div className="flex items-center gap-3">
           {currentStep === "preview" && hasErrors && (
             <span className="text-xs text-rose-600 dark:text-rose-300">
-              Install blocked: {blockedCount} error{blockedCount === 1 ? "" : "s"}
+              Installazione bloccata: {blockedCount} {blockedCount === 1 ? "errore" : "errori"}
             </span>
           )}
           {currentStep === "preview" && !hasErrors && missingRequiredSecretCount > 0 && (
             <span className="text-xs text-rose-600 dark:text-rose-300">
-              Required secrets missing: {missingRequiredSecretCount}
+              Segreti obbligatori mancanti: {missingRequiredSecretCount}
             </span>
           )}
           {currentStep === "preview" ? (
             needsScriptsConfirm && confirmScripts ? (
               <Button variant="destructive" onClick={submitInstall} disabled={installBlocked || previewMutation.isPending}>
                 <AlertTriangle className="h-4 w-4" />
-                Confirm — install with executables
+                Conferma: installa con eseguibili
               </Button>
             ) : (
               <Button onClick={submitInstall} disabled={installBlocked || previewMutation.isPending || !previewResult}>
                 {needsScriptsConfirm ? <AlertTriangle className="h-4 w-4" /> : <Download className="h-4 w-4" />}
-                {needsScriptsConfirm ? "Install with executables" : "Install team"}
+                {needsScriptsConfirm ? "Installa con eseguibili" : "Installa il team"}
               </Button>
             )
           ) : (
-            <Button onClick={goNext} disabled={!canContinue(currentStep)}>Continue</Button>
+            <Button onClick={goNext} disabled={!canContinue(currentStep)}>Continua</Button>
           )}
         </div>
       </div>
     ) : phase === "error" ? (
       <div className="flex justify-end">
-        <Button variant="ghost" onClick={onClose}>Close</Button>
+        <Button variant="ghost" onClick={onClose}>Chiudi</Button>
       </div>
     ) : null;
 
@@ -1442,12 +1442,12 @@ export function StepTargetManager({
         className="rounded-md border border-blue-500/30 bg-blue-500/10 px-3 py-2.5 text-sm text-blue-700 dark:text-blue-300"
         id="target-manager-help"
       >
-        This team&apos;s root agents need a manager in your organization. Pick the agent who will become
-        their parent. Internal team hierarchy is preserved.
+        Gli agenti principali di questo team richiedono un responsabile nella tua organizzazione.
+        Scegli il loro referente: la gerarchia interna del team verrà mantenuta.
       </div>
 
       <div className="space-y-1.5">
-        <SectionHeader>Root agents</SectionHeader>
+        <SectionHeader>Agenti principali</SectionHeader>
         <ul className="rounded-md border border-border">
           {team.rootAgentSlugs.map((slug) => (
             <li key={slug} className="flex items-center gap-2 border-b border-border/60 px-3 py-2 text-sm last:border-b-0">
@@ -1463,11 +1463,11 @@ export function StepTargetManager({
 
       {!fullCompany && (
         <div className="space-y-1.5" aria-describedby="target-manager-help">
-          <SectionHeader>Target manager</SectionHeader>
+          <SectionHeader>Responsabile</SectionHeader>
           <Command className="rounded-md border border-border">
-            <CommandInput placeholder="Search agents…" />
+            <CommandInput placeholder="Cerca agenti…" />
             <CommandList>
-              <CommandEmpty>No agents found.</CommandEmpty>
+              <CommandEmpty>Nessun agente trovato.</CommandEmpty>
               <CommandGroup>
                 {agents.map((agent) => (
                   <CommandItem
@@ -1496,7 +1496,7 @@ export function StepTargetManager({
             checked={fullCompany}
             onChange={(e) => onToggleFullCompany(e.target.checked)}
           />
-          Use this team as a full-organization package (no target manager)
+          Usa questo team come organizzazione completa, senza un responsabile superiore
         </label>
       )}
     </div>
@@ -1560,20 +1560,20 @@ export function StepSourcePolicy({
 
       <div className="space-y-2.5 rounded-md border border-border p-3">
         <PolicyToggle
-          label="Allow external sources"
-          description="Resolve github/url skill and team sources at install time."
+          label="Consenti fonti esterne"
+          description="Risolvi fonti GitHub o URL durante l’installazione."
           checked={allowExternalSources}
           onChange={(v) => onChange("external", v)}
         />
         <PolicyToggle
-          label="Allow unpinned optional sources"
-          description="Permit optional sources that are not pinned to a ref or checksum."
+          label="Consenti fonti opzionali non bloccate"
+          description="Permetti fonti opzionali senza riferimento o checksum fissato."
           checked={allowUnpinnedOptionalSources}
           onChange={(v) => onChange("unpinned", v)}
         />
         <PolicyToggle
-          label="Allow local-path sources"
-          description="Required for local_path / agent_package sources. Development use only."
+          label="Consenti percorsi locali"
+          description="Necessario per fonti locali o pacchetti agente. Solo sviluppo."
           checked={allowLocalPathSources}
           onChange={(v) => onChange("localPath", v)}
         />
@@ -1615,10 +1615,10 @@ const SKILL_ACTION_META: Record<
   CatalogTeamSkillPreparation["action"],
   { label: string; tone: string }
 > = {
-  already_in_package: { label: "Bundled in package", tone: "text-emerald-600 dark:text-emerald-300 border-emerald-500/30" },
-  catalog_install_required: { label: "Will install from catalog", tone: "text-blue-600 dark:text-blue-300 border-blue-500/30" },
-  external_import_required: { label: "Will import from source", tone: "text-amber-600 dark:text-amber-300 border-amber-500/30" },
-  blocked: { label: "Blocked", tone: "text-rose-600 dark:text-rose-300 border-rose-500/30" },
+  already_in_package: { label: "Inclusa nel pacchetto", tone: "text-emerald-600 dark:text-emerald-300 border-emerald-500/30" },
+  catalog_install_required: { label: "Installata dal catalogo", tone: "text-blue-600 dark:text-blue-300 border-blue-500/30" },
+  external_import_required: { label: "Importata dalla fonte", tone: "text-amber-600 dark:text-amber-300 border-amber-500/30" },
+  blocked: { label: "Bloccata", tone: "text-rose-600 dark:text-rose-300 border-rose-500/30" },
 };
 
 export function StepSkillPlan({
@@ -1785,25 +1785,25 @@ export function StepPreview({
     <div className="space-y-4">
       {/* Summary */}
       <div className="space-y-2">
-        <SectionHeader>Summary</SectionHeader>
+        <SectionHeader>Riepilogo</SectionHeader>
         <div className="grid grid-cols-2 gap-2 text-sm sm:grid-cols-4">
-          <SummaryCount label="Agents" value={plan.agentPlans.length} />
-          <SummaryCount label="Projects" value={plan.projectPlans.length} />
-          <SummaryCount label="Starter tasks" value={plan.issuePlans.length} />
-          <SummaryCount label="Required skills" value={result.skillPreparations.length} />
+          <SummaryCount label="Agenti" value={plan.agentPlans.length} />
+          <SummaryCount label="Progetti" value={plan.projectPlans.length} />
+          <SummaryCount label="Attività iniziali" value={plan.issuePlans.length} />
+          <SummaryCount label="Competenze richieste" value={result.skillPreparations.length} />
         </div>
       </div>
 
       {/* Collision strategy */}
       <div className="flex items-center gap-3">
-        <span className="text-sm font-medium">Collision strategy</span>
+        <span className="text-sm font-medium">Gestione conflitti</span>
         <Select value={collisionStrategy} onValueChange={(v) => onCollisionStrategyChange(v as CompanyPortabilityCollisionStrategy)}>
           <SelectTrigger className="h-8 w-40">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="rename">Rename collisions</SelectItem>
-            <SelectItem value="skip">Skip collisions</SelectItem>
+            <SelectItem value="rename">Rinomina i conflitti</SelectItem>
+            <SelectItem value="skip">Salta i conflitti</SelectItem>
           </SelectContent>
         </Select>
       </div>
@@ -1811,7 +1811,7 @@ export function StepPreview({
       {/* Errors / warnings */}
       {result.errors.length > 0 && (
         <div role="alert" className="rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2.5 text-sm text-rose-700 dark:text-rose-300">
-          <p className="font-medium">Install blocked</p>
+          <p className="font-medium">Installazione bloccata</p>
           <ul className="mt-1 list-disc space-y-0.5 pl-4 text-xs">
             {result.errors.map((e, i) => <li key={i}>{e}</li>)}
           </ul>
@@ -1827,7 +1827,7 @@ export function StepPreview({
 
       {/* Agents */}
       {plan.agentPlans.length > 0 && (
-        <PreviewSection title={`Agents · ${plan.agentPlans.length}`}>
+        <PreviewSection title={`Agenti · ${plan.agentPlans.length}`}>
           {plan.agentPlans.map((p) => (
             <PlanRow
               key={p.slug}
@@ -1845,7 +1845,7 @@ export function StepPreview({
 
       {/* Projects */}
       {plan.projectPlans.length > 0 && (
-        <PreviewSection title={`Projects · ${plan.projectPlans.length}`}>
+        <PreviewSection title={`Progetti · ${plan.projectPlans.length}`}>
           {plan.projectPlans.map((p) => (
             <PlanRow
               key={p.slug}
@@ -1863,7 +1863,7 @@ export function StepPreview({
 
       {/* Starter tasks */}
       {plan.issuePlans.length > 0 && (
-        <PreviewSection title={`Starter tasks · ${plan.issuePlans.length}`}>
+        <PreviewSection title={`Attività iniziali · ${plan.issuePlans.length}`}>
           {plan.issuePlans.map((p) => (
             <PlanRow key={p.slug} slug={p.slug} action={p.action} plannedName={p.plannedTitle} reason={p.reason} canRename={false} />
           ))}
@@ -1872,7 +1872,7 @@ export function StepPreview({
 
       {/* Adapter selection — install schema accepts adapterOverrides (design §4.4) */}
       {manifestAgents.length > 0 && (
-        <PreviewSection title={`Adapter selection · ${manifestAgents.length}`}>
+        <PreviewSection title={`Selezione adapter · ${manifestAgents.length}`}>
           {manifestAgents.map((agent) => {
             const selected = adapterOverrides[agent.slug] ?? agent.adapterType;
             return (
@@ -1902,7 +1902,7 @@ export function StepPreview({
 
       {/* Env inputs */}
       {envInputs.length > 0 && (
-        <PreviewSection title={`Secrets & env inputs · ${envInputs.length}`}>
+        <PreviewSection title={`Segreti e variabili · ${envInputs.length}`}>
           {envInputs.map((input) => {
             const formKey = envInputFormKey(input);
             const visible = Boolean(visibleSecretKeys[formKey]);
@@ -1914,7 +1914,7 @@ export function StepPreview({
                   <span className="font-mono text-xs uppercase tracking-wide">{input.key}</span>
                   {input.description && <span className="truncate text-xs text-muted-foreground">{input.description}</span>}
                   {input.requirement === "required" && (
-                    <Badge variant="outline" className="text-(length:--text-nano)">required</Badge>
+                    <Badge variant="outline" className="text-(length:--text-nano)">obbligatorio</Badge>
                   )}
                   <Badge
                     variant="outline"
@@ -1928,7 +1928,7 @@ export function StepPreview({
                     type={visible ? "text" : "password"}
                     value={secretValues[formKey] ?? ""}
                     onChange={(event) => onSecretChange(formKey, event.target.value)}
-                    placeholder={input.requirement === "required" ? "Required" : "Optional"}
+                    placeholder={input.requirement === "required" ? "Obbligatorio" : "Opzionale"}
                     aria-label={`${input.key} value`}
                     aria-invalid={missingRequired || undefined}
                     className={cn("h-8 min-w-0", missingRequired && "border-rose-500/60 focus-visible:ring-rose-500/30")}
@@ -1946,7 +1946,7 @@ export function StepPreview({
                         {visible ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
                       </Button>
                     </TooltipTrigger>
-                    <TooltipContent>{visible ? "Hide value" : "Show value"}</TooltipContent>
+                    <TooltipContent>{visible ? "Nascondi valore" : "Mostra valore"}</TooltipContent>
                   </Tooltip>
                 </div>
               </li>
@@ -2030,16 +2030,16 @@ export function ApplySuccess({
     <div className="space-y-4 py-2">
       <div className="flex items-center gap-2">
         <CheckCircle2 className="h-6 w-6 text-emerald-500" />
-        <p className="text-base font-semibold">Team installed</p>
+        <p className="text-base font-semibold">Team installato</p>
       </div>
       <p className="text-sm text-muted-foreground">
         {team.name} was imported into your organization. Imported entities are stamped with catalog provenance.
       </p>
       {result && (
         <ul className="divide-y divide-border/60 rounded-md border border-border px-3">
-          <ResultRow label="Agents imported" count={agentsCreated} />
-          <ResultRow label="Projects imported" count={projectsCreated} />
-          <ResultRow label="Skills resolved" count={skillsResolved} />
+          <ResultRow label="Agenti importati" count={agentsCreated} />
+          <ResultRow label="Progetti importati" count={projectsCreated} />
+          <ResultRow label="Competenze risolte" count={skillsResolved} />
         </ul>
       )}
       {warnings.length > 0 && (
@@ -2050,13 +2050,13 @@ export function ApplySuccess({
         </div>
       )}
       <ul className="space-y-1 text-sm">
-        <li><a className="text-primary hover:underline" href="/agents/all">View imported agents →</a></li>
-        <li><a className="text-primary hover:underline" href="/projects">View imported projects →</a></li>
-        <li><a className="text-primary hover:underline" href="/routines">View routines →</a></li>
-        <li><a className="text-primary hover:underline" href="/activity">View activity log →</a></li>
+        <li><a className="text-primary hover:underline" href="/agents/active">Vedi agenti importati →</a></li>
+        <li><a className="text-primary hover:underline" href="/projects">Vedi progetti importati →</a></li>
+        <li><a className="text-primary hover:underline" href="/routines">Vedi routine →</a></li>
+        <li><a className="text-primary hover:underline" href="/activity">Vedi registro attività →</a></li>
       </ul>
       <div className="flex justify-end">
-        <Button onClick={onClose}>Done</Button>
+        <Button onClick={onClose}>Fatto</Button>
       </div>
     </div>
   );
@@ -2097,13 +2097,13 @@ export function TeamRow({
           <Tooltip>
             <TooltipTrigger asChild>
               <span
-                aria-label="Update available"
+                aria-label="Aggiornamento disponibile"
                 className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-300"
               >
                 <ChevronUp className="h-3 w-3" />
               </span>
             </TooltipTrigger>
-            <TooltipContent>Update available — installed team is out of date</TooltipContent>
+            <TooltipContent>Aggiornamento disponibile: il team installato non è aggiornato</TooltipContent>
           </Tooltip>
         )}
         {risk !== "safe" && (
@@ -2111,7 +2111,7 @@ export function TeamRow({
             <TooltipTrigger asChild>
               <AlertTriangle className={cn("ml-auto h-3.5 w-3.5", risk === "blocked" ? "text-rose-500" : "text-amber-500")} />
             </TooltipTrigger>
-            <TooltipContent>Has external sources</TooltipContent>
+            <TooltipContent>Contiene fonti esterne</TooltipContent>
           </Tooltip>
         )}
       </div>
@@ -2237,8 +2237,8 @@ export function TeamCatalog() {
 
   useEffect(() => {
     setBreadcrumbs([
-      { label: "Org Chart", href: "/org" },
-      { label: "Teams", href: TEAM_CATALOG_ROUTE_ROOT },
+      { label: "Organigramma", href: "/org" },
+      { label: "Modelli team", href: TEAM_CATALOG_ROUTE_ROOT },
     ]);
   }, [setBreadcrumbs]);
 
@@ -2334,7 +2334,7 @@ export function TeamCatalog() {
   if (!selectedCompanyId) {
     return (
       <div className="p-8">
-        <EmptyState icon={Users2} message="Select an organization to browse the team catalog." />
+        <EmptyState icon={Users2} message="Seleziona un’organizzazione per vedere i modelli team." />
       </div>
     );
   }
@@ -2344,13 +2344,13 @@ export function TeamCatalog() {
       <CatalogIntro blueprintCount={teams.length} installedCount={installedById.size} />
       {/* Toolbar */}
       <div className="flex flex-wrap items-center gap-2 border-b border-border px-5 py-3">
-        <h1 className="text-lg font-semibold">Teams</h1>
+        <h1 className="text-lg font-semibold">Modelli team</h1>
         <div className="relative">
           <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
           <Input
             value={q}
             onChange={(e) => setFilterParam("search", e.target.value)}
-            placeholder="Search teams"
+            placeholder="Cerca modelli"
             className="h-8 w-56 pl-8"
           />
         </div>
@@ -2359,16 +2359,16 @@ export function TeamCatalog() {
           <DropdownMenuTrigger asChild>
             <Button variant="outline" size="sm" className="h-8">
               <Filter className="h-3.5 w-3.5" />
-              {kindFilter === "all" ? "All kinds" : kindFilter === "bundled" ? "Bundled" : "Optional"}
+              {kindFilter === "all" ? "Tutti i tipi" : kindFilter === "bundled" ? "Inclusi" : "Opzionali"}
               <ChevronDown className="h-3.5 w-3.5" />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start">
-            <DropdownMenuLabel>Kind</DropdownMenuLabel>
+            <DropdownMenuLabel>Tipo</DropdownMenuLabel>
             <DropdownMenuRadioGroup value={kindFilter} onValueChange={(v) => setFilterParam("kind", v)}>
-              <DropdownMenuRadioItem value="all">All kinds</DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="bundled">Bundled</DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="optional">Optional</DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="all">Tutti i tipi</DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="bundled">Inclusi</DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="optional">Opzionali</DropdownMenuRadioItem>
             </DropdownMenuRadioGroup>
           </DropdownMenuContent>
         </DropdownMenu>
@@ -2377,14 +2377,14 @@ export function TeamCatalog() {
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="outline" size="sm" className="h-8">
-                {categoryFilter ? `Category · ${titleCase(categoryFilter)}` : "All categories"}
+                {categoryFilter ? `Categoria · ${titleCase(categoryFilter)}` : "Tutte le categorie"}
                 <ChevronDown className="h-3.5 w-3.5" />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start">
-              <DropdownMenuLabel>Category</DropdownMenuLabel>
+              <DropdownMenuLabel>Categoria</DropdownMenuLabel>
               <DropdownMenuRadioGroup value={categoryFilter} onValueChange={(v) => setFilterParam("category", v)}>
-                <DropdownMenuRadioItem value="">All categories</DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="">Tutte le categorie</DropdownMenuRadioItem>
                 {categories.map((cat) => (
                   <DropdownMenuRadioItem key={cat} value={cat}>{titleCase(cat)}</DropdownMenuRadioItem>
                 ))}
@@ -2396,17 +2396,17 @@ export function TeamCatalog() {
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="outline" size="sm" className="h-8">
-              {riskFilter === "any" ? "Any risk" : riskFilter === "safe" ? "Safe only" : riskFilter === "has_warnings" ? "Has warnings" : "Blocked"}
+              {riskFilter === "any" ? "Qualsiasi rischio" : riskFilter === "safe" ? "Solo sicuri" : riskFilter === "has_warnings" ? "Con avvisi" : "Bloccati"}
               <ChevronDown className="h-3.5 w-3.5" />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start">
-            <DropdownMenuLabel>Risk</DropdownMenuLabel>
+            <DropdownMenuLabel>Rischio</DropdownMenuLabel>
             <DropdownMenuRadioGroup value={riskFilter} onValueChange={(v) => setFilterParam("risk", v)}>
-              <DropdownMenuRadioItem value="any">Any risk</DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="safe">Safe only</DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="has_warnings">Has warnings</DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="blocked">Blocked</DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="any">Qualsiasi rischio</DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="safe">Solo sicuri</DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="has_warnings">Con avvisi</DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="blocked">Bloccati</DropdownMenuRadioItem>
             </DropdownMenuRadioGroup>
             {anyFilterActive && (
               <>
@@ -2416,7 +2416,7 @@ export function TeamCatalog() {
                   className="flex w-full items-center gap-1.5 px-2 py-1.5 text-xs text-muted-foreground hover:text-foreground"
                   onClick={() => setSearchParams(new URLSearchParams())}
                 >
-                  <RotateCcw className="h-3 w-3" /> Reset filters
+                  <RotateCcw className="h-3 w-3" /> Azzera filtri
                 </button>
               </>
             )}
@@ -2425,7 +2425,7 @@ export function TeamCatalog() {
 
         {anyFilterActive && (
           <Button variant="ghost" size="sm" className="h-8 text-xs" onClick={() => setSearchParams(new URLSearchParams())}>
-            Reset filters
+            Azzera filtri
           </Button>
         )}
       </div>
@@ -2447,19 +2447,19 @@ export function TeamCatalog() {
           ) : catalogQuery.isError ? (
             <div className="p-4">
               <div role="alert" className="rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2.5 text-sm text-rose-700 dark:text-rose-300">
-                Failed to load team catalog.
+                Impossibile caricare il catalogo team.
               </div>
               <Button variant="outline" size="sm" className="mt-3" onClick={() => catalogQuery.refetch()}>
-                <RotateCcw className="h-3.5 w-3.5" /> Retry
+                <RotateCcw className="h-3.5 w-3.5" /> Riprova
               </Button>
             </div>
           ) : teams.length === 0 ? (
-            <EmptyState icon={Users2} message="No team catalog configured." />
+            <EmptyState icon={Users2} message="Nessun catalogo team configurato." />
           ) : filtered.length === 0 ? (
             <EmptyState
               icon={Search}
-              message="No teams match this filter."
-              action="Reset filters"
+              message="Nessun team corrisponde ai filtri."
+              action="Azzera filtri"
               onAction={() => setSearchParams(new URLSearchParams())}
             />
           ) : (
@@ -2467,7 +2467,7 @@ export function TeamCatalog() {
               {grouped.bundled.length > 0 && (
                 <>
                   <div className="px-3 py-2 text-(length:--text-micro) font-semibold uppercase tracking-wide text-muted-foreground">
-                    Bundled · {grouped.bundled.length}
+                    Inclusi · {grouped.bundled.length}
                   </div>
                   {grouped.bundled.map((team) => (
                     <TeamRow
@@ -2482,7 +2482,7 @@ export function TeamCatalog() {
               {grouped.optional.length > 0 && (
                 <>
                   <div className="px-3 py-2 text-(length:--text-micro) font-semibold uppercase tracking-wide text-muted-foreground">
-                    Optional · {grouped.optional.length}
+                    Opzionali · {grouped.optional.length}
                   </div>
                   {grouped.optional.map((team) => (
                     <TeamRow
@@ -2497,7 +2497,7 @@ export function TeamCatalog() {
               {grouped.installed.length > 0 && (
                 <>
                   <div className="px-3 py-2 text-(length:--text-micro) font-semibold uppercase tracking-wide text-muted-foreground">
-                    Installed · {grouped.installed.length}
+                    Installati · {grouped.installed.length}
                   </div>
                   {grouped.installed.map((team) => (
                     <TeamRow
@@ -2528,7 +2528,7 @@ export function TeamCatalog() {
                 onClick={() => navigate(withFilters(TEAM_CATALOG_ROUTE_ROOT))}
                 className="flex items-center gap-1.5 border-b border-border px-4 py-2 text-sm text-muted-foreground hover:text-foreground"
               >
-                <ChevronLeft className="h-4 w-4" /> Back to catalog
+                <ChevronLeft className="h-4 w-4" /> Torna al catalogo
               </button>
             )}
             {selectedTeam ? (
@@ -2545,7 +2545,7 @@ export function TeamCatalog() {
               />
             ) : (
               <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
-                Select a team to view details.
+                Seleziona un team per vedere i dettagli.
               </div>
             )}
           </div>
@@ -2560,7 +2560,7 @@ export function TeamCatalog() {
           open={installOpen}
           onClose={() => setInstallOpen(false)}
           onInstalled={() => {
-            pushToast({ tone: "success", title: "Team installed", body: `${selectedTeam.name} was imported.` });
+            pushToast({ tone: "success", title: "Team installato", body: `${selectedTeam.name} è stato importato.` });
             // Provenance now lives on the new agents — refresh installed/out-of-date state.
             void queryClient.invalidateQueries({
               queryKey: queryKeys.teamCatalog.installed(selectedCompanyId),

--- a/ui/src/pages/TeamCatalog.tsx
+++ b/ui/src/pages/TeamCatalog.tsx
@@ -503,6 +503,41 @@ function SectionHeader({ children }: { children: React.ReactNode }) {
   );
 }
 
+function CatalogIntro({ blueprintCount, installedCount }: { blueprintCount: number; installedCount: number }) {
+  return (
+    <section
+      data-testid="team-catalog-intro"
+      className="mx-5 mt-4 overflow-hidden rounded-2xl border border-emerald-950/10 bg-[#173d34] px-5 py-5 text-white shadow-sm sm:px-6"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="max-w-2xl">
+          <span className="inline-flex rounded-full bg-[#f5c76b] px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.16em] text-[#173d34]">
+            Paperclip / blueprint catalog
+          </span>
+          <h2 className="mt-3 text-2xl font-semibold tracking-tight sm:text-3xl">Design the crew. Ship the work.</h2>
+          <p className="mt-2 max-w-xl text-sm leading-6 text-emerald-50/75">
+            Import a proven operating shape, then keep ownership, budgets, and audit visible from one control plane.
+          </p>
+        </div>
+        <div className="grid min-w-[15rem] grid-cols-3 gap-2 text-center text-xs">
+          <div className="rounded-xl bg-white/10 px-3 py-2.5">
+            <div className="text-lg font-semibold tabular-nums">{blueprintCount}</div>
+            <div className="text-emerald-50/65">Blueprints</div>
+          </div>
+          <div className="rounded-xl bg-white/10 px-3 py-2.5">
+            <div className="text-lg font-semibold tabular-nums">{installedCount}</div>
+            <div className="text-emerald-50/65">Installed</div>
+          </div>
+          <div className="rounded-xl bg-[#f5c76b] px-3 py-2.5 text-[#173d34]">
+            <div className="text-sm font-semibold">Core360</div>
+            <div className="text-[#173d34]/70">+ OpenClaw</div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Detail pane
 // ---------------------------------------------------------------------------
@@ -2306,6 +2341,7 @@ export function TeamCatalog() {
 
   return (
     <div className="flex h-full flex-col">
+      <CatalogIntro blueprintCount={teams.length} installedCount={installedById.size} />
       {/* Toolbar */}
       <div className="flex flex-wrap items-center gap-2 border-b border-border px-5 py-3">
         <h1 className="text-lg font-semibold">Teams</h1>


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The OpenClaw gateway adapter sends authenticated requests to an OpenClaw gateway.
> - Older agent records can store the gateway token in HTTP headers.
> - The current edit and replay paths can persist that token again as plain adapter configuration.
> - Paperclip already has a secret reference service for adapter credentials.
> - This pull request routes all OpenClaw token fields through that service.
> - The benefit is one credential path with no plain token in persisted adapter configuration.

## Linked Issues or Issue Description

**What happened?**

An OpenClaw agent with a legacy `Authorization`, `x-openclaw-token`, or `x-openclaw-auth` header can expose the token in the edit form. A later edit, invite replay, or join can persist the token in adapter configuration again. The GitHub search found no active duplicate. Closed PR [#7016](https://github.com/paperclipai/paperclip/pull/7016) concerns general redaction and does not fix this persistence path.

**Expected behavior**

Paperclip must migrate the selected legacy token to `authToken`. It must persist only a `secret_ref`. It must remove all legacy secret headers. The adapter must resolve the reference only when it runs.

**Steps to reproduce**

1. Create an OpenClaw adapter config with different test values in `Authorization` and `x-openclaw-token`.
2. Open the agent configuration or replay an invite.
3. Save the configuration.
4. Inspect the persisted adapter config.
5. Observe that the legacy token can remain in editable or persisted headers without this change.

**Paperclip version or commit**

The issue was confirmed against commit `f038633bf5b04163ff985ef0542876bd9f455379`.

**Deployment mode**

Docker or self-hosted server.

**Installation method**

Built from source.

**Agent adapter(s) involved**

OpenClaw gateway.

**Database mode**

External PostgreSQL and embedded PostgreSQL use the same service path.

**Access context**

Board operator and agent invite flow.

## What Changed

- Classify all OpenClaw credential fields as secret fields.
- Migrate legacy token headers by the adapter precedence order.
- Remove sensitive OpenClaw headers before persistence.
- Keep secret references through agent edit, invite replay, and join flows.
- Hide legacy token values in the UI and write replacements to `authToken`.
- Add regression tests for precedence and replay persistence.
- Update OpenClaw onboarding and adapter documentation.

## Verification

- `pnpm --filter @paperclipai/adapter-openclaw-gateway typecheck`
- `pnpm --filter @paperclipai/ui typecheck`
- `cd server && pnpm exec tsc --noEmit`
- `pnpm exec vitest run src/ui/build-config.test.ts` in the OpenClaw adapter package: 4 tests passed.
- The focused UI and server command: 20 tests passed and one database-backed file skipped under root.
- The server secrets suite ran as a non-root user with no network: 80 tests passed.
- The invite replay suite ran as a non-root user with no network: 12 tests passed.

## Risks

Low migration risk. The migration removes only known credential headers after it selects the token. It preserves the established token precedence. Existing `secret_ref` values remain references. The new tests cover conflicting legacy headers and invite replay persistence.

The full server typecheck wrapper also builds a Rust runner. This host has no `cargo` binary. The runner TypeScript generation passed, and the direct server TypeScript check passed.

> I checked `ROADMAP.md`. OpenClaw support and the secrets manager already exist. This change fixes their shared persistence path and does not add a second feature.

## Model Used

OpenAI Codex with a GPT-5 family runtime. The exact model ID and context window are not exposed in this session. The runtime used extended reasoning, shell tools, code execution, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
