### PR TITLE
fix(heartbeat): make workspace_busy retry scheduling priority- and age-aware

### DIFF
--- a/server/src/__tests__/heartbeat-workspace-busy.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-busy.test.ts
@@ -73,6 +73,62 @@ describe("computeWorkspaceBusyRetryDelayMs", () => {
       WORKSPACE_BUSY_RETRY_BASE_DELAY_MS + WORKSPACE_BUSY_RETRY_JITTER_MS,
     );
   });
+
+  // Whichever issue's retry became due first when the shared workspace
+  // mutex freed used to win it regardless of priority or how long it had
+  // been waiting. These cases pin the fix: priority-based bands that never
+  // overlap, plus an aging discount so a same-priority issue that has
+  // waited (been deferred) longer checks sooner than one on an earlier
+  // attempt.
+  describe("priority- and age-aware retry bands", () => {
+    it("defaults to the pre-existing medium window when no priority is given", () => {
+      expect(computeWorkspaceBusyRetryDelayMs(() => 0, undefined, 0)).toBe(
+        WORKSPACE_BUSY_RETRY_BASE_DELAY_MS,
+      );
+      expect(computeWorkspaceBusyRetryDelayMs(() => 1, undefined, 0)).toBe(
+        WORKSPACE_BUSY_RETRY_BASE_DELAY_MS + WORKSPACE_BUSY_RETRY_JITTER_MS,
+      );
+    });
+
+    it("treats an unrecognized priority the same as medium (fail-safe default)", () => {
+      expect(computeWorkspaceBusyRetryDelayMs(() => 1, "not-a-real-priority", 0)).toBe(
+        WORKSPACE_BUSY_RETRY_BASE_DELAY_MS + WORKSPACE_BUSY_RETRY_JITTER_MS,
+      );
+    });
+
+    it("keeps every priority band's worst case no later than the next lower priority's best case", () => {
+      // This is the actual guarantee this fix is for: order the next grant
+      // by priority first. It only holds if the bands never overlap (a tie at
+      // an exact band boundary is fine -- it falls through to the existing
+      // scheduledRetryAt/createdAt/id tiebreak in promoteDueScheduledRetries'
+      // query, which is a strict, not probabilistic, ordering).
+      const worstCase = (priority: string) => computeWorkspaceBusyRetryDelayMs(() => 1, priority, 0);
+      const bestCase = (priority: string) => computeWorkspaceBusyRetryDelayMs(() => 0, priority, 0);
+
+      expect(worstCase("critical")).toBeLessThanOrEqual(bestCase("high"));
+      expect(worstCase("high")).toBeLessThanOrEqual(bestCase("medium"));
+      expect(worstCase("medium")).toBeLessThanOrEqual(bestCase("low"));
+    });
+
+    it("shrinks the jitter window as deferralAttempt grows, without crossing the band floor", () => {
+      const attempt0 = computeWorkspaceBusyRetryDelayMs(() => 1, "medium", 0);
+      const attempt3 = computeWorkspaceBusyRetryDelayMs(() => 1, "medium", 3);
+      const attempt100 = computeWorkspaceBusyRetryDelayMs(() => 1, "medium", 100);
+
+      expect(attempt3).toBeLessThan(attempt0);
+      // Aging never discounts past the band's own base delay.
+      expect(attempt100).toBe(WORKSPACE_BUSY_RETRY_BASE_DELAY_MS);
+    });
+
+    it("never lets aging on a lower-priority issue beat a fresh higher-priority issue", () => {
+      // A `low` priority issue on its 100th deferral attempt is still
+      // strictly behind a `critical` issue on its very first attempt.
+      const staleLowPriority = computeWorkspaceBusyRetryDelayMs(() => 0, "low", 100);
+      const freshCritical = computeWorkspaceBusyRetryDelayMs(() => 1, "critical", 0);
+
+      expect(freshCritical).toBeLessThan(staleLowPriority);
+    });
+  });
 });
 
 describeEmbeddedPostgres("shared-workspace run serialization", () => {
@@ -689,6 +745,102 @@ describeEmbeddedPostgres("shared-workspace run serialization", () => {
     const cancelledRetry = await heartbeat.getRun(retryRun!.id);
     expect(cancelledRetry?.status).toBe("cancelled");
     expect(cancelledRetry?.errorCode).toBe("issue_reassigned");
+  });
+
+  // Reproduces the reported starvation shape end to end. Two
+  // issues on the same shared-workspace project (one "critical" -- the QA
+  // sign-off stand-in -- one "medium" -- the routine drafting-work stand-in)
+  // both get bounced by the same live holder. Before this fix both retries
+  // drew from the same fixed window, so which one's scheduledRetryAt sorted
+  // first (and therefore which one promoteDueScheduledRetries would try to
+  // dispatch first once the mutex freed) was pure luck. This pins that the
+  // critical issue's retry is now always due first.
+  it("gives a higher-priority deferred issue's retry an earlier due time than a medium-priority one deferred at the same moment", async () => {
+    const fixture = await seedWorkspaceFixture();
+
+    const criticalAgentId = randomUUID();
+    const criticalIssueId = randomUUID();
+    await db.insert(agents).values({
+      id: criticalAgentId,
+      companyId: fixture.companyId,
+      name: "QASignoffCoder",
+      role: "engineer",
+      status: "idle",
+      adapterType: WORKSPACE_BUSY_TEST_ADAPTER,
+      adapterConfig: {},
+      runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: criticalIssueId,
+      companyId: fixture.companyId,
+      title: "QA sign-off issue",
+      status: "in_progress",
+      priority: "critical",
+      responsibleUserId: "responsible-user",
+      assigneeAgentId: criticalAgentId,
+      projectId: fixture.projectId,
+      projectWorkspaceId: fixture.projectWorkspaceId,
+      issueNumber: 3,
+      identifier: "QASIGNOFF-1",
+      executionWorkspaceSettings: { sharedWorkspaceConcurrency: "serialize" },
+    });
+
+    // Both the medium-priority (fixture.issueId) and critical-priority
+    // (criticalIssueId) runs are dispatched back to back, at effectively the
+    // same instant, against the one live holder -- the exact "rotating cast
+    // of issues pile up on the one contended workspace" starvation shape.
+    const mediumRun = await heartbeat.invoke(
+      fixture.agentId,
+      "assignment",
+      { issueId: fixture.issueId, wakeReason: "issue_assigned" },
+      "system",
+    );
+    const criticalRun = await heartbeat.invoke(
+      criticalAgentId,
+      "assignment",
+      { issueId: criticalIssueId, wakeReason: "issue_assigned" },
+      "system",
+    );
+    expect(mediumRun).not.toBeNull();
+    expect(criticalRun).not.toBeNull();
+
+    await waitForRunToLeaveActiveStates(mediumRun!.id);
+    await waitForRunToLeaveActiveStates(criticalRun!.id);
+
+    const mediumRetry = await waitForRetryRun(mediumRun!.id);
+    const criticalRetry = await waitForRetryRun(criticalRun!.id);
+    expect(mediumRetry?.status).toBe("scheduled_retry");
+    expect(criticalRetry?.status).toBe("scheduled_retry");
+
+    // The core assertion: the higher-priority issue's retry is due
+    // strictly earlier, so it is promoted (and gets first crack at the
+    // mutex) before the medium-priority one, regardless of which run
+    // happened to get deferred first or land in the DB first.
+    expect(new Date(criticalRetry!.scheduledRetryAt!).getTime()).toBeLessThan(
+      new Date(mediumRetry!.scheduledRetryAt!).getTime(),
+    );
+
+    // And promoteDueScheduledRetries' existing scheduledRetryAt ordering
+    // reflects that: once both are due, the critical issue's retry sorts
+    // before the medium issue's retry in the batch that gets promoted.
+    const bothDue = new Date(
+      Math.max(
+        new Date(mediumRetry!.scheduledRetryAt!).getTime(),
+        new Date(criticalRetry!.scheduledRetryAt!).getTime(),
+      ) + 1_000,
+    );
+    // The holder is still live, so promotion alone (without the holder
+    // finishing) only proves ordering, not dispatch -- finish the holder too
+    // so both retries can actually resolve and the fixture drains cleanly.
+    await db
+      .update(heartbeatRuns)
+      .set({ status: "succeeded", finishedAt: new Date() })
+      .where(eq(heartbeatRuns.id, fixture.holderRunId));
+    const promotion = await heartbeat.promoteDueScheduledRetries(bothDue);
+    expect(promotion.runIds.indexOf(criticalRetry!.id)).toBeLessThan(
+      promotion.runIds.indexOf(mediumRetry!.id),
+    );
   });
 
   it("does not defer when the holder issue explicitly uses an isolated workspace", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -767,12 +767,19 @@ export class WorkspaceBusyDeferral extends Error {
   projectWorkspaceId: string;
   deferralAttempt: number;
   wasIssueAssignee: boolean;
+  // The priority of the ISSUE BEING DEFERRED (not the holder's). Threaded
+  // through to computeWorkspaceBusyRetryDelayMs so the retry ladder can favor
+  // higher-priority work when the mutex next frees. Optional/nullable so a
+  // caller that cannot resolve issue priority (e.g. a loose task context with
+  // no persisted issue row) still gets the pre-existing "medium" schedule.
+  deferredIssuePriority: string | null;
 
   constructor(input: {
     holder: SharedWorkspaceHolder;
     projectWorkspaceId: string;
     deferralAttempt: number;
     wasIssueAssignee: boolean;
+    deferredIssuePriority?: string | null;
   }) {
     super(
       `Shared project workspace is busy: run ${input.holder.runId} (issue ${
@@ -784,6 +791,7 @@ export class WorkspaceBusyDeferral extends Error {
     this.projectWorkspaceId = input.projectWorkspaceId;
     this.deferralAttempt = input.deferralAttempt;
     this.wasIssueAssignee = input.wasIssueAssignee;
+    this.deferredIssuePriority = input.deferredIssuePriority ?? null;
   }
 }
 
@@ -793,14 +801,54 @@ function isWorkspaceBusyDeferral(
   return error instanceof WorkspaceBusyDeferral;
 }
 
+// Per-priority workspace_busy retry windows. Evidence trail from a managed
+// install running a multi-agent company workload: the retry ladder previously
+// used one fixed window
+// (WORKSPACE_BUSY_RETRY_BASE_DELAY_MS +/- WORKSPACE_BUSY_RETRY_JITTER_MS) for
+// every issue regardless of priority, so whichever deferred retry's random
+// jitter happened to land first when the mutex freed won the shared
+// workspace -- a high-priority QA sign-off had no better odds than routine
+// drafting work sharing the same project. These bands are disjoint and
+// ordered so a higher-priority issue's retry always becomes due before a
+// lower-priority issue's retry deferred at the same moment, without changing
+// anything about how the mutex itself is acquired or how ties are broken at
+// dispatch time. `medium` is byte-for-byte the pre-existing window, so a
+// caller that cannot resolve a priority (or resolves "medium") sees exactly
+// the same schedule as before this change.
+const WORKSPACE_BUSY_RETRY_BANDS: Record<string, { baseDelayMs: number; jitterMs: number }> = {
+  critical: { baseDelayMs: 15_000, jitterMs: 15_000 }, // 15s-30s
+  high: { baseDelayMs: 30_000, jitterMs: 30_000 }, // 30s-60s
+  medium: { baseDelayMs: WORKSPACE_BUSY_RETRY_BASE_DELAY_MS, jitterMs: WORKSPACE_BUSY_RETRY_JITTER_MS }, // 60s-120s, unchanged
+  low: { baseDelayMs: 120_000, jitterMs: 60_000 }, // 120s-180s
+};
+// Anti-starvation aging: each additional attempt while an issue has been
+// waiting shrinks its jitter window toward the band floor, so a same-priority
+// issue that has been deferred more times (has been waiting longer) checks
+// sooner than one on an earlier attempt. This is an age tiebreak within a
+// priority band, not a substitute for the band ordering above -- a lower
+// priority issue on its 50th attempt still cannot out-age a higher priority
+// issue on its 1st, because the bands themselves never overlap.
+const WORKSPACE_BUSY_RETRY_AGING_STEP_MS = 5_000;
+
+function normalizeWorkspaceBusyPriority(priority: string | null | undefined): keyof typeof WORKSPACE_BUSY_RETRY_BANDS {
+  return priority === "critical" || priority === "high" || priority === "medium" || priority === "low"
+    ? priority
+    : "medium";
+}
+
 export function computeWorkspaceBusyRetryDelayMs(
   random: () => number = Math.random,
+  priority?: string | null,
+  deferralAttempt = 0,
 ) {
+  const band = WORKSPACE_BUSY_RETRY_BANDS[normalizeWorkspaceBusyPriority(priority)];
   const jitter = Math.min(Math.max(random(), 0), 1);
-  return (
-    WORKSPACE_BUSY_RETRY_BASE_DELAY_MS +
-    Math.floor(jitter * WORKSPACE_BUSY_RETRY_JITTER_MS)
+  const agingDiscountMs = Math.min(
+    Math.max(deferralAttempt, 0) * WORKSPACE_BUSY_RETRY_AGING_STEP_MS,
+    band.jitterMs,
   );
+  const effectiveJitterMs = Math.max(0, band.jitterMs - agingDiscountMs);
+  return band.baseDelayMs + Math.floor(jitter * effectiveJitterMs);
 }
 
 // True for the retry of a workspace-busy deferral whose original run did NOT
@@ -14353,7 +14401,15 @@ export function heartbeatService(
           // Always admit the next attempt: workspace-busy deferral is bounded by
           // holder liveness, not by an attempt counter.
           maxAttempts: (cancelledRun.scheduledRetryAttempt ?? 0) + 1,
-          delayMs: computeWorkspaceBusyRetryDelayMs(),
+          // Priority- and age-aware: see WORKSPACE_BUSY_RETRY_BANDS. A high
+          // priority issue's retry becomes due sooner than a lower-priority
+          // issue's, and an issue that has been deferred more times checks
+          // sooner than a same-priority issue earlier in its own retry chain.
+          delayMs: computeWorkspaceBusyRetryDelayMs(
+            Math.random,
+            deferral.deferredIssuePriority,
+            deferral.deferralAttempt,
+          ),
         },
       ).catch((scheduleErr) => {
         logger.error(
@@ -14437,6 +14493,15 @@ export function heartbeatService(
 
   async function promoteDueScheduledRetries(now = new Date()) {
     const cutoff = await getWorktreeExecutionCutoff();
+    // Ordering by scheduledRetryAt is where workspace_busy fairness actually
+    // takes effect: computeWorkspaceBusyRetryDelayMs assigns a
+    // shorter, disjoint window to higher-priority issues, so when several
+    // issues are deferred waiting on the same shared-workspace mutex, the
+    // higher-priority one's scheduledRetryAt sorts earlier here and is
+    // promoted (and therefore reaches the dispatch gate) first once the
+    // mutex frees, instead of whichever retry's fixed-window jitter happened
+    // to land first. This query is intentionally unchanged otherwise -- it
+    // still governs every scheduled-retry reason, not only workspace_busy.
     const dueRuns = await db
       .select()
       .from(heartbeatRuns)
@@ -18220,6 +18285,7 @@ export function heartbeatService(
                   ? (run.scheduledRetryAttempt ?? 0)
                   : 0,
               wasIssueAssignee: issueContext?.assigneeAgentId === agent.id,
+              deferredIssuePriority: issueRef.priority ?? null,
             });
           }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - A project can pin its execution workspace policy to `shared_workspace` with `sharedWorkspaceConcurrency: serialize`, so concurrent agent runs never mutate the same working tree at once
> - When the mutex is held, a losing run is cancelled and given a `workspace_busy` scheduled retry with a flat, fixed delay window (60-120s), with no regard for the issue's priority or how long it has already been waiting
> - So when several issues pile up retrying for the same contended workspace, whichever retry's random jitter happens to land first wins the workspace once it frees -- effectively a coin-flip, not FIFO and not priority-aware
> - This pull request makes the `workspace_busy` retry delay priority- and age-aware: a disjoint delay band per issue priority, plus an aging discount so a same-priority issue that has waited longer checks sooner
> - The benefit is that a high-priority run (for example, an independent verification/sign-off step) very reliably wins the workspace ahead of routine lower-priority work sharing the same project, instead of losing an unpredictable fraction of the time

## Linked Issues or Issue Description

Refs: #10806

This PR addresses the fairness half of Defect 1 in #10806 ("losing runs are cancelled, not queued, and the retry is unbounded"). It does not claim to close #10806: that issue also asks for exponential backoff with an attempt ceiling and escalation path (this PR keeps the existing unbounded-while-holder-is-live design, since that is a separate, deliberate behavior distinct from fairness), and separately reports a productivity-reviewer false-positive defect and a silent-write defect on `executionWorkspaceSettings` that this PR does not touch.

No other existing issue or PR that I could find covers priority/age-aware ordering specifically, so I am also describing the underlying bug directly, following the bug report template:

**What happened?** A project using `sharedWorkspaceConcurrency: serialize` had several issues, of different priorities, contending for the one shared workspace mutex over an extended period. A high-priority verification run was deferred and retried repeatedly (dozens of times over roughly an hour), each attempt dying in under 200ms with `errorCode: workspace_busy`, while a rotating set of unrelated medium-priority issues on the same project kept winning the mutex instead. There was only one real (non-deferred) execution window for the high-priority run across the whole period.

**Expected behavior:** When multiple issues are deferred waiting on the same shared-workspace mutex, a higher-priority issue should reliably get the next grant ahead of a lower-priority one, and an issue that has been waiting longer should not be perpetually out-raced by newer, same-priority contenders.

**Steps to reproduce:**
1. Set a project's `executionWorkspacePolicy` to `defaultMode: shared_workspace`, `sharedWorkspaceConcurrency: serialize`.
2. Start a long-running run on one issue (the "holder"), and dispatch runs on two other issues on the same project at roughly the same time -- one `critical` priority, one `medium` priority.
3. Both non-holder runs are deferred with `errorCode: workspace_busy` and get a `scheduled_retry` row.
4. Before this fix: `scheduledRetryAt` for both retries is drawn from the same fixed window, so which one sorts earlier (and is promoted/dispatched first once the holder finishes) is effectively random.
5. After this fix: the `critical` issue's `scheduledRetryAt` is always earlier than the `medium` issue's, because the two priorities draw from disjoint delay bands.

**Paperclip version or commit:** `08af15bd7629790a618e8787c11490c96a1b619a` (current `master` at the time of this PR)

**Deployment mode:** Self-hosted server

**Installation method:** Built from source (pnpm dev / pnpm build)

**Agent adapter(s) involved:** Not adapter-specific (core bug)

**Database mode:** Embedded PGlite (default -- `DATABASE_URL` unset), reproduced against the embedded-Postgres test harness

**Access context:** Agent (bearer API key via `agent_api_keys`)

## What Changed

- `computeWorkspaceBusyRetryDelayMs` now takes an optional `priority` and `deferralAttempt` and returns a delay drawn from one of four disjoint bands (`critical` 15-30s, `high` 30-60s, `medium` 60-120s -- unchanged from before, `low` 120-180s), so a higher-priority issue's retry always becomes due before a lower-priority issue's retry deferred at the same moment.
- Each additional deferral attempt shrinks the jitter window toward the band floor (an aging discount), so a same-priority issue that has been waiting (been deferred) longer checks sooner than one earlier in its own retry chain -- without ever letting a lower-priority issue's aging beat a fresh higher-priority one.
- `WorkspaceBusyDeferral` now carries the deferred issue's own priority (`deferredIssuePriority`), threaded from the pre-dispatch gate (where the issue row, including its priority, is already loaded) through to the retry-scheduling call site.
- `promoteDueScheduledRetries`'s existing `scheduledRetryAt` ordering is unchanged mechanically, but is now where the fairness actually takes effect -- documented with a comment explaining why.
- No changes to how the mutex itself is acquired, to dispatch-path concurrency, or to any other scheduled-retry reason (max-turn continuation, interaction continuation, bounded transient retries) -- this is scoped to `workspace_busy` only.
- Added unit tests pinning the band ordering, the aging discount, and the medium-priority/no-priority backward-compatibility case, plus an end-to-end integration test that reproduces the reported starvation shape (two issues of different priority deferred by the same holder at the same moment) and asserts the higher-priority issue's retry is promoted first.

## Verification

- `npx vitest run server/src/__tests__/heartbeat-workspace-busy.test.ts` -- 21/21 pass, including the new priority-band unit tests and the new end-to-end fairness integration test (uses the embedded-Postgres test harness).
- `npx vitest run server/src/__tests__/heartbeat-retry-scheduling.test.ts` -- 30/30 pass (no regression in the broader scheduled-retry machinery).
- `cd server && npx tsc --noEmit -p tsconfig.json` -- same pre-existing error count as `master` (140, all unrelated `@paperclipai/plugin-sdk` resolution errors in files this PR does not touch); zero new errors, none in `heartbeat.ts`.
- Manual review of every other call site of `computeWorkspaceBusyRetryDelayMs` and `WorkspaceBusyDeferral` (both are `heartbeat.ts`-internal aside from the one test file) to confirm no other caller is affected.

## Risks

- **Low-to-moderate.** This changes retry timing only, not correctness: the shared-workspace mutex is still acquired and released exactly as before, so this cannot introduce the concurrent-mutation corruption the mutex exists to prevent.
- The `medium` band is byte-for-byte the pre-existing window, so a caller that does not resolve a priority (or resolves `"medium"`) sees identical scheduling to before this change -- this is intentionally backward compatible, not a new default behavior for existing deployments that do not use issue priorities meaningfully.
- This does not fully close #10806's Defect 1: it does not add exponential backoff, an attempt ceiling, or an escalation path. Those remain open asks if a maintainer wants them tracked separately.
- The fairness guarantee is per retry-tick ordering (`promoteDueScheduledRetries`), not a true wait queue: if a higher-priority issue's deferral happens long enough after a lower-priority one's that their due windows do not overlap in the same processing batch, the lower-priority one can still win. In the common case this fix targets -- several issues piling up and getting deferred close together while a holder is live -- the disjoint bands make the higher-priority issue win deterministically.

## Model Used

Claude (Anthropic), model ID `claude-sonnet-5` (as `claude-sonnet-4-5` per API responses), accessed through an OpenCode-based coding agent. Standard reasoning mode (no extended/thinking-budget API used). Tool use: file read/edit, shell execution (vitest, tsc, git), GitHub REST API for issue search and PR creation. No code-execution sandbox beyond the local shell.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
