### PR TITLE
fix(server): prevent startup failure on large decision histories

### DIFF
--- a/server/src/__tests__/decision-retention-service.test.ts
+++ b/server/src/__tests__/decision-retention-service.test.ts
@@ -90,6 +90,30 @@ describePg("decision retention", () => {
     responsibleUserId: "board-user",
   };
 
+  it("syncs more rows than one PostgreSQL parameter window", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Large retention history",
+      issuePrefix: `L${companyId.slice(0, 6)}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    // Four bound values per row makes one unbatched insert exceed 65,534.
+    const itemCount = 16_384;
+    const activityAt = "2026-08-02T00:00:00.000Z";
+    const items = Array.from({ length: itemCount }, (_, index) => ({
+      sourceKind: "review" as const,
+      subject: { id: `retention-source-${index}` },
+      activityAt,
+    }));
+
+    const states = await decisionRetentionService(db).syncItems(companyId, items);
+
+    expect(states.size).toBe(itemCount);
+    expect(states.get("review:retention-source-0")?.sourceActivityAt.toISOString()).toBe(activityAt);
+    expect(states.get(`review:retention-source-${itemCount - 1}`)?.sourceActivityAt.toISOString()).toBe(activityAt);
+  }, 30_000);
+
   it("auto-archives, excludes by default, returns archived rows, and revives", async () => {
     const { companyId, issueIds } = await seedReviewItems(1);
     const now = new Date("2026-08-02T00:00:00.000Z");

--- a/server/src/services/decision-retention.ts
+++ b/server/src/services/decision-retention.ts
@@ -29,6 +29,14 @@ import {
 export const DEFAULT_DECISION_SHELF_DAYS = 30;
 export const DEFAULT_DECISION_ARCHIVE_DAYS = 90;
 const DAY_MS = 86_400_000;
+// Each insert row binds four values. Keep statements well below PostgreSQL's
+// 65,534-parameter limit and keep readback IN lists bounded too.
+const DECISION_RETENTION_INSERT_BATCH_SIZE = 5_000;
+const DECISION_RETENTION_LOOKUP_BATCH_SIZE = 10_000;
+
+type DecisionRetentionSyncItem = Pick<AttentionItem, "sourceKind" | "activityAt"> & {
+  subject: Pick<AttentionItem["subject"], "id">;
+};
 
 export type DecisionRetentionState = typeof decisionRetention.$inferSelect;
 export type ArchiveNotificationBatch = {
@@ -135,21 +143,29 @@ export function decisionRetentionService(
   db: Db,
   options: { notifyOriginAgent?: (batch: ArchiveNotificationBatch) => Promise<unknown> } = {},
 ) {
-  async function syncItems(companyId: string, items: readonly AttentionItem[]) {
+  async function syncItems(companyId: string, items: readonly DecisionRetentionSyncItem[]) {
     if (items.length === 0) return new Map<string, DecisionRetentionState>();
     const unique = [...new Map(items.map((item) => [itemSourceKey(item), item])).values()];
-    await db.insert(decisionRetention).values(unique.map((item) => ({
-      companyId,
-      sourceKind: item.sourceKind,
-      sourceId: item.subject.id,
-      sourceActivityAt: new Date(item.activityAt),
-    }))).onConflictDoNothing({
-      target: [decisionRetention.companyId, decisionRetention.sourceKind, decisionRetention.sourceId],
-    });
-    let rows = await db.select().from(decisionRetention).where(and(
-      eq(decisionRetention.companyId, companyId),
-      inArray(decisionRetention.sourceId, unique.map((item) => item.subject.id)),
-    ));
+    for (let start = 0; start < unique.length; start += DECISION_RETENTION_INSERT_BATCH_SIZE) {
+      const batch = unique.slice(start, start + DECISION_RETENTION_INSERT_BATCH_SIZE);
+      await db.insert(decisionRetention).values(batch.map((item) => ({
+        companyId,
+        sourceKind: item.sourceKind,
+        sourceId: item.subject.id,
+        sourceActivityAt: new Date(item.activityAt),
+      }))).onConflictDoNothing({
+        target: [decisionRetention.companyId, decisionRetention.sourceKind, decisionRetention.sourceId],
+      });
+    }
+
+    const sourceIds = [...new Set(unique.map((item) => item.subject.id))];
+    const rows: DecisionRetentionState[] = [];
+    for (let start = 0; start < sourceIds.length; start += DECISION_RETENTION_LOOKUP_BATCH_SIZE) {
+      rows.push(...await db.select().from(decisionRetention).where(and(
+        eq(decisionRetention.companyId, companyId),
+        inArray(decisionRetention.sourceId, sourceIds.slice(start, start + DECISION_RETENTION_LOOKUP_BATCH_SIZE)),
+      )));
+    }
     const byKey = new Map(rows.map((row) => [sourceKey(row.sourceKind, row.sourceId), row]));
     for (const item of unique) {
       const key = itemSourceKey(item);
@@ -166,11 +182,10 @@ export function decisionRetentionService(
       )).returning().then((values) => values[0] ?? null);
       if (updated) byKey.set(key, updated);
     }
-    rows = [...byKey.values()];
-    return new Map(rows.map((row) => [sourceKey(row.sourceKind, row.sourceId), row]));
+    return new Map([...byKey.values()].map((row) => [sourceKey(row.sourceKind, row.sourceId), row]));
   }
 
-  function itemSourceKey(item: AttentionItem) {
+  function itemSourceKey(item: DecisionRetentionSyncItem) {
     return sourceKey(item.sourceKind, item.subject.id);
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The attention service stores decision-retention state for each attention item.
> - The startup sync inserted all unique retention rows in one SQL statement.
> - PostgreSQL rejected that statement when the bound parameter count was greater than 65,534.
> - The failed sync stopped server startup for installations with large histories.
> - This pull request uses bounded insert and readback batches.
> - The benefit is reliable startup without a change to retention behavior.

## Linked Issues or Issue Description

Fixes: #11909

Related: #12162 changes the retention sweep cadence and failed-run query shape. It does not batch the startup decision-retention sync that this pull request fixes.

## What Changed

- Insert decision-retention rows in batches of 5,000 rows.
- Read the stored rows in batches of 10,000 source IDs.
- Deduplicate source IDs before the readback queries.
- Add an embedded PostgreSQL regression test with 16,384 unique items.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/decision-retention-service.test.ts` passed. Four tests passed.
- `pnpm -r typecheck` passed for all workspace packages.
- `pnpm build` passed for the full workspace.
- An earlier `pnpm test:run` completed with 5,203 tests passed. Thirty unrelated tests failed on this macOS host. The failures use temporary-path aliases, unavailable test ports, and local runtime discovery. None of the failures use the decision-retention service.

## Risks

- Risk is low. Small syncs still use one insert and one readback query.
- Large syncs use more database round trips. Each query stays below the driver parameter limit.
- The inserts remain idempotent because each batch uses the existing conflict target.
- No schema or migration changes are included.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with GPT-5.6. The client did not expose the exact service model suffix or context-window size. Agentic reasoning, local tool use, and code execution were enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
