### PR TITLE
fix(release): skip lifecycle scripts for bundle staging

### DIFF
--- a/scripts/acpx-patch-packaging.test.mjs
+++ b/scripts/acpx-patch-packaging.test.mjs
@@ -295,9 +295,15 @@ test("bundled package dry runs preview without querying published versions", () 
   assert.match(releaseScript, /run_bundled_npm_pack pack --pack-destination "\$publish_dir"/);
   assert.match(releaseLib, /BUNDLED_NPM_PACK_VERSION="10\.9\.7"/);
   assert.match(releaseLib, /BUNDLED_NPM_PUBLISH_VERSION="11\.18\.0"/);
-  assert.match(releaseLib, /npx --yes "npm@\$BUNDLED_NPM_PACK_VERSION"/);
-  assert.match(releaseLib, /npx --yes "npm@\$BUNDLED_NPM_PUBLISH_VERSION"/);
-  assert.match(releaseLib, /"\$@" --loglevel verbose/);
+  assert.match(
+    releaseLib,
+    /npx --yes "npm@\$BUNDLED_NPM_PACK_VERSION" "\$@" --ignore-scripts/,
+  );
+  assert.match(
+    releaseLib,
+    /npx --yes "npm@\$BUNDLED_NPM_PUBLISH_VERSION" "\$@" --ignore-scripts/,
+  );
+  assert.match(releaseLib, /"\$@" --ignore-scripts --loglevel verbose/);
   assert.match(releaseLib, /run_bundled_npm_publish publish --tag "\$dist_tag"/);
   assert.doesNotMatch(releaseLib, /run_bundled_npm_publish publish "\.\/\$tarball"/);
 });

--- a/scripts/release-lib.sh
+++ b/scripts/release-lib.sh
@@ -336,11 +336,11 @@ BUNDLED_NPM_PACK_VERSION="10.9.7"
 BUNDLED_NPM_PUBLISH_VERSION="11.18.0"
 
 run_bundled_npm_pack() {
-  npx --yes "npm@$BUNDLED_NPM_PACK_VERSION" "$@"
+  npx --yes "npm@$BUNDLED_NPM_PACK_VERSION" "$@" --ignore-scripts
 }
 
 run_bundled_npm_publish() {
-  npx --yes "npm@$BUNDLED_NPM_PUBLISH_VERSION" "$@" --loglevel verbose
+  npx --yes "npm@$BUNDLED_NPM_PUBLISH_VERSION" "$@" --ignore-scripts --loglevel verbose
 }
 
 run_package_publish() {

--- a/scripts/release-lib.test.mjs
+++ b/scripts/release-lib.test.mjs
@@ -181,11 +181,11 @@ test("publish_package_to_npm uses trusted publishing from the bundled staging di
   assert.equal(result.status, 0);
   assert.match(
     result.calls,
-    /^npx --yes npm@11\.18\.0 publish --tag canary --access public --loglevel verbose$/m,
+    /^npx --yes npm@11\.18\.0 publish --tag canary --access public --ignore-scripts --loglevel verbose$/m,
   );
   assert.match(
     result.calls,
-    /^npm publish --tag canary --access public --loglevel verbose$/m,
+    /^npm publish --tag canary --access public --ignore-scripts --loglevel verbose$/m,
   );
   assert.doesNotMatch(result.calls, / pack /);
   assert.doesNotMatch(result.calls, /^pnpm publish/m);
@@ -198,7 +198,7 @@ test("publish_package_to_npm retries bundled directory tlog failures without pro
   assert.match(result.calls, /^npm view @paperclipai\/example@1\.2\.3 version$/m);
   assert.match(
     result.calls,
-    /^npm publish --tag canary --access public --provenance=false --loglevel verbose$/m,
+    /^npm publish --tag canary --access public --provenance=false --ignore-scripts --loglevel verbose$/m,
   );
 });
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The release system builds the workspace before it prepares npm packages.
> - Bundled packages then move the built files and runtime dependencies into a standalone staging directory.
> - npm pack and npm publish still run package lifecycle scripts in that directory.
> - The server `prepack` script requires the source workspace and cannot run from the standalone directory.
> - This pull request disables lifecycle scripts only for npm operations on prepared bundled packages.
> - The benefit is that release packaging uses the artifacts that the release already built.

## Linked Issues or Issue Description

Refs #12584

**What happened?**

The canary dry run passed bundled dependency installation and then failed while it packed `@paperclipai/server`. npm ran the server `prepack` script in the standalone staging directory. That script called `pnpm run prepare:ui-dist && pnpm run build`, which requires files from the source workspace. See the [failed canary dry-run job](https://github.com/paperclipai/paperclip/actions/runs/33399041712/job/99510762364).

**Expected behavior**

Bundled package packing and publishing must use the artifacts that the release already built. They must not run workspace-only package lifecycle scripts from the standalone staging directory.

**Steps to reproduce**

1. Build the Paperclip workspace.
2. Prepare the bundled server package in a temporary directory.
3. Run npm pack from that directory.
4. Observe that npm runs the server `prepack` script outside the source workspace.

**Paperclip version or commit**

`08af15bd7629790a618e8787c11490c96a1b619a`

## What Changed

- Add `--ignore-scripts` to npm pack for prepared bundled packages.
- Add `--ignore-scripts` to both normal and no-provenance npm publish attempts for prepared bundled packages.
- Update release helper tests to require this behavior.

## Verification

- `node --test scripts/acpx-patch-packaging.test.mjs scripts/release-lib.test.mjs` (22 passed)
- `pnpm test:release-registry` (98 passed)
- `git diff --check`
- The full test suite and build were not run locally. GitHub runs the canary dry run and full matrix.

## Risks

- Low risk. The flag applies only to bundled packages that the release prepares after the workspace build.
- Normal pnpm package publishing is unchanged.
- Package lifecycle scripts remain in the published manifest.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with `gpt-5.6-sol`. The model used agentic reasoning, tool use, and code execution. The context window size is not exposed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
