### PR TITLE
fix(server): honour blockParentUntilDone on company issue create

### DIFF
--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -513,7 +513,7 @@ export function createToolDefinitions(client: PaperclipApiClient): ToolDefinitio
     ),
     makeTool(
       "paperclipCreateIssue",
-      "Create a new issue",
+      "Create a new issue. With parentId, optional blockParentUntilDone adds a parent blocker edge; acceptanceCriteria append to the description.",
       createIssueToolSchema,
       async ({ companyId, ...body }) =>
         client.requestJson("POST", `/companies/${client.resolveCompanyId(companyId)}/issues`, { body }),

--- a/packages/shared/src/validators/issue.test.ts
+++ b/packages/shared/src/validators/issue.test.ts
@@ -361,6 +361,16 @@ describe("issue validators", () => {
       assigneeAgentId: "22222222-2222-4222-8222-222222222222",
     }).status).toBe("todo");
     expect(createIssueSchema.parse({ title: "Unassigned work" }).status).toBe("backlog");
+
+    expect(createIssueSchema.parse({
+      title: "Child with parent blocker",
+      parentId: "11111111-1111-4111-8111-111111111111",
+      blockParentUntilDone: true,
+    }).blockParentUntilDone).toBe(true);
+    expect(createIssueSchema.safeParse({
+      title: "Flag without parent",
+      blockParentUntilDone: true,
+    }).success).toBe(false);
     expect(createIssueSchema.parse({
       title: "Deliberately parked",
       assigneeAgentId: "22222222-2222-4222-8222-222222222222",

--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -544,18 +544,46 @@ const onboardingFirstTaskMarkerSchema = {
   onboardingFirstTask: z.boolean().optional(),
 };
 
+const createIssueParentBlockerFields = {
+  acceptanceCriteria: z.array(z.string().trim().min(1).max(500)).max(20).optional()
+    .describe("Appended to the issue description as Acceptance Criteria; create-only"),
+  blockParentUntilDone: z.boolean().optional().default(false)
+    .describe("When true with parentId, adds this issue as a blocks-edge on the parent (same as POST /issues/:id/children)"),
+};
+
+function requireParentIdForBlockParentUntilDone(
+  value: { parentId?: string | null; blockParentUntilDone?: boolean },
+  ctx: z.RefinementCtx,
+) {
+  if (value.blockParentUntilDone && !value.parentId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "blockParentUntilDone requires parentId",
+      path: ["blockParentUntilDone"],
+    });
+  }
+}
+
 export const createIssueInputSchema = createIssueBaseSchema.extend({
   status: createIssueBaseSchema.shape.status.optional(),
   ...createIssueDuplicateGuardSchema,
   ...onboardingFirstTaskMarkerSchema,
+  ...createIssueParentBlockerFields,
+}).superRefine((value, ctx) => {
+  requireBlockedStatusForUnblockDescriptor(value, ctx);
+  requireParentIdForBlockParentUntilDone(value, ctx);
 });
 
 export const createIssueSchema = withCreateIssueStatusDefault(
   createIssueBaseSchema.extend({
     ...createIssueDuplicateGuardSchema,
     ...onboardingFirstTaskMarkerSchema,
+    ...createIssueParentBlockerFields,
   }),
-).superRefine(requireBlockedStatusForUnblockDescriptor);
+).superRefine((value, ctx) => {
+  requireBlockedStatusForUnblockDescriptor(value, ctx);
+  requireParentIdForBlockParentUntilDone(value, ctx);
+});
 
 export type CreateIssue = z.infer<typeof createIssueSchema>;
 
@@ -572,10 +600,7 @@ export const createChildIssueSchema = withCreateIssueStatusDefault(createIssueBa
     inheritExecutionWorkspaceFromIssueId: true,
     watchdogDiscovery: true,
   })
-  .extend({
-    acceptanceCriteria: z.array(z.string().trim().min(1).max(500)).max(20).optional(),
-    blockParentUntilDone: z.boolean().optional().default(false),
-  })).superRefine(requireBlockedStatusForUnblockDescriptor);
+  .extend(createIssueParentBlockerFields)).superRefine(requireBlockedStatusForUnblockDescriptor);
 
 export type CreateChildIssue = z.infer<typeof createChildIssueSchema>;
 

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -4138,6 +4138,67 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     expect(child.blockedBy).toEqual([]);
   });
 
