### PR TITLE
Fix governed secret binding acceptance through gateway

### DIFF
--- a/server/src/__tests__/issue-thread-interaction-routes.test.ts
+++ b/server/src/__tests__/issue-thread-interaction-routes.test.ts
@@ -1388,6 +1388,7 @@ describe.sequential("issue thread interaction routes", () => {
       issueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
       interactionId: "interaction-secret-proposal",
       proposalId,
+      cascade: true,
       actor: { agentId: null, userId: "local-board" },
     });
     expect(mockInteractionService.recordSecretProposalExecutionResult).toHaveBeenCalledWith(
@@ -1406,6 +1407,55 @@ describe.sequential("issue thread interaction routes", () => {
             executionStatus: "executed",
             instructions: expect.stringContaining("GET /api/agents/me/secrets"),
           }),
+        }),
+      }),
+    );
+  });
+
+  it("reconciles an accepted secret-proposal confirmation that is missing its execution receipt", async () => {
+    const proposalId = "66666666-6666-4666-8666-666666666666";
+    const acceptedWithoutReceipt = {
+      id: "interaction-secret-proposal-replay",
+      companyId: "company-1",
+      issueId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      kind: "request_confirmation",
+      status: "accepted",
+      continuationPolicy: "wake_assignee",
+      requestedResolverPolicy: "human_only",
+      effectiveResolverPolicy: "human_only",
+      resolverPolicyProvenance: "explicit",
+      effectiveResolverPolicySource: "governed_action",
+      payload: {
+        version: 1,
+        prompt: "Create the binding?",
+        secretProposal: {
+          version: 1,
+          proposalId,
+          configPath: "access.NEW_ALIAS",
+        },
+      },
+      result: { version: 1, outcome: "accepted" },
+    };
+    mockInteractionService.getForIssue.mockResolvedValueOnce(acceptedWithoutReceipt);
+    const approveSecretProposal = vi.fn().mockResolvedValue({ status: "approved" });
+    const app = await createApp(undefined, { approveSecretProposal });
+
+    const res = await request(app)
+      .post("/api/issues/aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa/interactions/interaction-secret-proposal-replay/accept")
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(mockInteractionService.acceptInteraction).not.toHaveBeenCalled();
+    expect(approveSecretProposal).toHaveBeenCalledWith(expect.objectContaining({
+      proposalId,
+      cascade: true,
+    }));
+    expect(res.body.result.secretProposal).toMatchObject({ status: "executed" });
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      ASSIGNEE_AGENT_ID,
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          secretProposal: expect.objectContaining({ proposalId, executionStatus: "executed" }),
         }),
       }),
     );

