### PR TITLE
fix(deps): restore frozen patch metadata

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,9 +10,15 @@ overrides:
   react-dom: ^19.2.8
 
 patchedDependencies:
+  '@agentclientprotocol/codex-acp@1.6.2':
+    hash: grbydorkxatbzksnwwfuawwtim
+    path: patches/@agentclientprotocol__codex-acp@1.6.2.patch
   acpx@0.12.0:
-    hash: x3fethhotv43zektyl5prdwf54
+    hash: b2ggqg6aj4hdob4whk6vq6jmc4
     path: patches/acpx@0.12.0.patch
+  acpx@0.13.1:
+    hash: klzqvo4xom3l6xnrgmyg2xpqci
+    path: patches/acpx@0.13.1.patch
   embedded-postgres@18.1.0-beta.16:
     hash: 55uhvnotpqyiy37rn3pqpukhei
     path: patches/embedded-postgres@18.1.0-beta.16.patch
@@ -123,7 +129,7 @@ importers:
         version: link:../shared
       acpx:
         specifier: 0.12.0
-        version: 0.12.0(patch_hash=x3fethhotv43zektyl5prdwf54)
+        version: 0.12.0(patch_hash=b2ggqg6aj4hdob4whk6vq6jmc4)
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -164,7 +170,7 @@ importers:
     dependencies:
       '@agentclientprotocol/codex-acp':
         specifier: ^1.6.2
-        version: 1.6.2
+        version: 1.6.2(patch_hash=grbydorkxatbzksnwwfuawwtim)
       '@paperclipai/adapter-utils':
         specifier: workspace:*
         version: link:../../adapter-utils
@@ -453,6 +459,12 @@ importers:
 
   packages/paperclip-runner:
     dependencies:
+      '@agentclientprotocol/codex-acp':
+        specifier: 1.6.2
+        version: 1.6.2(patch_hash=grbydorkxatbzksnwwfuawwtim)
+      acpx:
+        specifier: 0.13.1
+        version: 0.13.1(patch_hash=klzqvo4xom3l6xnrgmyg2xpqci)
       ajv:
         specifier: ^8.20.0
         version: 8.20.0
@@ -463,6 +475,9 @@ importers:
       '@types/node':
         specifier: ^24.0.0
         version: 24.13.3
+      tsx:
+        specifier: ^4.23.12
+        version: 4.23.12
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -5080,6 +5095,11 @@ packages:
     engines: {node: '>=22.13.0'}
     hasBin: true
 
+  acpx@0.13.1:
+    resolution: {integrity: sha512-9zhvUrAR4XxSIgaLCiiWmrwmEWh+m6jxu2KUFC8BMOiK4sFsnrRL7H6VF54ZLTTpt0IHrZQju2V7+8wiMf9DXQ==}
+    engines: {node: '>=22.13.0'}
+    hasBin: true
+
   address@2.0.3:
     resolution: {integrity: sha512-XNAb/a6TCqou+TufU8/u11HCu9x1gYvOoxLwtlXgIqmkrYQADVv6ljyW2zwiPhHz9R1gItAWpuDrdJMmrOBFEA==}
     engines: {node: '>= 16.0.0'}
