### PR TITLE
fix(release): omit dev dependencies from bundle staging

### DIFF
--- a/scripts/acpx-patch-packaging.test.mjs
+++ b/scripts/acpx-patch-packaging.test.mjs
@@ -87,22 +87,27 @@ test("bundled package staging materializes workspace dependency versions", () =>
 });
 
 test("bundled package staging installs only dependencies included in the tarball", () => {
-  const installManifest = createBundledInstallManifest(
-    {
-      name: "@paperclipai/db",
-      version: "2026.723.0-canary.8",
-      dependencies: {
-        "@paperclipai/shared": "2026.723.0-canary.8",
-        "drizzle-orm": "^0.45.2",
-        "embedded-postgres": "^18.1.0-beta.16",
-      },
-      bundleDependencies: ["embedded-postgres"],
+  const publishManifest = {
+    name: "@paperclipai/db",
+    version: "2026.723.0-canary.8",
+    dependencies: {
+      "@paperclipai/shared": "2026.723.0-canary.8",
+      "drizzle-orm": "^0.45.2",
+      "embedded-postgres": "^18.1.0-beta.16",
     },
-    ["embedded-postgres"],
-  );
+    devDependencies: {
+      "@paperclipai/paperclip-runner": "2026.723.0-canary.8",
+    },
+    bundleDependencies: ["embedded-postgres"],
+  };
+  const installManifest = createBundledInstallManifest(publishManifest, ["embedded-postgres"]);
 
   assert.deepEqual(installManifest.dependencies, {
     "embedded-postgres": "^18.1.0-beta.16",
+  });
+  assert.equal(installManifest.devDependencies, undefined);
+  assert.deepEqual(publishManifest.devDependencies, {
+    "@paperclipai/paperclip-runner": "2026.723.0-canary.8",
   });
   assert.deepEqual(installManifest.bundleDependencies, ["embedded-postgres"]);
 });
@@ -227,6 +232,7 @@ mkdir -p "$destination/node_modules/.pnpm"
 set -euo pipefail
 printf 'npm %s\\n' "$*" >> "$FAKE_CALL_LOG"
 [ "$*" = "install --omit=dev --ignore-scripts --no-audit --no-fund" ]
+node -e 'const pkg = require("./package.json"); if ("devDependencies" in pkg) process.exit(1)'
 mkdir -p node_modules/acpx/dist
 printf 'unpatched runtime\\n' > node_modules/acpx/dist/runtime.js
 printf '{"name":"acpx","version":"0.13.1"}\\n' > node_modules/acpx/package.json

--- a/scripts/prepare-bundled-package.mjs
+++ b/scripts/prepare-bundled-package.mjs
@@ -35,6 +35,8 @@ export function createBundledInstallManifest(publishManifest, bundledDependencie
   const bundledDependencyNames = new Set(bundledDependencies);
   const installManifest = structuredClone(publishManifest);
 
+  delete installManifest.devDependencies;
+
   for (const section of ["dependencies", "optionalDependencies", "peerDependencies"]) {
     if (!installManifest[section]) continue;
     installManifest[section] = Object.fromEntries(


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The release system publishes the server package with selected runtime dependencies inside its tarball.
> - The staging step writes a temporary package manifest before it runs npm install.
> - That manifest kept private development dependencies that npm still tried to resolve with `--omit=dev`.
> - The canary release then stopped because the matching private runner version was not published yet.
> - This pull request removes development dependencies from only the temporary install manifest.
> - The benefit is that bundled package staging installs only the runtime dependencies that the tarball includes.

## Linked Issues or Issue Description

Refs #12582

**What happened?**

The canary release failed while it prepared `@paperclipai/server`. npm tried to resolve `@paperclipai/paperclip-runner@2026.831.0-canary.8` from the temporary staging manifest. The runner package was not published at that version, so npm returned `ETARGET`. See the [failed release job](https://github.com/paperclipai/paperclip/actions/runs/33395418107/job/99504474818).

**Expected behavior**

Bundled package staging must install only dependencies that the published tarball bundles. Private development dependencies must not affect the staging install.

**Steps to reproduce**

1. Prepare a bundled package with a public bundled runtime dependency.
2. Add an unpublished package version to `devDependencies`.
3. Run `scripts/prepare-bundled-package.mjs`.
4. Observe that npm resolves the development dependency even when the command uses `--omit=dev`.

**Paperclip version or commit**

`5a988df600ebda30e446496862bf83c76d6d53d6`

## What Changed

- Remove `devDependencies` from the temporary manifest used for bundled package installation.
- Keep the final publish manifest unchanged.
- Add unit and staging regression checks for the unpublished development dependency case.

## Verification

- `pnpm install --frozen-lockfile`
- `node --test scripts/acpx-patch-packaging.test.mjs` (12 passed)
- `pnpm test:release-registry` (98 passed)
- `git diff --check`
- The full test suite and build were not run. This change has focused release-packaging coverage.

## Risks

- Low risk. The change affects only the temporary manifest used to install bundled runtime dependencies.
- The script restores the complete publish manifest before it creates the package tarball.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with `gpt-5.6-sol`. The model used agentic reasoning, tool use, and code execution. The context window size is not exposed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