--- a/server/src/__tests__/plugin-orchestration-apis.test.ts
+++ b/server/src/__tests__/plugin-orchestration-apis.test.ts
@@ -12,6 +12,10 @@ import {
   assets,
   companies,
   companyMemberships,
+  companySecretBindings,
+  companySecretProposals,
+  companySecrets,
+  companySecretVersions,
   costEvents,
   createDb,
   executionWorkspaces,
@@ -22,6 +26,7 @@ import {
   issueRelations,
   issueThreadInteractions,
   issues,
+  instanceUserRoles,
   pluginManagedResources,
   plugins,
   projects,
@@ -33,6 +38,7 @@ import {
 import { buildHostServices } from "../services/plugin-host-services.js";
 import { heartbeatService } from "../services/heartbeat.js";
 import { drainHeartbeatRunsToQuiescence } from "./helpers/drain-heartbeat-runs.js";
+import { createSecretProposalsService } from "../services/secret-proposals.js";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -61,9 +67,13 @@ if (!embeddedPostgresSupport.supported) {
 describeEmbeddedPostgres("plugin orchestration APIs", () => {
   let db!: ReturnType<typeof createDb>;
   let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+  let secretsRoot: string | null = null;
+  const previousSecretsMasterKeyFile = process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE;
   const tempRoots: string[] = [];
 
   beforeAll(async () => {
+    secretsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-plugin-orchestration-secrets-"));
+    process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE = path.join(secretsRoot, "master.key");
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-plugin-orchestration-");
     db = createDb(tempDb.connectionString);
   }, 20_000);
@@ -109,7 +119,11 @@ describeEmbeddedPostgres("plugin orchestration APIs", () => {
     await db.delete(agentWakeupRequests);
     await db.delete(issueRelations);
     await db.delete(issueComments);
+    await db.delete(companySecretProposals);
     await db.delete(issueThreadInteractions);
+    await db.delete(companySecretBindings);
+    await db.delete(companySecretVersions);
+    await db.delete(companySecrets);
     await db.delete(issueAttachments);
     await db.delete(assets);
     await db.delete(approvals);
@@ -119,12 +133,16 @@ describeEmbeddedPostgres("plugin orchestration APIs", () => {
     await db.delete(projects);
     await db.delete(plugins);
     await db.delete(companyMemberships);
+    await db.delete(instanceUserRoles);
     await db.delete(agents);
     await db.delete(companies);
   });
 
   afterAll(async () => {
     await tempDb?.cleanup();
+    if (previousSecretsMasterKeyFile === undefined) delete process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE;
+    else process.env.PAPERCLIP_SECRETS_MASTER_KEY_FILE = previousSecretsMasterKeyFile;
+    if (secretsRoot) await fs.rm(secretsRoot, { recursive: true, force: true });
   });
 
   async function seedCompanyAndAgent() {
@@ -979,6 +997,106 @@ describeEmbeddedPostgres("plugin orchestration APIs", () => {
     return interactionId;
   }
 
+  async function seedGovernedSecretBinding(options: {
+    conflictingConfig?: boolean;
+    acceptedWithoutReceipt?: boolean;
+  } = {}) {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const actorUserId = randomUUID();
+    const issueId = randomUUID();
+    const heartbeatRunId = randomUUID();
+    await db.insert(companyMemberships).values({
+      companyId,
+      principalType: "user",
+      principalId: actorUserId,
+      status: "active",
+      membershipRole: "owner",
+    });
+    await db.insert(instanceUserRoles).values({ userId: actorUserId, role: "instance_admin" });
+    await db.update(agents).set({
+      runtimeConfig: { heartbeat: { maxConcurrentRuns: 1 } },
+      ...(options.conflictingConfig
+        ? { adapterConfig: { command: "true", env: { GATEWAY_TOKEN: { type: "plain", value: "test-placeholder" } } } }
+        : {}),
+    }).where(eq(agents.id, agentId));
+    await db.insert(heartbeatRuns).values({
+      id: heartbeatRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "assignment",
+      responsibleUserId: actorUserId,
+      contextSnapshot: { issueId },
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Create governed secret binding",
+      status: "in_review",
+      priority: "high",
+      assigneeAgentId: agentId,
+      executionRunId: heartbeatRunId,
+      responsibleUserId: actorUserId,
+    });
+
+    const proposals = createSecretProposalsService(db);
+    const secretProposal = await proposals.createSecret({
+      companyId,
+      heartbeatRunId,
+      registerForRedaction: async () => {},
+    }, {
+      name: `tests/gateway/${randomUUID()}`,
+      key: "GATEWAY_TOKEN",
+      value: "test-only-secret-material",
+      justification: "Exercise the governed gateway acceptance path",
+    });
+    const bindingProposal = await proposals.createBinding({ companyId, heartbeatRunId }, {
+      secretProposalId: secretProposal.id,
+      configPath: "env.GATEWAY_TOKEN",
+      justification: "Bind the test credential through a governed confirmation",
+      bindingTargetPolicy: "self_and_reports",
+    });
+    const interactionId = bindingProposal.interactionId!;
+    if (options.acceptedWithoutReceipt) {
+      await db.update(issueThreadInteractions).set({
+        status: "accepted",
+        result: { version: 1, outcome: "accepted" },
+        resolvedByUserId: actorUserId,
+        resolvedAt: new Date(),
+      }).where(eq(issueThreadInteractions.id, interactionId));
+    }
+    return {
+      companyId,
+      agentId,
+      actorUserId,
+      issueId,
+      heartbeatRunId,
+      secretProposalId: secretProposal.id,
+      bindingProposalId: bindingProposal.id,
+      interactionId,
+    };
+  }
+
+  async function waitForSecretProposalWake(
+    companyId: string,
+    agentId: string,
+    executionStatus: "executed" | "failed",
+  ) {
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+      const runs = await db.select().from(heartbeatRuns).where(and(
+        eq(heartbeatRuns.companyId, companyId),
+        eq(heartbeatRuns.agentId, agentId),
+      ));
+      const match = runs.find((run) => {
+        const snapshot = run.contextSnapshot as { secretProposal?: { executionStatus?: string } } | null;
+        return snapshot?.secretProposal?.executionStatus === executionStatus;
+      });
+      if (match) return match;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    throw new Error(`Timed out waiting for ${executionStatus} secret-proposal wake`);
+  }
+
   it("respondInteraction fails closed when actorUserId is omitted", async () => {
     const { companyId, agentId } = await seedCompanyAndAgent();
     const issueId = randomUUID();
@@ -1057,6 +1175,121 @@ describeEmbeddedPostgres("plugin orchestration APIs", () => {
     expect(result.applied).toBe(true);
     const [row] = await db.select().from(issueThreadInteractions).where(eq(issueThreadInteractions.id, interactionId));
     expect(row?.status).toBe("accepted");
+  });
+
+  it("respondInteraction cascades an accepted secret binding and wakes with an executed receipt", async () => {
+    const fixture = await seedGovernedSecretBinding();
+    const services = buildHostServices(
+      db,
+      "plugin-record-id",
+      "paperclip.gateway",
+      createEventBusStub(),
+      undefined,
+      { heartbeatRuntimeEnv: {} },
+    );
+
+    const result = await services.issues.respondInteraction({
+      issueId: fixture.issueId,
+      interactionId: fixture.interactionId,
+      companyId: fixture.companyId,
+      action: "accept",
+      actorUserId: fixture.actorUserId,
+    });
+
+    expect(result.applied).toBe(true);
+    expect(result.interaction.result).toMatchObject({
+      secretProposal: { status: "executed" },
+    });
+    expect(await db.select().from(companySecretProposals)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: fixture.secretProposalId, status: "approved" }),
+      expect.objectContaining({ id: fixture.bindingProposalId, status: "approved" }),
+    ]));
+    const [binding] = await db.select().from(companySecretBindings);
+    const [agent] = await db.select().from(agents).where(eq(agents.id, fixture.agentId));
+    expect(agent?.adapterConfig).toMatchObject({
+      env: { GATEWAY_TOKEN: { type: "secret_ref", secretId: binding?.secretId, version: "latest" } },
+    });
+    const wake = await waitForSecretProposalWake(fixture.companyId, fixture.agentId, "executed");
+    expect(wake.contextSnapshot).toMatchObject({
+      secretProposal: {
+        proposalId: fixture.bindingProposalId,
+        configPath: "env.GATEWAY_TOKEN",
+        executionStatus: "executed",
+      },
+    });
+  });
+
+  it("respondInteraction records a terminal failure when the secret binding cannot be applied", async () => {
+    const fixture = await seedGovernedSecretBinding({ conflictingConfig: true });
+    const services = buildHostServices(
+      db,
+      "plugin-record-id",
+      "paperclip.gateway",
+      createEventBusStub(),
+      undefined,
+      { heartbeatRuntimeEnv: {} },
+    );
+
+    const result = await services.issues.respondInteraction({
+      issueId: fixture.issueId,
+      interactionId: fixture.interactionId,
+      companyId: fixture.companyId,
+      action: "accept",
+      actorUserId: fixture.actorUserId,
+    });
+
+    expect(result.applied).toBe(true);
+    expect(result.interaction.result).toMatchObject({
+      secretProposal: { status: "failed", errorCode: "http_409" },
+    });
+    expect(await db.select().from(companySecrets)).toHaveLength(0);
+    expect(await db.select().from(companySecretBindings)).toHaveLength(0);
+    expect(await db.select().from(companySecretProposals)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: fixture.secretProposalId, status: "pending" }),
+      expect.objectContaining({ id: fixture.bindingProposalId, status: "rejected" }),
+    ]));
+    const [agent] = await db.select().from(agents).where(eq(agents.id, fixture.agentId));
+    expect(agent?.adapterConfig).toMatchObject({
+      env: { GATEWAY_TOKEN: { type: "plain", value: "test-placeholder" } },
+    });
+    await expect(waitForSecretProposalWake(fixture.companyId, fixture.agentId, "failed"))
+      .resolves.toMatchObject({ contextSnapshot: expect.objectContaining({ secretProposal: expect.objectContaining({ executionStatus: "failed" }) }) });
+  });
+
+  it("respondInteraction idempotently repairs an accepted card that has no execution receipt", async () => {
+    const fixture = await seedGovernedSecretBinding({ acceptedWithoutReceipt: true });
+    const services = buildHostServices(
+      db,
+      "plugin-record-id",
+      "paperclip.gateway",
+      createEventBusStub(),
+      undefined,
+      { heartbeatRuntimeEnv: {} },
+    );
+
+    const first = await services.issues.respondInteraction({
+      issueId: fixture.issueId,
+      interactionId: fixture.interactionId,
+      companyId: fixture.companyId,
+      action: "accept",
+      actorUserId: fixture.actorUserId,
+    });
+    const second = await services.issues.respondInteraction({
+      issueId: fixture.issueId,
+      interactionId: fixture.interactionId,
+      companyId: fixture.companyId,
+      action: "accept",
+      actorUserId: fixture.actorUserId,
+    });
+
+    expect(first).toMatchObject({ applied: false, interaction: { result: { secretProposal: { status: "executed" } } } });
+    expect(second).toMatchObject({ applied: false, interaction: { result: { secretProposal: { status: "executed" } } } });
+    expect(await db.select().from(companySecrets)).toHaveLength(1);
+    expect(await db.select().from(companySecretBindings)).toHaveLength(1);
+    expect(await db.select().from(companySecretProposals)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: fixture.secretProposalId, status: "approved" }),
+      expect.objectContaining({ id: fixture.bindingProposalId, status: "approved" }),
+    ]));
   });
 
   it.each(["accept", "reject"] as const)(

--- a/server/src/__tests__/plugin-orchestration-apis.test.ts
+++ b/server/src/__tests__/plugin-orchestration-apis.test.ts
@@ -29,6 +29,7 @@ import {
   instanceUserRoles,
   pluginManagedResources,
   plugins,
+  principalPermissionGrants,
   projects,
 } from "@paperclipai/db";
 import {
@@ -132,6 +133,7 @@ describeEmbeddedPostgres("plugin orchestration APIs", () => {
     await db.delete(pluginManagedResources);
     await db.delete(projects);
     await db.delete(plugins);
+    await db.delete(principalPermissionGrants);
     await db.delete(companyMemberships);
     await db.delete(instanceUserRoles);
     await db.delete(agents);
@@ -1000,6 +1002,7 @@ describeEmbeddedPostgres("plugin orchestration APIs", () => {
   async function seedGovernedSecretBinding(options: {
     conflictingConfig?: boolean;
     acceptedWithoutReceipt?: boolean;
+    grantAgentsConfigure?: boolean;
   } = {}) {
     const { companyId, agentId } = await seedCompanyAndAgent();
     const actorUserId = randomUUID();
@@ -1012,7 +1015,19 @@ describeEmbeddedPostgres("plugin orchestration APIs", () => {
       status: "active",
       membershipRole: "owner",
     });
+    // Keep a stale instance-admin row in every fixture. Gateway attribution
+    // must never use it as authority; successful fixtures receive the explicit
+    // company-scoped grant that the governed effect requires.
     await db.insert(instanceUserRoles).values({ userId: actorUserId, role: "instance_admin" });
+    if (options.grantAgentsConfigure !== false) {
+      await db.insert(principalPermissionGrants).values({
+        companyId,
+        principalType: "user",
+        principalId: actorUserId,
+        permissionKey: "agents:configure",
+        grantedByUserId: actorUserId,
+      });
+    }
     await db.update(agents).set({
       runtimeConfig: { heartbeat: { maxConcurrentRuns: 1 } },
       ...(options.conflictingConfig
@@ -1217,6 +1232,67 @@ describeEmbeddedPostgres("plugin orchestration APIs", () => {
         executionStatus: "executed",
       },
     });
+  });
+
+  it("respondInteraction ignores a stale instance-admin row and allows an authorized replay", async () => {
+    const fixture = await seedGovernedSecretBinding({ grantAgentsConfigure: false });
+    const services = buildHostServices(
+      db,
+      "plugin-record-id",
+      "paperclip.gateway",
+      createEventBusStub(),
+      undefined,
+      { heartbeatRuntimeEnv: {} },
+    );
+
+    await expect(services.issues.respondInteraction({
+      issueId: fixture.issueId,
+      interactionId: fixture.interactionId,
+      companyId: fixture.companyId,
+      action: "accept",
+      actorUserId: fixture.actorUserId,
+    })).rejects.toThrow("Missing permission: agents:configure");
+
+    const [acceptedWithoutReceipt] = await db
+      .select()
+      .from(issueThreadInteractions)
+      .where(eq(issueThreadInteractions.id, fixture.interactionId));
+    expect(acceptedWithoutReceipt).toMatchObject({
+      status: "accepted",
+      result: { version: 1, outcome: "accepted" },
+    });
+    expect((acceptedWithoutReceipt?.result as { secretProposal?: unknown } | null)?.secretProposal)
+      .toBeUndefined();
+    expect(await db.select().from(companySecrets)).toHaveLength(0);
+    expect(await db.select().from(companySecretBindings)).toHaveLength(0);
+    expect(await db.select().from(companySecretProposals)).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: fixture.secretProposalId, status: "pending" }),
+      expect.objectContaining({ id: fixture.bindingProposalId, status: "pending" }),
+    ]));
+    const [unchangedAgent] = await db.select().from(agents).where(eq(agents.id, fixture.agentId));
+    expect(unchangedAgent?.adapterConfig).toEqual({ command: "true" });
+
+    await db.insert(principalPermissionGrants).values({
+      companyId: fixture.companyId,
+      principalType: "user",
+      principalId: fixture.actorUserId,
+      permissionKey: "agents:configure",
+      grantedByUserId: fixture.actorUserId,
+    });
+    const repaired = await services.issues.respondInteraction({
+      issueId: fixture.issueId,
+      interactionId: fixture.interactionId,
+      companyId: fixture.companyId,
+      action: "accept",
+      actorUserId: fixture.actorUserId,
+    });
+
+    expect(repaired).toMatchObject({
+      applied: false,
+      interaction: { result: { secretProposal: { status: "executed" } } },
+    });
+    expect(await db.select().from(companySecrets)).toHaveLength(1);
+    expect(await db.select().from(companySecretBindings)).toHaveLength(1);
   });
 
   it("respondInteraction records a terminal failure when the secret binding cannot be applied", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -142,7 +142,6 @@ import {
 } from "../services/index.js";
 import { questionResponseDeliveryService } from "../services/question-response-delivery.js";
 import { artifactReviewDocumentService } from "../services/artifact-review-documents.js";
-import { assertCanResolveProposal } from "../services/secret-proposal-authorization.js";
 import { buildDocumentReviewContext, buildPlanReviewContext } from "../services/plan-review-context.js";
 import {
   decideIssueReviewPathRecovery,
@@ -177,8 +176,12 @@ import {
   SVG_CONTENT_TYPE,
 } from "../attachment-types.js";
 import { queueIssueAssignmentWakeup } from "../services/issue-assignment-wakeup.js";
-import { createSecretProposalsService } from "../services/secret-proposals.js";
-import { notifySecretProposalResolution } from "../services/secret-proposal-notifications.js";
+import {
+  executeAcceptedSecretProposalInteraction,
+  readSecretProposalContinuationContext,
+  readSecretProposalInteractionContext,
+  type ApproveInteractionSecretProposal,
+} from "../services/governed-interaction-side-effects.js";
 import {
   buildOnboardingGreeting,
   ONBOARDING_GREETING_AUTHORIZATION_REASON,
@@ -1937,14 +1940,6 @@ function readToolActionExecutionStatus(value: unknown) {
     : null;
 }
 
-function secretProposalExecutionErrorCode(error: unknown) {
-  if (error instanceof HttpError) {
-    const details = readObject(error.details);
-    return readNonEmptyString(details.code) ?? `http_${error.status}`;
-  }
-  return "secret_proposal_execution_failed";
-}
-
 function readToolActionContinuationContext(interaction: {
   status: string;
   payload?: unknown;
@@ -2020,54 +2015,6 @@ function readToolActionContinuationContext(interaction: {
     decision: "accepted",
     executionStatus,
     instructions: `the approved ${toolName} action is ${executionStatus}; do not call the tool again while this approval is being processed.`,
-  };
-}
-
-function readSecretProposalContinuationContext(interaction: {
-  status: string;
-  payload?: unknown;
-  result?: unknown;
-}) {
-  const payload = readObject(interaction.payload);
-  const proposal = readObject(payload.secretProposal);
-  const proposalId = readNonEmptyString(proposal.proposalId);
-  const configPath = readNonEmptyString(proposal.configPath);
-  if (!proposalId || !configPath) return null;
-  const result = readObject(interaction.result);
-  const execution = readObject(result.secretProposal);
-  const executionStatus = readNonEmptyString(execution.status);
-  const errorCode = readNonEmptyString(execution.errorCode);
-  const sourceSecretLabel = readNonEmptyString(proposal.sourceSecretLabel);
-
-  if (interaction.status === "rejected") {
-    return {
-      proposalId,
-      configPath,
-      decision: "rejected",
-      executionStatus: "rejected",
-      instructions: "the secret binding proposal was rejected; do not assume the alias exists.",
-    };
-  }
-  if (interaction.status !== "accepted" || (executionStatus !== "executed" && executionStatus !== "failed")) {
-    return null;
-  }
-  if (executionStatus === "executed") {
-    return {
-      proposalId,
-      configPath,
-      decision: "accepted",
-      executionStatus,
-      ...(sourceSecretLabel ? { sourceSecretLabel } : {}),
-      instructions: `the binding was created at ${configPath}; verify it with GET /api/agents/me/secrets before using it.`,
-    };
-  }
-  return {
-    proposalId,
-    configPath,
-    decision: "accepted",
-    executionStatus,
-    ...(errorCode ? { errorCode } : {}),
-    instructions: "the binding was not created; inspect the failure comment and submit a fresh proposal after fixing the cause.",
   };
 }
 
@@ -2817,20 +2764,13 @@ export function issueRoutes(
       actionRequestId: string;
       actor: { agentId?: string | null; userId?: string | null };
     }) => Promise<unknown>;
-    approveSecretProposal?: (input: {
-      companyId: string;
-      issueId: string;
-      interactionId: string;
-      proposalId: string;
-      actor: { agentId?: string | null; userId?: string | null };
-    }) => Promise<unknown>;
+    approveSecretProposal?: ApproveInteractionSecretProposal;
   } = {},
 ) {
   const router = Router();
   const svc = issueService(db);
   const runRedactions = createRunSecretRedactionRegistry(db);
   const access = accessService(db);
-  const secretProposals = createSecretProposalsService(db);
   const heartbeat = heartbeatService(db, {
     pluginWorkerManager: opts.pluginWorkerManager,
   });
@@ -11400,6 +11340,52 @@ export function issueRoutes(
       if (!suggestedTaskEffectsAuthorized) return;
 
       const actor = getActorInfo(req);
+      const resolvedByUserId = actor.actorType === "user" ? actor.actorId : "board";
+      if (current.status === "accepted" && readSecretProposalInteractionContext(current)) {
+        const replay = await executeAcceptedSecretProposalInteraction({
+          db,
+          issue,
+          interaction: current,
+          authorizationActor: req.actor,
+          resolvedByUserId,
+          actor: { agentId: actor.agentId, userId: actor.actorType === "user" ? actor.actorId : null },
+          interactions: interactionSvc,
+          issues: svc,
+          heartbeat,
+          approveSecretProposal: opts.approveSecretProposal,
+        });
+        if (replay.disposition !== "already_terminal") {
+          await logActivity(db, {
+            companyId: issue.companyId,
+            actorType: actor.actorType,
+            actorId: actor.actorId,
+            agentId: actor.agentId,
+            runId: actor.runId,
+            agentApiKeyId: actor.agentApiKeyId,
+            action: "issue.thread_interaction_side_effect_reconciled",
+            entityType: "issue",
+            entityId: issue.id,
+            details: {
+              interactionId: current.id,
+              interactionKind: current.kind,
+              interactionStatus: current.status,
+              sideEffect: "secret_proposal",
+              executionDisposition: replay.disposition,
+            },
+          });
+          await queueResolvedInteractionContinuationWakeup({
+            db,
+            heartbeat,
+            issue,
+            interaction: replay.interaction,
+            actor,
+            source: "issue.interaction.accept.reconcile",
+          });
+        }
+        res.json(replay.interaction);
+        return;
+      }
+
       const { interaction, createdIssues, continuationIssue } = await interactionSvc.acceptInteraction(issue, interactionId, req.body, {
         agentId: actor.agentId,
         runId: actor.runId,
@@ -11409,9 +11395,6 @@ export function issueRoutes(
       });
       const toolAction = interaction.payload && typeof interaction.payload === "object"
         ? (interaction.payload as { toolAction?: { actionRequestId?: unknown } }).toolAction
-        : null;
-      const secretProposal = interaction.payload && typeof interaction.payload === "object"
-        ? (interaction.payload as { secretProposal?: { proposalId?: unknown; configPath?: unknown } }).secretProposal
         : null;
       let continuationInteraction = interaction;
       if (
@@ -11449,81 +11432,19 @@ export function issueRoutes(
           };
         }
       }
-      if (
-        interaction.kind === "request_confirmation"
-        && interaction.status === "accepted"
-        && typeof secretProposal?.proposalId === "string"
-      ) {
-        const resolvedByUserId = actor.actorType === "user" ? actor.actorId : "board";
-        try {
-          if (opts.approveSecretProposal) {
-            await opts.approveSecretProposal({
-              companyId: issue.companyId,
-              issueId: issue.id,
-              interactionId: interaction.id,
-              proposalId: secretProposal.proposalId,
-              actor: { agentId: actor.agentId, userId: actor.actorType === "user" ? actor.actorId : null },
-            });
-          } else {
-            const proposal = await secretProposals.getById(issue.companyId, secretProposal.proposalId);
-            if (
-              !proposal
-              || proposal.kind !== "binding"
-              || proposal.originIssueId !== issue.id
-              || proposal.interactionId !== interaction.id
-            ) {
-              throw notFound("Secret proposal not found");
-            }
-            await secretProposals.approve(issue.companyId, proposal.id, {
-              resolvedByUserId,
-              assertCanResolve: (lockedProposal, txDb) => assertCanResolveProposal({
-                db: txDb,
-                actor: req.actor,
-                companyId: issue.companyId,
-                proposal: lockedProposal,
-              }),
-            });
-            await notifySecretProposalResolution({
-              proposal,
-              status: "approved",
-              userId: resolvedByUserId,
-              issues: svc,
-              heartbeat,
-            });
-          }
-          continuationInteraction = await interactionSvc.recordSecretProposalExecutionResult(
-            issue,
-            interaction.id,
-            secretProposal.proposalId,
-            { status: "executed" },
-          );
-        } catch (error) {
-          const errorCode = secretProposalExecutionErrorCode(error);
-          continuationInteraction = await interactionSvc.recordSecretProposalExecutionResult(
-            issue,
-            interaction.id,
-            secretProposal.proposalId,
-            { status: "failed", errorCode },
-          );
-          const recordedResult = readObject(continuationInteraction.result);
-          const recordedSecretProposal = readObject(recordedResult.secretProposal);
-          if (recordedSecretProposal.status !== "executed") {
-            const configPath = typeof secretProposal.configPath === "string" ? secretProposal.configPath : "unknown";
-            try {
-              await svc.addComment(
-                issue.id,
-                `Secret binding execution failed\n\n- Config path: \`${configPath}\`\n- Error code: \`${errorCode}\`\n- Binding created: **no**`,
-                { userId: resolvedByUserId },
-              );
-            } catch (commentError) {
-              logger.warn(
-                { err: commentError, issueId: issue.id, interactionId: interaction.id, errorCode },
-                "failed to post secret proposal execution failure comment",
-              );
-            }
-          }
-        }
-      }
+      const secretProposalExecution = await executeAcceptedSecretProposalInteraction({
+        db,
+        issue,
+        interaction: continuationInteraction,
+        authorizationActor: req.actor,
+        resolvedByUserId,
+        actor: { agentId: actor.agentId, userId: actor.actorType === "user" ? actor.actorId : null },
+        interactions: interactionSvc,
+        issues: svc,
+        heartbeat,
+        approveSecretProposal: opts.approveSecretProposal,
+      });
+      continuationInteraction = secretProposalExecution.interaction as typeof continuationInteraction;
       const continuationWakeIssue = continuationIssue ?? issue;
 
       await logActivity(db, {

--- a/server/src/services/governed-interaction-side-effects.ts
+++ b/server/src/services/governed-interaction-side-effects.ts
@@ -1,0 +1,236 @@
+import type { Db } from "@paperclipai/db";
+import { HttpError, conflict, notFound } from "../errors.js";
+import { logger } from "../middleware/logger.js";
+import type { AuthorizationActor } from "./authorization.js";
+import type { IssueAssignmentWakeupDeps } from "./issue-assignment-wakeup.js";
+import type { issueService } from "./issues.js";
+import type { issueThreadInteractionService } from "./issue-thread-interactions.js";
+import { notifySecretProposalResolution } from "./secret-proposal-notifications.js";
+import { assertCanResolveProposal } from "./secret-proposal-authorization.js";
+import { createSecretProposalsService } from "./secret-proposals.js";
+
+type SecretProposalInteraction = {
+  id: string;
+  kind: string;
+  status: string;
+  continuationPolicy: string;
+  sourceCommentId?: string | null;
+  sourceRunId?: string | null;
+  payload?: unknown;
+  result?: unknown;
+};
+
+type SecretProposalExecutionDisposition =
+  | "not_applicable"
+  | "already_terminal"
+  | "executed"
+  | "failed";
+
+export type ApproveInteractionSecretProposal = (input: {
+  companyId: string;
+  issueId: string;
+  interactionId: string;
+  proposalId: string;
+  cascade: true;
+  actor: { agentId?: string | null; userId?: string | null };
+}) => Promise<unknown>;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function readNonEmptyString(value: unknown) {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+export function readSecretProposalInteractionContext(interaction: SecretProposalInteraction) {
+  if (interaction.kind !== "request_confirmation") return null;
+  const payload = asRecord(interaction.payload);
+  const proposal = asRecord(payload.secretProposal);
+  const proposalId = readNonEmptyString(proposal.proposalId);
+  const configPath = readNonEmptyString(proposal.configPath);
+  if (!proposalId || !configPath) return null;
+  return {
+    proposalId,
+    configPath,
+    sourceSecretLabel: readNonEmptyString(proposal.sourceSecretLabel),
+  };
+}
+
+export function readSecretProposalContinuationContext(interaction: SecretProposalInteraction) {
+  const proposal = readSecretProposalInteractionContext(interaction);
+  if (!proposal) return null;
+  const result = asRecord(interaction.result);
+  const execution = asRecord(result.secretProposal);
+  const executionStatus = readNonEmptyString(execution.status);
+  const errorCode = readNonEmptyString(execution.errorCode);
+
+  if (interaction.status === "rejected") {
+    return {
+      proposalId: proposal.proposalId,
+      configPath: proposal.configPath,
+      decision: "rejected",
+      executionStatus: "rejected",
+      instructions: "the secret binding proposal was rejected; do not assume the alias exists.",
+    };
+  }
+  if (interaction.status !== "accepted" || (executionStatus !== "executed" && executionStatus !== "failed")) {
+    return null;
+  }
+  if (executionStatus === "executed") {
+    return {
+      proposalId: proposal.proposalId,
+      configPath: proposal.configPath,
+      decision: "accepted",
+      executionStatus,
+      ...(proposal.sourceSecretLabel ? { sourceSecretLabel: proposal.sourceSecretLabel } : {}),
+      instructions: `the binding was created at ${proposal.configPath}; verify it with GET /api/agents/me/secrets before using it.`,
+    };
+  }
+  return {
+    proposalId: proposal.proposalId,
+    configPath: proposal.configPath,
+    decision: "accepted",
+    executionStatus,
+    ...(errorCode ? { errorCode } : {}),
+    instructions: "the binding was not created; inspect the failure comment and submit a fresh proposal after fixing the cause.",
+  };
+}
+
+function executionErrorCode(error: unknown) {
+  if (error instanceof HttpError) {
+    const details = asRecord(error.details);
+    return readNonEmptyString(details.code) ?? `http_${error.status}`;
+  }
+  return "secret_proposal_execution_failed";
+}
+
+/**
+ * Executes the governed effect behind an accepted secret-binding card.
+ *
+ * The interaction resolution and the governed effect intentionally remain
+ * separate authorization boundaries. This executor is the single server-owned
+ * effect path for HTTP and plugin/gateway resolvers. It is replay-safe:
+ * terminal receipts are no-ops, while an approved binding that lost its receipt
+ * is reconciled to `executed` without creating another secret or binding.
+ */
+export async function executeAcceptedSecretProposalInteraction(input: {
+  db: Db;
+  issue: { id: string; companyId: string };
+  interaction: SecretProposalInteraction;
+  authorizationActor: AuthorizationActor;
+  resolvedByUserId: string;
+  actor: { agentId?: string | null; userId?: string | null };
+  interactions: Pick<ReturnType<typeof issueThreadInteractionService>, "recordSecretProposalExecutionResult">;
+  issues: Pick<ReturnType<typeof issueService>, "getById" | "addComment">;
+  heartbeat: IssueAssignmentWakeupDeps;
+  approveSecretProposal?: ApproveInteractionSecretProposal;
+}): Promise<{
+  interaction: SecretProposalInteraction;
+  disposition: SecretProposalExecutionDisposition;
+}> {
+  const context = readSecretProposalInteractionContext(input.interaction);
+  if (!context || input.interaction.status !== "accepted") {
+    return { interaction: input.interaction, disposition: "not_applicable" };
+  }
+
+  const receipt = asRecord(asRecord(input.interaction.result).secretProposal);
+  if (receipt.status === "executed" || receipt.status === "failed") {
+    return { interaction: input.interaction, disposition: "already_terminal" };
+  }
+
+  const proposals = createSecretProposalsService(input.db);
+  let approvedProposalForNotification: {
+    originIssueId: string | null;
+    kind: string;
+    proposedName: string | null;
+    configPath: string | null;
+  } | null = null;
+  try {
+    if (input.approveSecretProposal) {
+      await input.approveSecretProposal({
+        companyId: input.issue.companyId,
+        issueId: input.issue.id,
+        interactionId: input.interaction.id,
+        proposalId: context.proposalId,
+        cascade: true,
+        actor: input.actor,
+      });
+    } else {
+      const proposal = await proposals.getById(input.issue.companyId, context.proposalId);
+      if (
+        !proposal
+        || proposal.kind !== "binding"
+        || proposal.originIssueId !== input.issue.id
+        || proposal.interactionId !== input.interaction.id
+      ) {
+        throw notFound("Secret proposal not found");
+      }
+
+      const alreadyApplied = proposal.status === "approved"
+        && proposal.appliedBindingConfigPath === context.configPath;
+      if (!alreadyApplied) {
+        if (proposal.status !== "pending") {
+          throw conflict("Secret binding proposal is not pending or applied");
+        }
+        await proposals.approve(input.issue.companyId, proposal.id, {
+          resolvedByUserId: input.resolvedByUserId,
+          cascade: true,
+          assertCanResolve: (lockedProposal, txDb) => assertCanResolveProposal({
+            db: txDb,
+            actor: input.authorizationActor,
+            companyId: input.issue.companyId,
+            proposal: lockedProposal,
+          }),
+        });
+        approvedProposalForNotification = proposal;
+      }
+    }
+
+    const interaction = await input.interactions.recordSecretProposalExecutionResult(
+      input.issue,
+      input.interaction.id,
+      context.proposalId,
+      { status: "executed" },
+    );
+    if (approvedProposalForNotification) {
+      await notifySecretProposalResolution({
+        proposal: approvedProposalForNotification,
+        status: "approved",
+        userId: input.resolvedByUserId,
+        issues: input.issues,
+        heartbeat: input.heartbeat,
+      });
+    }
+    return { interaction, disposition: "executed" };
+  } catch (error) {
+    const errorCode = executionErrorCode(error);
+    const interaction = await input.interactions.recordSecretProposalExecutionResult(
+      input.issue,
+      input.interaction.id,
+      context.proposalId,
+      { status: "failed", errorCode },
+    );
+    const recordedReceipt = asRecord(asRecord(interaction.result).secretProposal);
+    if (recordedReceipt.status !== "executed") {
+      try {
+        await input.issues.addComment(
+          input.issue.id,
+          `Secret binding execution failed\n\n- Config path: \`${context.configPath}\`\n- Error code: \`${errorCode}\`\n- Binding created: **no**`,
+          { userId: input.resolvedByUserId },
+        );
+      } catch (commentError) {
+        logger.warn(
+          { err: commentError, issueId: input.issue.id, interactionId: input.interaction.id, errorCode },
+          "failed to post secret proposal execution failure comment",
+        );
+      }
+    }
+    return {
+      interaction,
+      disposition: recordedReceipt.status === "executed" ? "executed" : "failed",
+    };
+  }
+}

--- a/server/src/services/governed-interaction-side-effects.ts
+++ b/server/src/services/governed-interaction-side-effects.ts
@@ -107,6 +107,12 @@ function executionErrorCode(error: unknown) {
   return "secret_proposal_execution_failed";
 }
 
+function isAuthorizationDenial(error: unknown) {
+  if (!(error instanceof HttpError) || error.status !== 403) return false;
+  const reason = readNonEmptyString(asRecord(error.details).reason);
+  return reason?.startsWith("deny_") ?? false;
+}
+
 /**
  * Executes the governed effect behind an accepted secret-binding card.
  *
@@ -206,6 +212,12 @@ export async function executeAcceptedSecretProposalInteraction(input: {
     }
     return { interaction, disposition: "executed" };
   } catch (error) {
+    // An unauthorized resolver must not be able to poison a card that an
+    // authorized human already accepted. Approval authorization runs before
+    // the transaction mutates the proposal, so preserve the missing receipt
+    // and let a properly granted human reconcile it later.
+    if (isAuthorizationDenial(error)) throw error;
+
     const errorCode = executionErrorCode(error);
     const interaction = await input.interactions.recordSecretProposalExecutionResult(
       input.issue,
@@ -215,6 +227,9 @@ export async function executeAcceptedSecretProposalInteraction(input: {
     );
     const recordedReceipt = asRecord(asRecord(interaction.result).secretProposal);
     if (recordedReceipt.status !== "executed") {
+      // Only the binding proposal becomes terminal here. Its source-secret
+      // proposal intentionally remains pending so a corrected binding proposal
+      // can reuse it without asking for the secret value again.
       try {
         await input.issues.addComment(
           input.issue.id,

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -7,6 +7,7 @@ import {
   companyMemberships,
   costEvents,
   heartbeatRuns,
+  instanceUserRoles,
   invites,
   issues as issuesTable,
   pluginLogs,
@@ -84,6 +85,11 @@ import {
   SANDBOX_STARTUP_SPAN_ATTRS,
 } from "@paperclipai/adapter-utils/acpx-engine/startup-timing";
 import { recordProviderPluginSpan, type ParsedTraceparent } from "../instrumentation.js";
+import {
+  executeAcceptedSecretProposalInteraction,
+  readSecretProposalContinuationContext,
+  readSecretProposalInteractionContext,
+} from "./governed-interaction-side-effects.js";
 
 // ---------------------------------------------------------------------------
 // SSRF protection for plugin HTTP fetch
@@ -890,7 +896,7 @@ export function buildHostServices(
     companyId: string,
     userId: string,
     { allowViewer = false }: { allowViewer?: boolean } = {},
-  ): Promise<void> => {
+  ) => {
     const [membership] = await db
       .select({ id: companyMemberships.id, membershipRole: companyMemberships.membershipRole })
       .from(companyMemberships)
@@ -907,6 +913,18 @@ export function buildHostServices(
     if (!allowViewer && membership.membershipRole === "viewer") {
       throw new Error(`actorUserId "${userId}" has viewer (read-only) access and cannot take this write action`);
     }
+    const isInstanceAdmin = Boolean(
+      await db
+        .select({ id: instanceUserRoles.id })
+        .from(instanceUserRoles)
+        .where(and(
+          eq(instanceUserRoles.userId, userId),
+          eq(instanceUserRoles.role, "instance_admin"),
+        ))
+        .limit(1)
+        .then((rows) => rows[0] ?? null),
+    );
+    return { ...membership, isInstanceAdmin };
   };
 
   /**
@@ -931,6 +949,7 @@ export function buildHostServices(
       sourceCommentId?: string | null;
       sourceRunId?: string | null;
       payload?: unknown;
+      result?: unknown;
     };
     actorUserId: string;
     source: string;
@@ -966,6 +985,7 @@ export function buildHostServices(
         };
       }
     }
+    const secretProposal = readSecretProposalContinuationContext(interaction);
 
     void heartbeat.wakeup(issue.assigneeAgentId, {
       source: "automation",
@@ -979,6 +999,7 @@ export function buildHostServices(
         sourceCommentId: interaction.sourceCommentId ?? null,
         sourceRunId: interaction.sourceRunId ?? null,
         ...(planReviewInteraction ? { planReviewInteraction } : {}),
+        ...(secretProposal ? { secretProposal } : {}),
         mutation: "interaction",
       },
       requestedByActorType: "user",
@@ -990,6 +1011,7 @@ export function buildHostServices(
         interactionKind: interaction.kind,
         interactionStatus: interaction.status,
         ...(planReviewInteraction ? { planReviewInteraction } : {}),
+        ...(secretProposal ? { secretProposal } : {}),
         wakeReason: "issue_commented",
         source: `plugin:${pluginKey}`,
       },
@@ -2504,15 +2526,69 @@ export function buildHostServices(
         if (!params.actorUserId) {
           throw new Error("actorUserId is required to respond to an interaction on behalf of a board user");
         }
-        await requireActiveHumanMember(companyId, params.actorUserId);
+        const membership = await requireActiveHumanMember(companyId, params.actorUserId);
+        const authorizationActor: AuthorizationActor = {
+          type: "board",
+          userId: params.actorUserId,
+          companyIds: [companyId],
+          memberships: [{
+            companyId,
+            membershipRole: membership.membershipRole,
+            status: "active",
+          }],
+          isInstanceAdmin: membership.isInstanceAdmin,
+          source: "session",
+        };
 
         const current = await interactions.getById(params.interactionId);
         if (!current || current.issueId !== issue.id || current.companyId !== companyId) {
           throw new Error(`Interaction "${params.interactionId}" not found for this issue`);
         }
         // Idempotent replay: an already-resolved interaction converges without
-        // re-applying, so a duplicate button tap from chat is a safe no-op.
+        // re-resolving it. Accepted secret-binding cards still pass through the
+        // shared governed-effect executor so a prior accept/effect crash can be
+        // reconciled without another human decision.
         if (current.status !== "pending") {
+          if (
+            params.action === "accept"
+            && current.status === "accepted"
+            && readSecretProposalInteractionContext(current)
+          ) {
+            const replay = await executeAcceptedSecretProposalInteraction({
+              db,
+              issue,
+              interaction: current,
+              authorizationActor,
+              resolvedByUserId: params.actorUserId,
+              actor: { userId: params.actorUserId },
+              interactions,
+              issues,
+              heartbeat,
+            });
+            if (replay.disposition !== "already_terminal") {
+              await logPluginActivity({
+                companyId,
+                action: "issue.thread_interaction_side_effect_reconciled",
+                entityType: "issue",
+                entityId: issue.id,
+                actor: { actorUserId: params.actorUserId },
+                details: {
+                  identifier: issue.identifier,
+                  interactionId: current.id,
+                  interactionKind: current.kind,
+                  sideEffect: "secret_proposal",
+                  executionDisposition: replay.disposition,
+                },
+              });
+              queuePluginInteractionContinuationWakeup({
+                issue,
+                interaction: replay.interaction as typeof current,
+                actorUserId: params.actorUserId,
+                source: `plugin:${pluginKey}:interaction.accept.reconcile`,
+              });
+            }
+            return { interaction: replay.interaction as any, applied: false };
+          }
           return { interaction: current as any, applied: false };
         }
 
@@ -2537,6 +2613,18 @@ export function buildHostServices(
             actor,
           );
           resolved = result.interaction as typeof current;
+          const secretProposalExecution = await executeAcceptedSecretProposalInteraction({
+            db,
+            issue,
+            interaction: resolved,
+            authorizationActor,
+            resolvedByUserId: params.actorUserId,
+            actor: { userId: params.actorUserId },
+            interactions,
+            issues,
+            heartbeat,
+          });
+          resolved = secretProposalExecution.interaction as typeof current;
           if (result.continuationIssue) {
             continuationTarget = {
               id: result.continuationIssue.id,

--- a/server/src/services/plugin-host-services.ts
+++ b/server/src/services/plugin-host-services.ts
@@ -7,7 +7,6 @@ import {
   companyMemberships,
   costEvents,
   heartbeatRuns,
-  instanceUserRoles,
   invites,
   issues as issuesTable,
   pluginLogs,
@@ -913,18 +912,7 @@ export function buildHostServices(
     if (!allowViewer && membership.membershipRole === "viewer") {
       throw new Error(`actorUserId "${userId}" has viewer (read-only) access and cannot take this write action`);
     }
-    const isInstanceAdmin = Boolean(
-      await db
-        .select({ id: instanceUserRoles.id })
-        .from(instanceUserRoles)
-        .where(and(
-          eq(instanceUserRoles.userId, userId),
-          eq(instanceUserRoles.role, "instance_admin"),
-        ))
-        .limit(1)
-        .then((rows) => rows[0] ?? null),
-    );
-    return { ...membership, isInstanceAdmin };
+    return membership;
   };
 
   /**
@@ -2536,7 +2524,11 @@ export function buildHostServices(
             membershipRole: membership.membershipRole,
             status: "active",
           }],
-          isInstanceAdmin: membership.isInstanceAdmin,
+          // Gateway pairing proves active company membership, not instance
+          // administration. Ignore persisted instance-admin rows so a stale
+          // role cannot bypass the normal agents:configure grant check.
+          isInstanceAdmin: false,
+          ignoreInstanceAdmin: true,
           source: "session",
         };
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The control plane lets a human approve a governed secret binding before Paperclip changes an agent configuration.
> - The REST route executed this effect, but the plugin gateway only recorded the approval.
> - The REST route also did not approve the linked source secret with cascade behavior.
> - An accepted card could therefore stay pending and leave the agent configuration unchanged.
> - This pull request gives all supported acceptance paths one governed effect executor.
> - The benefit is that an accepted card creates the secret and binding once, or records a safe terminal failure.

## Linked Issues or Issue Description

**What happened?**

The plugin gateway accepted a governed secret-binding confirmation card but did not execute its staged proposal. The REST acceptance path executed the binding proposal without cascade behavior. A binding with a pending source-secret proposal could stay pending after the human decision.

**Expected behavior**

Each supported acceptance path must execute the same governed effect. The effect must create the linked secret and binding in one cascade transaction. A replay must repair a missing execution receipt without a second human decision.

**Steps to reproduce**

1. Stage a secret proposal and a binding proposal for one agent configuration path.
2. Create a governed confirmation card for the binding proposal.
3. Accept the card through the plugin gateway.
4. Observe that the card is accepted but the proposals stay pending.

**Paperclip version or commit**

`ad0ad43cf`

**Deployment mode**

Local dev with the plugin gateway.

## What Changed

- Add one server-owned executor for accepted secret-binding cards.
- Use cascade approval so Paperclip creates the source secret and binding in one transaction.
- Use the executor from the REST route and the plugin gateway.
- Add replay logic for an accepted card that has no terminal execution receipt.
- Record an `executed` or `failed` receipt before Paperclip queues the continuation wake.
- Add route and plugin-host tests for success, failure, and idempotent replay.
- Ignore persisted instance-admin rows for gateway-attributed actors; governed agent configuration now requires the explicit `agents:configure` grant.
- Preserve accepted cards without a terminal receipt when authorization is denied so an authorized replay can repair them later.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-thread-interaction-routes.test.ts src/__tests__/plugin-orchestration-apis.test.ts src/__tests__/secret-proposals-routes.test.ts --reporter=dot`
- Result: 3 test files passed. 133 tests passed.
- The gateway regression proves a stale `instance_admin` row cannot create a secret, binding, or config mutation; adding `agents:configure` then repairs the accepted card by replay.
- `git diff --check`
- Result: passed.
- Targeted server TypeScript checking could not complete because this isolated worktree could not resolve the generated `@paperclipai/paperclip-runner` package after its frozen dependency install was rejected by the existing patch-config/lock mismatch. CI will run the complete gate with its normal dependency setup.

## Risks

- Medium risk. This change runs a governed effect from one more acceptance path.
- The executor checks the company, issue, interaction, proposal kind, and current board authorization before it applies the proposal.
- Terminal receipts make replay a no-op. An applied binding with a missing receipt converges to `executed`.
- Failure details contain only the configuration path and an error code. The code does not read, log, or copy a secret value.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI `gpt-5.6-sol` through the Codex CLI. The run used high reasoning, repository tools, code execution, and test execution. The adapter runtime did not expose the context window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

