### PR TITLE
fix(heartbeat): carry the successful-run handoff instruction into the wake

### DIFF
--- a/docs/guides/agent-developer/heartbeat-protocol.md
+++ b/docs/guides/agent-developer/heartbeat-protocol.md
@@ -124,5 +124,6 @@ Paperclip records run liveness as metadata on heartbeat runs. It is not an issue
 - Continuations re-wake the same assigned agent on the same issue when the issue is still active and budget/execution policy allow it.
 - `continuationAttempt` counts semantic liveness continuations for a source run chain. It is separate from process recovery, queued wake delivery, adapter session resume, and other operational retries.
 - Liveness continuation wake prompts include the attempt, source run, liveness state, liveness reason, and the instruction for the next heartbeat.
+- Successful-run handoff wake prompts include the attempt, source run, handoff reason, the missing disposition, the valid disposition options, and the producer's remediation instruction.
 - Continuations do not mark the issue `blocked` or `done`. If automatic continuations are exhausted, Paperclip leaves an audit comment so a human or manager can clarify, block, or assign follow-up work.
 - Workspace provisioning alone is not treated as concrete task progress. Durable progress should appear as tool/action events, issue comments, document or work-product revisions, activity log entries, commits, or tests.

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -651,6 +651,16 @@ type PaperclipWakeLivenessContinuation = {
   instruction: string | null;
 };
 
+type PaperclipWakeSuccessfulRunHandoff = {
+  attempt: number | null;
+  maxAttempts: number | null;
+  sourceRunId: string | null;
+  reason: string | null;
+  missingDisposition: string | null;
+  validDispositionOptions: string[];
+  instruction: string | null;
+};
+
 type PaperclipWakeChildIssueSummary = {
   id: string | null;
   identifier: string | null;
@@ -730,6 +740,7 @@ type PaperclipWakePayload = {
   planReviewContext: PaperclipWakePlanReviewContext | null;
   documentReviewContext: PaperclipWakeDocumentReviewContext | null;
   livenessContinuation: PaperclipWakeLivenessContinuation | null;
+  successfulRunHandoff: PaperclipWakeSuccessfulRunHandoff | null;
   taskWatchdog: PaperclipWakeTaskWatchdogContext | null;
   interactionKind: string | null;
   interactionStatus: string | null;
@@ -1112,6 +1123,34 @@ function normalizePaperclipWakeLivenessContinuation(value: unknown): PaperclipWa
   };
 }
 
