### PR TITLE
fix(server): fail closed on secret-shaped issue comments

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -7017,11 +7017,13 @@ describeEmbeddedPostgres("issueService.addComment createdByRunId", () => {
   it("sanitizes synthetic infrastructure output at the single comment persistence boundary", async () => {
     const encodedConfig =
       "c2VydmljZXM6CiAgYXBwOgogICAgZW52aXJvbm1lbnQ6CiAgICAtIERBVEFCQVNFX1VSTD1wb3N0Z3JlczovL3VzZXI6cGFzc0BkYi9hcHA=";
+    const coolifyToken = "67|abcthisisa123dummytoken";
     const body = [
       "App: synthetic-app",
       "Status: running",
       "FQDN: https://synthetic.example.test",
       'raw inventory: {"manual_webhook_secret":"synthetic-webhook-value"}',
+      `Coolify token: ${coolifyToken}`,
       `encoded configuration: ${encodedConfig}`,
       "HTTP: 200 in 42ms",
       "Last deploy: succeeded",
@@ -7041,6 +7043,7 @@ describeEmbeddedPostgres("issueService.addComment createdByRunId", () => {
     expect(persisted).toContain("Last deploy: succeeded");
     expect(persisted).toContain(REDACTED_UNCLASSIFIED_COMMENT_VALUE);
     expect(persisted).not.toContain("synthetic-webhook-value");
+    expect(persisted).not.toContain(coolifyToken);
     expect(persisted).not.toContain(encodedConfig);
   });
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -31,6 +31,7 @@ import {
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { instanceSettingsService } from "../services/instance-settings.ts";
+import { REDACTED_UNCLASSIFIED_COMMENT_VALUE } from "../redaction.ts";
 import {
   clampIssueListLimit,
   deriveIssueCommentRunLogAttribution,
@@ -7011,5 +7012,35 @@ describeEmbeddedPostgres("issueService.addComment createdByRunId", () => {
     const comment = await svc.addComment(issueId, "hello from a live run", { runId });
 
     expect(await createdByRunIdFor(comment.id)).toBe(runId);
+  });
+
+  it("sanitizes synthetic infrastructure output at the single comment persistence boundary", async () => {
+    const encodedConfig =
+      "c2VydmljZXM6CiAgYXBwOgogICAgZW52aXJvbm1lbnQ6CiAgICAtIERBVEFCQVNFX1VSTD1wb3N0Z3JlczovL3VzZXI6cGFzc0BkYi9hcHA=";
+    const body = [
+      "App: synthetic-app",
+      "Status: running",
+      "FQDN: https://synthetic.example.test",
+      'raw inventory: {"manual_webhook_secret":"synthetic-webhook-value"}',
+      `encoded configuration: ${encodedConfig}`,
+      "HTTP: 200 in 42ms",
+      "Last deploy: succeeded",
+    ].join("\n");
+
+    const comment = await svc.addComment(issueId, body, { agentId });
+    const persisted = await db
+      .select({ body: issueComments.body })
+      .from(issueComments)
+      .where(eq(issueComments.id, comment.id))
+      .then((rows) => rows[0]?.body ?? "");
+
+    expect(persisted).toContain("App: synthetic-app");
+    expect(persisted).toContain("Status: running");
+    expect(persisted).toContain("FQDN: https://synthetic.example.test");
+    expect(persisted).toContain("HTTP: 200 in 42ms");
+    expect(persisted).toContain("Last deploy: succeeded");
+    expect(persisted).toContain(REDACTED_UNCLASSIFIED_COMMENT_VALUE);
+    expect(persisted).not.toContain("synthetic-webhook-value");
+    expect(persisted).not.toContain(encodedConfig);
   });
 });

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { REDACTED_EVENT_VALUE, redactEventPayload, redactSensitiveText, sanitizeRecord } from "../redaction.js";
+import {
+  REDACTED_EVENT_VALUE,
+  REDACTED_UNCLASSIFIED_COMMENT_VALUE,
+  redactEventPayload,
+  redactSensitiveText,
+  sanitizeIssueCommentBody,
+  sanitizeRecord,
+} from "../redaction.js";
 
 describe("redaction", () => {
   it("redacts sensitive keys and nested secret values", () => {
@@ -138,6 +145,89 @@ describe("redaction", () => {
     expect(result).not.toContain("paperclip-shell-secret");
     expect(result).not.toContain(githubToken);
     expect(result).not.toContain(jwt);
+  });
+
+  it("redacts every required comment credential class", () => {
+    const values = [
+      "Authorization: Basic c3ludGhldGljOnZhbHVl",
+      'apiKey="synthetic-api-key-value"',
+      "passphrase=synthetic-passphrase-value",
+      'webhook_secret: "synthetic-webhook-value"',
+      "postgres://synthetic:password@db.example.test:5432/app",
+      "mysql://synthetic:password@db.example.test/app",
+      "redis://:password@cache.example.test:6379/0",
+      "mongodb://synthetic:password@mongo.example.test/app",
+      "ghp_1234567890abcdefghijklmnopqrstuvwxyz",
+      "github_pat_11AA22BB33CC44DD55EE66FF77GG88HH",
+      "ops_11AA22BB33CC44DD55EE66FF",
+      "tskey-auth-11AA22BB33CC44DD55EE66FF",
+      "PRIVATE_KEY=synthetic-private-key-value",
+      "CREDENTIAL=synthetic-credential-value",
+    ];
+
+    const result = sanitizeIssueCommentBody(values.join("\n"));
+
+    expect(result).toContain(REDACTED_EVENT_VALUE);
+    for (const value of values) {
+      const secretPart = value.includes("=") ? value.split("=").at(-1)! : value;
+      expect(result).not.toContain(secretPart);
+    }
+  });
+
+  it("fails closed on an unclassified secret-shaped line", () => {
+    const opaque = "QWxhZGRpbjpPcGVuU2VzYW1lMTIzNDU2Nzg5MDEyMzQ1Njc4OTA=";
+    const result = sanitizeIssueCommentBody([
+      "App: synthetic-monitor status=running",
+      `encoded configuration: ${opaque}`,
+      "HTTP: 200 in 42ms",
+    ].join("\n"));
+
+    expect(result).toBe([
+      "App: synthetic-monitor status=running",
+      REDACTED_UNCLASSIFIED_COMMENT_VALUE,
+      "HTTP: 200 in 42ms",
+    ].join("\n"));
+    expect(result).not.toContain(opaque);
+  });
+
+  it("fully redacts a synthetic Coolify inventory payload before comment persistence", () => {
+    const syntheticPayload = JSON.stringify({
+      name: "synthetic-app",
+      status: "running",
+      fqdn: "https://synthetic.example.test",
+      manual_webhook_secret_github: "synthetic-github-webhook-secret",
+      apiKey: "synthetic-api-key",
+      environment_variables: "POSTGRES_PASSWORD=synthetic-db-password",
+      docker_compose_raw:
+        "c2VydmljZXM6CiAgYXBwOgogICAgZW52aXJvbm1lbnQ6CiAgICAtIERBVEFCQVNFX1VSTD1wb3N0Z3JlczovL3VzZXI6cGFzc0BkYi9hcHA=",
+      custom_labels:
+        "dHJhZWZpay5odHRwLnJvdXRlcnMuYXBwLnJ1bGU9SG9zdChgc3ludGhldGljLmV4YW1wbGUudGVzdGAp",
+    });
+
+    const result = sanitizeIssueCommentBody(`Inventory result:\n${syntheticPayload}`);
+
+    expect(result).toContain("Inventory result:");
+    expect(result).toContain(REDACTED_UNCLASSIFIED_COMMENT_VALUE);
+    expect(result).not.toContain("synthetic-github-webhook-secret");
+    expect(result).not.toContain("synthetic-api-key");
+    expect(result).not.toContain("synthetic-db-password");
+    expect(result).not.toContain("c2VydmljZXM6");
+    expect(result).not.toContain("dHJhZWZpay5odHRw");
+  });
+
+  it("preserves allowlisted monitor fields and common non-secret identifiers", () => {
+    const input = [
+      "App: synthetic-app",
+      "Status: running",
+      "FQDN: https://synthetic.example.test",
+      "HTTP: 200",
+      "Latency: 42ms",
+      "Last deploy: succeeded",
+      "Run: 019ec394-e246-4b98-aaa4-fb9072130a7c",
+      "Commit: 8478ddbce8478ddbce8478ddbce8478ddbce8478d",
+    ].join("\n");
+
+    expect(sanitizeIssueCommentBody(input)).toBe(input);
   });
 
   it("redacts inline secrets from command metadata without hiding safe command text", () => {

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -175,6 +175,20 @@ describe("redaction", () => {
     }
   });
 
+  it("redacts only the authorization credential when fields follow on the same line", () => {
+    const input = "Authorization: Bearer synthetic-bearer-value OPENAI_API_KEY=synthetic-api-key";
+
+    expect(sanitizeIssueCommentBody(input)).toBe(
+      `Authorization: Bearer ${REDACTED_EVENT_VALUE} OPENAI_API_KEY=${REDACTED_EVENT_VALUE}`,
+    );
+  });
+
+  it("redacts an unclassified authorization header value as a whole", () => {
+    expect(sanitizeIssueCommentBody("Authorization: Digest synthetic credential material")).toBe(
+      `Authorization: ${REDACTED_EVENT_VALUE}`,
+    );
+  });
+
   it("redacts a documented Coolify numeric API token without relying on context", () => {
     const token = "67|abcthisisa123dummytoken";
 

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -160,6 +160,7 @@ describe("redaction", () => {
       "ghp_1234567890abcdefghijklmnopqrstuvwxyz",
       "github_pat_11AA22BB33CC44DD55EE66FF77GG88HH",
       "ops_11AA22BB33CC44DD55EE66FF",
+      "67|abcthisisa123dummytoken",
       "tskey-auth-11AA22BB33CC44DD55EE66FF",
       "PRIVATE_KEY=synthetic-private-key-value",
       "CREDENTIAL=synthetic-credential-value",
@@ -172,6 +173,12 @@ describe("redaction", () => {
       const secretPart = value.includes("=") ? value.split("=").at(-1)! : value;
       expect(result).not.toContain(secretPart);
     }
+  });
+
+  it("redacts a documented Coolify numeric API token without relying on context", () => {
+    const token = "67|abcthisisa123dummytoken";
+
+    expect(sanitizeIssueCommentBody(token)).toBe(REDACTED_EVENT_VALUE);
   });
 
   it("fails closed on an unclassified secret-shaped line", () => {

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -51,6 +51,8 @@ const CONNECTION_STRING_RE =
 const AUTHORIZATION_HEADER_RE = /(\bAuthorization\s*:\s*)[^\r\n]+/gi;
 const GITHUB_FINE_GRAINED_TOKEN_RE = /\bgithub_pat_[A-Za-z0-9_]{16,}\b/g;
 const COOLIFY_TOKEN_RE = /\bops_[A-Za-z0-9_-]{12,}\b/g;
+const COOLIFY_NUMERIC_TOKEN_RE = /\b\d+\|[A-Za-z0-9_-]{12,}\b/g;
+const COOLIFY_NUMERIC_TOKEN_HINT_RE = /\b\d+\|[A-Za-z0-9_-]{12,}\b/;
 const TAILNET_AUTH_KEY_RE = /\btskey-[A-Za-z0-9_-]{12,}\b/g;
 const SECRET_SHAPED_VALUE_RE = /[A-Za-z0-9+/_=-]{32,}/g;
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -90,7 +92,9 @@ export const REDACTED_UNCLASSIFIED_COMMENT_VALUE =
 
 function maybeContainsSecretText(input: string) {
   const lower = input.toLowerCase();
-  return SECRET_TEXT_HINTS.some((hint) => lower.includes(hint)) || input.includes(".");
+  return SECRET_TEXT_HINTS.some((hint) => lower.includes(hint))
+    || input.includes(".")
+    || COOLIFY_NUMERIC_TOKEN_HINT_RE.test(input);
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -203,6 +207,7 @@ export function redactSensitiveText(input: string): string {
       .replace(CONNECTION_STRING_RE, REDACTED_EVENT_VALUE)
       .replace(GITHUB_FINE_GRAINED_TOKEN_RE, REDACTED_EVENT_VALUE)
       .replace(COOLIFY_TOKEN_RE, REDACTED_EVENT_VALUE)
+      .replace(COOLIFY_NUMERIC_TOKEN_RE, REDACTED_EVENT_VALUE)
       .replace(TAILNET_AUTH_KEY_RE, REDACTED_EVENT_VALUE),
     REDACTED_EVENT_VALUE,
   );

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -48,7 +48,8 @@ const SECRET_ENV_ASSIGNMENT_RE = new RegExp(
 );
 const CONNECTION_STRING_RE =
   /\b(?:postgres(?:ql)?|mysql|redis(?:s)?|mongodb(?:\+srv)?):\/\/[^\s<>"'`]+/gi;
-const AUTHORIZATION_HEADER_RE = /(\bAuthorization\s*:\s*)[^\r\n]+/gi;
+const AUTHORIZATION_TOKEN_RE = /(\bAuthorization\s*:\s*(?:Bearer|Basic)\s+)[^\s,;]+/gi;
+const AUTHORIZATION_HEADER_RE = /(\bAuthorization\s*:\s*)(?!\s*(?:Bearer|Basic)\b)[^\r\n]+/gi;
 const GITHUB_FINE_GRAINED_TOKEN_RE = /\bgithub_pat_[A-Za-z0-9_]{16,}\b/g;
 const COOLIFY_TOKEN_RE = /\bops_[A-Za-z0-9_-]{12,}\b/g;
 const COOLIFY_NUMERIC_TOKEN_RE = /\b\d+\|[A-Za-z0-9_-]{12,}\b/g;
@@ -203,6 +204,7 @@ export function redactSensitiveText(input: string): string {
             ? `${prefix}${quote}${REDACTED_EVENT_VALUE}${quote}`
             : `${prefix}${REDACTED_EVENT_VALUE}`,
       )
+      .replace(AUTHORIZATION_TOKEN_RE, `$1${REDACTED_EVENT_VALUE}`)
       .replace(AUTHORIZATION_HEADER_RE, `$1${REDACTED_EVENT_VALUE}`)
       .replace(CONNECTION_STRING_RE, REDACTED_EVENT_VALUE)
       .replace(GITHUB_FINE_GRAINED_TOKEN_RE, REDACTED_EVENT_VALUE)

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -1,7 +1,7 @@
 import { redactCommandText } from "@paperclipai/adapter-utils";
 
 const SECRET_FIELD_NAME_PATTERN =
-  String.raw`[A-Za-z0-9_-]*(?:api[-_]?key|access[-_]?token|auth(?:_?token)?|token|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring|browser[-_]?code|login[-_]?url)[A-Za-z0-9_-]*`;
+  String.raw`[A-Za-z0-9_-]*(?:api[-_]?key|access[-_]?token|auth(?:_?token)?|token|authorization|bearer|secret|passwd|password|passphrase|credential|webhook|jwt|private[-_]?key|cookie|connection[-_]?string|browser[-_]?code|login[-_]?url)[A-Za-z0-9_-]*`;
 
 const SECRET_PAYLOAD_KEY_RE = new RegExp(SECRET_FIELD_NAME_PATTERN, "i");
 // Authorization reasons are policy decision codes, not credentials. They must
@@ -42,6 +42,19 @@ const ESCAPED_JSON_SECRET_FIELD_TEXT_RE = new RegExp(
   String.raw`((?:\\")?${SECRET_FIELD_NAME_PATTERN}(?:\\")?\s*:\s*(?:\\"))[^\\\r\n]+((?:\\"))`,
   "gi",
 );
+const SECRET_ENV_ASSIGNMENT_RE = new RegExp(
+  String.raw`(\b${SECRET_FIELD_NAME_PATTERN}\s*=\s*)(?:(["'])([^"'` + "`" + String.raw`\r\n]*)\2|([^\s"'` + "`" + String.raw`]+))`,
+  "gi",
+);
+const CONNECTION_STRING_RE =
+  /\b(?:postgres(?:ql)?|mysql|redis(?:s)?|mongodb(?:\+srv)?):\/\/[^\s<>"'`]+/gi;
+const AUTHORIZATION_HEADER_RE = /(\bAuthorization\s*:\s*)[^\r\n]+/gi;
+const GITHUB_FINE_GRAINED_TOKEN_RE = /\bgithub_pat_[A-Za-z0-9_]{16,}\b/g;
+const COOLIFY_TOKEN_RE = /\bops_[A-Za-z0-9_-]{12,}\b/g;
+const TAILNET_AUTH_KEY_RE = /\btskey-[A-Za-z0-9_-]{12,}\b/g;
+const SECRET_SHAPED_VALUE_RE = /[A-Za-z0-9+/_=-]{32,}/g;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const HEX_DIGEST_RE = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/i;
 const SECRET_TEXT_HINTS = [
   "api",
   "key",
@@ -51,6 +64,7 @@ const SECRET_TEXT_HINTS = [
   "secret",
   "pass",
   "credential",
+  "webhook",
   "jwt",
   "private",
   "cookie",
@@ -61,8 +75,18 @@ const SECRET_TEXT_HINTS = [
   "ghu_",
   "ghs_",
   "ghr_",
+  "github_pat_",
+  "ops_",
+  "tskey-",
+  "postgres://",
+  "postgresql://",
+  "mysql://",
+  "redis://",
+  "mongodb://",
 ] as const;
 export const REDACTED_EVENT_VALUE = "***REDACTED***";
+export const REDACTED_UNCLASSIFIED_COMMENT_VALUE =
+  "[redacted: unclassified secret-shaped value]";
 
 function maybeContainsSecretText(input: string) {
   const lower = input.toLowerCase();
@@ -167,7 +191,62 @@ export function redactSensitiveText(input: string): string {
   return redactCommandText(
     input
       .replace(JSON_SECRET_FIELD_TEXT_RE, `$1${REDACTED_EVENT_VALUE}$2`)
-      .replace(ESCAPED_JSON_SECRET_FIELD_TEXT_RE, `$1${REDACTED_EVENT_VALUE}$2`),
+      .replace(ESCAPED_JSON_SECRET_FIELD_TEXT_RE, `$1${REDACTED_EVENT_VALUE}$2`)
+      .replace(
+        SECRET_ENV_ASSIGNMENT_RE,
+        (_match, prefix: string, quote: string | undefined) =>
+          quote
+            ? `${prefix}${quote}${REDACTED_EVENT_VALUE}${quote}`
+            : `${prefix}${REDACTED_EVENT_VALUE}`,
+      )
+      .replace(AUTHORIZATION_HEADER_RE, `$1${REDACTED_EVENT_VALUE}`)
+      .replace(CONNECTION_STRING_RE, REDACTED_EVENT_VALUE)
+      .replace(GITHUB_FINE_GRAINED_TOKEN_RE, REDACTED_EVENT_VALUE)
+      .replace(COOLIFY_TOKEN_RE, REDACTED_EVENT_VALUE)
+      .replace(TAILNET_AUTH_KEY_RE, REDACTED_EVENT_VALUE),
     REDACTED_EVENT_VALUE,
   );
+}
+
+function shannonEntropy(value: string): number {
+  const counts = new Map<string, number>();
+  for (const character of value) {
+    counts.set(character, (counts.get(character) ?? 0) + 1);
+  }
+  let entropy = 0;
+  for (const count of counts.values()) {
+    const probability = count / value.length;
+    entropy -= probability * Math.log2(probability);
+  }
+  return entropy;
+}
+
+function isUnclassifiedSecretShapedValue(value: string): boolean {
+  if (UUID_RE.test(value) || HEX_DIGEST_RE.test(value)) return false;
+  const characterClasses = [/[a-z]/.test(value), /[A-Z]/.test(value), /\d/.test(value), /[+/_=-]/.test(value)]
+    .filter(Boolean).length;
+  return characterClasses >= 3 && shannonEntropy(value) >= 4.2;
+}
+
+/**
+ * Sanitize a would-be issue comment at the final persistence boundary.
+ *
+ * Classified credential forms are replaced in place. If a line still contains
+ * an opaque, high-entropy value after classified redaction, the whole line is
+ * dropped so an unknown credential format cannot pass through by accident.
+ */
+export function sanitizeIssueCommentBody(input: string): string {
+  const classified = redactSensitiveText(input);
+  return classified
+    .split("\n")
+    .map((line) => {
+      SECRET_SHAPED_VALUE_RE.lastIndex = 0;
+      for (const match of line.matchAll(SECRET_SHAPED_VALUE_RE)) {
+        if (isUnclassifiedSecretShapedValue(match[0])) {
+          return REDACTED_UNCLASSIFIED_COMMENT_VALUE;
+        }
+      }
+      return line;
+    })
+    .join("\n");
 }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -90,7 +90,7 @@ import { mergeExecutionWorkspaceConfig } from "./execution-workspaces.js";
 import { buildInitialIssueMonitorFields, normalizeIssueExecutionPolicy } from "./issue-execution-policy.js";
 import { instanceSettingsService } from "./instance-settings.js";
 import { redactCurrentUserText } from "../log-redaction.js";
-import { redactSensitiveText } from "../redaction.js";
+import { redactSensitiveText, sanitizeIssueCommentBody } from "../redaction.js";
 import { resolveIssueGoalId, resolveNextIssueGoalId } from "./issue-goal-fallback.js";
 import { getRunLogStore } from "./run-log-store.js";
 import { getDefaultCompanyGoal } from "./goals.js";
@@ -4641,7 +4641,11 @@ export function issueService(db: Db) {
     return {
       ...comment,
       authorType: deriveIssueCommentAuthorType(comment),
-      body: redactCurrentUserText(comment.body, { enabled: censorUsernameInLogs }),
+      // Sanitize again on read so legacy rows and internal inserts cannot turn
+      // into a bypass of the comment egress boundary.
+      body: sanitizeIssueCommentBody(
+        redactCurrentUserText(comment.body, { enabled: censorUsernameInLogs }),
+      ),
       presentation: issueCommentPresentationSchema.nullable().catch(null).parse(comment.presentation ?? null),
       metadata: issueCommentMetadataSchema.nullable().catch(null).parse(comment.metadata ?? null),
     };
@@ -8911,7 +8915,11 @@ export function issueService(db: Db) {
       const currentUserRedactionOptions = {
         enabled: (await instanceSettings.getGeneral()).censorUsernameInLogs,
       };
-      const redactedBody = redactCurrentUserText(body, currentUserRedactionOptions);
+      // This is the single issue-comment persistence boundary. Keep secret
+      // sanitization here so routes and internal callers cannot bypass it.
+      const redactedBody = sanitizeIssueCommentBody(
+        redactCurrentUserText(body, currentUserRedactionOptions),
+      );
       const authorType = issueCommentAuthorTypeSchema.parse(
         options?.authorType ?? (actor.agentId ? "agent" : actor.userId ? "user" : "system"),
       );


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Issue comments are a durable output surface for agent work.
> - Existing redaction handles many named fields and command values.
> - It does not cover several provider token formats, database URLs, or unknown high-entropy values.
> - A comment can also leave through a read path after a legacy or internal insert.
> - This pull request adds one comment sanitizer at the write and read boundaries.
> - The benefit is that classified and unknown secret-shaped values fail closed before a comment leaves the server.

## Linked Issues or Issue Description

- Fixes #12580.
- Refs #8841. That pull request adds broad persistence sanitization. This change adds comment-specific provider patterns, connection URLs, an entropy guard, and a read-side guard.
- Refs #12102. That pull request adds issue-route middleware. This change protects service callers and legacy or internal rows as well.

## What Changed

- Added comment redaction for passphrases, webhook fields, authorization headers, database connection URLs, GitHub fine-grained tokens, Coolify tokens, and Tailscale auth keys.
- Added a fail-closed entropy guard. It replaces a line that contains an unknown secret-shaped value with a clear redaction marker.
- Applied the sanitizer in `issueService.addComment` immediately before persistence.
- Applied the same sanitizer when comments leave the service. This protects legacy rows and direct internal inserts.
- Added synthetic Coolify inventory tests. The fixtures contain no live values.
- Added a database test that proves the stored comment is sanitized and the allowed monitor fields remain visible.

## Verification

- `vitest run server/src/__tests__/redaction.test.ts`: 13 tests passed.
- `vitest run server/src/__tests__/issues-service.test.ts -t 'sanitizes synthetic infrastructure output'`: 1 test passed.
- The mandatory commit hook ran `pnpm run typecheck` across all workspace packages. It passed.
- `git diff --check` passed.

## Risks

- The entropy guard can redact a non-secret opaque value. This is intentional fail-closed behavior.
- The guard drops the full affected line. It keeps the rest of the comment unchanged.
- The write behavior is lossy. A redacted value cannot be recovered from the comment row.
- This pull request covers issue comments. Other output surfaces must keep their own egress controls.
- The branch name follows the contributor governance policy. It does not meet the upstream branch naming guidance.

## Model Used

- OpenAI Codex with GPT-5. The deployment did not expose a more specific model ID. High-reasoning mode and tool use were enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