@@ -7627,6 +7647,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  skillflag@0.2.1:
+    resolution: {integrity: sha512-47lfgUr6xzgljtTD5XfJrS+6muNb9R44OEr+o31Nco2R65W1xOA8Pi6QSbLa90tDYE6TqW5Hrh3N1egserGrhQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
@@ -8280,7 +8305,7 @@ snapshots:
       - '@anthropic-ai/sdk'
       - '@modelcontextprotocol/sdk'
 
-  '@agentclientprotocol/codex-acp@1.6.2':
+  '@agentclientprotocol/codex-acp@1.6.2(patch_hash=grbydorkxatbzksnwwfuawwtim)':
     dependencies:
       '@agentclientprotocol/sdk': 1.4.0(zod@4.4.3)
       '@openai/codex': 0.148.0
@@ -12215,11 +12240,23 @@ snapshots:
 
   acorn@8.18.0: {}
 
-  acpx@0.12.0(patch_hash=x3fethhotv43zektyl5prdwf54):
+  acpx@0.12.0(patch_hash=b2ggqg6aj4hdob4whk6vq6jmc4):
     dependencies:
       '@agentclientprotocol/sdk': 1.2.1(zod@4.4.3)
       commander: 15.0.0
       skillflag: 0.2.0
+      tsx: 4.23.12
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  acpx@0.13.1(patch_hash=klzqvo4xom3l6xnrgmyg2xpqci):
+    dependencies:
+      '@agentclientprotocol/sdk': 1.4.0(zod@4.4.3)
+      commander: 15.0.0
+      skillflag: 0.2.1
       tsx: 4.23.12
       zod: 4.4.3
     transitivePeerDependencies:
@@ -15185,6 +15222,15 @@ snapshots:
   sisteransi@1.0.5: {}
 
   skillflag@0.2.0:
+    dependencies:
+      '@clack/prompts': 1.7.0
+      tar-stream: 3.2.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
+  skillflag@0.2.1:
     dependencies:
       '@clack/prompts': 1.7.0
       tar-stream: 3.2.0


### PR DESCRIPTION
## Thinking Path

> - Paperclip uses pnpm to install all workspace dependencies.
> - The root manifest configures four patched dependencies.
> - The committed lockfile did not contain current patch metadata for two dependencies.
> - The committed lockfile also contained an old hash for one existing patch.
> - pnpm could not use this metadata for a frozen install.
> - This pull request updates only the lockfile metadata and the required package records.
> - The benefit is a repeatable frozen install with the repository package manager.

## Linked Issues or Issue Description

Refs: #10128

The existing issue describes the same class of patch and lockfile mismatch. This pull request repairs the current committed metadata. It does not change the workflow that generates lockfiles.

## What Changed

- Added lockfile patch metadata for `@agentclientprotocol/codex-acp@1.6.2` and `acpx@0.13.1`.
- Updated the `acpx@0.12.0` patch hash to match its existing patch file.
- Added the package and snapshot records that pnpm 9.15.4 generated for the existing runner dependencies.
- Kept all package manifests, dependency versions, patch files, and application source unchanged.

## Verification

- Verified the official Node.js 24.11.0 archive with the published SHA-256 file.
- Ran `CI=1 corepack pnpm@9.15.4 install --frozen-lockfile` in a fresh disposable copy. It passed and reported that the lockfile was up to date.
- Repeated `corepack pnpm@9.15.4 install --lockfile-only --no-frozen-lockfile` in the disposable copy. The lockfile had no byte change. Its SHA-256 value was `cb5329794adbf94f80f7d06d9593acd940dd7085bb053e78962780154aa97bcf`.
- Ran `node --test scripts/acpx-patch-packaging.test.mjs packages/paperclip-runner/test/acpx-codex-package-contract.test.mjs`. All 18 tests passed.
- Ran `git diff --check` for the exact one-commit change. It passed.
- Confirmed that the changed path is only `pnpm-lock.yaml`.

The frozen install reported warnings for workspace binary links whose build output does not exist in a fresh source archive. The install completed successfully. No embedded Postgres test was skipped. The package contract test covered its patch packaging path.

## Risks

- Risk is low because this change updates only generated lockfile data for dependencies that the manifests and patch configuration already declare.
- Repository policy can require an approved bot path for lockfile changes. This draft keeps that policy visible for review.
- Revert commit `f65d8e53031b8af343d139ec08280a97de7126a5` to roll back this change.
- This source change does not install or activate any runtime service.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex on the GPT-5 model family. The runtime does not expose the exact model build or context-window size. Reasoning, shell tool use, and code execution were enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