+  it("honours blockParentUntilDone on company create with parentId", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    const parentId = randomUUID();
+    await db.insert(issues).values({
+      id: parentId,
+      companyId,
+      title: "Delegation parent",
+      status: "in_progress",
+      priority: "medium",
+    });
+
+    const child = await svc.create(companyId, {
+      title: "Company-create child blocker",
+      status: "todo",
+      priority: "medium",
+      parentId,
+      description: "Implement the workstream.",
+      acceptanceCriteria: ["Parent blockedBy includes this child"],
+      blockParentUntilDone: true,
+    });
+
+    expect(child.parentId).toBe(parentId);
+    expect(child.description).toContain("## Acceptance Criteria");
+    expect(child.description).toContain("- Parent blockedBy includes this child");
+    expect(child.blocks.map((relation) => relation.id)).toEqual([parentId]);
+
+    const parentRelations = await svc.getRelationSummaries(parentId);
+    expect(parentRelations.blockedBy).toEqual([
+      expect.objectContaining({
+        id: child.id,
+        title: "Company-create child blocker",
+      }),
+    ]);
+  });
+
+  it("rejects blockParentUntilDone on create without parentId", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+
+    await expect(svc.create(companyId, {
+      title: "Orphan blocker flag",
+      status: "todo",
+      priority: "medium",
+      blockParentUntilDone: true,
+    })).rejects.toMatchObject({
+      message: expect.stringContaining("blockParentUntilDone requires parentId"),
+    });
+  });
+
   it("adds terminal blockers to immediate blocked-by summaries", async () => {
     const companyId = randomUUID();
     await db.insert(companies).values({

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -8676,6 +8676,8 @@ export function issueRoutes(
       actorRunId: actor.runId,
       actorResponsibleUserId: authenticatedActorResponsibleUserId(req),
       trustExplicitResponsibleUserId: actor.actorType === "user",
+      actorAgentId: actor.agentId,
+      actorUserId: actor.actorType === "user" ? actor.actorId : null,
       watchdogActorRunId: actor.runId,
       onDeduplicated: (reason: "idempotency_key" | "recent_open_title") => {
         deduplicationReason = reason;
@@ -8740,6 +8742,7 @@ export function issueRoutes(
           : {}),
         ...buildCreateIssueActivityStatusDetails(issue, res),
         ...(Array.isArray(req.body.blockedByIssueIds) ? { blockedByIssueIds: req.body.blockedByIssueIds } : {}),
+        ...(req.body.blockParentUntilDone ? { parentBlockerAdded: true } : {}),
         ...summarizeIssueReferenceActivityDetails({
           addedReferencedIssues: referenceDiff.addedReferencedIssues.map(summarizeIssueRelationForActivity),
           removedReferencedIssues: referenceDiff.removedReferencedIssues.map(summarizeIssueRelationForActivity),

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -708,13 +708,13 @@ type IssueCreateInput = Omit<typeof issues.$inferInsert, "companyId"> & {
   idempotencyKey?: string | null;
   allowDuplicate?: boolean;
   onDeduplicated?: (reason: "idempotency_key" | "recent_open_title") => void;
-};
-type IssueChildCreateInput = IssueCreateInput & {
   acceptanceCriteria?: string[];
   blockParentUntilDone?: boolean;
-  executionWorkspaceInheritanceMode?: "linkage" | "strategy_only";
   actorAgentId?: string | null;
   actorUserId?: string | null;
+};
+type IssueChildCreateInput = IssueCreateInput & {
+  executionWorkspaceInheritanceMode?: "linkage" | "strategy_only";
 };
 type AcceptedPlanDecompositionInput = {
   acceptedPlanRevisionId: string;
@@ -7099,8 +7099,19 @@ export function issueService(db: Db) {
         idempotencyKey: rawIdempotencyKey,
         allowDuplicate,
         onDeduplicated,
+        acceptanceCriteria,
+        blockParentUntilDone,
+        actorAgentId,
+        actorUserId,
         ...issueData
       } = data;
+      if (blockParentUntilDone && !issueData.parentId) {
+        throw unprocessable("blockParentUntilDone requires parentId");
+      }
+      issueData.description = appendAcceptanceCriteriaToDescription(
+        issueData.description,
+        acceptanceCriteria,
+      );
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
       if (!isolatedWorkspacesEnabled) {
         delete issueData.executionWorkspaceId;
@@ -7412,6 +7423,26 @@ export function issueService(db: Db) {
             {
               agentId: issueData.createdByAgentId ?? null,
               userId: issueData.createdByUserId ?? null,
+            },
+            tx,
+          );
+        }
+        if (blockParentUntilDone && issueData.parentId) {
+          const existingBlockers = await tx
+            .select({ blockerIssueId: issueRelations.issueId })
+            .from(issueRelations)
+            .where(and(
+              eq(issueRelations.companyId, companyId),
+              eq(issueRelations.relatedIssueId, issueData.parentId),
+              eq(issueRelations.type, "blocks"),
+            ));
+          await syncBlockedByIssueIds(
+            issueData.parentId,
+            companyId,
+            [...new Set([...existingBlockers.map((row) => row.blockerIssueId), issue.id])],
+            {
+              agentId: actorAgentId ?? issueData.createdByAgentId ?? null,
+              userId: actorUserId ?? issueData.createdByUserId ?? null,
             },
             tx,
           );


### PR DESCRIPTION
POST /companies/:id/issues accepted blockParentUntilDone and acceptanceCriteria in spirit but the create-issue validators dropped them, so the fields were silently stripped: no blocks-edge was added to the parent and acceptance criteria never reached the description. Callers had to follow up with a separate POST /issues/:id/children or PATCH to get the dependency they had already asked for.

This moves acceptanceCriteria and blockParentUntilDone onto the shared create-issue field group so both createIssueInputSchema and createIssueSchema carry them, adds a refinement rejecting blockParentUntilDone without parentId, and honours both in the company create path: acceptance criteria are appended to the description and the parent blocks-edge is synced inside the same transaction as the existing child-create route. The route records parentBlockerAdded in the create activity and the MCP tool description now states the behaviour.

Covered by new unit tests in packages/shared/src/validators/issue.test.ts and server/src/__tests__/issues-service.test.ts.