+function normalizePaperclipWakeSuccessfulRunHandoff(value: unknown): PaperclipWakeSuccessfulRunHandoff | null {
+  const handoff = parseObject(value);
+  const attempt = asNumber(handoff.attempt, 0);
+  const maxAttempts = asNumber(handoff.maxAttempts, 0);
+  const sourceRunId = asString(handoff.sourceRunId, "").trim() || null;
+  const reason = asString(handoff.reason, "").trim() || null;
+  const missingDisposition = asString(handoff.missingDisposition, "").trim() || null;
+  const validDispositionOptions = Array.isArray(handoff.validDispositionOptions)
+    ? handoff.validDispositionOptions
+        .map((entry) => asString(entry, "").trim())
+        .filter((entry) => entry.length > 0)
+    : [];
+  const instruction = asString(handoff.instruction, "").trim() || null;
+  if (
+    !attempt && !maxAttempts && !sourceRunId && !reason && !missingDisposition
+    && validDispositionOptions.length === 0 && !instruction
+  ) return null;
+  return {
+    attempt: attempt > 0 ? attempt : null,
+    maxAttempts: maxAttempts > 0 ? maxAttempts : null,
+    sourceRunId,
+    reason,
+    missingDisposition,
+    validDispositionOptions,
+    instruction,
+  };
+}
+
 function normalizePaperclipWakeChildIssueSummary(value: unknown): PaperclipWakeChildIssueSummary | null {
   const child = parseObject(value);
   const id = asString(child.id, "").trim() || null;
@@ -1378,6 +1417,7 @@ export function normalizePaperclipWakePayload(value: unknown): PaperclipWakePayl
         .filter((entry): entry is PaperclipWakeAnnotationDelta => Boolean(entry))
     : [];
   const livenessContinuation = normalizePaperclipWakeLivenessContinuation(payload.livenessContinuation);
+  const successfulRunHandoff = normalizePaperclipWakeSuccessfulRunHandoff(payload.successfulRunHandoff);
   const taskWatchdog = normalizePaperclipWakeTaskWatchdog(payload.taskWatchdog);
   const recovery = normalizePaperclipWakeRecovery(payload.recovery);
   const childIssueSummaries = Array.isArray(payload.childIssueSummaries)
@@ -1413,7 +1453,7 @@ export function normalizePaperclipWakePayload(value: unknown): PaperclipWakePayl
     : null;
   const executionWorkspace = normalizePaperclipWakeExecutionWorkspace(payload.executionWorkspace);
   const agentMessage = normalizePaperclipWakeAgentMessage(payload.agentMessage);
-  if (comments.length === 0 && commentIds.length === 0 && annotationDeltas.length === 0 && childIssueSummaries.length === 0 && unresolvedBlockerIssueIds.length === 0 && unresolvedBlockerSummaries.length === 0 && !activeTreeHold && !executionStage && !continuationSummary && !planReviewContext && !documentReviewContext && !livenessContinuation && !taskWatchdog && !checkboxSelection && !questionResponse && !executionWorkspace && !agentMessage && !recovery && !normalizePaperclipWakeIssue(payload.issue)) {
+  if (comments.length === 0 && commentIds.length === 0 && annotationDeltas.length === 0 && childIssueSummaries.length === 0 && unresolvedBlockerIssueIds.length === 0 && unresolvedBlockerSummaries.length === 0 && !activeTreeHold && !executionStage && !continuationSummary && !planReviewContext && !documentReviewContext && !livenessContinuation && !successfulRunHandoff && !taskWatchdog && !checkboxSelection && !questionResponse && !executionWorkspace && !agentMessage && !recovery && !normalizePaperclipWakeIssue(payload.issue)) {
     return null;
   }
 
@@ -1434,6 +1474,7 @@ export function normalizePaperclipWakePayload(value: unknown): PaperclipWakePayl
     documentReviewContext,
     annotationDeltas,
     livenessContinuation,
+    successfulRunHandoff,
     taskWatchdog,
     interactionKind: asString(payload.interactionKind, "").trim() || null,
     interactionStatus: asString(payload.interactionStatus, "").trim() || null,
@@ -1476,7 +1517,11 @@ export function stringifyPaperclipWakePayload(
 
 export function isPaperclipRecoveryWakePayload(value: unknown): boolean {
   const normalized = normalizePaperclipWakePayload(value);
-  return Boolean(normalized?.recovery || normalized?.reason === "source_scoped_recovery_action");
+  return Boolean(
+    normalized?.recovery
+    || normalized?.successfulRunHandoff
+    || normalized?.reason === "source_scoped_recovery_action",
+  );
 }
 
 export function readPaperclipIssueWorkModeFromContext(value: unknown): string | null {
@@ -2045,6 +2090,33 @@ export function renderPaperclipWakePrompt(
     }
     if (continuation.instruction) {
       lines.push(`- instruction: ${continuation.instruction}`);
+    }
+  }
+
+  if (normalized.successfulRunHandoff) {
+    const handoff = normalized.successfulRunHandoff;
+    lines.push("", "Successful run missing a disposition:");
+    if (handoff.attempt) {
+      lines.push(
+        `- attempt: ${handoff.attempt}${handoff.maxAttempts ? `/${handoff.maxAttempts}` : ""}`,
+      );
+    }
+    if (handoff.sourceRunId) {
+      lines.push(`- source run: ${handoff.sourceRunId}`);
+    }
+    if (handoff.reason) {
+      lines.push(`- reason: ${handoff.reason}`);
+    }
+    if (handoff.missingDisposition) {
+      lines.push(`- missing: ${handoff.missingDisposition}`);
+    }
+    if (handoff.validDispositionOptions.length > 0) {
+      lines.push(`- valid dispositions: ${handoff.validDispositionOptions.join(", ")}`);
+    }
+    if (handoff.instruction) {
+      // The producer writes a multi-line markdown instruction, so it goes on its
+      // own lines instead of inside the bullet.
+      lines.push("- instruction:", handoff.instruction);
     }
   }
 

--- a/packages/adapter-utils/src/wake-successful-run-handoff.test.ts
+++ b/packages/adapter-utils/src/wake-successful-run-handoff.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import {
+  isPaperclipRecoveryWakePayload,
+  renderPaperclipWakePrompt,
+  selectPaperclipTaskMarkdown,
+} from "./server-utils.js";
+
+// A corrective "your run succeeded but the issue has no disposition" wake carries
+// its remediation text in the handoff block. Before this block existed on the
+// payload, the retry prompt said nothing about recording a disposition, so the
+// corrective run repeated the previous run instead of closing it out.
+const HANDOFF_WAKE = {
+  reason: "finish_successful_run_handoff",
+  issue: {
+    id: "11111111-1111-4111-8111-111111111111",
+    identifier: "PAP-123",
+    title: "Answer a question",
+    status: "in_progress",
+    priority: "medium",
+    workMode: "standard",
+  },
+  successfulRunHandoff: {
+    attempt: 1,
+    maxAttempts: 1,
+    sourceRunId: "22222222-2222-4222-8222-222222222222",
+    reason: "successful_run_missing_state",
+    missingDisposition: "clear_next_step",
+    validDispositionOptions: ["done", "blocked", "in_review"],
+    instruction:
+      "This is a status-only retry to the original agent. Record a disposition; do not start new work.",
+  },
+};
+
+describe("successful-run handoff wake", () => {
+  it("renders the remediation instruction", () => {
+    const prompt = renderPaperclipWakePrompt(HANDOFF_WAKE);
+
+    expect(prompt).toContain("Successful run missing a disposition:");
+    expect(prompt).toContain("Record a disposition; do not start new work.");
+  });
+
+  it("names the reason, the missing value, the valid options and the attempt", () => {
+    const prompt = renderPaperclipWakePrompt(HANDOFF_WAKE);
+
+    expect(prompt).toContain("- reason: successful_run_missing_state");
+    expect(prompt).toContain("- missing: clear_next_step");
+    expect(prompt).toContain("- valid dispositions: done, blocked, in_review");
+    expect(prompt).toContain("- attempt: 1/1");
+  });
+
+  it("counts as a recovery-scoped wake (full task brief on resume; recovery-style prompt selection in adapters)", () => {
+    // The classification does two things: adapters that ask for the task brief on
+    // a resumed session get the full brief instead of the compact delta, and the
+    // adapters that skip their heartbeat prompt template on recovery wakes skip it
+    // here too. It does not change the execution-contract lines that
+    // renderPaperclipWakePrompt selects; those follow the local recovery block.
+    expect(isPaperclipRecoveryWakePayload(HANDOFF_WAKE)).toBe(true);
+    expect(
+      selectPaperclipTaskMarkdown(
+        {
+          paperclipTaskMarkdown: "Full task brief.",
+          paperclipTaskMarkdownCompact: "Compact resume delta.",
+          paperclipWake: HANDOFF_WAKE,
+        },
+        { resumedSession: true },
+      ),
+    ).toBe("Full task brief.");
+  });
+
+  it("leaves an ordinary wake untouched", () => {
+    const ordinary = { reason: "issue_assigned", issue: HANDOFF_WAKE.issue };
+
+    expect(isPaperclipRecoveryWakePayload(ordinary)).toBe(false);
+    expect(renderPaperclipWakePrompt(ordinary)).not.toContain("Successful run missing a disposition");
+  });
+
+  it("ignores a handoff block with nothing in it", () => {
+    const empty = { ...HANDOFF_WAKE, successfulRunHandoff: {} };
+
+    expect(isPaperclipRecoveryWakePayload(empty)).toBe(false);
+    expect(renderPaperclipWakePrompt(empty)).not.toContain("Successful run missing a disposition");
+  });
+});

--- a/server/src/__tests__/heartbeat-successful-run-handoff-wake.test.ts
+++ b/server/src/__tests__/heartbeat-successful-run-handoff-wake.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import {
+  isPaperclipRecoveryWakePayload,
+  renderPaperclipWakePrompt,
+} from "@paperclipai/adapter-utils/server-utils";
+import { buildPaperclipWakePayload } from "../services/heartbeat.js";
+import { decideIssueReviewPathRecovery } from "../services/recovery/review-path-recovery.js";
+import {
+  SUCCESSFUL_RUN_HANDOFF_OPTIONS,
+  SUCCESSFUL_RUN_MISSING_STATE_REASON,
+  decideSuccessfulRunHandoff,
+} from "../services/recovery/successful-run-handoff.js";
+
+// buildPaperclipWakePayload only reads the run-secret registry through the
+// injected db, so a stub that returns no rows keeps this suite off Postgres.
+const db = {
+  select: () => ({
+    from: () => ({
+      where: async () => [],
+    }),
+  }),
+} as never;
+
+const issueSummary = {
+  id: "issue-1",
+  identifier: "PAP-1",
+  title: "Finish backend handoff",
+  description: "Implement and verify the backend handoff behavior.",
+  status: "in_progress",
+  priority: "medium",
+  workMode: "standard",
+};
+
+function handoffContextSnapshot() {
+  const decision = decideSuccessfulRunHandoff({
+    run: {
+      id: "run-1",
+      companyId: "company-1",
+      agentId: "agent-1",
+      status: "succeeded",
+      contextSnapshot: { issueId: "issue-1" },
+    } as never,
+    issue: {
+      id: "issue-1",
+      companyId: "company-1",
+      identifier: "PAP-1",
+      title: "Finish backend handoff",
+      description: "Implement and verify the backend handoff behavior.",
+      status: "in_progress",
+      assigneeAgentId: "agent-1",
+      assigneeUserId: null,
+      executionState: null,
+    } as never,
+    agent: { id: "agent-1", companyId: "company-1", status: "idle" } as never,
+    livenessState: "advanced",
+    detectedProgressSummary: "Run produced concrete action evidence: 1 issue comment(s)",
+    finalReport: "Implemented the handoff path and ran the focused test.",
+    nextAction: "Record the correct issue disposition.",
+    taskKey: "issue-1",
+    hasActiveExecutionPath: false,
+    hasQueuedWake: false,
+    hasPendingInteractionOrApproval: false,
+    hasPersistedMonitor: false,
+    hasExplicitBlockerPath: false,
+    hasOpenRecoveryIssue: false,
+    hasPauseHold: false,
+    hasActiveRoutineContinuation: false,
+    budgetBlocked: false,
+    idempotentWakeExists: false,
+  });
+  if (decision.kind !== "enqueue") throw new Error(`expected an enqueue decision, got ${decision.kind}`);
+  return decision.contextSnapshot;
+}
+
+function reviewPathContextSnapshot() {
+  const decision = decideIssueReviewPathRecovery({
+    issueId: "issue-1",
+    sourceRunId: "run-1",
+    assigneeAgentId: "agent-1",
+    contextSnapshot: { issueId: "issue-1", wakeReason: "issue_assigned" },
+    reviewAttention: { state: "stalled", paths: [], reason: null },
+    existingWake: false,
+  });
+  if (decision.kind !== "enqueue") throw new Error(`expected an enqueue decision, got ${decision.kind}`);
+  return decision.contextSnapshot;
+}
+
+describe("successful-run handoff wake payload", () => {
+  it("carries the producer's remediation instruction into the payload and the prompt", async () => {
+    const payload = await buildPaperclipWakePayload({
+      db,
+      companyId: "company-1",
+      contextSnapshot: handoffContextSnapshot(),
+      issueSummary,
+    });
+
+    expect(payload?.successfulRunHandoff).toMatchObject({
+      attempt: 1,
+      maxAttempts: 1,
+      sourceRunId: "run-1",
+      reason: SUCCESSFUL_RUN_MISSING_STATE_REASON,
+      missingDisposition: "clear_next_step",
+      validDispositionOptions: [...SUCCESSFUL_RUN_HANDOFF_OPTIONS],
+    });
+
+    const prompt = renderPaperclipWakePrompt(payload, { resumedSession: true });
+    expect(prompt).toContain("Successful run missing a disposition:");
+    expect(prompt).toContain(`- reason: ${SUCCESSFUL_RUN_MISSING_STATE_REASON}`);
+    expect(prompt).toContain("- missing: clear_next_step");
+    expect(prompt).toContain("Your last run on this issue ended successfully");
+    expect(isPaperclipRecoveryWakePayload(payload)).toBe(true);
+  });
+
+  it("does not read a review-path recovery wake as a successful-run handoff", async () => {
+    // Review-path recovery writes a bare `instruction` and `sourceRunId` into its
+    // context snapshot. Only `handoffRequired` and `handoffReason` mark a
+    // successful-run handoff, so this wake must keep its own shape.
+    const contextSnapshot = reviewPathContextSnapshot();
+    expect(contextSnapshot).toMatchObject({
+      instruction: expect.stringContaining("still in review"),
+      sourceRunId: "run-1",
+    });
+
+    const payload = await buildPaperclipWakePayload({
+      db,
+      companyId: "company-1",
+      contextSnapshot,
+      issueSummary,
+    });
+
+    expect(payload?.successfulRunHandoff ?? null).toBeNull();
+    expect(renderPaperclipWakePrompt(payload, { resumedSession: true }))
+      .not.toContain("Successful run missing a disposition");
+    expect(isPaperclipRecoveryWakePayload(payload)).toBe(false);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7085,6 +7085,30 @@ export async function buildPaperclipWakePayload(input: {
       : [],
     childIssueSummaryTruncated:
       input.contextSnapshot.childIssueSummaryTruncated === true,
+    // A corrective "successful run, no disposition" handoff keeps its remediation
+    // text under handoffReason/instruction, not under recoveryActionId or
+    // recoveryCause, so the recovery block above does not see it. Only
+    // handoffRequired and handoffReason mark this wake: review-path recovery also
+    // writes a bare instruction and sourceRunId, and must not match here.
+    successfulRunHandoff:
+      input.contextSnapshot.handoffRequired === true ||
+      readNonEmptyString(input.contextSnapshot.handoffReason)
+        ? {
+            attempt: input.contextSnapshot.handoffAttempt,
+            maxAttempts: input.contextSnapshot.maxHandoffAttempts,
+            sourceRunId: readNonEmptyString(input.contextSnapshot.sourceRunId),
+            reason: readNonEmptyString(input.contextSnapshot.handoffReason),
+            missingDisposition: readNonEmptyString(
+              input.contextSnapshot.missingDisposition,
+            ),
+            validDispositionOptions: Array.isArray(
+              input.contextSnapshot.validDispositionOptions,
+            )
+              ? input.contextSnapshot.validDispositionOptions
+              : [],
+            instruction: readNonEmptyString(input.contextSnapshot.instruction),
+          }
+        : null,
     livenessContinuation:
       readNonEmptyString(input.contextSnapshot.livenessContinuationState) ||
       readNonEmptyString(


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Paperclip must always know whether an issue is finished, blocked, or still moving, so it watches for runs that succeed and leave the issue with no disposition
> - When it finds one, the recovery path writes a remediation instruction and queues exactly one corrective "status-only retry" wake
> - But the wake-payload builder reads only the two recovery-action keys, and a handoff wake carries neither, so the instruction never reaches the prompt
> - The corrective run therefore sees an ordinary resume, repeats the previous run, and spends the single allowed attempt for nothing
> - This pull request puts the handoff on the wake payload, renders it in the wake prompt, and counts it as a recovery-scoped wake
> - The benefit is that one corrective run is enough for the common case, so each affected issue costs one run less

## Linked Issues or Issue Description

Fixes: #12603

Related open issues. Each describes a different failure in the same missing-disposition path, and none of them reports this payload gap:

- Refs #11529: the corrective run echoes the wake payload back as text, the liveness classifier reads the echo as progress, and the issue escalates to `blocked`. Same corrective run, different failure.
- Refs #8060: a `finish_successful_run_handoff` / `missing_disposition` cycle on `routine_execution` issues, with the resulting `blocked` issues routed to the wrong owner. Its timeline records the handoff wake as a no-op, which is what an empty payload looks like from the outside.
- Refs #7496: asks for the `missing_disposition` recovery refire loop to be bounded and debounced.
- Refs #7661: asks to gate `successful_run_missing_state` recovery on `wakeNotBefore` plus a per-issue cooldown.
- Refs #8146: `finish_successful_run_handoff` wakes bypass the terminal-status check and cause re-close loops.

Related open pull requests. None of them changes the wake payload:

- #11275: accepts a structured disposition on issue comments to resolve the handoff. It gives the agent another way to answer. It does not make the wake carry the question.
- #8357: gates `successful_run_missing_state` wakes on `wakeNotBefore` plus a 30-minute per-issue cooldown (implements #7661).
- #8136: cancels `finish_successful_run_handoff` wakes when the issue is already terminal (implements #8146).

## What Changed

- Added a `successfulRunHandoff` block to the wake payload in `buildPaperclipWakePayload` (`server/src/services/heartbeat.ts`). It mirrors the existing `livenessContinuation` block and carries `attempt`, `maxAttempts`, `sourceRunId`, `reason`, `missingDisposition`, `validDispositionOptions`, and `instruction`.
- Gated that block on `handoffRequired === true` or a non-empty `handoffReason`. Only `decideSuccessfulRunHandoff` writes those two keys into a wake context snapshot. Review-path recovery writes a bare `instruction` and `sourceRunId` (`server/src/services/recovery/review-path-recovery.ts`), so a gate on those keys would read a review-path wake as a handoff.
- Added the matching type and normalizer in `packages/adapter-utils/src/server-utils.ts`, and included the block in the "payload is empty" check so a wake that carries nothing else still renders.
- Rendered the block in `renderPaperclipWakePrompt`. The scalars follow the `livenessContinuation` bullet style. The producer's instruction is multi-line markdown, so it goes on its own lines.
- Counted a handoff wake in `isPaperclipRecoveryWakePayload`.
- Added `packages/adapter-utils/src/wake-successful-run-handoff.test.ts` (5 cases) and `server/src/__tests__/heartbeat-successful-run-handoff-wake.test.ts` (2 cases).

### What the classification changes, exactly

`isPaperclipRecoveryWakePayload` has eleven call sites in three kinds of place, so counting the handoff wake there has three effects:

1. `selectPaperclipTaskMarkdown` returns the full task brief instead of the compact resume delta. A corrective run that must judge whether the work is done needs the brief.
2. The adapters that skip their heartbeat prompt template on recovery wakes now skip it for a handoff wake too: `claude-local`, `codex-local`, `cursor-local`, `cursor-cloud`, `gemini-local`, `grok-local`, `kimi-local`, `opencode-local`, `pi-local`, and `hermes`.
3. The Hermes gateway lane (`packages/adapters/hermes/src/gateway/server/execute.ts:296`) drops its own generic execution-contract lines, because that block gates on `isPaperclipRecoveryWakePayload` directly. That lane renders the wake prompt without `resumedSession`, so nothing replaces those lines. See Risks.

It does **not** change the contract lines that `renderPaperclipWakePrompt` selects. That function uses a local `recoveryScoped` check built from the `recovery` block and the `source_scoped_recovery_action` reason, and this pull request leaves it alone. See Risks.

## Verification

I ran everything on Node.js v24.20.0. The baseline is a clean checkout of `master` at `2e5a24e17769f206fb350a719bf7c85eadb348c7`. The "after" runs are this branch on top of that commit.

New tests, before the fix (test files added on top of clean `master`):

```
$ npx vitest run packages/adapter-utils/src/wake-successful-run-handoff.test.ts
 Test Files  1 failed (1)
      Tests  3 failed | 2 passed (5)

$ npx vitest run server/src/__tests__/heartbeat-successful-run-handoff-wake.test.ts
 Test Files  1 failed (1)
      Tests  1 failed | 1 passed (2)
```

New tests, after the fix:

```
$ npx vitest run packages/adapter-utils/src/wake-successful-run-handoff.test.ts
 Test Files  1 passed (1)
      Tests  5 passed (5)

$ npx vitest run server/src/__tests__/heartbeat-successful-run-handoff-wake.test.ts
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

The server case that already passed on `master` is the review-path guard. It must pass on both sides: it proves the new gate does not claim a wake that is not a handoff.

Touched and neighboring suites, after the fix:

```
$ npx vitest run packages/adapter-utils/src/server-utils.test.ts \
    packages/adapter-utils/src/server-utils-env.test.ts \
    packages/adapter-utils/src/published-exports.test.ts
 Test Files  3 passed (3)
      Tests  104 passed (104)

$ npx vitest run server/src/services/recovery/successful-run-handoff.test.ts \
    server/src/__tests__/heartbeat-agent-session-message.test.ts
 Test Files  2 passed (2)
      Tests  35 passed (35)

$ npx vitest run server/src/__tests__/heartbeat-process-recovery.test.ts \
    server/src/__tests__/heartbeat-comment-wake-batching.test.ts \
    server/src/__tests__/issue-recovery-actions.test.ts \
    server/src/__tests__/issue-comment-redaction.test.ts \
    server/src/__tests__/document-annotations-service.test.ts
 Test Files  5 passed (5)
      Tests  187 passed (187)
```

The last group is the set of suites that exercise `buildPaperclipWakePayload` or `renderPaperclipWakePrompt`. Those suites boot embedded Postgres and skip themselves when it is unavailable. Here it was available, so they ran.

The adapter suites that cover prompt selection also pass:

```
$ npx vitest run packages/adapters/claude-local/src/server/acp.test.ts
 Test Files  1 passed (1)
      Tests  22 passed (22)

$ cd packages/adapters/hermes && npx vitest run
 Test Files  9 passed (9)
      Tests  75 passed (75)
```

Type checks pass in both packages:

```
$ cd packages/adapter-utils && npx tsc --noEmit   # exit 0
$ cd server && npx tsc --noEmit                   # exit 0
```

Manual check of the rendered prompt. Both prompts come from the same context snapshot, produced by `decideSuccessfulRunHandoff` and passed through `buildPaperclipWakePayload` with `resumedSession: true`.

On `master` the corrective wake is indistinguishable from any other resume delta. Only the `reason` line hints at it:

```
- reason: finish_successful_run_handoff
- issue: PAP-1 Finish backend handoff
- fallback fetch needed: no
- issue status: in_progress
- issue work mode: standard
- issue priority: medium
- issue description: omitted from this resume delta; fetch the issue if you need the latest brief
```

On this branch the same wake gains the handoff block:

```
Successful run missing a disposition:
- attempt: 1/1
- source run: run-1
- reason: successful_run_missing_state
- missing: clear_next_step
- valid dispositions: mark_done_or_cancelled, send_for_review_or_ask_for_input, mark_blocked, delegate_or_continue_from_checkpoint
- instruction:
## What you were supposed to do
You are assigned PAP-1: Finish backend handoff.
[...]
## Your options
Choose **exactly one** outcome and perform the matching Paperclip action:
[...]
```

One measured flake, present on clean `master` and unrelated to this change. I ran `packages/adapter-utils/src/execution-target-stdin-race.test.ts` three times on clean `master`: 34 passed, 34 passed, then `1 failed | 33 passed (34)`. The failing case was `T24 leaves a peer's replacement symbolic link and its target untouched instead of deleting or following it` (4082 ms). This pull request does not touch that file.

I tested on Node.js v24.20.0. The repository requires `>=24.11.0` and CI runs Node 24, so this is inside the supported range.

## Risks

Low risk overall. The change adds one payload field, one prompt block, and one term in an existing boolean. It changes no schema and no stored data.

Three behaviors are worth naming.

**The generic execution contract still renders on a resumed session.** `renderPaperclipWakePrompt` builds its contract lines from a local `recoveryScoped` value. That value comes from the `recovery` block and the `source_scoped_recovery_action` reason. This pull request does not change it. On a resumed session the generic "take concrete action, do not stop at a plan" contract still renders above the new handoff block. (`resumeIntent: true` on the wake does not decide that: the local adapters resume from their own stored session id, not from that flag.)

That is deliberate. Extending the local check would add two lines that contradict the producer: "your job is to RECOVER this task, not to do the work", and a "recovery cause: unknown" line. The producer's own instruction says the opposite. It tells the agent it is on its normal model and may work in this wake. The handoff block is specific, and it appears in the same prompt, so the agent now has the instruction it was missing. Aligning the two contracts is a separate change.

**Some lanes now carry no execution contract.** A recovery-scoped wake suppresses each local adapter's heartbeat prompt template, and the Hermes lanes drop their own contract block the same way. Three cases follow.

On the local adapters and on `hermes`, a resumed session still renders the generic contract from the wake prompt. A fresh session does not: the wake prompt is rendered without `includeExecutionContract`, the local `recoveryScoped` value stays false, and the prompt carries no contract lines at all. Before this change that lane received the heartbeat prompt template instead.

On the Hermes gateway lane the loss is unconditional. That lane calls `renderPaperclipWakePrompt` without `resumedSession` and without `includeExecutionContract` (`packages/adapters/hermes/src/gateway/server/execute.ts:276`), so a handoff wake renders no contract lines on any run, and the lane's own four-bullet block at lines 299-303 is now gated off. Three of those four bullets are restated, more specifically, by the producer's instruction. The fourth is not: "Use X-Paperclip-Run-Id on mutating Paperclip API requests when a Paperclip API key is available." The corrective run exists to make exactly that kind of write. Every other recovery wake on that lane already loses the same bullet, so this follows existing behavior rather than introducing it.

This is a new shape rather than parity with the neighbors. Every other recovery wake carries a `recovery` block or the `source_scoped_recovery_action` reason, so `recoveryScoped` is true and the Recovery contract lines still render. The handoff wake is the only recovery-scoped wake that renders neither contract. I left it this way because the producer's instruction is specific and self-contained. If you want a contract kept on these lanes, the smallest fix is to pass `includeExecutionContract: true` for a handoff wake. `openclaw-gateway` is unaffected. It passes `includeExecutionContract: true` and does not gate on the classification.

The gate is the part most worth reviewing. Only `decideSuccessfulRunHandoff` writes `handoffRequired` or `handoffReason` into a wake context snapshot. The other hits in the repository are readers (`server/src/services/recovery/service.ts`), an activity-log `details` object (`server/src/services/heartbeat.ts`), or test fixtures. The second server test pins this. It drives `decideIssueReviewPathRecovery`, confirms the resulting snapshot really does carry a bare `instruction` and `sourceRunId`, then asserts that the payload gets no handoff block and is not classified as recovery-scoped.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

Provider: Anthropic. Model: Claude Opus 5, model ID `claude-opus-5`, running in Claude Code with extended reasoning and tool use (file editing, shell, git, GitHub CLI). I am not able to state a verified context-window figure for this configuration, so I am leaving that out rather than guessing at it.

How the change was produced, since the disclosure is only useful with the workflow attached: the defect was found in a live self-hosted deployment running v2026.722.0 during a load test, root-caused against this repository's source, and the patch, both test files and this description were written by the model. Every claim here was then re-verified against `master` by separate model instances running an adversarial review, which is what caught two false statements in earlier drafts of this text: one about the execution contract yielding, and one claiming parity with other recovery wakes. Both were corrected before filing. The human maintainer of that deployment directed the work, approved this submission, and is accountable for it.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green <!-- 29 of 29 repository checks pass and 1 is skipped, with 0 failures. `security/snyk` reports no status at all, which is what that third-party integration does on a pull request from a fork; leaving this unticked rather than claiming a green I cannot see. -->
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups <!-- 5/5 confidence, "appears safe to merge", zero inline review comments. -->
- [x] I will address all Greptile and reviewer comments before requesting merge

Notes on the unchecked boxes:

- Model used: see the placeholder above.
- Documentation: `docs/guides/agent-developer/heartbeat-protocol.md` documents the liveness-continuation wake-prompt block, which is the block this change mirrors, so this branch adds the parallel line for the successful-run handoff block next to it. The change adds no run-log event, no telemetry dimension, and no OpenTelemetry span attribute.
- CI gates and Greptile: these cannot be true before the pull request exists.

On the roadmap check: `ROADMAP.md` lists "Enforced Outcomes (watchdogs, recovery actions, review gates)" and "Self-healing runs & automatic recovery", both marked as delivered. This pull request is a bug fix inside that shipped path, not roadmap-level feature work, so it does not duplicate planned core work.

