### PR TITLE
refactor(docker): install rust via a verified rustup, pinned by rust-toolchain.toml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,9 +52,14 @@ RUN pnpm install --frozen-lockfile
 
 FROM base AS build
 WORKDIR /app
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends cargo rustc \
-  && rm -rf /var/lib/apt/lists/*
+# Debian's packaged rust lags the ecosystem (trixie ships 1.85) and the
+# runner's dependency tree now requires rustc >= 1.88 (icu_* 2.3). Install a
+# pinned stable via rustup instead, matching what the hosted CI runners
+# already provide, so image builds and CI can't drift apart again.
+ENV RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+RUN curl -fsSL https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.89.0 --profile minimal
 COPY --from=deps /app /app
 COPY . .
 RUN pnpm --filter @paperclipai/ui build

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,13 +53,28 @@ RUN pnpm install --frozen-lockfile
 FROM base AS build
 WORKDIR /app
 # Debian's packaged rust lags the ecosystem (trixie ships 1.85) and the
-# runner's dependency tree now requires rustc >= 1.88 (icu_* 2.3). Install a
-# pinned stable via rustup instead, matching what the hosted CI runners
-# already provide, so image builds and CI can't drift apart again.
+# runner's dependency tree now requires a newer rustc. Install rustup from a
+# version-pinned, checksum-verified installer and let the runner's own
+# rust-toolchain.toml choose the compiler — one pin, owned by the runner
+# package, shared by CI and image builds alike.
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
-RUN curl -fsSL https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.89.0 --profile minimal
+ARG RUSTUP_VERSION=1.29.0
+ARG RUSTUP_SHA256_AMD64=4acc9acc76d5079515b46346a485974457b5a79893cfb01112423c89aeb5aa10
+ARG RUSTUP_SHA256_ARM64=9732d6c5e2a098d3521fca8145d826ae0aaa067ef2385ead08e6feac88fa5792
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+      amd64) rustTarget="x86_64-unknown-linux-gnu"; sha256="$RUSTUP_SHA256_AMD64" ;; \
+      arm64) rustTarget="aarch64-unknown-linux-gnu"; sha256="$RUSTUP_SHA256_ARM64" ;; \
+      *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSLo /tmp/rustup-init "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${rustTarget}/rustup-init"; \
+    echo "${sha256}  /tmp/rustup-init" | sha256sum -c -; \
+    chmod +x /tmp/rustup-init; \
+    /tmp/rustup-init -y --no-modify-path --profile minimal --default-toolchain none; \
+    rm /tmp/rustup-init
 COPY --from=deps /app /app
 COPY . .
 RUN pnpm --filter @paperclipai/ui build


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The Docker images ship the server together with the Rust runner binary (paperclip-runnerd)
> - The Dockerfile installed rust from Debian trixie's apt archive, which provides rustc 1.85
> - The runner's dependency tree and its `rust-toolchain.toml` now require rustc 1.97.1, so every master docker build fails while hosted CI (with a newer preinstalled rust) stays green
> - No image has been published since the dependency refresh, so deployments cannot receive current builds
> - This pull request installs rustup from a version-pinned, checksum-verified installer and defers the compiler choice to the runner's own `rust-toolchain.toml`
> - The benefit is one toolchain pin, owned by the runner package, shared by CI and image builds, installed without executing an unverified remote script

## Linked Issues or Issue Description

**What happened?**

Every `docker.yml` build on `master` fails since the runner dependency refresh. The failing step is `pnpm --filter @paperclipai/server build`, which runs `cargo build` for `paperclip-runnerd`. Cargo reports: `rustc 1.85.0 is not supported by the following packages: icu_collections@2.3.0 requires rustc 1.88` (and sibling icu crates). The build exits with code 101 and no image is published.

**Expected behavior**

Master docker builds compile the runner and publish images.

**Steps to reproduce**

1. Run the `docker.yml` workflow on current `master`.
2. Observe the `build-and-push` and `build-and-push-cloud` jobs fail in the server build step with the rustc version error.

**Paperclip version or commit**

`master` (first failing build ~2026-08-31 12:21 UTC; last successful image build `fd7cb77d8`).

## What Changed

- The docker build stage downloads a pinned `rustup-init` (1.29.0) for the build architecture, verifies it against an embedded sha256, and installs with `--default-toolchain none`.
- The compiler version comes from `packages/paperclip-runner/rust-toolchain.toml` (1.97.1) — one pin, no drift between the Docker layer and the runner package.
- A comment records why apt rust is not used: Debian's archive lags the ecosystem.

## Verification

- In the exact base image (`node:24-trixie-slim`): the checksum check passes, rustup installs with no default toolchain, and `cargo build --release --manifest-path runner/Cargo.toml --locked -p paperclip-runner-core --bin paperclip-runnerd` completes with `rustc 1.97.1` selected from the toml.
- This PR's own docker build exercises the same path end to end for both architectures.
- No test files: this is a build-infrastructure refactor with no runtime code change (hence the `refactor:` prefix); the docker build itself is the executable check.

## Risks

- Low risk. The change is scoped to the docker build stage; the production stage is unchanged. The rustup installer version and checksums are pinned; bumping rust later means editing only `rust-toolchain.toml`.

## Model Used

- Claude Fable 5 (`claude-fable-5`), Anthropic — Claude Code harness, extended thinking + tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details