### PR TITLE
fix(codex-local): require safe live onboarding proof

### DIFF
--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -166,6 +166,9 @@ async function runExecutor(
     executionTarget?: Record<string, unknown>;
     runtimeMcp?: AdapterRuntimeMcpAccess;
     prepareRemoteManagedHome?: AcpxEngineExecutorOptions["prepareRemoteManagedHome"];
+    omitInheritedEnvKeys?: readonly string[];
+    denyEnvironmentKeys?: readonly string[];
+    skipRuntimeSkillPreparation?: boolean;
     startupTraceContext?: AdapterExecutionContext["startupTraceContext"];
   } = {},
 ) {
@@ -176,6 +179,9 @@ async function runExecutor(
   const logs: Array<{ stream: string; text: string }> = [];
   const events: Array<{ eventType: string; payload?: Record<string, unknown> }> = [];
   const execute = createAcpxEngineExecutor({
+    omitInheritedEnvKeys: options.omitInheritedEnvKeys,
+    denyEnvironmentKeys: options.denyEnvironmentKeys,
+    skipRuntimeSkillPreparation: options.skipRuntimeSkillPreparation,
     ...(options.prepareRemoteManagedHome
       ? { prepareRemoteManagedHome: options.prepareRemoteManagedHome }
       : {}),
@@ -1406,6 +1412,87 @@ describe("shared ACPX engine runtime behavior", () => {
     expect(env.PAPERCLIP_CLOUD_PROVIDER_TOKEN).toBe("cloud-token");
   });
 
+  it("omits selected ambient provider credentials without mutating process.env", async () => {
+    const root = await makeTempRoot();
+    const inheritedKey = "OPENAI_API_KEY";
+    const previous = process.env[inheritedKey];
+    process.env[inheritedKey] = "ambient-provider-secret";
+    try {
+      const { sessionInputs } = await runExecutor(
+        {
+          agent: "codex",
+          stateDir: path.join(root, "state"),
+          env: { CODEX_HOME: path.join(root, "codex-home") },
+          paperclipRuntimeSkills: [],
+          paperclipSkillSync: { desiredSkills: [] },
+        },
+        { omitInheritedEnvKeys: ["openai_api_key"] },
+      );
+
+      const env = (sessionInputs[0]!.sessionOptions as { env: Record<string, string> }).env;
+      expect(env.OPENAI_API_KEY).toBeUndefined();
+      expect(process.env[inheritedKey]).toBe("ambient-provider-secret");
+    } finally {
+      if (previous === undefined) delete process.env[inheritedKey];
+      else process.env[inheritedKey] = previous;
+    }
+  });
+
+  it("keeps explicit ACP configuration for an omitted inherited key", async () => {
+    const root = await makeTempRoot();
+    const inheritedKey = "OPENAI_API_KEY";
+    const previous = process.env[inheritedKey];
+    process.env[inheritedKey] = "ambient-provider-secret";
+    try {
+      const { sessionInputs } = await runExecutor(
+        {
+          agent: "codex",
+          stateDir: path.join(root, "state"),
+          env: {
+            CODEX_HOME: path.join(root, "codex-home"),
+            OPENAI_API_KEY: "explicit-config-secret",
+          },
+          paperclipRuntimeSkills: [],
+          paperclipSkillSync: { desiredSkills: [] },
+        },
+        { omitInheritedEnvKeys: [inheritedKey] },
+      );
+
+      const env = (sessionInputs[0]!.sessionOptions as { env: Record<string, string> }).env;
+      expect(env.OPENAI_API_KEY).toBe("explicit-config-secret");
+      expect(process.env[inheritedKey]).toBe("ambient-provider-secret");
+    } finally {
+      if (previous === undefined) delete process.env[inheritedKey];
+      else process.env[inheritedKey] = previous;
+    }
+  });
+
+  it("skips Codex skill preparation without mutating a configured CODEX_HOME", async () => {
+    const root = await makeTempRoot();
+    const codexHome = path.join(root, "durable-codex-home");
+
+    const { events, result, sessionInputs } = await runExecutor(
+      {
+        agent: "codex",
+        stateDir: path.join(root, "state"),
+        env: { CODEX_HOME: codexHome },
+        paperclipRuntimeSkills: ["maintainer-skill"],
+        paperclipSkillSync: { desiredSkills: ["maintainer-skill"] },
+      },
+      { skipRuntimeSkillPreparation: true },
+    );
+
+    const env = (sessionInputs[0]!.sessionOptions as { env: Record<string, string> }).env;
+    expect(env.CODEX_HOME).toBe(codexHome);
+    expect(await pathExists(codexHome)).toBe(false);
+    expect((result.sessionParams?.skills as { mode?: string } | undefined)?.mode).toBe("disabled");
+    const startupSteps = events
+      .filter((event) => event.eventType === "run.startup.step")
+      .map((event) => event.payload?.step);
+    expect(startupSteps).not.toContain("codex-home.seed");
+    expect(startupSteps).not.toContain("skills.reconcile");
+  });
+
   it("busts the session fingerprint when resolved adapter env changes but not across wakes", async () => {
     const root = await makeTempRoot();
     const stateDir = path.join(root, "state");
@@ -1920,6 +2007,93 @@ describe("shared ACPX engine runtime behavior", () => {
     );
     expect(payloadEnv.PAPERCLIP_API_KEY).toBeTruthy();
     expect(payloadEnv.PAPERCLIP_API_KEY).not.toBe("real-run-jwt");
+  });
+
+  it("denies credentials after a remote login shell loads its profile", async () => {
+    const root = await makeTempRoot();
+    const localCwd = path.join(root, "worktree");
+    const remoteCwd = path.join(root, "remote-workspace");
+    await fs.mkdir(localCwd, { recursive: true });
+    await fs.mkdir(remoteCwd, { recursive: true });
+    let sessionPayload: Record<string, unknown> | null = null;
+    const runner = createLocalSandboxRunner((input) => {
+      if (input.env?.PAPERCLIP_SANDBOX_EXEC_CHANNEL !== "bridge") return;
+      const script = input.args?.[1] ?? "";
+      const match = script.match(/PAPERCLIP_PROCESS_SESSION_COMMAND_B64='([^']+)'/);
+      if (match) {
+        sessionPayload = JSON.parse(Buffer.from(match[1]!, "base64").toString("utf8")) as Record<
+          string,
+          unknown
+        >;
+      }
+    });
+    const omittedKeys = [
+      "OPENAI_API_KEY",
+      "CODEX_API_KEY",
+      "CODEX_AUTH_JSON",
+      "_PAPERCLIP_CODEX_AUTH_JSON",
+    ] as const;
+    const profileEnv = {
+      openai_api_key: "profile-openai-secret",
+      CoDeX_ApI_Key: "profile-codex-secret",
+      codex_AUTH_json: "profile-auth-json-secret",
+      _paperclip_codex_auth_json: "profile-paperclip-auth-secret",
+    };
+    const previous = Object.fromEntries(omittedKeys.map((key) => [key, process.env[key]]));
+    for (const key of omittedKeys) process.env[key] = `profile-secret-${key}`;
+    try {
+      await runExecutor(
+        {
+          agent: "codex",
+          agentCommand: "env",
+          stateDir: path.join(root, "state"),
+          cwd: localCwd,
+          env: { CODEX_HOME: path.join(root, "codex-home") },
+          paperclipRuntimeSkills: [],
+          paperclipSkillSync: { desiredSkills: [] },
+        },
+        {
+          authToken: "profile-test-run-token",
+          executionTarget: {
+            kind: "remote",
+            transport: "sandbox",
+            providerKey: "fake-plugin",
+            remoteCwd,
+            runner,
+          },
+          denyEnvironmentKeys: omittedKeys,
+        },
+      );
+
+      const payload = sessionPayload as { args?: string[]; env?: Record<string, string> } | null;
+      expect(payload?.args?.[1]).toContain("_paperclip_env_dump=$(command env) || exit 126");
+      expect(payload?.args?.[1]).toContain("exec env");
+      for (const key of omittedKeys) expect(payload?.env?.[key]).toBeUndefined();
+
+      const launched = await runChildProcess(
+        "profile-env-omission",
+        "/bin/sh",
+        payload!.args!,
+        {
+          cwd: remoteCwd,
+          env: profileEnv,
+          timeoutSec: 5,
+          graceSec: 1,
+          onLog: async () => {},
+        },
+      );
+      expect(launched.exitCode).toBe(0);
+      for (const [key, secret] of Object.entries(profileEnv)) {
+        expect(launched.stdout).not.toContain(`${key}=`);
+        expect(launched.stdout).not.toContain(secret);
+      }
+    } finally {
+      for (const key of omittedKeys) {
+        const value = previous[key];
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
   });
 
   it("keeps the session fingerprint stable when only the host spawn cwd changes", async () => {
@@ -5895,6 +6069,84 @@ describe("ACPX engine run lifecycle corrections (F3: one teardown error policy)"
     expect(result.errorCode).toBe("acpx_turn_failed");
     expect(result.errorMessage).toContain("turn upstream boom");
     expect(result.errorMessage).not.toContain("close boom");
+  });
+
+  it("reports only allowlisted teardown failure steps to an isolated caller", async () => {
+    const root = await makeTempRoot();
+    const teardownFailures: string[] = [];
+    const execute = createAcpxEngineExecutor({
+      warmHandles: new Map(),
+      stagedRuntimes: new Map(),
+      stagingLocks: new Map(),
+      onTeardownFailure: (step) => {
+        teardownFailures.push(step);
+      },
+      createRuntime: () =>
+        ({
+          ensureSession: async () => okHandle,
+          startTurn: () => completedTurn(),
+          close: async () => {
+            throw new Error("sk-close-secret /private/runtime");
+          },
+        }) as never,
+    });
+
+    const result = await execute({
+      runId: "td-allowlisted-hook",
+      agent: { id: "agent-1", companyId: "company-1" },
+      runtime: {},
+      config: {
+        agent: "custom",
+        agentCommand: "node ./fake-acp.js",
+        stateDir: path.join(root, "state"),
+        cwd: root,
+        mode: "oneshot",
+      },
+      context: {},
+      onLog: async () => {},
+      onMeta: async () => {},
+    } as never);
+
+    expect(result.exitCode).toBe(0);
+    expect(teardownFailures).toEqual(["runtime_close"]);
+    expect(JSON.stringify(teardownFailures)).not.toMatch(/sk-close-secret|private\/runtime/);
+  });
+
+  it("reports an allowlisted staged-runtime disposal failure", async () => {
+    const { stateDir, localCwd, executionTarget } = await setupRemoteSandbox();
+    stubBridges();
+    const teardownFailures: string[] = [];
+    const execute = createAcpxEngineExecutor({
+      warmHandles: new Map(),
+      stagedRuntimes: new Map(),
+      stagingLocks: new Map(),
+      onTeardownFailure: (step) => {
+        teardownFailures.push(step);
+      },
+      createRuntime: () =>
+        ({
+          ensureSession: async () => okHandle,
+          startTurn: () => throwingTurn(),
+          close: async () => {},
+        }) as never,
+      prepareRemoteManagedHome: async (input) => ({
+        stagedRuntime: await input.stage([]),
+        disposeStaged: async () => {
+          throw new Error("sk-dispose-secret user@example.test /private/staged");
+        },
+      }),
+    });
+
+    const result = await execute({
+      runId: "td-staged-dispose-hook",
+      ...remoteArgs(stateDir, localCwd, executionTarget),
+    } as never);
+
+    expect(result.exitCode).toBe(1);
+    expect(teardownFailures).toContain("staged_runtime_dispose");
+    expect(JSON.stringify(teardownFailures)).not.toMatch(
+      /sk-dispose-secret|example\.test|private\/staged/,
+    );
   });
 
   it("test_flush_child_stderr_runs_on_every_exit_path", async () => {

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -14,6 +14,7 @@ import type {
 } from "@paperclipai/adapter-utils";
 import {
   adapterExecutionTargetSessionIdentity,
+  buildPostProfileEnvironmentScrubShell,
   describeAdapterExecutionTarget,
   adapterExecutionTargetDuplexObservabilityRecorder,
   adapterExecutionTargetEnablesSandboxDuplexBridge,
@@ -250,6 +251,10 @@ export interface AcpxEngineBillingIdentity {
   billingType?: AdapterBillingType | null;
 }
 
+export type AcpxTeardownFailureStep =
+  | "runtime_close"
+  | "staged_runtime_dispose";
+
 /**
  * Per-adapter remote managed-home seed seam, injected by each adapter's ACP
  * wiring ({codex,claude,gemini}-local `acp.ts`). The adapter-specific
@@ -339,6 +344,23 @@ export interface AcpxRemoteManagedHomeResult {
 export interface AcpxEngineExecutorOptions {
   createRuntime?: AcpxRuntimeFactory;
   now?: () => number;
+  /**
+   * Case-insensitive keys to omit from the ambient host environment before
+   * building a local ACP process launch environment. Explicit adapter config
+   * is preserved.
+   */
+  omitInheritedEnvKeys?: readonly string[];
+  /**
+   * Case-insensitive keys that must be absent from inherited environment,
+   * explicit adapter config, and remote login profiles.
+   */
+  denyEnvironmentKeys?: readonly string[];
+  /**
+   * Skip adapter runtime skill preparation entirely. This is intended for
+   * isolated capability probes that must use a preconfigured durable home
+   * without reconciling or materializing skills into it.
+   */
+  skipRuntimeSkillPreparation?: boolean;
   warmHandles?: Map<string, RuntimeCacheEntry>;
   /**
    * Per-session staged-runtime cache for the remote runner-backed lane (PR 3).
@@ -375,6 +397,12 @@ export interface AcpxEngineExecutorOptions {
   prepareRemoteManagedHome?: (
     input: AcpxRemoteManagedHomeContext,
   ) => Promise<AcpxRemoteManagedHomeResult>;
+  /**
+   * Observe teardown failures through a closed, adapter-safe step code. The
+   * callback never receives the caught error, command, path, or provider text.
+   * It is best-effort and cannot change the engine result or teardown flow.
+   */
+  onTeardownFailure?: (step: AcpxTeardownFailureStep) => void;
   /**
    * Observe the final per-resource disposition report the run records at the end
    * of the attempt (`finalized` vs `transferred`). The coordinator records it on
@@ -635,6 +663,8 @@ export function finalizeLaunchEnvironment(
     acpxAgent: string;
     inheritHostEnvironment: boolean;
     inheritedEnv?: NodeJS.ProcessEnv;
+    omitInheritedEnvKeys?: readonly string[];
+    denyEnvironmentKeys?: readonly string[];
     platform?: typeof process.platform;
   },
 ): LaunchEnvironment {
@@ -1956,6 +1986,11 @@ async function buildRuntime(input: {
         paperclipClaudeSettings.overrodeDontAsk ? "; overrode user dontAsk" : ""
       }, +${paperclipClaudeSettings.additionalDirectories.length} read root(s), +${paperclipClaudeSettings.allow.length} allow rule(s)).`,
     );
+  } else if (acpxAgent === "codex" && input.deps.skipRuntimeSkillPreparation) {
+    // A live capability probe may need the configured durable CODEX_HOME for
+    // subscription authentication. Do not inspect, create, reconcile, or
+    // materialize anything in that operator-owned home.
+    skillsIdentity = { mode: "disabled" };
   } else if (acpxAgent === "codex") {
     // Step 2 — codex-home.seed: the codex managed-home + skills preparation.
     // The nested skills.reconcile boundary (step 3) is timed inside via the
@@ -2023,6 +2058,8 @@ async function buildRuntime(input: {
       agentCommandShell,
       resolveRuntimeEnv(env, acpxAgent, {
         inheritHostEnvironment: !useRemoteProcessSession,
+        omitInheritedEnvKeys: input.deps.omitInheritedEnvKeys,
+        denyEnvironmentKeys: input.deps.denyEnvironmentKeys,
       }),
     );
     if (normalized !== agentCommandShell) {
@@ -2268,7 +2305,13 @@ async function buildRuntime(input: {
           runtimeRootDir,
           adapterKey: input.engine.adapterType,
           command: "sh",
-          args: ["-lc", `exec ${agentCommandShell}`],
+          args: [
+            "-lc",
+            buildRemoteAgentLaunchShell(
+              agentCommandShell,
+              input.deps.denyEnvironmentKeys,
+            ),
+          ],
           cwd: sessionCwd,
           env: launchEnv,
           timeoutSec,
@@ -2283,6 +2326,8 @@ async function buildRuntime(input: {
         finalizeLaunchEnvironment(env, contributions, {
           acpxAgent,
           inheritHostEnvironment: !useRemoteProcessSession,
+          omitInheritedEnvKeys: input.deps.omitInheritedEnvKeys,
+          denyEnvironmentKeys: input.deps.denyEnvironmentKeys,
         }).env,
       onPaperclipBridgeLog: () =>
         input.ctx.onLog("stdout", "[paperclip] Sandbox ACP API callback bridge enabled for this run.\n"),
@@ -2335,6 +2380,8 @@ async function buildRuntime(input: {
       runtimeEnv = finalizeLaunchEnvironment(env, [], {
         acpxAgent,
         inheritHostEnvironment: !useRemoteProcessSession,
+        omitInheritedEnvKeys: input.deps.omitInheritedEnvKeys,
+        denyEnvironmentKeys: input.deps.denyEnvironmentKeys,
       }).env;
     }
   } catch (err) {
@@ -2368,6 +2415,8 @@ async function buildRuntime(input: {
       sessionKey,
       stagedRuntime,
       dispose: remoteStagingDispose,
+      onDisposeFailure: () =>
+        notifyTeardownFailure(input.deps.onTeardownFailure, "staged_runtime_dispose"),
     });
     sessionStagingLeaseRelease?.();
     await emitRunPhaseTiming(input.ctx, "start_transport", nowMs() - startTransportStart, "failed");
@@ -2501,10 +2550,19 @@ function resolveRuntimeEnv(
   options: {
     inheritHostEnvironment: boolean;
     inheritedEnv?: NodeJS.ProcessEnv;
+    omitInheritedEnvKeys?: readonly string[];
+    denyEnvironmentKeys?: readonly string[];
     platform?: typeof process.platform;
   },
 ): Record<string, string> {
-  const inheritedEnv = options.inheritedEnv ?? process.env;
+  const omittedKeys = new Set(
+    (options.omitInheritedEnvKeys ?? []).map((key) => key.toUpperCase()),
+  );
+  const inheritedEnv = Object.fromEntries(
+    Object.entries(options.inheritedEnv ?? process.env).filter(
+      ([key]) => !omittedKeys.has(key.toUpperCase()),
+    ),
+  );
   const projectedHostEnv = projectAcpxInheritedHostEnvironment(
     inheritedEnv,
     acpxAgent,
@@ -2518,11 +2576,29 @@ function resolveRuntimeEnv(
     env,
     (options.platform ?? process.platform) === "win32",
   );
+  const deniedKeys = new Set(
+    (options.denyEnvironmentKeys ?? [])
+      .map((key) => key.trim())
+      .filter((key) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(key))
+      .map((key) => key.toUpperCase()),
+  );
   return Object.fromEntries(
     Object.entries(mergedEnv).filter(
-      (entry): entry is [string, string] => typeof entry[1] === "string",
+      (entry): entry is [string, string] =>
+        typeof entry[1] === "string" && !deniedKeys.has(entry[0].toUpperCase()),
     ),
   );
+}
+
+function buildRemoteAgentLaunchShell(
+  commandShell: string,
+  denyEnvironmentKeys: readonly string[] | undefined,
+): string {
+  // `sh -lc` may source a provider-controlled login profile before evaluating
+  // this script. Enumerate and scrub case-insensitive names after profile
+  // loading and immediately before exec so a denied credential cannot be
+  // reintroduced by that profile under alternate casing.
+  return buildPostProfileEnvironmentScrubShell(commandShell, denyEnvironmentKeys);
 }
 
 function mergeRuntimeEnvironment(
@@ -3317,6 +3393,7 @@ async function cleanupIdleStagedRuntimes(input: {
   locks: Map<string, Promise<unknown>>;
   now: () => number;
   idleMs: number;
+  onDisposeFailure?: () => void;
 }) {
   if (input.idleMs <= 0) return;
   const stale: Array<[string, StagedRuntimeCacheEntry]> = [];
@@ -3329,7 +3406,11 @@ async function cleanupIdleStagedRuntimes(input: {
       if (current !== entry) return;
       if (input.now() - current.lastUsedAt < input.idleMs) return;
       input.handles.delete(key);
-      if (entry.dispose) await entry.dispose().catch(() => {});
+      if (entry.dispose) {
+        await entry.dispose().catch(() => {
+          input.onDisposeFailure?.();
+        });
+      }
     });
     lease.release();
   }
@@ -3368,6 +3449,7 @@ function saveStagedRuntimeAfterCleanTurn(input: {
 async function discardStagedRuntime(input: {
   handles: Map<string, StagedRuntimeCacheEntry>;
   prepared: AcpxPreparedRuntime;
+  onDisposeFailure?: () => void;
 }): Promise<void> {
   const { handles, prepared } = input;
   await releaseStagedRuntimeEntry({
@@ -3375,6 +3457,7 @@ async function discardStagedRuntime(input: {
     sessionKey: prepared.sessionKey,
     stagedRuntime: prepared.stagedRuntime,
     dispose: prepared.remoteStagingDispose,
+    onDisposeFailure: input.onDisposeFailure,
   });
 }
 
@@ -3392,13 +3475,29 @@ async function releaseStagedRuntimeEntry(input: {
   sessionKey: string;
   stagedRuntime: PreparedAdapterExecutionTargetRuntime | null;
   dispose: (() => Promise<void>) | null;
+  onDisposeFailure?: () => void;
 }): Promise<void> {
   const { handles, sessionKey, stagedRuntime, dispose } = input;
   const existing = handles.get(sessionKey);
   if (existing && stagedRuntime && existing.stagedRuntime === stagedRuntime) {
     handles.delete(sessionKey);
   }
-  if (dispose) await dispose().catch(() => {});
+  if (dispose) {
+    await dispose().catch(() => {
+      input.onDisposeFailure?.();
+    });
+  }
+}
+
+function notifyTeardownFailure(
+  callback: AcpxEngineExecutorOptions["onTeardownFailure"],
+  step: AcpxTeardownFailureStep,
+): void {
+  try {
+    callback?.(step);
+  } catch {
+    // A diagnostic observer cannot change teardown or the adapter result.
+  }
 }
 
 // Per-`sessionKey` async lease: chains each caller after the previous one so
@@ -3450,6 +3549,7 @@ async function closeWarmHandle(input: {
   entry: RuntimeCacheEntry;
   reason: string;
   discardPersistentState?: boolean;
+  onCloseFailure?: () => void;
 }) {
   if (input.handles.get(input.key) === input.entry) {
     input.handles.delete(input.key);
@@ -3459,7 +3559,9 @@ async function closeWarmHandle(input: {
     handle: input.entry.handle,
     reason: input.reason,
     discardPersistentState: input.discardPersistentState ?? false,
-  }).catch(() => {});
+  }).catch(() => {
+    input.onCloseFailure?.();
+  });
   flushChildStderr(input.entry.childStderrState);
 }
 
@@ -3715,7 +3817,9 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
       closeWarmEntry: async (entry) => {
         await entry.runtime
           .close({ handle: entry.handle, reason: "paperclip idle cleanup", discardPersistentState: false })
-          .catch(() => {});
+          .catch(() => {
+            notifyTeardownFailure(deps.onTeardownFailure, "runtime_close");
+          });
         flushChildStderr(entry.childStderrState);
       },
     });
@@ -3787,6 +3891,8 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
         locks: stagingLocks,
         now,
         idleMs: warmIdleMs,
+        onDisposeFailure: () =>
+          notifyTeardownFailure(deps.onTeardownFailure, "staged_runtime_dispose"),
       });
       // The sum of the step wall times. The root span records it as `root.work_ms`
       // and the difference from its own wall time as `root.diff_ms` (the overlap
@@ -4127,14 +4233,15 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
               reason: "paperclip late handshake cleanup",
               discardPersistentState: false,
             })
-            .catch(() =>
-              ctx
+            .catch(() => {
+              notifyTeardownFailure(deps.onTeardownFailure, "runtime_close");
+              return ctx
                 .onLog(
                   "stderr",
                   "[paperclip] ACPX handshake late close failed: acpx_handshake_late_close_failed\n",
                 )
-                .catch(() => {}),
-            );
+                .catch(() => {});
+            });
         };
         // The late rejection comes from inside the sandbox. It crosses the
         // sandbox-to-host trust boundary, so it must never reach the run log,
@@ -4957,12 +5064,17 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
               entry: existing,
               reason: settlement.reason,
               discardPersistentState: settlement.discardPersistentState,
+              onCloseFailure: () =>
+                notifyTeardownFailure(deps.onTeardownFailure, "runtime_close"),
             });
             return;
           }
-          const onCloseError = settlement.recordCloseError
-            ? (closeErr: unknown) => recordTeardownError("runtime-close", closeErr)
-            : () => {};
+          const onCloseError = (closeErr: unknown) => {
+            notifyTeardownFailure(deps.onTeardownFailure, "runtime_close");
+            return settlement.recordCloseError
+              ? recordTeardownError("runtime-close", closeErr)
+              : undefined;
+          };
           await runtime
             .close({
               handle: settlement.handle,
@@ -4984,7 +5096,12 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
             saveStagedRuntimeAfterCleanTurn({ handles: stagedRuntimes, prepared, now: now() });
             return;
           }
-          await discardStagedRuntime({ handles: stagedRuntimes, prepared });
+          await discardStagedRuntime({
+            handles: stagedRuntimes,
+            prepared,
+            onDisposeFailure: () =>
+              notifyTeardownFailure(deps.onTeardownFailure, "staged_runtime_dispose"),
+          });
         }),
         // Stop both bridges in one allSettled.
         stopTransport: () => timedPhase("stop_transport", async () => {

--- a/packages/adapter-utils/src/execution-target.test.ts
+++ b/packages/adapter-utils/src/execution-target.test.ts
@@ -3,6 +3,7 @@ import * as ssh from "./ssh.js";
 import * as serverUtils from "./server-utils.js";
 import {
   adapterExecutionTargetUsesManagedHome,
+  buildPostProfileEnvironmentScrubShell,
   ensureAdapterExecutionTargetRuntimeCommandInstalled,
   resolveAdapterExecutionTargetCwd,
   runAdapterExecutionTargetProcess,
@@ -266,6 +267,7 @@ describe("runAdapterExecutionTargetProcess", () => {
         timeoutSec: 5,
         graceSec: 1,
         onLog: async () => {},
+        omitInheritedEnvKeys: ["OPENAI_API_KEY"],
       },
     );
 
@@ -277,8 +279,251 @@ describe("runAdapterExecutionTargetProcess", () => {
         env: {
           SAFE_VALUE: "visible",
         },
+        omitInheritedEnvKeys: ["OPENAI_API_KEY"],
       }),
     );
+  });
+
+  it("preserves explicit remote configuration when only inherited keys are omitted", async () => {
+    const runner = {
+      execute: vi.fn(async (input: {
+        command: string;
+        args?: string[];
+        cwd: string;
+        env?: Record<string, string>;
+      }) => serverUtils.runChildProcess(
+        "explicit-remote-env",
+        input.command,
+        input.args ?? [],
+        {
+          cwd: input.cwd,
+          env: input.env ?? {},
+          omitInheritedEnvKeys: Object.keys(process.env),
+          timeoutSec: 5,
+          graceSec: 1,
+          onLog: async () => {},
+        },
+      )),
+    };
+
+    const result = await runAdapterExecutionTargetProcess(
+      "explicit-remote-env",
+      {
+        kind: "remote",
+        transport: "sandbox",
+        providerKey: "fake-plugin",
+        remoteCwd: "/tmp",
+        runner,
+      },
+      process.execPath,
+      ["-e", "process.stdout.write(process.env.OPENAI_API_KEY ?? 'missing')"],
+      {
+        cwd: "/tmp",
+        env: { OPENAI_API_KEY: "explicit-config-secret" },
+        timeoutSec: 5,
+        graceSec: 1,
+        onLog: async () => {},
+        omitInheritedEnvKeys: ["OPENAI_API_KEY"],
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("explicit-config-secret");
+    expect(runner.execute.mock.calls[0]?.[0].command).toBe(process.execPath);
+  });
+
+  it("denies env names case-insensitively after sandbox profile injection", async () => {
+    const profileEnv = {
+      openai_api_key: "profile-openai-secret",
+      CoDeX_ApI_Key: "profile-codex-secret",
+      codex_AUTH_json: "profile-auth-json-secret",
+      _paperclip_codex_auth_json: "profile-paperclip-auth-secret",
+    };
+    const runner = {
+      execute: vi.fn(async (input: {
+        command: string;
+        args?: string[];
+        cwd: string;
+        env?: Record<string, string>;
+        stdin?: string;
+      }) => serverUtils.runChildProcess(
+        "profile-simulated-sandbox",
+        input.command,
+        input.args ?? [],
+        {
+          cwd: input.cwd,
+          env: { ...(input.env ?? {}), ...profileEnv, SAFE_VALUE: "visible" },
+          omitInheritedEnvKeys: Object.keys(process.env),
+          stdin: input.stdin,
+          timeoutSec: 5,
+          graceSec: 1,
+          onLog: async () => {},
+        },
+      )),
+    };
+
+    const result = await runAdapterExecutionTargetProcess(
+      "profile-simulated-sandbox",
+      {
+        kind: "remote",
+        transport: "sandbox",
+        providerKey: "fake-plugin",
+        remoteCwd: "/tmp",
+        runner,
+      },
+      "env",
+      [],
+      {
+        cwd: "/tmp",
+        env: {},
+        timeoutSec: 5,
+        graceSec: 1,
+        onLog: async () => {},
+        denyEnvironmentKeys: [
+          "OPENAI_API_KEY",
+          "CODEX_API_KEY",
+          "CODEX_AUTH_JSON",
+          "_PAPERCLIP_CODEX_AUTH_JSON",
+        ],
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("SAFE_VALUE=visible");
+    for (const [key, secret] of Object.entries(profileEnv)) {
+      expect(result.stdout).not.toContain(`${key}=`);
+      expect(result.stdout).not.toContain(secret);
+    }
+    const launch = runner.execute.mock.calls[0]?.[0];
+    expect(launch?.command).toBe("sh");
+    expect(launch?.args?.join(" ")).not.toContain("profile-openai-secret");
+  });
+
+  it("keeps the post-profile scrub inside a sandbox run-log wrapper", async () => {
+    const wrapCommand = vi.fn((command: string, args: string[]) => ({ command, args }));
+    const runner = {
+      execute: vi.fn(async (_input: { command: string; args?: string[] }) => ({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: "",
+        stderr: "",
+        pid: null,
+        startedAt: new Date().toISOString(),
+      })),
+    };
+    const runLogTail = {
+      create: () => ({
+        wrapCommand,
+        start: () => {},
+        finish: async () => {},
+        abort: async () => {},
+      }),
+    };
+
+    await runAdapterExecutionTargetProcess(
+      "profile-scrub-with-tail",
+      {
+        kind: "remote",
+        transport: "sandbox",
+        providerKey: "fake-plugin",
+        remoteCwd: "/tmp",
+        runner,
+      },
+      "agent-cli",
+      ["--json"],
+      {
+        cwd: "/tmp",
+        env: {},
+        timeoutSec: 5,
+        graceSec: 1,
+        onLog: async () => {},
+        denyEnvironmentKeys: ["OPENAI_API_KEY"],
+        runLogTail,
+      },
+    );
+
+    expect(wrapCommand).toHaveBeenCalledOnce();
+    const wrapped = wrapCommand.mock.results[0]?.value;
+    expect(wrapped?.command).toBe("sh");
+    expect(wrapped?.args).toEqual([
+      "-c",
+      expect.stringMatching(/unset .*paperclip_env_name.*exec 'agent-cli' '--json'/),
+    ]);
+    expect(runner.execute.mock.calls[0]?.[0]).toMatchObject(wrapped ?? {});
+  });
+
+  it("fails closed when the remote scrub cannot enumerate a restricted read-only PATH", async () => {
+    const shell = buildPostProfileEnvironmentScrubShell(
+      "printf 'TARGET_RAN'",
+      ["OPENAI_API_KEY"],
+    );
+    const result = await serverUtils.runChildProcess(
+      "profile-scrub-restricted-path",
+      "/bin/sh",
+      ["-c", `readonly PATH; export PATH; ${shell}`],
+      {
+        cwd: "/tmp",
+        env: { PATH: "/paperclip/definitely-missing" },
+        timeoutSec: 5,
+        graceSec: 1,
+        onLog: async () => {},
+      },
+    );
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).not.toContain("TARGET_RAN");
+  });
+
+  it("fails closed when a denied environment name is read-only", async () => {
+    const scrub = buildPostProfileEnvironmentScrubShell(
+      "printf 'TARGET_RAN'",
+      ["OPENAI_API_KEY"],
+    );
+    const result = await serverUtils.runChildProcess(
+      "profile-scrub-readonly-key",
+      "/bin/sh",
+      [
+        "-c",
+        `OPENAI_API_KEY=profile-secret; readonly OPENAI_API_KEY; export OPENAI_API_KEY; ${scrub}`,
+      ],
+      {
+        cwd: "/tmp",
+        env: {},
+        timeoutSec: 5,
+        graceSec: 1,
+        onLog: async () => {},
+      },
+    );
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout).not.toContain("TARGET_RAN");
+  });
+
+  it("disables inherited xtrace before environment values are captured", async () => {
+    const shell = buildPostProfileEnvironmentScrubShell(
+      "/bin/sh -c 'if [ -n \"${OPENAI_API_KEY+x}\" ]; then exit 99; fi; printf \"TARGET_RAN\"'",
+      ["OPENAI_API_KEY"],
+    );
+    const result = await serverUtils.runChildProcess(
+      "profile-scrub-xtrace",
+      "/bin/sh",
+      ["-xc", shell],
+      {
+        cwd: "/tmp",
+        env: {
+          OPENAI_API_KEY: "denied-xtrace-secret",
+          UNRELATED_SECRET: "ambient-xtrace-secret",
+        },
+        timeoutSec: 5,
+        graceSec: 1,
+        onLog: async () => {},
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("TARGET_RAN");
+    expect(result.stderr).not.toMatch(/denied-xtrace-secret|ambient-xtrace-secret/);
   });
 });
 

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -231,6 +231,13 @@ export interface AdapterExecutionTargetProcessOptions {
   cwd: string;
   env: Record<string, string>;
   stdin?: string;
+  /** Case-insensitive keys to remove only from the inherited host environment before spawn. */
+  omitInheritedEnvKeys?: readonly string[];
+  /**
+   * Case-insensitive keys that must be absent regardless of whether they came
+   * from host inheritance, explicit configuration, or a remote login profile.
+   */
+  denyEnvironmentKeys?: readonly string[];
   timeoutSec: number;
   graceSec: number;
   onLog: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
@@ -264,6 +271,89 @@ export interface AdapterExecutionTargetShellOptions {
   timeoutSec?: number;
   graceSec?: number;
   onLog?: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+}
+
+function normalizeOmittedEnvironmentKeys(keys: readonly string[] | undefined): string[] {
+  const normalized = new Map<string, string>();
+  for (const rawKey of keys ?? []) {
+    const key = rawKey.trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue;
+    normalized.set(key.toUpperCase(), key);
+  }
+  return [...normalized.values()];
+}
+
+function caseInsensitiveShellPattern(key: string): string {
+  return [...key]
+    .map((character) => {
+      const lower = character.toLowerCase();
+      const upper = character.toUpperCase();
+      return lower === upper ? character : `[${lower}${upper}]`;
+    })
+    .join("");
+}
+
+function withoutEnvironmentKeys(
+  env: Record<string, string>,
+  keys: readonly string[] | undefined,
+): Record<string, string> {
+  const denied = new Set(normalizeOmittedEnvironmentKeys(keys).map((key) => key.toUpperCase()));
+  if (denied.size === 0) return { ...env };
+  return Object.fromEntries(
+    Object.entries(env).filter(([key]) => !denied.has(key.toUpperCase())),
+  );
+}
+
+/**
+ * Builds the command body evaluated after a remote provider's login profile.
+ * Environment names are enumerated without serializing their values and are
+ * matched case-insensitively before the requested command is exec'd.
+ */
+export function buildPostProfileEnvironmentScrubShell(
+  commandShell: string,
+  denyEnvironmentKeys: readonly string[] | undefined,
+): string {
+  const keys = normalizeOmittedEnvironmentKeys(denyEnvironmentKeys);
+  if (keys.length === 0) return `exec ${commandShell}`;
+  const patterns = keys.map(caseInsensitiveShellPattern).join("|");
+  return [
+    // A remote login profile may enable shell xtrace. Disable it before any
+    // assignment can capture environment values into the trace stream.
+    "set +x || exit 126",
+    "unset _paperclip_env_dump _paperclip_env_entry _paperclip_env_name _paperclip_saved_ifs || exit 126",
+    "_paperclip_env_dump=$(command env) || exit 126",
+    "_paperclip_saved_ifs=$IFS",
+    "IFS='\n' || exit 126",
+    "for _paperclip_env_entry in $_paperclip_env_dump",
+    "do case \"$_paperclip_env_entry\" in *=*) _paperclip_env_name=${_paperclip_env_entry%%=*} ;; *) continue ;; esac",
+    `case \"$_paperclip_env_name\" in ${patterns}) unset \"$_paperclip_env_name\" || exit 126 ;; esac`,
+    "done",
+    "IFS=$_paperclip_saved_ifs || exit 126",
+    "_paperclip_env_dump=$(command env) || exit 126",
+    "IFS='\n' || exit 126",
+    "for _paperclip_env_entry in $_paperclip_env_dump",
+    "do case \"$_paperclip_env_entry\" in *=*) _paperclip_env_name=${_paperclip_env_entry%%=*} ;; *) continue ;; esac",
+    `case \"$_paperclip_env_name\" in ${patterns}) exit 126 ;; esac`,
+    "done",
+    "IFS=$_paperclip_saved_ifs || exit 126",
+    "unset _paperclip_env_dump _paperclip_env_entry _paperclip_env_name _paperclip_saved_ifs || exit 126",
+    `exec ${commandShell}`,
+  ].join("; ");
+}
+
+function wrapRemoteProcessWithPostProfileEnvironmentScrub(
+  command: string,
+  args: string[],
+  denyEnvironmentKeys: readonly string[] | undefined,
+): { command: string; args: string[] } {
+  if (normalizeOmittedEnvironmentKeys(denyEnvironmentKeys).length === 0) {
+    return { command, args };
+  }
+  const commandShell = [command, ...args].map(shellQuote).join(" ");
+  return {
+    command: "sh",
+    args: ["-c", buildPostProfileEnvironmentScrubShell(commandShell, denyEnvironmentKeys)],
+  };
 }
 
 export interface AdapterExecutionTargetPaperclipBridgeHandle {
@@ -786,18 +876,31 @@ export async function runAdapterExecutionTargetProcess(
   args: string[],
   options: AdapterExecutionTargetProcessOptions,
 ): Promise<RunProcessResult> {
+  const remoteProcess = target?.kind === "remote"
+    ? wrapRemoteProcessWithPostProfileEnvironmentScrub(
+        command,
+        args,
+        options.denyEnvironmentKeys,
+      )
+    : { command, args };
   if (target?.kind === "remote" && target.transport === "sandbox") {
     const runner = requireSandboxRunner(target);
-    const env = sanitizeRemoteExecutionEnv(options.env);
+    const env = withoutEnvironmentKeys(
+      sanitizeRemoteExecutionEnv(options.env),
+      options.denyEnvironmentKeys,
+    );
     await options.onRuntimeProgress?.({
       phase: "adapter_startup",
       message: "Starting adapter in environment",
     });
     const runLogTail = options.runLogTail?.create() ?? null;
-    let execCommand = command;
-    let execArgs = args;
+    let execCommand = remoteProcess.command;
+    let execArgs = remoteProcess.args;
     if (runLogTail) {
-      ({ command: execCommand, args: execArgs } = runLogTail.wrapCommand(command, args));
+      ({ command: execCommand, args: execArgs } = runLogTail.wrapCommand(
+        remoteProcess.command,
+        remoteProcess.args,
+      ));
       runLogTail.start(options.onLog);
     }
     try {
@@ -836,13 +939,18 @@ export async function runAdapterExecutionTargetProcess(
 
   const env =
     target?.kind === "remote" && target.transport === "ssh"
-      ? sanitizeRemoteExecutionEnv(options.env)
-      : options.env;
+      ? withoutEnvironmentKeys(
+          sanitizeRemoteExecutionEnv(options.env),
+          options.denyEnvironmentKeys,
+        )
+      : withoutEnvironmentKeys(options.env, options.denyEnvironmentKeys);
 
-  return await runChildProcess(runId, command, args, {
+  return await runChildProcess(runId, remoteProcess.command, remoteProcess.args, {
     cwd: options.cwd,
     env,
     stdin: options.stdin,
+    omitInheritedEnvKeys: options.omitInheritedEnvKeys,
+    denyEnvironmentKeys: options.denyEnvironmentKeys,
     timeoutSec: options.timeoutSec,
     graceSec: options.graceSec,
     onLog: options.onLog,

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -547,6 +547,90 @@ describe("adapter skill snapshots", () => {
 });
 
 describe("runChildProcess", () => {
+  it("omits selected inherited environment keys without mutating process.env", async () => {
+    const inheritedKey = "PAPERCLIP_TEST_OMITTED_INHERITED_SECRET";
+    const inheritedValue = process.env[inheritedKey];
+    process.env[inheritedKey] = "host-secret";
+    try {
+      const result = await runChildProcess(
+        randomUUID(),
+        process.execPath,
+        ["-e", `process.stdout.write(String(process.env.${inheritedKey} ?? "missing"))`],
+        {
+          cwd: process.cwd(),
+          env: {},
+          omitInheritedEnvKeys: [inheritedKey.toLowerCase()],
+          timeoutSec: 5,
+          graceSec: 1,
+          onLog: async () => {},
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe("missing");
+      expect(process.env[inheritedKey]).toBe("host-secret");
+    } finally {
+      if (inheritedValue === undefined) delete process.env[inheritedKey];
+      else process.env[inheritedKey] = inheritedValue;
+    }
+  });
+
+  it("keeps explicit configuration for an omitted inherited key", async () => {
+    const inheritedKey = "PAPERCLIP_TEST_EXPLICIT_ENV_OVERRIDE";
+    const inheritedValue = process.env[inheritedKey];
+    process.env[inheritedKey] = "host-secret";
+    try {
+      const result = await runChildProcess(
+        randomUUID(),
+        process.execPath,
+        ["-e", `process.stdout.write(String(process.env.${inheritedKey} ?? "missing"))`],
+        {
+          cwd: process.cwd(),
+          env: { [inheritedKey]: "explicit-config" },
+          omitInheritedEnvKeys: [inheritedKey],
+          timeoutSec: 5,
+          graceSec: 1,
+          onLog: async () => {},
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe("explicit-config");
+      expect(process.env[inheritedKey]).toBe("host-secret");
+    } finally {
+      if (inheritedValue === undefined) delete process.env[inheritedKey];
+      else process.env[inheritedKey] = inheritedValue;
+    }
+  });
+
+  it("denies selected environment keys from inherited and explicit sources", async () => {
+    const inheritedKey = "PAPERCLIP_TEST_DENIED_ENV_SECRET";
+    const inheritedValue = process.env[inheritedKey];
+    process.env[inheritedKey] = "host-secret";
+    try {
+      const result = await runChildProcess(
+        randomUUID(),
+        process.execPath,
+        ["-e", `process.stdout.write(String(process.env.${inheritedKey} ?? "missing"))`],
+        {
+          cwd: process.cwd(),
+          env: { [inheritedKey.toLowerCase()]: "explicit-secret" },
+          denyEnvironmentKeys: [inheritedKey],
+          timeoutSec: 5,
+          graceSec: 1,
+          onLog: async () => {},
+        },
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe("missing");
+      expect(process.env[inheritedKey]).toBe("host-secret");
+    } finally {
+      if (inheritedValue === undefined) delete process.env[inheritedKey];
+      else process.env[inheritedKey] = inheritedValue;
+    }
+  });
+
   it("does not arm a timeout when timeoutSec is 0", async () => {
     const result = await runChildProcess(
       randomUUID(),

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -3358,15 +3358,41 @@ export async function runChildProcess(
     onSpawn?: (meta: { pid: number; processGroupId: number | null; startedAt: string }) => Promise<void>;
     terminalResultCleanup?: TerminalResultCleanupOptions;
     stdin?: string;
+    /** Case-insensitive keys to remove only from the inherited host environment before spawn. */
+    omitInheritedEnvKeys?: readonly string[];
+    /** Case-insensitive keys to remove from inherited and explicit child environments. */
+    denyEnvironmentKeys?: readonly string[];
     remoteExecution?: RemoteExecutionSpec | null;
     localProcessSandbox?: LocalProcessSandboxOptions | null;
   },
 ): Promise<RunProcessResult> {
   const onLogError = opts.onLogError ?? ((err, id, msg) => console.warn({ err, runId: id }, msg));
   return new Promise<RunProcessResult>((resolve, reject) => {
+    const filterEnvironment = (
+      env: NodeJS.ProcessEnv,
+      keys: readonly string[] | undefined,
+    ): Record<string, string> => {
+      const denied = new Set(
+        (keys ?? [])
+          .map((key) => key.trim())
+          .filter((key) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(key))
+          .map((key) => key.toUpperCase()),
+      );
+      return Object.fromEntries(
+        Object.entries(env).filter(
+          (entry): entry is [string, string] =>
+            typeof entry[1] === "string" && !denied.has(entry[0].toUpperCase()),
+        ),
+      );
+    };
+    const inheritedEnv = filterEnvironment(
+      sanitizeInheritedPaperclipEnv(process.env),
+      opts.omitInheritedEnvKeys,
+    );
+    const explicitEnv = filterEnvironment(opts.env, opts.denyEnvironmentKeys);
     const rawMerged: NodeJS.ProcessEnv = {
-      ...sanitizeInheritedPaperclipEnv(process.env),
-      ...opts.env,
+      ...inheritedEnv,
+      ...explicitEnv,
     };
 
     // Strip Claude Code nesting-guard env vars so spawned `claude` processes
@@ -3384,17 +3410,23 @@ export async function runChildProcess(
       delete rawMerged[key];
     }
 
-    const mergedEnv = ensurePathInEnv(rawMerged);
+    const mergedEnv = filterEnvironment(
+      ensurePathInEnv(rawMerged),
+      opts.denyEnvironmentKeys,
+    );
     if (opts.localProcessSandbox?.homeDir) {
       mergedEnv.HOME = opts.localProcessSandbox.homeDir;
     }
     void resolveSpawnTarget(command, args, opts.cwd, mergedEnv, {
       remoteExecution: opts.remoteExecution ?? null,
-      remoteEnv: opts.remoteExecution ? opts.env : null,
+      remoteEnv: opts.remoteExecution ? explicitEnv : null,
       localProcessSandbox: opts.localProcessSandbox ?? null,
     })
       .then((target) => {
-        const childEnv = { ...mergedEnv, ...target.env };
+        const childEnv = filterEnvironment(
+          { ...mergedEnv, ...target.env },
+          opts.denyEnvironmentKeys,
+        );
         for (const [key, value] of Object.entries(childEnv)) {
           if (value === undefined) delete childEnv[key];
         }

--- a/packages/adapters/codex-local/src/server/acp.test.ts
+++ b/packages/adapters/codex-local/src/server/acp.test.ts
@@ -2,7 +2,11 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { AdapterExecutionContext, AdapterInvocationMeta } from "@paperclipai/adapter-utils";
+import type {
+  AdapterEnvironmentTestContext,
+  AdapterExecutionContext,
+  AdapterInvocationMeta,
+} from "@paperclipai/adapter-utils";
 import { runChildProcess } from "@paperclipai/adapter-utils/server-utils";
 
 // Every test in this file needs a real teardown, so the mock below delegates
@@ -25,6 +29,7 @@ import {
   buildCodexAcpConfig,
   createCodexAcpExecutor,
   nodeVersionMeetsCodexAcpMinimum,
+  probeCodexAcpLiveReply,
   resolveCodexAcpBillingIdentity,
   resolveCodexExecutionEngine,
   resolveCodexExecutionEngineForRun,
@@ -60,6 +65,34 @@ function createLocalSandboxRunner() {
   };
 }
 
+function createLocalSandboxRunnerWithSyncOut() {
+  const runner = createLocalSandboxRunner();
+  return {
+    ...runner,
+    syncOut: async (operations: Array<{
+      operationId: string;
+      files: Array<{ sourcePath: string; targetPath: string; mode?: number }>;
+    }>) => {
+      const results: Array<{ operationId: string; filesTransferred: number; bytesTransferred: number }> = [];
+      for (const operation of operations) {
+        let bytesTransferred = 0;
+        for (const file of operation.files) {
+          await fs.mkdir(path.dirname(file.targetPath), { recursive: true });
+          await fs.copyFile(file.sourcePath, file.targetPath);
+          await fs.chmod(file.targetPath, file.mode ?? 0o600);
+          bytesTransferred += (await fs.stat(file.targetPath)).size;
+        }
+        results.push({
+          operationId: operation.operationId,
+          filesTransferred: operation.files.length,
+          bytesTransferred,
+        });
+      }
+      return { operations: results };
+    },
+  };
+}
+
 type FakeRuntimeOptions = Record<string, unknown>;
 type FakeRuntimeEvent = { type: string; text?: string; stream?: string; tag?: string };
 type FakeRuntimeHandle = {
@@ -86,6 +119,7 @@ const originalPaperclipHome = process.env.PAPERCLIP_HOME;
 const originalPaperclipInstanceId = process.env.PAPERCLIP_INSTANCE_ID;
 const originalCodexHome = process.env.CODEX_HOME;
 const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
+const originalCodexApiKey = process.env.CODEX_API_KEY;
 
 // Older/newer ISO timestamps for the copy-back monotonic (strictly-newer)
 // decision predicate, plus a subscription-shaped auth.json fixture matching the
@@ -138,6 +172,8 @@ afterEach(async () => {
   else process.env.CODEX_HOME = originalCodexHome;
   if (originalOpenAiApiKey === undefined) delete process.env.OPENAI_API_KEY;
   else process.env.OPENAI_API_KEY = originalOpenAiApiKey;
+  if (originalCodexApiKey === undefined) delete process.env.CODEX_API_KEY;
+  else process.env.CODEX_API_KEY = originalCodexApiKey;
   await Promise.all(tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
 });
 
@@ -157,7 +193,7 @@ class FakeRuntime {
   constructor(
     readonly options: FakeRuntimeOptions,
     readonly events: FakeRuntimeEvent[] = [
-      { type: "text_delta", text: "hello", stream: "output", tag: "agent_message_chunk" },
+      { type: "text_delta", text: "Hello.", stream: "output", tag: "agent_message_chunk" },
     ],
     readonly terminal: FakeRuntimeTurnResult = { status: "completed", stopReason: "end_turn" },
   ) {}
@@ -283,6 +319,32 @@ function buildContext(root: string, overrides: Partial<AdapterExecutionContext> 
       },
     },
     onLog: async () => {},
+    ...overrides,
+  };
+}
+
+function liveProbePassed() {
+  return [{
+    code: "codex_hello_probe_passed",
+    level: "info" as const,
+    message: "Codex hello probe succeeded.",
+    detail: "Hello.",
+  }];
+}
+
+function buildEnvironmentContext(
+  root: string,
+  overrides: Partial<AdapterEnvironmentTestContext> = {},
+): AdapterEnvironmentTestContext {
+  return {
+    adapterType: "codex_local",
+    companyId: "company-1",
+    config: {
+      engine: "acp",
+      cwd: root,
+      model: "gpt-5.6-sol",
+      env: { OPENAI_API_KEY: "secret-key" },
+    },
     ...overrides,
   };
 }
@@ -504,21 +566,20 @@ describe("codex_local ACP lane", () => {
 
   it("reports ACP prerequisites for the ACP lane", async () => {
     const root = await makeTempRoot("paperclip-codex-acp-env-");
-    const commandPath = path.join(root, "bin", "codex-acp");
-    await fs.mkdir(path.dirname(commandPath), { recursive: true });
-    await fs.writeFile(commandPath, "#!/usr/bin/env sh\n", "utf8");
     setNodeVersion("v24.11.0");
 
-    const result = await testCodexAcpEnvironment({
-      adapterType: "codex_local",
-      companyId: "company-1",
-      config: {
-        engine: "acp",
-        cwd: root,
-        agentCommand: commandPath,
-        env: { OPENAI_API_KEY: "test-key" },
+    const result = await testCodexAcpEnvironment(
+      {
+        adapterType: "codex_local",
+        companyId: "company-1",
+        config: {
+          engine: "acp",
+          cwd: root,
+          env: { OPENAI_API_KEY: "test-key" },
+        },
       },
-    });
+      { liveProbe: async () => liveProbePassed() },
+    );
 
     expect(result.status).toBe("pass");
     expect(result.checks).toContainEqual(
@@ -541,9 +602,40 @@ describe("codex_local ACP lane", () => {
     );
   });
 
+  it("does not accept a custom ACP command as live Codex proof", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-custom-proof-");
+    const liveProbe = vi.fn(async () => liveProbePassed());
+    setNodeVersion("v24.11.0");
+
+    const result = await testCodexAcpEnvironment(
+      {
+        adapterType: "codex_local",
+        companyId: "company-1",
+        config: {
+          engine: "acp",
+          cwd: root,
+          agentCommand: "node ./fake-acp.js",
+          env: { OPENAI_API_KEY: "test-key" },
+        },
+      },
+      { liveProbe },
+    );
+
+    expect(result.status).toBe("fail");
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        code: "codex_acp_custom_command_unsupported_for_live_proof",
+        level: "error",
+      }),
+    );
+    expect(result.checks).not.toContainEqual(
+      expect.objectContaining({ code: "codex_hello_probe_passed" }),
+    );
+    expect(liveProbe).not.toHaveBeenCalled();
+  });
+
   it("detects shared managed Codex auth in ACP environment tests", async () => {
     const root = await makeTempRoot("paperclip-codex-acp-managed-auth-");
-    const commandPath = path.join(root, "bin", "codex-acp");
     const sharedCodexHome = path.join(root, "shared-codex-home");
     const managedAgentHome = path.join(
       root,
@@ -556,31 +648,30 @@ describe("codex_local ACP lane", () => {
       "agent-1",
       "codex-home",
     );
-    await fs.mkdir(path.dirname(commandPath), { recursive: true });
-    await fs.writeFile(commandPath, "#!/usr/bin/env sh\n", "utf8");
     await fs.mkdir(sharedCodexHome, { recursive: true });
     await fs.writeFile(path.join(sharedCodexHome, "auth.json"), '{"OPENAI_API_KEY":"sk-shared"}', "utf8");
     setNodeVersion("v24.11.0");
     process.env.CODEX_HOME = sharedCodexHome;
     delete process.env.OPENAI_API_KEY;
 
-    const result = await testCodexAcpEnvironment({
-      adapterType: "codex_local",
-      companyId: "company-1",
-      config: {
-        engine: "acp",
-        cwd: root,
-        agentCommand: commandPath,
-        env: { CODEX_HOME: managedAgentHome, OPENAI_API_KEY: "" },
+    const result = await testCodexAcpEnvironment(
+      {
+        adapterType: "codex_local",
+        companyId: "company-1",
+        config: {
+          engine: "acp",
+          cwd: root,
+          env: { CODEX_HOME: managedAgentHome, OPENAI_API_KEY: "" },
+        },
       },
-    });
+      { liveProbe: async () => liveProbePassed() },
+    );
 
     expect(result.status).toBe("pass");
     expect(result.checks).toContainEqual(
       expect.objectContaining({
         code: "codex_acp_native_auth_detected",
         level: "info",
-        detail: expect.stringContaining(sharedCodexHome),
       }),
     );
     expect(result.checks).not.toContainEqual(
@@ -592,7 +683,6 @@ describe("codex_local ACP lane", () => {
 
   it("explains the Paperclip server credential boundary when ACP auth is missing", async () => {
     const root = await makeTempRoot("paperclip-codex-acp-missing-auth-");
-    const commandPath = path.join(root, "bin", "codex-acp");
     const sharedCodexHome = path.join(root, "shared-codex-home");
     const managedAgentHome = path.join(
       root,
@@ -605,23 +695,29 @@ describe("codex_local ACP lane", () => {
       "agent-1",
       "codex-home",
     );
-    await fs.mkdir(path.dirname(commandPath), { recursive: true });
-    await fs.writeFile(commandPath, "#!/usr/bin/env sh\n", "utf8");
     await fs.mkdir(sharedCodexHome, { recursive: true });
     setNodeVersion("v24.11.0");
     process.env.CODEX_HOME = sharedCodexHome;
     delete process.env.OPENAI_API_KEY;
 
-    const result = await testCodexAcpEnvironment({
-      adapterType: "codex_local",
-      companyId: "company-1",
-      config: {
-        engine: "acp",
-        cwd: root,
-        agentCommand: commandPath,
-        env: { CODEX_HOME: managedAgentHome, OPENAI_API_KEY: "" },
+    const result = await testCodexAcpEnvironment(
+      {
+        adapterType: "codex_local",
+        companyId: "company-1",
+        config: {
+          engine: "acp",
+          cwd: root,
+          env: { CODEX_HOME: managedAgentHome, OPENAI_API_KEY: "" },
+        },
       },
-    });
+      {
+        liveProbe: async () => [{
+          code: "codex_hello_probe_auth_required",
+          level: "warn",
+          message: "Codex is available, but authentication is not ready.",
+        }],
+      },
+    );
 
     expect(result.status).toBe("warn");
     expect(result.checks).toContainEqual(
@@ -653,34 +749,41 @@ describe("codex_local ACP lane", () => {
     process.env.CODEX_HOME = sharedCodexHome;
     delete process.env.OPENAI_API_KEY;
 
-    const result = await testCodexAcpEnvironment({
-      adapterType: "codex_local",
-      companyId: "company-1",
-      config: {
-        engine: "acp",
-        cwd: root,
-        // A shell-style command resolves without a real binary in the sandbox.
-        agentCommand: "node ./fake-acp.js",
-        env: { CODEX_HOME: managedAgentHome, OPENAI_API_KEY: "" },
-      },
-      executionTarget: {
-        kind: "remote",
-        transport: "sandbox",
-        providerKey: "fake-plugin",
-        remoteCwd: "/work",
-        runner: {
-          execute: async () => ({
-            exitCode: 0,
-            signal: null,
-            timedOut: false,
-            stdout: "",
-            stderr: "",
-            pid: null,
-            startedAt: new Date().toISOString(),
-          }),
+    const result = await testCodexAcpEnvironment(
+      {
+        adapterType: "codex_local",
+        companyId: "company-1",
+        config: {
+          engine: "acp",
+          cwd: root,
+          env: { CODEX_HOME: managedAgentHome, OPENAI_API_KEY: "" },
         },
-      } as never,
-    });
+        executionTarget: {
+          kind: "remote",
+          transport: "sandbox",
+          providerKey: "fake-plugin",
+          remoteCwd: "/work",
+          runner: {
+            execute: async () => ({
+              exitCode: 0,
+              signal: null,
+              timedOut: false,
+              stdout: "",
+              stderr: "",
+              pid: null,
+              startedAt: new Date().toISOString(),
+            }),
+          },
+        } as never,
+      },
+      {
+        liveProbe: async () => [{
+          code: "codex_hello_probe_auth_required",
+          level: "warn",
+          message: "Codex is available, but authentication is not ready.",
+        }],
+      },
+    );
 
     // A missing-auth sandbox is a warning, not a failure, and it carries the
     // neutral canonical check code for the user interface.
@@ -691,6 +794,697 @@ describe("codex_local ACP lane", () => {
         level: "warn",
       }),
     );
+  });
+
+  it("does not create or validate a sandbox-only cwd on the Paperclip host", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-remote-only-cwd-");
+    const remoteOnlyCwd = path.join(root, "must-not-be-created-on-host");
+    setNodeVersion("v24.11.0");
+    const result = await testCodexAcpEnvironment(
+      buildEnvironmentContext(root, {
+        config: {
+          engine: "acp",
+          cwd: remoteOnlyCwd,
+          env: { OPENAI_API_KEY: "test-key" },
+        },
+        executionTarget: {
+          kind: "remote",
+          transport: "sandbox",
+          providerKey: "fake-plugin",
+          remoteCwd: root,
+          runner: createLocalSandboxRunner(),
+        } as never,
+      }),
+      { liveProbe: async () => liveProbePassed() },
+    );
+
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({ code: "codex_acp_cwd_valid", level: "info" }),
+    );
+    await expect(fs.lstat(remoteOnlyCwd)).rejects.toThrow();
+  });
+
+  it("runs a real ACP proof in an isolated one-shot workspace and disposes probe caches", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-live-proof-");
+    const dispose = vi.fn(async () => {});
+    let executionContext: AdapterExecutionContext | null = null;
+
+    const checks = await probeCodexAcpLiveReply(
+      buildEnvironmentContext(root),
+      {
+        engine: "acp",
+        cwd: root,
+        model: "gpt-5.6-sol",
+        env: { OPENAI_API_KEY: "secret-key" },
+        paperclipRuntimeSkills: [{ key: "must-not-sync" }],
+        paperclipSkillSync: { desiredSkills: ["must-not-sync"] },
+      },
+      {
+        createExecutor: (options) => {
+          options.stagedRuntimes?.set("probe", { dispose } as never);
+          return async (ctx) => {
+            executionContext = ctx;
+            await expect(fs.stat(String(ctx.config.cwd))).resolves.toBeDefined();
+            return {
+              exitCode: 0,
+              signal: null,
+              timedOut: false,
+              summary: "Hello.",
+            };
+          };
+        },
+      },
+    );
+
+    expect(checks).toEqual(liveProbePassed());
+    expect(JSON.stringify(checks)).not.toMatch(/secret-key|example\.test|private\/worktree/);
+    expect(executionContext).not.toBeNull();
+    const probeConfig = executionContext!.config;
+    const probeWorkspace = String(probeConfig.cwd);
+    expect(probeWorkspace).not.toBe(root);
+    expect(probeConfig).toMatchObject({
+      engine: "acp",
+      mode: "oneshot",
+      permissionMode: "deny-all",
+      nonInteractivePermissions: "fail",
+      model: "gpt-5.6-sol",
+      promptTemplate: "Reply with exactly Hello. Do not use tools.",
+    });
+    expect(probeConfig).not.toHaveProperty("paperclipRuntimeSkills");
+    expect(probeConfig).not.toHaveProperty("paperclipSkillSync");
+    expect(executionContext!.context).toMatchObject({
+      paperclipWorkspace: {
+        cwd: probeWorkspace,
+        source: "project_workspace",
+      },
+    });
+    expect(dispose).toHaveBeenCalledOnce();
+    await expect(fs.access(probeWorkspace)).rejects.toThrow();
+  });
+
+  it("materializes configured API auth at 0600 and removes every credential env copy", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-auth-file-");
+    const sourceHome = path.join(root, "source-home");
+    await fs.mkdir(sourceHome, { recursive: true });
+    await fs.writeFile(
+      path.join(sourceHome, "config.toml"),
+      '[mcp_servers.private]\nhttp_headers = { Authorization = "Bearer local-mcp-secret" }\n',
+      { mode: 0o600 },
+    );
+    const inheritedKeys = [
+      "OPENAI_API_KEY",
+      "CODEX_API_KEY",
+      "CODEX_AUTH_JSON",
+      "_PAPERCLIP_CODEX_AUTH_JSON",
+    ] as const;
+    const previous = Object.fromEntries(inheritedKeys.map((key) => [key, process.env[key]]));
+    for (const key of inheritedKeys) process.env[key] = `ambient-${key}`;
+    let executorOptions: Record<string, unknown> | null = null;
+    try {
+      const context = buildEnvironmentContext(root, {
+        config: {
+          engine: "acp",
+          cwd: root,
+          env: {
+            CODEX_HOME: sourceHome,
+            OPENAI_API_KEY: "configured-api-secret",
+            codex_auth_json: "must-be-stripped-case-insensitively",
+          },
+        },
+      });
+      const checks = await probeCodexAcpLiveReply(context, context.config, {
+        createExecutor: (options) => {
+          executorOptions = options as unknown as Record<string, unknown>;
+          return async (executionContext) => {
+            const env = executionContext.config.env as Record<string, string>;
+            expect(Object.keys(env).map((key) => key.toUpperCase())).not.toEqual(
+              expect.arrayContaining([...inheritedKeys]),
+            );
+            const authPath = path.join(env.CODEX_HOME!, "auth.json");
+            expect(env.CODEX_HOME).not.toBe(sourceHome);
+            expect(JSON.parse(await fs.readFile(authPath, "utf8"))).toEqual({
+              OPENAI_API_KEY: "configured-api-secret",
+            });
+            expect((await fs.stat(authPath)).mode & 0o777).toBe(0o600);
+            await expect(fs.lstat(path.join(env.CODEX_HOME!, "config.toml"))).rejects.toThrow();
+            return { exitCode: 0, signal: null, timedOut: false, summary: "Hello." };
+          };
+        },
+      });
+
+      expect(checks).toEqual(liveProbePassed());
+      expect(executorOptions).toMatchObject({
+        denyEnvironmentKeys: [...inheritedKeys],
+        skipRuntimeSkillPreparation: true,
+      });
+      expect(executorOptions).not.toHaveProperty("omitInheritedEnvKeys");
+      expect(JSON.stringify(checks)).not.toMatch(
+        /configured-api-secret|must-be-stripped-case-insensitively|local-mcp-secret|ambient-/,
+      );
+    } finally {
+      for (const key of inheritedKeys) {
+        const value = previous[key];
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  });
+
+  it("uses the durable local subscription home so token rotation persists immediately", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-local-rotation-");
+    const sourceHome = path.join(root, "source-home");
+    const sourceAuthPath = path.join(sourceHome, "auth.json");
+    const older = subscriptionAuthJson("acct-local", OLDER_REFRESH, "local-older");
+    const newer = subscriptionAuthJson("acct-local", NEWER_REFRESH, "local-newer");
+    await fs.mkdir(sourceHome, { recursive: true });
+    await fs.writeFile(sourceAuthPath, older, { mode: 0o600 });
+    const context = buildEnvironmentContext(root, {
+      config: {
+        engine: "acp",
+        cwd: root,
+        env: { CODEX_HOME: sourceHome },
+      },
+    });
+
+    const checks = await probeCodexAcpLiveReply(context, context.config, {
+      createExecutor: () => async (executionContext) => {
+        const probeHome = String((executionContext.config.env as Record<string, string>).CODEX_HOME);
+        expect(probeHome).toBe(sourceHome);
+        await fs.writeFile(path.join(probeHome, "auth.json"), newer, { mode: 0o600 });
+        return { exitCode: 0, signal: null, timedOut: false, summary: "Hello." };
+      },
+    });
+
+    expect(checks).toEqual(liveProbePassed());
+    expect(await fs.readFile(sourceAuthPath, "utf8")).toBe(newer);
+    expect((await fs.stat(sourceAuthPath)).mode & 0o777).toBe(0o600);
+  });
+
+  it("does not reconcile runtime skills inside the durable subscription home", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-local-skill-isolation-");
+    const sourceHome = path.join(root, "source-home");
+    const sourceAuthPath = path.join(sourceHome, "auth.json");
+    const skillsHome = path.join(sourceHome, "skills");
+    const managedSkill = path.join(skillsHome, "keep-existing");
+    const manifestPath = path.join(skillsHome, ".paperclip-managed-skills.json");
+    const manifest = `${JSON.stringify({
+      version: 1,
+      managedSkillNames: ["keep-existing"],
+    }, null, 2)}\n`;
+    await fs.mkdir(managedSkill, { recursive: true });
+    await fs.writeFile(
+      sourceAuthPath,
+      subscriptionAuthJson("acct-local-skill", OLDER_REFRESH, "local-skill"),
+      { mode: 0o600 },
+    );
+    await fs.writeFile(path.join(managedSkill, "SKILL.md"), "operator-owned skill\n", "utf8");
+    await fs.writeFile(manifestPath, manifest, "utf8");
+    const context = buildEnvironmentContext(root, {
+      config: {
+        engine: "acp",
+        cwd: root,
+        env: { CODEX_HOME: sourceHome },
+      },
+    });
+
+    const checks = await probeCodexAcpLiveReply(context, context.config, {
+      createExecutor: (options) => createCodexAcpExecutor({
+        ...options,
+        createRuntime: (runtimeOptions: FakeRuntimeOptions) =>
+          new FakeRuntime(runtimeOptions) as never,
+      }),
+    });
+
+    expect(checks).toEqual(liveProbePassed());
+    await expect(fs.readFile(path.join(managedSkill, "SKILL.md"), "utf8"))
+      .resolves.toBe("operator-owned skill\n");
+    await expect(fs.readFile(manifestPath, "utf8")).resolves.toBe(manifest);
+  });
+
+  it("rejects a sandbox subscription probe before execution even when sync-out exists", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-remote-rotation-");
+    const sourceHome = path.join(root, "source-home");
+    const sourceAuthPath = path.join(sourceHome, "auth.json");
+    const older = subscriptionAuthJson("acct-remote", OLDER_REFRESH, "remote-older");
+    await fs.mkdir(sourceHome, { recursive: true });
+    await fs.writeFile(sourceAuthPath, older, { mode: 0o600 });
+    const context = buildEnvironmentContext(root, {
+      config: {
+        engine: "acp",
+        cwd: root,
+        env: { CODEX_HOME: sourceHome },
+      },
+      executionTarget: {
+        kind: "remote",
+        transport: "sandbox",
+        providerKey: "local-rotation-fixture",
+        remoteCwd: path.join(root, "operator-workspace"),
+        runner: createLocalSandboxRunnerWithSyncOut(),
+      } as never,
+    });
+    const execute = vi.fn(async () => ({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      summary: "Hello.",
+    }));
+
+    const checks = await probeCodexAcpLiveReply(context, context.config, {
+      createExecutor: () => execute,
+    });
+
+    expect(checks).toEqual([
+      expect.objectContaining({ code: "codex_hello_probe_failed", level: "error" }),
+    ]);
+    expect(execute).not.toHaveBeenCalled();
+    expect(await fs.readFile(sourceAuthPath, "utf8")).toBe(older);
+    expect((await fs.stat(sourceAuthPath)).mode & 0o777).toBe(0o600);
+  });
+
+  it("rejects inline and sandbox subscription auth before execution", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-copyback-unavailable-");
+    const sourceHome = path.join(root, "source-home");
+    const sourceAuthPath = path.join(sourceHome, "auth.json");
+    const older = subscriptionAuthJson("acct-blocked", OLDER_REFRESH, "blocked-older");
+    await fs.mkdir(sourceHome, { recursive: true });
+    await fs.writeFile(sourceAuthPath, older, { mode: 0o600 });
+    const execute = vi.fn(async () => ({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      summary: "Hello.",
+    }));
+
+    const configuredChecks = await probeCodexAcpLiveReply(
+      buildEnvironmentContext(root),
+      {
+        engine: "acp",
+        cwd: root,
+        env: { CODEX_AUTH_JSON: older },
+      },
+      { execute },
+    );
+    const sandboxContext = buildEnvironmentContext(root, {
+      config: { engine: "acp", cwd: root, env: { CODEX_HOME: sourceHome } },
+      executionTarget: {
+        kind: "remote",
+        transport: "sandbox",
+        providerKey: "no-sync-out",
+        remoteCwd: "/operator/workspace",
+        runner: createLocalSandboxRunner(),
+      } as never,
+    });
+    const sandboxChecks = await probeCodexAcpLiveReply(
+      sandboxContext,
+      sandboxContext.config,
+      { execute },
+    );
+
+    for (const checks of [configuredChecks, sandboxChecks]) {
+      expect(checks).toEqual([
+        expect.objectContaining({ code: "codex_hello_probe_failed", level: "error" }),
+      ]);
+      expect(JSON.stringify(checks)).not.toMatch(/blocked-older|acct-blocked|ref-blocked/);
+    }
+    expect(execute).not.toHaveBeenCalled();
+    expect(await fs.readFile(sourceAuthPath, "utf8")).toBe(older);
+  });
+
+  it("stages a sandbox proof under an isolated remote root and preserves operator files", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-isolated-sandbox-");
+    const operatorRemoteCwd = path.join(root, "operator-workspace");
+    const sourceHome = path.join(root, "source-codex-home");
+    const sentinelPath = path.join(operatorRemoteCwd, "sentinel.txt");
+    await fs.mkdir(operatorRemoteCwd, { recursive: true });
+    await fs.mkdir(sourceHome, { recursive: true });
+    await fs.writeFile(sentinelPath, "operator-owned-bytes", "utf8");
+    await fs.writeFile(
+      path.join(sourceHome, "auth.json"),
+      JSON.stringify({ OPENAI_API_KEY: "sandbox-auth-secret" }),
+      { mode: 0o600 },
+    );
+    await fs.writeFile(
+      path.join(sourceHome, "config.toml"),
+      '[mcp_servers.private]\nhttp_headers = { Authorization = "Bearer sandbox-mcp-secret" }\n',
+      { mode: 0o600 },
+    );
+    const runtimes: FakeRuntime[] = [];
+    const stagePayloads: Array<Record<string, unknown>> = [];
+    const localRunner = createLocalSandboxRunner();
+    const runner = {
+      ...localRunner,
+      execute: async (input: Parameters<typeof localRunner.execute>[0]) => {
+        if (input.stdin) {
+          try {
+            const payload = JSON.parse(input.stdin) as Record<string, unknown>;
+            if (Object.prototype.hasOwnProperty.call(payload, "authJson")) {
+              stagePayloads.push(payload);
+            }
+          } catch {
+            // The remote ACP process bridge also writes JSON-RPC frames to stdin.
+          }
+        }
+        return localRunner.execute(input);
+      },
+    };
+    const context = buildEnvironmentContext(root, {
+      config: {
+        engine: "acp",
+        cwd: root,
+        model: "gpt-5.6-sol",
+        env: { CODEX_HOME: sourceHome },
+      },
+      executionTarget: {
+        kind: "remote",
+        transport: "sandbox",
+        providerKey: "fake-plugin",
+        remoteCwd: operatorRemoteCwd,
+        runner,
+      } as never,
+    });
+
+    const checks = await probeCodexAcpLiveReply(context, context.config, {
+      createExecutor: (options) => createCodexAcpExecutor({
+        ...options,
+        createRuntime: (runtimeOptions: FakeRuntimeOptions) => {
+          const runtime = new FakeRuntime(runtimeOptions);
+          runtimes.push(runtime);
+          return runtime as never;
+        },
+      }),
+    });
+
+    expect(checks).toEqual(liveProbePassed());
+    expect(await fs.readFile(sentinelPath, "utf8")).toBe("operator-owned-bytes");
+    const remoteProbeCwd = String(runtimes[0]?.options.cwd ?? "");
+    expect(remoteProbeCwd).toMatch(/^\/tmp\/paperclip-codex-acp-envtest-/);
+    expect(remoteProbeCwd).not.toBe(operatorRemoteCwd);
+    await expect(fs.lstat(remoteProbeCwd)).rejects.toThrow();
+    expect(stagePayloads).toHaveLength(1);
+    expect(stagePayloads[0]).toEqual(expect.objectContaining({ authJson: expect.any(String) }));
+    expect(stagePayloads[0]).not.toHaveProperty("configToml");
+    expect(JSON.stringify(stagePayloads)).not.toContain("sandbox-mcp-secret");
+  });
+
+  it("runs remote removal and dangling-link verification and lets cleanup failure dominate", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-remote-cleanup-failure-");
+    const calls: Array<{ command: string; args: string[]; env?: Record<string, string> }> = [];
+    const runner = {
+      execute: async (input: {
+        command: string;
+        args?: string[];
+        env?: Record<string, string>;
+      }) => {
+        calls.push({ command: input.command, args: input.args ?? [], env: input.env });
+        const launchText = [input.command, ...(input.args ?? [])].join(" ");
+        return {
+          exitCode: launchText.includes("exec 'rm' '-rf'") ? 1 : 0,
+          signal: null,
+          timedOut: false,
+          stdout: "",
+          stderr: "",
+          pid: null,
+          startedAt: new Date().toISOString(),
+        };
+      },
+    };
+    const context = buildEnvironmentContext(root, {
+      executionTarget: {
+        kind: "remote",
+        transport: "sandbox",
+        providerKey: "fake-plugin",
+        remoteCwd: "/operator/workspace",
+        runner,
+      } as never,
+    });
+    const checks = await probeCodexAcpLiveReply(context, context.config, {
+      execute: async () => ({ exitCode: 0, signal: null, timedOut: false, summary: "Hello." }),
+    });
+
+    expect(checks).toEqual([
+      expect.objectContaining({ code: "codex_hello_probe_cleanup_failed", level: "error" }),
+    ]);
+    const launchText = calls.map((call) => [call.command, ...call.args].join(" ")).join("\n");
+    expect(launchText).toContain("exec 'rm' '-rf'");
+    expect(launchText).toContain('[ ! -e "$1" ] && [ ! -L "$1" ]');
+    expect(JSON.stringify(calls)).not.toMatch(/sandbox-auth-secret|configured-api-secret/);
+  });
+
+  it("canonicalizes probe temp allocation failures without leaking raw errors", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-mkdtemp-failure-");
+    const realMkdtemp = fs.mkdtemp.bind(fs);
+    const mkdtempSpy = vi.spyOn(fs, "mkdtemp").mockImplementationOnce(async () => {
+      throw new Error("sk-temp-secret user@example.test /private/probe-root");
+    });
+    try {
+      const checks = await probeCodexAcpLiveReply(
+        buildEnvironmentContext(root),
+        buildEnvironmentContext(root).config,
+      );
+      expect(checks).toEqual([
+        expect.objectContaining({ code: "codex_hello_probe_failed", level: "error" }),
+      ]);
+      expect(JSON.stringify(checks)).not.toMatch(/sk-temp-secret|example\.test|private\/probe-root/);
+    } finally {
+      mkdtempSpy.mockRestore();
+      void realMkdtemp;
+    }
+  });
+
+  it("fails closed when the real ACP lifecycle cannot close its runtime", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-cleanup-error-");
+    const close = vi.fn(async () => {
+      throw new Error("sk-close-secret /private/runtime");
+    });
+
+    const checks = await probeCodexAcpLiveReply(
+      buildEnvironmentContext(root),
+      buildEnvironmentContext(root).config,
+      {
+        createExecutor: (options) => createCodexAcpExecutor({
+          ...options,
+          createRuntime: (runtimeOptions: FakeRuntimeOptions) => {
+            const runtime = new FakeRuntime(runtimeOptions);
+            runtime.close = close;
+            return runtime as never;
+          },
+        }),
+      },
+    );
+
+    expect(close).toHaveBeenCalledOnce();
+    expect(checks).toEqual([
+      expect.objectContaining({
+        code: "codex_hello_probe_cleanup_failed",
+        level: "error",
+      }),
+    ]);
+    expect(JSON.stringify(checks)).not.toMatch(/sk-close-secret|private\/runtime/);
+  });
+
+  it("fails closed when the isolated probe root cannot be removed", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-cleanup-root-error-");
+    const probePrefix = "paperclip-codex-acp-envtest-";
+    const before = new Set(
+      (await fs.readdir(os.tmpdir())).filter((name) => name.startsWith(probePrefix)),
+    );
+    const realRm = fs.rm.bind(fs);
+    const rmSpy = vi.spyOn(fs, "rm").mockImplementation(async (candidate, options) => {
+      if (
+        options?.recursive === true &&
+        path.basename(String(candidate)).startsWith(probePrefix)
+      ) {
+        throw new Error("sk-cleanup-secret user@example.test /private/probe-home");
+      }
+      return realRm(candidate, options);
+    });
+    try {
+      const context = buildEnvironmentContext(root);
+      const checks = await probeCodexAcpLiveReply(context, context.config, {
+        execute: async () => ({
+          exitCode: 0,
+          signal: null,
+          timedOut: false,
+          summary: "Hello.",
+        }),
+      });
+
+      expect(checks).toEqual([
+        expect.objectContaining({
+          code: "codex_hello_probe_cleanup_failed",
+          level: "error",
+        }),
+      ]);
+      expect(JSON.stringify(checks)).not.toMatch(
+        /sk-cleanup-secret|example\.test|private\/probe-home/,
+      );
+    } finally {
+      rmSpy.mockRestore();
+      const probeDirs = (await fs.readdir(os.tmpdir()))
+        .filter((name) => name.startsWith(probePrefix) && !before.has(name))
+        .map((name) => path.join(os.tmpdir(), name));
+      await Promise.all(
+        probeDirs.map((dir) => fs.rm(dir, { recursive: true, force: true })),
+      );
+    }
+  });
+
+  it("never exposes unexpected or failed ACP provider output in diagnostics", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-redaction-");
+    const rawEvidence = "sk-secret user@example.test /private/worktree";
+    const results = [
+      {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        summary: `Not hello ${rawEvidence}`,
+      },
+      {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        summary: `Hello. ${rawEvidence}`,
+      },
+      {
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        summary: rawEvidence,
+        errorMessage: rawEvidence,
+        errorMeta: { rawEvidence },
+        resultJson: { stopReason: rawEvidence },
+      },
+    ];
+
+    for (const result of results) {
+      const checks = await probeCodexAcpLiveReply(
+        buildEnvironmentContext(root),
+        buildEnvironmentContext(root).config,
+        { execute: async () => result },
+      );
+      expect(JSON.stringify(checks)).not.toMatch(/sk-secret|example\.test|private\/worktree/);
+      expect(checks).not.toContainEqual(expect.objectContaining({ code: "codex_hello_probe_passed" }));
+    }
+  });
+
+  it("classifies ACP auth families canonically for sandbox probes", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-auth-classification-");
+    const context = buildEnvironmentContext(root, {
+      executionTarget: {
+        kind: "remote",
+        transport: "sandbox",
+        providerKey: "fixture",
+        remoteCwd: "/work",
+        runner: createLocalSandboxRunner(),
+      } as never,
+    });
+
+    for (const result of [
+      { errorCode: "acpx_auth_required" as const },
+      { errorFamily: "refresh_token_reused" as const },
+    ]) {
+      const checks = await probeCodexAcpLiveReply(context, context.config, {
+        execute: async () => ({
+          exitCode: 1,
+          signal: null,
+          timedOut: false,
+          summary: "sensitive provider failure",
+          ...result,
+        }),
+      });
+      expect(checks.map((check) => check.code)).toEqual([
+        "codex_hello_probe_auth_required",
+        "adapter_auth_missing",
+      ]);
+      expect(JSON.stringify(checks)).not.toContain("sensitive provider failure");
+    }
+  });
+
+  it("fails closed when ACP workspace or authentication copy-back cannot be restored", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-restore-failure-");
+    const checks = await probeCodexAcpLiveReply(
+      buildEnvironmentContext(root),
+      buildEnvironmentContext(root).config,
+      {
+        execute: async () => ({
+          exitCode: 0,
+          signal: null,
+          timedOut: true,
+          summary: "Hello. leaked-refresh-token",
+          resultJson: { workspaceRestoreFailure: "sensitive-copy-back-detail" },
+        }),
+      },
+    );
+
+    expect(checks).toEqual([
+      expect.objectContaining({
+        code: "codex_hello_probe_cleanup_failed",
+        level: "error",
+      }),
+    ]);
+    expect(JSON.stringify(checks)).not.toMatch(/leaked-refresh-token|sensitive-copy-back-detail/);
+  });
+
+  it("lets the live turn validate CODEX_API_KEY and removes stale predictive auth warnings", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-codex-api-key-");
+    setNodeVersion("v24.11.0");
+
+    const result = await testCodexAcpEnvironment(
+      buildEnvironmentContext(root, {
+        config: {
+          engine: "acp",
+          cwd: root,
+          env: { CODEX_API_KEY: "codex-key" },
+        },
+      }),
+      { liveProbe: async () => liveProbePassed() },
+    );
+
+    expect(result.status).toBe("pass");
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({ code: "codex_hello_probe_passed" }),
+    );
+    expect(result.checks).not.toContainEqual(
+      expect.objectContaining({ code: "codex_acp_credentials_missing" }),
+    );
+  });
+
+  it("does not start an ACP live turn for unsupported SSH targets", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-ssh-proof-");
+    const liveProbe = vi.fn(async () => liveProbePassed());
+    setNodeVersion("v24.11.0");
+
+    const result = await testCodexAcpEnvironment(
+      buildEnvironmentContext(root, {
+        config: {
+          engine: "acp",
+          cwd: root,
+          agentCommand: "node ./fake-acp.js",
+        },
+        executionTarget: {
+          kind: "remote",
+          transport: "ssh",
+          remoteCwd: "/work",
+          spec: {
+            host: "127.0.0.1",
+            port: 22,
+            username: "fixture",
+            remoteCwd: "/work",
+            remoteWorkspacePath: "/work",
+            privateKey: null,
+            knownHosts: null,
+            strictHostKeyChecking: true,
+          },
+        } as never,
+      }),
+      { liveProbe },
+    );
+
+    expect(result.status).toBe("fail");
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({ code: "codex_acp_remote_target_unsupported", level: "error" }),
+    );
+    expect(liveProbe).not.toHaveBeenCalled();
   });
 
   it("executes through ACPX with Codex session config and ephemeral skills", async () => {

--- a/packages/adapters/codex-local/src/server/acp.ts
+++ b/packages/adapters/codex-local/src/server/acp.ts
@@ -1,5 +1,7 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
+import { randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import type {
   AdapterBillingType,
@@ -16,8 +18,10 @@ import {
 import { inferOpenAiCompatibleBiller } from "@paperclipai/adapter-utils";
 import {
   ensureAdapterExecutionTargetCommandResolvable,
+  overrideAdapterExecutionTargetRemoteCwd,
   readAdapterExecutionTarget,
   resolveAdapterExecutionTargetCwd,
+  runAdapterExecutionTargetProcess,
 } from "@paperclipai/adapter-utils/execution-target";
 import {
   DEFAULT_ACP_ENGINE_MODE,
@@ -41,15 +45,51 @@ import { classifyCodexAuthRefreshFailure } from "./parse.js";
 import { copyBackCodexAuth } from "./codex-auth-copyback.js";
 import { buildCodexAuthInboundProvision } from "./codex-auth-merge-scripts.js";
 import {
+  codexHomeHasUsableAuth,
   evaluateCodexCredentialReadiness,
   resolveSharedCodexHomeDir,
   stageCodexHomeForSync,
 } from "./codex-home.js";
 import { ADAPTER_AUTH_MISSING_CHECK_CODE } from "./auth-check.js";
+import {
+  classifyCodexProbeAuth,
+  snapshotDurableCodexProbeAuth,
+} from "./codex-probe-auth.js";
 
 const moduleDir = path.dirname(fileURLToPath(import.meta.url));
 const packageRootDir = path.resolve(moduleDir, "../..");
 const MIN_ACP_NODE_VERSION = "24.11.0";
+const CODEX_AUTH_REQUIRED_RE =
+  /(?:not\s+logged\s+in|login\s+required|authentication\s+required|unauthorized|invalid(?:\s+or\s+missing)?\s+api(?:[_\s-]?key)?|openai[_\s-]?api[_\s-]?key|api[_\s-]?key.*required|please\s+run\s+`?codex\s+login`?)/i;
+const CODEX_ACP_PROBE_AUTH_ENV_KEY_NAMES = [
+  "OPENAI_API_KEY",
+  "CODEX_API_KEY",
+  "CODEX_AUTH_JSON",
+  "_PAPERCLIP_CODEX_AUTH_JSON",
+] as const;
+const CODEX_ACP_PROBE_AUTH_ENV_KEYS = new Set<string>(
+  CODEX_ACP_PROBE_AUTH_ENV_KEY_NAMES,
+);
+const CODEX_ACP_PROBE_HOME_STAGE_SCRIPT = [
+  "set -eu",
+  "umask 077",
+  `node -e '${[
+    'const fs=require("node:fs")',
+    'const path=require("node:path")',
+    'const home=process.env.CODEX_HOME',
+    'if(!home)throw new Error("missing probe home")',
+    'const parent=path.dirname(home)',
+    'fs.mkdirSync(parent,{recursive:true,mode:0o700})',
+    'fs.chmodSync(parent,0o700)',
+    'const parentStat=fs.lstatSync(parent)',
+    'if(!parentStat.isDirectory()||parentStat.isSymbolicLink())throw new Error("invalid probe parent")',
+    'fs.mkdirSync(home,{mode:0o700})',
+    'const homeStat=fs.lstatSync(home)',
+    'if(!homeStat.isDirectory()||homeStat.isSymbolicLink())throw new Error("invalid probe home")',
+    'const payload=JSON.parse(fs.readFileSync(0,"utf8"))',
+    'if(typeof payload.authJson==="string")fs.writeFileSync(path.join(home,"auth.json"),Buffer.from(payload.authJson,"base64"),{mode:0o600,flag:"wx"})',
+  ].join(";")}'`,
+].join("; ");
 
 export type CodexExecutionEngine = "cli" | "acp";
 
@@ -484,10 +524,508 @@ function isNonEmpty(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+type CodexAcpLiveProbeExecutor = (
+  ctx: AdapterExecutionContext,
+) => Promise<AdapterExecutionResult>;
+
+type CodexAcpLiveProbeOptions = {
+  execute?: CodexAcpLiveProbeExecutor;
+  createExecutor?: (options: CodexAcpExecutorOptions) => CodexAcpLiveProbeExecutor;
+};
+
+function buildCodexAcpAuthRequiredChecks(targetIsSandbox: boolean): AdapterEnvironmentCheck[] {
+  const checks: AdapterEnvironmentCheck[] = [
+    {
+      code: "codex_hello_probe_auth_required",
+      level: "warn",
+      message: "Codex is available, but authentication is not ready.",
+      hint: "Configure Codex authentication in the selected environment and retry the live test.",
+    },
+  ];
+  if (targetIsSandbox) {
+    checks.push({
+      code: ADAPTER_AUTH_MISSING_CHECK_CODE,
+      level: "warn",
+      message: "This environment has no ready authentication for this adapter.",
+      hint: "Provide credentials for this adapter, or start login in the environment.",
+    });
+  }
+  return checks;
+}
+
+function classifyCodexAcpLiveProbeResult(
+  result: AdapterExecutionResult,
+  targetIsSandbox: boolean,
+): AdapterEnvironmentCheck[] {
+  const resultJson = parseObject(result.resultJson);
+  if (isNonEmpty(resultJson.workspaceRestoreFailure)) {
+    return [{
+      code: "codex_hello_probe_cleanup_failed",
+      level: "error",
+      message: "Codex replied, but environment cleanup did not complete safely.",
+      hint: "Repair Codex authentication in the selected environment, then retry the live test.",
+    }];
+  }
+
+  if (result.timedOut) {
+    return [{
+      code: "codex_hello_probe_timed_out",
+      level: "warn",
+      message: "Codex hello probe timed out.",
+      hint: "Retry the live test after verifying Codex can reach its model provider.",
+    }];
+  }
+
+  const summary = result.summary?.trim() ?? "";
+  if ((result.exitCode ?? 1) === 0) {
+    const hasHello = summary === "Hello.";
+    return [{
+      code: hasHello ? "codex_hello_probe_passed" : "codex_hello_probe_unexpected_output",
+      level: hasHello ? "info" : "warn",
+      message: hasHello
+        ? "Codex hello probe succeeded."
+        : "Codex probe ran but did not return `hello` as expected.",
+      ...(hasHello ? { detail: "Hello." } : {}),
+      ...(!hasHello ? { hint: "Retry the live test before hiring this agent." } : {}),
+    }];
+  }
+
+  const classifiedError = firstNonEmptyString(
+    result.errorCode,
+    result.errorFamily,
+    resultJson.errorFamily,
+  );
+  if (
+    classifiedError === "acpx_auth_required" ||
+    classifiedError?.startsWith("refresh_token_")
+  ) {
+    return buildCodexAcpAuthRequiredChecks(targetIsSandbox);
+  }
+
+  const stopReason = asString(resultJson.stopReason, "");
+  const authEvidence = [result.errorMessage ?? "", summary, stopReason].join("\n");
+  if (CODEX_AUTH_REQUIRED_RE.test(authEvidence)) {
+    return buildCodexAcpAuthRequiredChecks(targetIsSandbox);
+  }
+  return [{
+    code: "codex_hello_probe_failed",
+    level: "error",
+    message: "Codex hello probe failed.",
+    hint: "Verify the selected Codex model, authentication, and execution environment, then retry.",
+  }];
+}
+
+function isCodexAcpCleanupFailureLog(
+  stream: "stdout" | "stderr",
+  chunk: string,
+): boolean {
+  if (stream !== "stderr") return false;
+  return (
+    (chunk.includes('[paperclip] ACPX teardown step "') && chunk.includes('" failed:')) ||
+    chunk.includes("[paperclip] Failed to remove staged Codex home ") ||
+    chunk.includes("[paperclip] Codex ACP teardown restore/copy-back failed:")
+  );
+}
+
+function codexAcpProbeFailedCheck(): AdapterEnvironmentCheck[] {
+  return [{
+    code: "codex_hello_probe_failed",
+    level: "error",
+    message: "Codex hello probe failed.",
+    hint: "Verify the selected Codex model, authentication, and execution environment, then retry.",
+  }];
+}
+
+function codexAcpProbeCleanupFailedCheck(): AdapterEnvironmentCheck[] {
+  return [{
+    code: "codex_hello_probe_cleanup_failed",
+    level: "error",
+    message: "Codex replied, but environment cleanup did not complete safely.",
+    hint: "Retry the live test after checking the selected environment's runtime health.",
+  }];
+}
+
+function stripCodexAcpProbeAuthEnv(env: Record<string, unknown>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(env).filter(
+      (entry): entry is [string, string] =>
+        typeof entry[1] === "string" &&
+        !CODEX_ACP_PROBE_AUTH_ENV_KEYS.has(entry[0].toUpperCase()),
+    ),
+  );
+}
+
+async function materializeCodexAcpProbeHome(input: {
+  probeRoot: string;
+  runId: string;
+  companyId: string;
+  config: Record<string, unknown>;
+  targetIsSandbox: boolean;
+}): Promise<{
+  probeHome: string;
+}> {
+  const configEnv = parseObject(input.config.env);
+  const configuredCodexHome = isNonEmpty(configEnv.CODEX_HOME)
+    ? configEnv.CODEX_HOME
+    : null;
+  const readiness = await evaluateCodexCredentialReadiness({
+    env: process.env,
+    companyId: input.companyId,
+    configuredCodexHome,
+    configuredApiKey: null,
+  });
+  const sourceHome = readiness.managed &&
+      !(await codexHomeHasUsableAuth(readiness.effectiveHome))
+    ? readiness.sharedSourceHome
+    : readiness.effectiveHome;
+  const configuredAuthJson = firstNonEmptyString(
+    configEnv.CODEX_AUTH_JSON,
+    configEnv._PAPERCLIP_CODEX_AUTH_JSON,
+  );
+  const configDefinesApiKey =
+    Object.prototype.hasOwnProperty.call(configEnv, "OPENAI_API_KEY") ||
+    Object.prototype.hasOwnProperty.call(configEnv, "CODEX_API_KEY");
+  const configuredApiKey = firstNonEmptyString(
+    configEnv.OPENAI_API_KEY,
+    configEnv.CODEX_API_KEY,
+  );
+  const hostApiKey = input.targetIsSandbox || configDefinesApiKey
+    ? null
+    : firstNonEmptyString(process.env.OPENAI_API_KEY, process.env.CODEX_API_KEY);
+  const apiKey = configuredApiKey ?? hostApiKey;
+  const authJson = configuredAuthJson ?? (
+    apiKey ? JSON.stringify({ OPENAI_API_KEY: apiKey }) : null
+  );
+  if (authJson && classifyCodexProbeAuth(Buffer.from(authJson, "utf8")) !== "api_key") {
+    throw new Error("codex_probe_nonpersistent_subscription_auth_unsupported");
+  }
+  const durableSnapshot = authJson
+    ? null
+    : await snapshotDurableCodexProbeAuth(sourceHome).catch((error) => {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+        throw error;
+      });
+  if (durableSnapshot?.kind === "unsupported") {
+    throw new Error("codex_probe_auth_format_unsupported");
+  }
+  if (durableSnapshot?.kind === "subscription") {
+    if (input.targetIsSandbox) {
+      // A sandbox can rotate a refresh token before the result is copied back.
+      // A host crash in that interval would destroy the only usable token, so
+      // subscription-backed probes stay local until the runner offers a
+      // transactional credential channel. Local probes use the durable home
+      // directly, making any Codex rotation durable at the write boundary.
+      throw new Error("codex_probe_remote_subscription_auth_unsupported");
+    }
+    // The probe executor disables all Paperclip skill preparation before it
+    // points Codex at this durable home. That leaves refresh-token rotation on
+    // its crash-durable path without reconciling or rewriting operator skills.
+    return { probeHome: sourceHome };
+  }
+  const probeHome = path.join(input.probeRoot, "codex-home");
+  try {
+    // The probe home starts empty. Copying the operator home would also copy
+    // config.toml, which can contain MCP bearer headers and tool definitions.
+    // Authentication is the only state this bounded proof needs.
+    await fs.mkdir(probeHome, { mode: 0o700 });
+  } catch {
+    throw new Error("codex_probe_home_materialization_failed");
+  }
+
+  if (authJson) {
+    const authPath = path.join(probeHome, "auth.json");
+    await fs.rm(authPath, { force: true });
+    await fs.writeFile(authPath, authJson, { encoding: "utf8", mode: 0o600, flag: "wx" });
+    await fs.chmod(authPath, 0o600);
+  } else if (durableSnapshot) {
+    const authPath = path.join(probeHome, "auth.json");
+    await fs.rm(authPath, { force: true });
+    await fs.writeFile(authPath, durableSnapshot.bytes, { mode: 0o600, flag: "wx" });
+    await fs.chmod(authPath, 0o600);
+  }
+  await fs.chmod(probeHome, 0o700);
+  return { probeHome };
+}
+
+async function prepareCodexAcpProbeRemoteManagedHome(
+  input: AcpxRemoteManagedHomeContext,
+): Promise<AcpxRemoteManagedHomeResult> {
+  // The credential home was staged separately over stdin so credential bytes
+  // never enter the generic archive uploader's command text. This callback
+  // stages only the workspace and preserves the already-bound remote home.
+  return { stagedRuntime: await input.stage([]) };
+}
+
+async function stageCodexAcpRemoteProbeHome(input: {
+  ctx: AdapterEnvironmentTestContext;
+  runId: string;
+  localProbeHome: string;
+  remoteProbeHome: string;
+}): Promise<void> {
+  // Never forward config.toml: it can contain MCP Authorization headers. The
+  // bounded proof receives only auth.json; model/runtime settings travel via
+  // the non-secret run config built below.
+  const authJson = await fs.readFile(path.join(input.localProbeHome, "auth.json")).catch((error) => {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  });
+  const stageTarget = overrideAdapterExecutionTargetRemoteCwd(input.ctx.executionTarget, "/tmp");
+  const staged = await runAdapterExecutionTargetProcess(
+    `${input.runId}-auth-stage`,
+    stageTarget,
+    "sh",
+    ["-c", CODEX_ACP_PROBE_HOME_STAGE_SCRIPT],
+    {
+      cwd: "/tmp",
+      env: { CODEX_HOME: input.remoteProbeHome },
+      denyEnvironmentKeys: CODEX_ACP_PROBE_AUTH_ENV_KEY_NAMES,
+      stdin: JSON.stringify({
+        authJson: authJson?.toString("base64") ?? null,
+      }),
+      timeoutSec: 15,
+      graceSec: 5,
+      onLog: async () => {},
+    },
+  );
+  if (!adapterProcessSucceeded(staged)) {
+    throw new Error("codex_probe_auth_stage_failed");
+  }
+}
+
+function adapterProcessSucceeded(result: {
+  exitCode: number | null;
+  signal: string | null;
+  timedOut: boolean;
+}): boolean {
+  return !result.timedOut && result.signal === null && result.exitCode === 0;
+}
+
+async function removeAndVerifyCodexAcpRemoteProbeRoot(input: {
+  ctx: AdapterEnvironmentTestContext;
+  runId: string;
+  remoteProbeRoot: string;
+}): Promise<boolean> {
+  const cleanupTarget = overrideAdapterExecutionTargetRemoteCwd(
+    input.ctx.executionTarget,
+    "/tmp",
+  );
+  let succeeded = true;
+  try {
+    const removal = await runAdapterExecutionTargetProcess(
+      `${input.runId}-cleanup`,
+      cleanupTarget,
+      "rm",
+      ["-rf", "--", input.remoteProbeRoot],
+      {
+        cwd: "/tmp",
+        env: {},
+        denyEnvironmentKeys: CODEX_ACP_PROBE_AUTH_ENV_KEY_NAMES,
+        timeoutSec: 15,
+        graceSec: 5,
+        onLog: async () => {},
+      },
+    );
+    if (!adapterProcessSucceeded(removal)) succeeded = false;
+  } catch {
+    succeeded = false;
+  }
+  try {
+    const verification = await runAdapterExecutionTargetProcess(
+      `${input.runId}-cleanup-verify`,
+      cleanupTarget,
+      "sh",
+      ["-c", '[ ! -e "$1" ] && [ ! -L "$1" ]', "sh", input.remoteProbeRoot],
+      {
+        cwd: "/tmp",
+        env: {},
+        denyEnvironmentKeys: CODEX_ACP_PROBE_AUTH_ENV_KEY_NAMES,
+        timeoutSec: 15,
+        graceSec: 5,
+        onLog: async () => {},
+      },
+    );
+    if (!adapterProcessSucceeded(verification)) succeeded = false;
+  } catch {
+    succeeded = false;
+  }
+  return succeeded;
+}
+
+/** Run one bounded ACP turn without exposing provider output in diagnostics. */
+export async function probeCodexAcpLiveReply(
+  ctx: AdapterEnvironmentTestContext,
+  config: Record<string, unknown>,
+  options: CodexAcpLiveProbeOptions = {},
+): Promise<AdapterEnvironmentCheck[]> {
+  const runId = `codex-acp-envtest-${randomUUID()}`;
+  let probeRoot: string;
+  try {
+    probeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-acp-envtest-"));
+  } catch {
+    return codexAcpProbeFailedCheck();
+  }
+  const workspaceDir = path.join(probeRoot, "workspace");
+  const warmHandles: NonNullable<AcpxEngineExecutorOptions["warmHandles"]> = new Map();
+  const stagedRuntimes: NonNullable<AcpxEngineExecutorOptions["stagedRuntimes"]> = new Map();
+  const stagingLocks: NonNullable<AcpxEngineExecutorOptions["stagingLocks"]> = new Map();
+  const {
+    paperclipRuntimeSkills: _paperclipRuntimeSkills,
+    paperclipSkillSync: _paperclipSkillSync,
+    agentCommand: _agentCommand,
+    acpAgentCommand: _acpAgentCommand,
+    ...probeBaseConfig
+  } = config;
+  const targetIsSandbox =
+    ctx.executionTarget?.kind === "remote" && ctx.executionTarget.transport === "sandbox";
+  const remoteProbeRoot = targetIsSandbox
+    ? path.posix.join("/tmp", `paperclip-codex-acp-envtest-${runId}`)
+    : null;
+  const probeExecutionTarget = remoteProbeRoot
+    ? overrideAdapterExecutionTargetRemoteCwd(ctx.executionTarget, remoteProbeRoot)
+    : ctx.executionTarget;
+  let probeAuth: {
+    probeHome: string;
+  } | null = null;
+  let activeProbeHome: string | null = null;
+  let checks = codexAcpProbeFailedCheck();
+  let cleanupFailed = false;
+  try {
+    await fs.mkdir(workspaceDir, { recursive: true });
+    probeAuth = await materializeCodexAcpProbeHome({
+      probeRoot,
+      runId,
+      companyId: ctx.companyId,
+      config: probeBaseConfig,
+      targetIsSandbox,
+    });
+    activeProbeHome = probeAuth.probeHome;
+    if (remoteProbeRoot) {
+      activeProbeHome = path.posix.join(remoteProbeRoot, "codex-home");
+      await stageCodexAcpRemoteProbeHome({
+        ctx,
+        runId,
+        localProbeHome: probeAuth.probeHome,
+        remoteProbeHome: activeProbeHome,
+      });
+    }
+    const probeConfig = {
+      ...probeBaseConfig,
+      env: {
+        ...stripCodexAcpProbeAuthEnv(parseObject(probeBaseConfig.env)),
+        CODEX_HOME: activeProbeHome,
+      },
+      engine: "acp",
+      mode: "oneshot",
+      permissionMode: "deny-all",
+      nonInteractivePermissions: "fail",
+      warmHandleIdleMs: 0,
+      cwd: workspaceDir,
+      stateDir: path.join(probeRoot, "state"),
+      timeoutSec: targetIsSandbox ? 90 : 45,
+      instructionsFilePath: "",
+      bootstrapPromptTemplate: "",
+      promptTemplate: "Reply with exactly Hello. Do not use tools.",
+    };
+    const execute = options.execute ?? (options.createExecutor ?? createCodexAcpExecutor)({
+      warmHandles,
+      stagedRuntimes,
+      stagingLocks,
+      denyEnvironmentKeys: CODEX_ACP_PROBE_AUTH_ENV_KEY_NAMES,
+      // A local subscription probe must use the durable auth home directly so
+      // token rotation survives a host crash. Do not let this read-only proof
+      // reconcile skills or write the managed-skill manifest in that home.
+      skipRuntimeSkillPreparation: true,
+      prepareRemoteManagedHome: prepareCodexAcpProbeRemoteManagedHome,
+      onTeardownFailure: () => {
+        cleanupFailed = true;
+      },
+    });
+    const result = await execute({
+      runId,
+      agent: {
+        id: runId,
+        companyId: ctx.companyId,
+        name: "Codex connection test",
+        adapterType: ctx.adapterType,
+        adapterConfig: probeConfig,
+      },
+      runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+      config: probeConfig,
+      // The proof never grants Paperclip API authority. A non-secret, invalid
+      // run-local token satisfies the bridge transport contract while any
+      // accidental Paperclip tool call remains unauthorized.
+      authToken: runId,
+      context: {
+        paperclipWorkspace: {
+          cwd: workspaceDir,
+          source: "project_workspace",
+          workspaceId: runId,
+        },
+      },
+      executionTarget: probeExecutionTarget,
+      onLog: async (stream, chunk) => {
+        if (isCodexAcpCleanupFailureLog(stream, chunk)) cleanupFailed = true;
+      },
+    });
+    checks = classifyCodexAcpLiveProbeResult(result, targetIsSandbox);
+  } catch {
+    checks = codexAcpProbeFailedCheck();
+  } finally {
+    for (const entry of warmHandles.values()) {
+      if (entry.cleanupTimer) clearTimeout(entry.cleanupTimer);
+      try {
+        await entry.runtime.close({
+          handle: entry.handle,
+          reason: "paperclip environment test cleanup",
+          discardPersistentState: true,
+        });
+      } catch {
+        cleanupFailed = true;
+      }
+    }
+    warmHandles.clear();
+    for (const entry of stagedRuntimes.values()) {
+      try {
+        await entry.dispose?.();
+      } catch {
+        cleanupFailed = true;
+      }
+    }
+    stagedRuntimes.clear();
+    stagingLocks.clear();
+    if (remoteProbeRoot) {
+      const removed = await removeAndVerifyCodexAcpRemoteProbeRoot({
+        ctx,
+        runId,
+        remoteProbeRoot,
+      });
+      if (!removed) cleanupFailed = true;
+    }
+    try {
+      await fs.rm(probeRoot, { recursive: true, force: true });
+      if (await fs.lstat(probeRoot).catch(() => null)) cleanupFailed = true;
+    } catch {
+      cleanupFailed = true;
+    }
+  }
+  if (cleanupFailed) {
+    return codexAcpProbeCleanupFailedCheck();
+  }
+  return checks;
+}
+
+type CodexAcpEnvironmentTestOptions = {
+  liveProbe?: (
+    ctx: AdapterEnvironmentTestContext,
+    config: Record<string, unknown>,
+  ) => Promise<AdapterEnvironmentCheck[]>;
+};
+
 export async function testCodexAcpEnvironment(
   ctx: AdapterEnvironmentTestContext,
+  options: CodexAcpEnvironmentTestOptions = {},
 ): Promise<AdapterEnvironmentTestResult> {
-  const checks: AdapterEnvironmentCheck[] = [];
+  let checks: AdapterEnvironmentCheck[] = [];
   const config = parseObject(ctx.config);
   const target = ctx.executionTarget ?? null;
   const targetIsRemote = target?.kind === "remote";
@@ -507,22 +1045,42 @@ export async function testCodexAcpEnvironment(
       message: "Codex ACP will run against the remote execution environment.",
       hint: "Remote ACP requires a bidirectional process target such as SSH or Paperclip's sandbox process-session bridge.",
     });
+    if (!targetIsSandbox) {
+      checks.push({
+        code: "codex_acp_remote_target_unsupported",
+        level: "error",
+        message: "Codex ACP live testing supports local and sandbox environments only.",
+        hint: "Use the Codex CLI engine for this remote environment, or select a sandbox environment with a process-session runner.",
+      });
+    } else if (!sandboxTargetHasProcessSessionBridge(target)) {
+      checks.push({
+        code: "codex_acp_sandbox_runner_missing",
+        level: "error",
+        message: "This sandbox cannot run a live Codex ACP session.",
+        hint: "Select a sandbox environment with a bidirectional process-session runner.",
+      });
+    }
   }
 
   const cwd = asString(config.cwd, process.cwd());
   try {
-    await fs.mkdir(cwd, { recursive: true });
+    if (target?.kind === "remote") {
+      if (!target.remoteCwd.trim() || !path.posix.isAbsolute(target.remoteCwd)) {
+        throw new Error("invalid_remote_cwd");
+      }
+    } else {
+      await fs.mkdir(cwd, { recursive: true });
+    }
     checks.push({
       code: "codex_acp_cwd_valid",
       level: "info",
-      message: `Working directory is valid: ${cwd}`,
+      message: "Working directory is valid.",
     });
-  } catch (err) {
+  } catch {
     checks.push({
       code: "codex_acp_cwd_invalid",
       level: "error",
-      message: err instanceof Error ? err.message : "Invalid working directory",
-      detail: cwd,
+      message: "Working directory is invalid or inaccessible.",
     });
   }
 
@@ -537,31 +1095,45 @@ export async function testCodexAcpEnvironment(
       : `Run Codex ACP with Node >=${MIN_ACP_NODE_VERSION} or switch engine=cli.`,
   });
 
-  const command = await resolveCodexAcpCommandForTarget(config, target);
-  const commandResolvable = await commandIsResolvable(command, {
-    config,
-    executionTarget: ctx.executionTarget,
-  });
-  checks.push({
-    code: commandResolvable ? "codex_acp_command_resolvable" : "codex_acp_command_missing",
-    level: commandResolvable ? "info" : "error",
-    message: commandResolvable
-      ? `Codex ACP server command is executable: ${command}`
-      : `Codex ACP server command is not available: ${command}`,
-    hint: commandResolvable
-      ? undefined
-      : "Install dependencies so @agentclientprotocol/codex-acp is present, or set agentCommand to a valid Codex ACP server command.",
-  });
+  const configuredAgentCommand = firstNonEmptyString(
+    config.agentCommand,
+    config.acpAgentCommand,
+  );
+  if (configuredAgentCommand) {
+    checks.push({
+      code: "codex_acp_custom_command_unsupported_for_live_proof",
+      level: "error",
+      message: "Codex ACP live proof requires the canonical Codex ACP command.",
+      hint: "Remove the custom ACP agent command and retry the live test.",
+    });
+  } else {
+    const command = await resolveCodexAcpCommandForTarget(config, target);
+    const commandResolvable = await commandIsResolvable(command, {
+      config,
+      executionTarget: ctx.executionTarget,
+    });
+    checks.push({
+      code: commandResolvable ? "codex_acp_command_resolvable" : "codex_acp_command_missing",
+      level: commandResolvable ? "info" : "error",
+      message: commandResolvable
+        ? "Codex ACP server command is executable."
+        : "Codex ACP server command is not available.",
+      hint: commandResolvable
+        ? undefined
+        : "Install dependencies so @agentclientprotocol/codex-acp is present.",
+    });
+  }
 
   const envConfig = parseObject(config.env);
   if (!targetIsRemote) {
-    const configApiKey = isNonEmpty(envConfig.OPENAI_API_KEY) ? envConfig.OPENAI_API_KEY : null;
+    const configApiKey = firstNonEmptyString(envConfig.OPENAI_API_KEY, envConfig.CODEX_API_KEY) ?? null;
+    const configDefinesApiKey =
+      Object.prototype.hasOwnProperty.call(envConfig, "OPENAI_API_KEY") ||
+      Object.prototype.hasOwnProperty.call(envConfig, "CODEX_API_KEY");
     const hostApiKey =
-      Object.prototype.hasOwnProperty.call(envConfig, "OPENAI_API_KEY")
+      configDefinesApiKey
         ? null
-        : isNonEmpty(process.env.OPENAI_API_KEY)
-        ? process.env.OPENAI_API_KEY
-        : null;
+        : firstNonEmptyString(process.env.OPENAI_API_KEY, process.env.CODEX_API_KEY) ?? null;
     const configuredApiKey = configApiKey ?? hostApiKey;
     const configuredCodexHome = isNonEmpty(envConfig.CODEX_HOME) ? envConfig.CODEX_HOME : null;
     const credentialReadiness = await evaluateCodexCredentialReadiness({
@@ -575,22 +1147,19 @@ export async function testCodexAcpEnvironment(
       checks.push({
         code: "codex_acp_openai_api_key_detected",
         level: "info",
-        message: "OPENAI_API_KEY is set for Codex ACP authentication.",
-        detail: `Detected in ${configApiKey ? "adapter config env" : "server environment"}.`,
+        message: "An API key is set for Codex ACP authentication.",
       });
     } else if (credentialReadiness.ready && !credentialReadiness.managed) {
       checks.push({
         code: "codex_acp_external_home_configured",
         level: "info",
         message: "Codex ACP will use an externally managed CODEX_HOME.",
-        detail: credentialReadiness.effectiveHome,
       });
     } else if (credentialReadiness.ready) {
       checks.push({
         code: "codex_acp_native_auth_detected",
         level: "info",
         message: "Codex ACP can use Codex native authentication.",
-        detail: `Credentials are available through ${credentialReadiness.effectiveHome} or shared source ${credentialReadiness.sharedSourceHome}.`,
       });
     } else {
       checks.push({
@@ -601,10 +1170,9 @@ export async function testCodexAcpEnvironment(
       });
     }
   } else if (targetIsSandbox) {
-    // The ACP Test does not probe the sandbox, so it predicts readiness from the
-    // credentials the Paperclip server can seed into the sandbox. The host
-    // environment is not seeded, so only the adapter config key counts here.
-    const configApiKey = isNonEmpty(envConfig.OPENAI_API_KEY) ? envConfig.OPENAI_API_KEY : null;
+    // Predict readiness from credentials Paperclip can seed, but let the live
+    // sandbox turn decide because the selected environment may provide its own auth.
+    const configApiKey = firstNonEmptyString(envConfig.OPENAI_API_KEY, envConfig.CODEX_API_KEY) ?? null;
     const configuredCodexHome = isNonEmpty(envConfig.CODEX_HOME) ? envConfig.CODEX_HOME : null;
     const credentialReadiness = await evaluateCodexCredentialReadiness({
       env: process.env,
@@ -625,16 +1193,29 @@ export async function testCodexAcpEnvironment(
     }
   }
 
-  const mode = firstNonEmptyString(config.mode, config.acpMode) ?? DEFAULT_ACP_ENGINE_MODE;
-  const warmHandleIdleMs = asNumber(
-    config.warmHandleIdleMs ?? config.acpWarmHandleIdleMs,
-    DEFAULT_ACP_ENGINE_WARM_HANDLE_IDLE_MS,
-  );
+  const canRunLiveProbe = !checks.some((check) => check.level === "error");
+  if (canRunLiveProbe) {
+    const liveChecks = await (options.liveProbe ?? probeCodexAcpLiveReply)(ctx, config);
+    if (
+      liveChecks.some(
+        (check) => check.code === "codex_hello_probe_passed" && check.level === "info",
+      )
+    ) {
+      const predictiveAuthWarnings = new Set([
+        "codex_acp_credentials_missing",
+        ADAPTER_AUTH_MISSING_CHECK_CODE,
+      ]);
+      const retainedChecks = checks.filter((check) => !predictiveAuthWarnings.has(check.code));
+      checks = [...retainedChecks, ...liveChecks];
+    } else {
+      checks.push(...liveChecks);
+    }
+  }
+
   checks.push({
     code: "codex_acp_runtime_scaffold",
     level: "info",
     message: "Codex ACP runtime execution is available through the shared ACP engine.",
-    detail: `mode=${mode}; warmHandleIdleMs=${warmHandleIdleMs}`,
   });
 
   return {

--- a/packages/adapters/codex-local/src/server/codex-probe-auth.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-probe-auth.test.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  classifyCodexProbeAuth,
+  snapshotDurableCodexProbeAuth,
+} from "./codex-probe-auth.js";
+
+function subscriptionAuth(accountId = "acct-probe"): string {
+  return JSON.stringify({
+    tokens: {
+      account_id: accountId,
+      access_token: "access-token",
+      refresh_token: "refresh-token",
+    },
+    last_refresh: "2026-08-31T00:00:00Z",
+  });
+}
+
+describe("Codex live-probe auth classification", () => {
+  it("accepts only an exact API-key payload or a usable subscription identity", () => {
+    expect(classifyCodexProbeAuth(Buffer.from('{"OPENAI_API_KEY":"sk-test"}')))
+      .toBe("api_key");
+    expect(classifyCodexProbeAuth(Buffer.from(
+      '{"OPENAI_API_KEY":"sk-test","tokens":{"account_id":"mixed"}}',
+    ))).toBe("unsupported");
+    expect(classifyCodexProbeAuth(Buffer.from(subscriptionAuth())))
+      .toBe("subscription");
+    expect(classifyCodexProbeAuth(Buffer.from("not-json"))).toBe("unsupported");
+  });
+});
+
+describe("snapshotDurableCodexProbeAuth", () => {
+  it("resolves the managed-home auth symlink and reads the bounded regular target", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-probe-auth-link-"));
+    try {
+      const home = path.join(root, "home");
+      const shared = path.join(root, "shared-auth.json");
+      const bytes = subscriptionAuth("acct-shared");
+      await fs.mkdir(home);
+      await fs.writeFile(shared, bytes, { mode: 0o600 });
+      await fs.symlink(shared, path.join(home, "auth.json"));
+
+      const snapshot = await snapshotDurableCodexProbeAuth(home);
+
+      expect(snapshot.kind).toBe("subscription");
+      expect(snapshot.bytes.toString("utf8")).toBe(bytes);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an auth source larger than the one-megabyte probe bound", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-probe-auth-large-"));
+    try {
+      await fs.writeFile(path.join(root, "auth.json"), Buffer.alloc(1024 * 1024 + 1));
+      await expect(snapshotDurableCodexProbeAuth(root)).rejects.toThrow(
+        "codex_probe_auth_source_invalid",
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/adapters/codex-local/src/server/codex-probe-auth.ts
+++ b/packages/adapters/codex-local/src/server/codex-probe-auth.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import path from "node:path";
+import { readSubscriptionAccountId } from "./codex-auth-cache.js";
+
+const MAX_CODEX_PROBE_AUTH_BYTES = 1024 * 1024;
+
+export type CodexProbeAuthKind = "api_key" | "subscription" | "unsupported";
+
+export function classifyCodexProbeAuth(bytes: Buffer): CodexProbeAuthKind {
+  let parsed: Record<string, unknown>;
+  try {
+    const candidate = JSON.parse(bytes.toString("utf8")) as unknown;
+    if (candidate === null || typeof candidate !== "object" || Array.isArray(candidate)) {
+      return "unsupported";
+    }
+    parsed = candidate as Record<string, unknown>;
+    if (
+      typeof parsed.OPENAI_API_KEY === "string" &&
+      parsed.OPENAI_API_KEY.trim() &&
+      Object.keys(parsed).every((key) => key === "OPENAI_API_KEY")
+    ) {
+      return "api_key";
+    }
+  } catch {
+    return "unsupported";
+  }
+  return readSubscriptionAccountId(bytes) ? "subscription" : "unsupported";
+}
+
+export interface DurableCodexProbeAuthSnapshot {
+  bytes: Buffer;
+  kind: CodexProbeAuthKind;
+}
+
+async function readBoundedRegularFile(filePath: string): Promise<Buffer> {
+  const handle = await fs.open(
+    filePath,
+    fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0),
+  );
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile() || stat.size > MAX_CODEX_PROBE_AUTH_BYTES) {
+      throw new Error("codex_probe_auth_source_invalid");
+    }
+    const bounded = Buffer.allocUnsafe(MAX_CODEX_PROBE_AUTH_BYTES + 1);
+    let offset = 0;
+    while (offset < bounded.length) {
+      const { bytesRead } = await handle.read(
+        bounded,
+        offset,
+        bounded.length - offset,
+        offset,
+      );
+      if (bytesRead === 0) break;
+      offset += bytesRead;
+    }
+    if (offset > MAX_CODEX_PROBE_AUTH_BYTES) {
+      throw new Error("codex_probe_auth_source_invalid");
+    }
+    return Buffer.from(bounded.subarray(0, offset));
+  } finally {
+    await handle.close();
+  }
+}
+
+export async function snapshotDurableCodexProbeAuth(
+  sourceHome: string,
+): Promise<DurableCodexProbeAuthSnapshot> {
+  const resolved = await fs.realpath(path.join(sourceHome, "auth.json"));
+  const bytes = await readBoundedRegularFile(resolved);
+  const kind = classifyCodexProbeAuth(bytes);
+  return {
+    bytes,
+    kind,
+  };
+}

--- a/packages/adapters/codex-local/src/server/test.remote.test.ts
+++ b/packages/adapters/codex-local/src/server/test.remote.test.ts
@@ -1,7 +1,9 @@
 import fs from "node:fs/promises";
 import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AdapterExecutionTarget } from "@paperclipai/adapter-utils/execution-target";
+import { runChildProcess } from "@paperclipai/adapter-utils/server-utils";
 
 const {
   ensureAdapterExecutionTargetDirectory,
@@ -10,28 +12,19 @@ const {
   runAdapterExecutionTargetProcess,
   describeAdapterExecutionTarget,
   resolveAdapterExecutionTargetCwd,
-  prepareAdapterExecutionTargetRuntime,
   prepareManagedCodexHome,
-  restoreWorkspace,
-  capturedHomeAssetFiles,
 } = vi.hoisted(() => {
-  const restoreWorkspace = vi.fn(async () => {});
-  // Records the files staged in the uploaded "home" asset at call time, before
-  // the probe's cleanup deletes the temp dir. Lets tests assert the upload is a
-  // minimal credentials-only home and not the full managed CODEX_HOME.
-  const capturedHomeAssetFiles: { value: string[] | null } = { value: null };
   return {
-    capturedHomeAssetFiles,
     ensureAdapterExecutionTargetDirectory: vi.fn(async () => {}),
     ensureAdapterExecutionTargetCommandResolvable: vi.fn(async () => {}),
     maybeRunSandboxInstallCommand: vi.fn(async () => null),
-    runAdapterExecutionTargetProcess: vi.fn(async () => ({
+    runAdapterExecutionTargetProcess: vi.fn(async (..._args: unknown[]) => ({
       exitCode: 0,
       signal: null,
       timedOut: false,
       stdout: [
         "{\"type\":\"thread.started\",\"thread_id\":\"thread-1\"}",
-        "{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"hello\"}}",
+        "{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"Hello.\"}}",
         "{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":1,\"cached_input_tokens\":0,\"output_tokens\":1}}",
       ].join("\n"),
       stderr: "",
@@ -46,30 +39,14 @@ const {
       }
       return fallbackCwd;
     }),
-    prepareAdapterExecutionTargetRuntime: vi.fn(async (input: { assets?: Array<{ key: string; localDir: string }> }) => {
-      const homeAsset = input?.assets?.find((asset) => asset.key === "home");
-      if (homeAsset) {
-        capturedHomeAssetFiles.value = (await fs.readdir(homeAsset.localDir)).sort();
-      }
-      return {
-        target: null,
-        workspaceRemoteDir: "/remote/workspace/.paperclip-runtime/runs/test/workspace",
-        runtimeRootDir: "/remote/workspace/.paperclip-runtime/runs/test/workspace/.paperclip-runtime/codex",
-        assetDirs: {
-          home: "/remote/workspace/.paperclip-runtime/runs/test/workspace/.paperclip-runtime/codex/home",
-        },
-        restoreWorkspace,
-      };
-    }),
     prepareManagedCodexHome: vi.fn(async () => {
-      // Return a real managed home seeded with credentials so the probe's
-      // minimal-home copy step (auth.json/config.toml) has something to read.
+      // Return a real managed home seeded with credentials. The probe may read
+      // auth.json, but it must never forward secret-bearing config.toml.
       const dir = await fs.mkdtemp(`${os.tmpdir()}/paperclip-managed-codex-home-`);
       await fs.writeFile(`${dir}/auth.json`, JSON.stringify({ OPENAI_API_KEY: "sk-managed" }));
       await fs.writeFile(`${dir}/config.toml`, "model = \"gpt-5\"\n");
       return dir;
     }),
-    restoreWorkspace,
   };
 });
 
@@ -85,7 +62,6 @@ vi.mock("@paperclipai/adapter-utils/execution-target", async () => {
     runAdapterExecutionTargetProcess,
     describeAdapterExecutionTarget,
     resolveAdapterExecutionTargetCwd,
-    prepareAdapterExecutionTargetRuntime,
   };
 });
 
@@ -99,13 +75,65 @@ vi.mock("./codex-home.js", async () => {
 
 import { testEnvironment } from "./test.js";
 
+type ExecutionProcessCall = [
+  string,
+  AdapterExecutionTarget | null,
+  string,
+  string[],
+  {
+    cwd: string;
+    env: Record<string, string>;
+    stdin?: string;
+    denyEnvironmentKeys?: readonly string[];
+  },
+];
+
+function executionProcessCalls(): ExecutionProcessCall[] {
+  return runAdapterExecutionTargetProcess.mock.calls as unknown as ExecutionProcessCall[];
+}
+
+function buildSandboxTarget(): AdapterExecutionTarget {
+  return {
+    kind: "remote",
+    transport: "sandbox",
+    providerKey: "fixture",
+    remoteCwd: "/remote/workspace",
+    runner: {
+      execute: async () => ({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: "",
+        stderr: "",
+        pid: null,
+        startedAt: new Date().toISOString(),
+      }),
+    },
+  };
+}
+
+function subscriptionAuthJson(accountId: string, lastRefresh: string, marker: string): string {
+  return JSON.stringify({
+    tokens: {
+      id_token: `id-${marker}`,
+      access_token: `access-${marker}`,
+      refresh_token: `refresh-${marker}`,
+      account_id: accountId,
+    },
+    last_refresh: lastRefresh,
+  });
+}
+
 describe("codex remote environment diagnostics", () => {
   afterEach(() => {
     vi.clearAllMocks();
     delete process.env.OPENAI_API_KEY;
+    delete process.env.CODEX_API_KEY;
+    delete process.env.CODEX_AUTH_JSON;
+    delete process.env._PAPERCLIP_CODEX_AUTH_JSON;
   });
 
-  it("stages managed CODEX_HOME in an isolated runtime dir and keeps the probe cwd on the original remote workspace", async () => {
+  it("stages native auth only through stdin and keeps it out of argv and child env", async () => {
     const remoteTarget: AdapterExecutionTarget = {
       kind: "remote",
       transport: "ssh",
@@ -136,33 +164,13 @@ describe("codex remote environment diagnostics", () => {
     expect(result.status).toBe("pass");
     expect(result.checks.some((check) => check.code === "codex_hello_probe_passed")).toBe(true);
     expect(prepareManagedCodexHome).toHaveBeenCalledTimes(1);
-    expect(prepareAdapterExecutionTargetRuntime).toHaveBeenCalledTimes(1);
-    const runtimeCalls = prepareAdapterExecutionTargetRuntime.mock.calls as unknown as Array<[
-      {
-        workspaceLocalDir: string;
-        target?: { remoteCwd?: string };
-        workspaceRemoteDir?: string;
-        assets?: Array<{ key: string; localDir: string }>;
-      },
-    ]>;
-    const runtimeInput = runtimeCalls[0]?.[0];
-    // The probe must upload only a minimal credentials-only home, never the
-    // full managed CODEX_HOME (which can be hundreds of MB of session history).
-    const homeAsset = runtimeInput?.assets?.find((asset) => asset.key === "home");
-    expect(homeAsset?.localDir).toContain(`${os.tmpdir()}/paperclip-codex-probe-home-`);
-    expect(capturedHomeAssetFiles.value).toEqual(["auth.json", "config.toml"]);
-    expect(runtimeInput?.workspaceLocalDir).toContain(`${os.tmpdir()}/paperclip-codex-envtest-`);
-    expect(runtimeInput?.workspaceLocalDir).not.toBe("/remote/workspace");
-    expect(await fs.stat(runtimeInput!.workspaceLocalDir).catch(() => null)).toBeNull();
-    expect(runtimeInput?.target?.remoteCwd).toBe("/remote/workspace");
-    // `workspaceRemoteDir` is the base path passed to the runtime; the
-    // helper's per-run subdirectory is appended internally inside
-    // `prepareRemoteManagedRuntime`. Pre-building a per-run prefix here
-    // would double-nest the run id in the final path.
-    expect(runtimeInput?.workspaceRemoteDir).toBe("/remote/workspace");
-    expect(runAdapterExecutionTargetProcess).toHaveBeenCalledTimes(1);
+    expect(runAdapterExecutionTargetProcess).toHaveBeenCalledTimes(3);
     const probeCall = runAdapterExecutionTargetProcess.mock.calls[0] as unknown as
-      | [string, { kind: string; remoteCwd: string }, string, string[], { cwd: string; env: Record<string, string> }]
+      | [string, { kind: string; remoteCwd: string }, string, string[], {
+          cwd: string;
+          env: Record<string, string>;
+          stdin?: string;
+        }]
       | undefined;
     expect(probeCall?.[1]).toMatchObject({
       kind: "remote",
@@ -170,14 +178,35 @@ describe("codex remote environment diagnostics", () => {
     });
     expect(probeCall?.[4]).toMatchObject({
       cwd: "/remote/workspace",
-      env: expect.objectContaining({
-        CODEX_HOME: "/remote/workspace/.paperclip-runtime/runs/test/workspace/.paperclip-runtime/codex/home",
-      }),
+      env: expect.objectContaining({ CODEX_HOME: expect.stringMatching(/^\/tmp\/paperclip-codex-probe-/) }),
     });
-    expect(restoreWorkspace).toHaveBeenCalledTimes(1);
+    const nativeStdin = JSON.parse(probeCall?.[4].stdin ?? "{}") as { authJson?: string };
+    expect(nativeStdin).not.toHaveProperty("configToml");
+    expect(Buffer.from(nativeStdin.authJson ?? "", "base64").toString("utf8")).toContain(
+      "sk-managed",
+    );
+    expect(JSON.stringify([probeCall?.[2], probeCall?.[3], probeCall?.[4].env])).not.toContain(
+      "sk-managed",
+    );
+    expect(probeCall?.[4].env.OPENAI_API_KEY).toBeUndefined();
+    expect(probeCall?.[4].env.CODEX_AUTH_JSON).toBeUndefined();
+    expect(probeCall?.[4].env._PAPERCLIP_CODEX_AUTH_JSON).toBeUndefined();
+
+    const cleanupRoot = path.posix.dirname(probeCall?.[4].env.CODEX_HOME ?? "");
+    const removeCall = executionProcessCalls()[1];
+    const verifyCall = executionProcessCalls()[2];
+    expect(removeCall?.[2]).toBe("rm");
+    expect(removeCall?.[3]).toEqual(["-rf", "--", cleanupRoot]);
+    expect(verifyCall?.[2]).toBe("sh");
+    expect(verifyCall?.[3]).toEqual([
+      "-c",
+      '[ ! -e "$1" ] && [ ! -L "$1" ]',
+      "sh",
+      cleanupRoot,
+    ]);
   });
 
-  it("avoids /tmp CODEX_HOME for remote API-key hello probes", async () => {
+  it("stages a remote API key only through stdin and verifies auth-root removal", async () => {
     const remoteTarget: AdapterExecutionTarget = {
       kind: "remote",
       transport: "sandbox",
@@ -202,6 +231,9 @@ describe("codex remote environment diagnostics", () => {
       config: {
         engine: "cli",
         command: "codex",
+        search: true,
+        dangerouslyBypassApprovalsAndSandbox: true,
+        extraArgs: ["--dangerously-bypass-approvals-and-sandbox", "--search", "unsafe-marker"],
         env: {
           OPENAI_API_KEY: "sk-test",
         },
@@ -211,12 +243,212 @@ describe("codex remote environment diagnostics", () => {
     });
 
     expect(result.status).toBe("pass");
+    expect(runAdapterExecutionTargetProcess).toHaveBeenCalledTimes(3);
     const probeCall = runAdapterExecutionTargetProcess.mock.calls[0] as unknown as
-      | [string, AdapterExecutionTarget, string, string[], { cwd: string; env: Record<string, string> }]
+      | [string, AdapterExecutionTarget, string, string[], {
+          cwd: string;
+          env: Record<string, string>;
+          stdin?: string;
+        }]
       | undefined;
-    expect(probeCall?.[4].env.CODEX_HOME).toContain("/remote/workspace/.paperclip-runtime/codex/probe-home-codex-envtest-");
-    expect(probeCall?.[4].env.CODEX_HOME?.startsWith("/tmp/")).toBe(false);
+    expect(probeCall?.[4].env.CODEX_HOME).toMatch(/^\/tmp\/paperclip-codex-probe-/);
+    const apiKeyStdin = JSON.parse(probeCall?.[4].stdin ?? "{}") as { authJson?: string };
+    expect(apiKeyStdin).not.toHaveProperty("configToml");
+    expect(Buffer.from(apiKeyStdin.authJson ?? "", "base64").toString("utf8")).toContain(
+      "sk-test",
+    );
+    expect(JSON.stringify([probeCall?.[2], probeCall?.[3], probeCall?.[4].env])).not.toContain(
+      "sk-test",
+    );
+    expect(probeCall?.[4].env.OPENAI_API_KEY).toBeUndefined();
+    expect(probeCall?.[4].env.CODEX_AUTH_JSON).toBeUndefined();
+    expect(probeCall?.[4].env._PAPERCLIP_CODEX_AUTH_JSON).toBeUndefined();
+    const installCalls = maybeRunSandboxInstallCommand.mock.calls as unknown as Array<[
+      { env?: Record<string, string> },
+    ]>;
+    const installEnv = installCalls[0]?.[0].env;
+    expect(installEnv?.OPENAI_API_KEY).toBeUndefined();
+    expect(installEnv?.CODEX_AUTH_JSON).toBeUndefined();
+    expect(installEnv?._PAPERCLIP_CODEX_AUTH_JSON).toBeUndefined();
+    const resolvableCalls = ensureAdapterExecutionTargetCommandResolvable.mock.calls as unknown as Array<[
+      string,
+      AdapterExecutionTarget | null,
+      string,
+      Record<string, string>,
+    ]>;
+    const resolvableEnv = resolvableCalls[0]?.[3];
+    expect(resolvableEnv?.OPENAI_API_KEY).toBeUndefined();
+    expect(resolvableEnv?.CODEX_AUTH_JSON).toBeUndefined();
+    expect(resolvableEnv?._PAPERCLIP_CODEX_AUTH_JSON).toBeUndefined();
+    expect(JSON.stringify(result)).not.toContain("sk-test");
     expect(probeCall?.[3]).toContain("--skip-git-repo-check");
+    expect(probeCall?.[3]).not.toContain("--dangerously-bypass-approvals-and-sandbox");
+    expect(probeCall?.[3]).not.toContain("--search");
+    expect(probeCall?.[3]).not.toContain("unsafe-marker");
+
+    const cleanupRoot = path.posix.dirname(probeCall?.[4].env.CODEX_HOME ?? "");
+    expect(executionProcessCalls()[1]?.[3]).toEqual([
+      "-rf",
+      "--",
+      cleanupRoot,
+    ]);
+    expect(executionProcessCalls()[2]?.[3]).toEqual([
+      "-c",
+      '[ ! -e "$1" ] && [ ! -L "$1" ]',
+      "sh",
+      cleanupRoot,
+    ]);
+  });
+
+  it("rejects a sandbox subscription probe before execution even when sync-out exists", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-cli-rotation-"));
+    const managedHome = path.join(root, "managed-home");
+    const managedAuthPath = path.join(managedHome, "auth.json");
+    const older = subscriptionAuthJson("acct-cli", "2026-01-01T00:00:00Z", "older");
+    await fs.mkdir(managedHome, { recursive: true });
+    await fs.writeFile(managedAuthPath, older, { mode: 0o600 });
+    prepareManagedCodexHome.mockResolvedValueOnce(managedHome);
+    const target = buildSandboxTarget() as Extract<AdapterExecutionTarget, { transport: "sandbox" }>;
+    target.runner = {
+      ...target.runner!,
+      syncOut: vi.fn(async () => ({ operations: [] })),
+    };
+
+    try {
+      const result = await testEnvironment({
+        companyId: "company-1",
+        adapterType: "codex_local",
+        config: { engine: "cli", command: "codex" },
+        executionTarget: target,
+        environmentName: "Rotation sandbox",
+      });
+
+      expect(result.checks).toContainEqual(
+        expect.objectContaining({ code: "codex_hello_probe_failed", level: "error" }),
+      );
+      expect(runAdapterExecutionTargetProcess).not.toHaveBeenCalled();
+      expect(target.runner.syncOut).not.toHaveBeenCalled();
+      expect(await fs.readFile(managedAuthPath, "utf8")).toBe(older);
+      expect((await fs.stat(managedAuthPath)).mode & 0o777).toBe(0o600);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed for inline and sandbox subscription auth", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-cli-copyback-fail-"));
+    const managedHome = path.join(root, "managed-home");
+    const managedAuthPath = path.join(managedHome, "auth.json");
+    const authJson = subscriptionAuthJson("acct-cli-fail", "2026-01-01T00:00:00Z", "secret-marker");
+    await fs.mkdir(managedHome, { recursive: true });
+    await fs.writeFile(managedAuthPath, authJson, { mode: 0o600 });
+
+    try {
+      const configured = await testEnvironment({
+        companyId: "company-1",
+        adapterType: "codex_local",
+        config: {
+          engine: "cli",
+          command: "codex",
+          env: { CODEX_AUTH_JSON: authJson },
+        },
+        executionTarget: null,
+      });
+      expect(configured.checks).toContainEqual(
+        expect.objectContaining({ code: "codex_hello_probe_failed", level: "error" }),
+      );
+
+      prepareManagedCodexHome.mockResolvedValueOnce(managedHome);
+      const target = buildSandboxTarget() as Extract<AdapterExecutionTarget, { transport: "sandbox" }>;
+      const remote = await testEnvironment({
+        companyId: "company-1",
+        adapterType: "codex_local",
+        config: { engine: "cli", command: "codex" },
+        executionTarget: target,
+        environmentName: "No copy-back sandbox",
+      });
+      expect(remote.checks).toContainEqual(
+        expect.objectContaining({ code: "codex_hello_probe_failed", level: "error" }),
+      );
+      expect(JSON.stringify([configured, remote])).not.toMatch(/secret-marker|acct-cli-fail/);
+      expect(await fs.readFile(managedAuthPath, "utf8")).toBe(authJson);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers configured auth JSON and keeps it out of argv and child env", async () => {
+    const authJson = JSON.stringify({ OPENAI_API_KEY: "sk-json-secret" });
+    const result = await testEnvironment({
+      companyId: "company-1",
+      adapterType: "codex_local",
+      config: {
+        engine: "cli",
+        command: "codex",
+        env: {
+          CODEX_AUTH_JSON: authJson,
+          OPENAI_API_KEY: "sk-lower-priority",
+        },
+      },
+      executionTarget: buildSandboxTarget(),
+      environmentName: "QA sandbox",
+    });
+
+    expect(result.status).toBe("pass");
+    const probeCall = executionProcessCalls()[0];
+    const payload = JSON.parse(probeCall?.[4].stdin ?? "{}") as { authJson?: string };
+    expect(Buffer.from(payload.authJson ?? "", "base64").toString("utf8")).toBe(authJson);
+    expect(JSON.stringify([probeCall?.[2], probeCall?.[3], probeCall?.[4].env])).not.toMatch(
+      /sk-json-secret|sk-lower-priority/,
+    );
+    expect(probeCall?.[4].env.CODEX_AUTH_JSON).toBeUndefined();
+    expect(probeCall?.[4].env.OPENAI_API_KEY).toBeUndefined();
+    expect(prepareManagedCodexHome).not.toHaveBeenCalled();
+    expect(JSON.stringify(result)).not.toMatch(/sk-json-secret|sk-lower-priority/);
+  });
+
+  it("removes and verifies the remote auth root after a killed probe", async () => {
+    runAdapterExecutionTargetProcess.mockResolvedValueOnce({
+      exitCode: null,
+      signal: "SIGKILL",
+      timedOut: true,
+      stdout: "",
+      stderr: "",
+      pid: 321,
+      startedAt: new Date().toISOString(),
+    } as never);
+
+    const result = await testEnvironment({
+      companyId: "company-1",
+      adapterType: "codex_local",
+      config: {
+        engine: "cli",
+        command: "codex",
+        env: { OPENAI_API_KEY: "sk-timeout" },
+      },
+      executionTarget: buildSandboxTarget(),
+      environmentName: "QA sandbox",
+    });
+
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({ code: "codex_hello_probe_timed_out", level: "warn" }),
+    );
+    expect(runAdapterExecutionTargetProcess).toHaveBeenCalledTimes(3);
+    const authRoot = path.posix.dirname(
+      executionProcessCalls()[0]?.[4].env.CODEX_HOME ?? "",
+    );
+    expect(executionProcessCalls()[1]?.[3]).toEqual([
+      "-rf",
+      "--",
+      authRoot,
+    ]);
+    expect(executionProcessCalls()[2]?.[3]).toEqual([
+      "-c",
+      '[ ! -e "$1" ] && [ ! -L "$1" ]',
+      "sh",
+      authRoot,
+    ]);
+    expect(JSON.stringify(result)).not.toContain("sk-timeout");
   });
 
   it("emits the canonical adapter_auth_missing check when a sandbox hello probe reports missing auth", async () => {
@@ -273,15 +505,21 @@ describe("codex remote environment diagnostics", () => {
     expect(result.checks.some((check) => check.code === "codex_hello_probe_auth_required")).toBe(true);
   });
 
-  it("does not override CODEX_HOME when the host has no credentials to seed", async () => {
-    // Custom-image flow: the login lives inside the captured snapshot, and the
-    // host has no Codex auth.json. The probe must not upload an empty home or
-    // set CODEX_HOME, so Codex falls back to the sandbox's baked-in login.
+  it("isolates a remote probe from native auth when the host has no credentials to seed", async () => {
     prepareManagedCodexHome.mockImplementationOnce(async () => {
       const dir = await fs.mkdtemp(`${os.tmpdir()}/paperclip-managed-codex-home-noauth-`);
       // No auth.json — only a config file.
       await fs.writeFile(`${dir}/config.toml`, "model = \"gpt-5\"\n");
       return dir;
+    });
+    runAdapterExecutionTargetProcess.mockResolvedValueOnce({
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      stdout: "",
+      stderr: "Not logged in. Please run `codex login` to authenticate.",
+      pid: 321,
+      startedAt: new Date().toISOString(),
     });
 
     const remoteTarget: AdapterExecutionTarget = {
@@ -310,12 +548,739 @@ describe("codex remote environment diagnostics", () => {
       environmentName: "QA Daytona",
     });
 
-    expect(result.status).toBe("pass");
-    // No managed-home upload, so the full-runtime staging is skipped entirely.
-    expect(prepareAdapterExecutionTargetRuntime).not.toHaveBeenCalled();
+    expect(result.status).toBe("warn");
     const probeCall = runAdapterExecutionTargetProcess.mock.calls[0] as unknown as
-      | [string, AdapterExecutionTarget, string, string[], { cwd: string; env: Record<string, string> }]
+      | [string, AdapterExecutionTarget, string, string[], {
+          cwd: string;
+          env: Record<string, string>;
+          stdin?: string;
+        }]
       | undefined;
-    expect(probeCall?.[4].env.CODEX_HOME).toBeUndefined();
+    expect(probeCall?.[4].env.CODEX_HOME).toMatch(/^\/tmp\/paperclip-codex-probe-/);
+    expect(probeCall?.[4].stdin).toContain('"authJson":null');
+    expect(runAdapterExecutionTargetProcess).toHaveBeenCalledTimes(3);
+  });
+
+  it("canonicalizes sandbox installation diagnostics without exposing provider details", async () => {
+    const rawEvidence = "sk-install-secret user@example.test /private/install/path";
+    maybeRunSandboxInstallCommand.mockResolvedValueOnce({
+      code: "codex_install_failed",
+      level: "warn",
+      message: rawEvidence,
+      detail: rawEvidence,
+      hint: rawEvidence,
+    } as never);
+
+    const result = await testEnvironment({
+      companyId: "company-1",
+      adapterType: "codex_local",
+      config: { engine: "cli", command: "custom-codex-wrapper" },
+      executionTarget: buildSandboxTarget(),
+      environmentName: "QA sandbox",
+    });
+
+    expect(result.status).toBe("warn");
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        code: "codex_install_failed",
+        message: "Codex installation check needs attention.",
+      }),
+    );
+    expect(JSON.stringify(result)).not.toMatch(/sk-install-secret|example\.test|private\/install/);
+  });
+
+  it("requires the real Codex CLI command instead of treating a custom command as proof", async () => {
+    const result = await testEnvironment({
+      companyId: "company-1",
+      adapterType: "codex_local",
+      config: { engine: "cli", command: "custom-codex-wrapper" },
+      executionTarget: buildSandboxTarget(),
+      environmentName: "QA sandbox",
+    });
+
+    expect(result.status).toBe("warn");
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        code: "codex_hello_probe_skipped_custom_command",
+        level: "warn",
+      }),
+    );
+    expect(result.checks).not.toContainEqual(
+      expect.objectContaining({ code: "codex_hello_probe_passed" }),
+    );
+    expect(runAdapterExecutionTargetProcess).not.toHaveBeenCalled();
+  });
+
+  it("rejects a configured executable path even when its basename is codex", async () => {
+    const result = await testEnvironment({
+      companyId: "company-1",
+      adapterType: "codex_local",
+      config: { engine: "cli", command: "/private/custom/bin/codex" },
+      executionTarget: buildSandboxTarget(),
+      environmentName: "QA sandbox",
+    });
+
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        code: "codex_hello_probe_skipped_custom_command",
+        level: "warn",
+      }),
+    );
+    expect(result.checks).not.toContainEqual(
+      expect.objectContaining({ code: "codex_hello_probe_passed" }),
+    );
+    expect(runAdapterExecutionTargetProcess).not.toHaveBeenCalled();
+  });
+
+  it("requires the exact bare lowercase codex command", async () => {
+    for (const command of ["codex.cmd", "codex.exe", "CODEX"]) {
+      const result = await testEnvironment({
+        companyId: "company-1",
+        adapterType: "codex_local",
+        config: { engine: "cli", command },
+        executionTarget: buildSandboxTarget(),
+        environmentName: "QA sandbox",
+      });
+
+      expect(result.checks).toContainEqual(
+        expect.objectContaining({
+          code: "codex_hello_probe_skipped_custom_command",
+          level: "warn",
+        }),
+      );
+      expect(result.checks).not.toContainEqual(
+        expect.objectContaining({ code: "codex_hello_probe_passed" }),
+      );
+    }
+    expect(runAdapterExecutionTargetProcess).not.toHaveBeenCalled();
+  });
+
+  it("returns only canonical Hello diagnostics for successful CLI output", async () => {
+    runAdapterExecutionTargetProcess.mockResolvedValueOnce({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: [
+        "{\"type\":\"thread.started\",\"thread_id\":\"thread-sensitive\"}",
+        JSON.stringify({
+          type: "item.completed",
+          item: { type: "agent_message", text: "Hello." },
+        }),
+        "{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":1,\"cached_input_tokens\":0,\"output_tokens\":1}}",
+      ].join("\n"),
+      stderr: "",
+      pid: 123,
+      startedAt: new Date().toISOString(),
+    });
+
+    const result = await testEnvironment({
+      companyId: "company-1",
+      adapterType: "codex_local",
+      config: { engine: "cli", command: "codex" },
+      executionTarget: buildSandboxTarget(),
+      environmentName: "QA sandbox",
+    });
+
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        code: "codex_hello_probe_passed",
+        level: "info",
+        detail: "Hello.",
+      }),
+    );
+    expect(JSON.stringify(result)).not.toContain("thread-sensitive");
+  });
+
+  it("requires an explicit successful terminal event with no protocol failure", async () => {
+    const rawEvidence = "sk-terminal-secret user@example.test /private/terminal";
+    const streams = [
+      [
+        '{"type":"thread.started","thread_id":"thread-1"}',
+        '{"type":"item.completed","item":{"type":"agent_message","text":"Hello."}}',
+      ].join("\n"),
+      [
+        '{"type":"item.completed","item":{"type":"agent_message","text":"Hello."}}',
+        JSON.stringify({ type: "error", message: rawEvidence }),
+        '{"type":"turn.completed","usage":{}}',
+      ].join("\n"),
+      [
+        '{"type":"item.completed","item":{"type":"agent_message","text":"Hello."}}',
+        '{"type":"turn.failed","error":{}}',
+      ].join("\n"),
+      [
+        "not-json",
+        '{"type":"item.completed","item":{"type":"agent_message","text":"Hello."}}',
+        '{"type":"turn.completed","usage":{}}',
+      ].join("\n"),
+      [
+        "[]",
+        '{"type":"item.completed","item":{"type":"agent_message","text":"Hello."}}',
+        '{"type":"turn.completed","usage":{}}',
+      ].join("\n"),
+      [
+        '{"type":"provider.custom"}',
+        '{"type":"item.completed","item":{"type":"agent_message","text":"Hello."}}',
+        '{"type":"turn.completed","usage":{}}',
+      ].join("\n"),
+      [
+        '{"type":"item.completed"}',
+        '{"type":"item.completed","item":{"type":"agent_message","text":"Hello."}}',
+        '{"type":"turn.completed","usage":{}}',
+      ].join("\n"),
+      [
+        '{"type":"turn.completed","usage":{}}',
+        '{"type":"item.completed","item":{"type":"agent_message","text":"Hello."}}',
+      ].join("\n"),
+      [
+        '{"type":"item.completed","item":{"type":"agent_message","text":"Hello."}}',
+        '{"type":"turn.completed","usage":{}}',
+        '{"type":"turn.completed","usage":{}}',
+      ].join("\n"),
+      [
+        '{"type":"item.completed","item":{"type":"agent_message","text":"Hello."}}',
+        '{"type":"turn.completed","usage":{}}',
+        '{"type":"thread.started","thread_id":"late"}',
+      ].join("\n"),
+      [
+        '{"type":"item.completed","item":{"type":"agent_message","text":"Not hello"}}',
+        '{"type":"item.completed","item":{"type":"agent_message","text":"Hello."}}',
+        '{"type":"turn.completed","usage":{}}',
+      ].join("\n"),
+      [
+        '{"type":"thread.started","thread_id":"thread-1"}',
+        '{"type":"item.completed","item":{"type":"command_execution","command":"touch sentinel"}}',
+        '{"type":"item.completed","item":{"type":"agent_message","text":"Hello."}}',
+        '{"type":"turn.completed","usage":{}}',
+      ].join("\n"),
+    ];
+
+    for (const stdout of streams) {
+      runAdapterExecutionTargetProcess.mockResolvedValueOnce({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout,
+        stderr: rawEvidence,
+        pid: 123,
+        startedAt: new Date().toISOString(),
+      });
+      const result = await testEnvironment({
+        companyId: "company-1",
+        adapterType: "codex_local",
+        config: { engine: "cli", command: "codex" },
+        executionTarget: buildSandboxTarget(),
+        environmentName: "QA sandbox",
+      });
+
+      expect(result.checks).toContainEqual(
+        expect.objectContaining({ code: "codex_hello_probe_failed", level: "error" }),
+      );
+      expect(result.checks).not.toContainEqual(
+        expect.objectContaining({ code: "codex_hello_probe_passed" }),
+      );
+      expect(JSON.stringify(result)).not.toMatch(
+        /sk-terminal-secret|example\.test|private\/terminal/,
+      );
+    }
+  });
+
+  it("replaces a successful CLI proof when remote auth-root verification fails", async () => {
+    const rawEvidence = "sk-cleanup-secret user@example.test /private/auth-root";
+    runAdapterExecutionTargetProcess
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: [
+          '{"type":"item.completed","item":{"type":"agent_message","text":"Hello."}}',
+          '{"type":"turn.completed","usage":{}}',
+        ].join("\n"),
+        stderr: "",
+        pid: 123,
+        startedAt: new Date().toISOString(),
+      })
+      .mockResolvedValueOnce({
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: "",
+        stderr: "",
+        pid: 124,
+        startedAt: new Date().toISOString(),
+      })
+      .mockResolvedValueOnce({
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        stdout: "",
+        stderr: rawEvidence,
+        pid: 125,
+        startedAt: new Date().toISOString(),
+      });
+
+    const result = await testEnvironment({
+      companyId: "company-1",
+      adapterType: "codex_local",
+      config: { engine: "cli", command: "codex" },
+      executionTarget: buildSandboxTarget(),
+      environmentName: "QA sandbox",
+    });
+
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({
+        code: "codex_hello_probe_cleanup_failed",
+        level: "error",
+      }),
+    );
+    expect(result.checks).not.toContainEqual(
+      expect.objectContaining({ code: "codex_hello_probe_passed" }),
+    );
+    expect(JSON.stringify(result)).not.toMatch(
+      /sk-cleanup-secret|example\.test|private\/auth-root/,
+    );
+  });
+
+  it("canonicalizes preparation failures without exposing raw errors", async () => {
+    prepareManagedCodexHome.mockRejectedValueOnce(
+      new Error("sk-prepare-secret user@example.test /private/managed-home"),
+    );
+
+    const result = await testEnvironment({
+      companyId: "company-1",
+      adapterType: "codex_local",
+      config: { engine: "cli", command: "codex" },
+      executionTarget: buildSandboxTarget(),
+      environmentName: "QA sandbox",
+    });
+
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({ code: "codex_hello_probe_failed", level: "error" }),
+    );
+    expect(JSON.stringify(result)).not.toMatch(
+      /sk-prepare-secret|example\.test|private\/managed-home/,
+    );
+  });
+
+  it("lets cleanup failure dominate a raw runner rejection", async () => {
+    runAdapterExecutionTargetProcess
+      .mockRejectedValueOnce(new Error("sk-spawn-secret user@example.test /private/spawn"))
+      .mockRejectedValueOnce(new Error("sk-cleanup-secret /private/cleanup"));
+
+    const result = await testEnvironment({
+      companyId: "company-1",
+      adapterType: "codex_local",
+      config: {
+        engine: "cli",
+        command: "codex",
+        env: { OPENAI_API_KEY: "sk-config-secret" },
+      },
+      executionTarget: buildSandboxTarget(),
+      environmentName: "QA sandbox",
+    });
+
+    expect(result.checks).toContainEqual(
+      expect.objectContaining({ code: "codex_hello_probe_cleanup_failed", level: "error" }),
+    );
+    expect(result.checks).not.toContainEqual(
+      expect.objectContaining({ code: "codex_hello_probe_passed" }),
+    );
+    expect(JSON.stringify(result)).not.toMatch(
+      /sk-spawn-secret|sk-cleanup-secret|sk-config-secret|example\.test|private\//,
+    );
+  });
+
+  it("replaces a successful local API-key proof when temp cleanup fails", async () => {
+    process.env.OPENAI_API_KEY = "sk-test";
+    const realRm = fs.rm.bind(fs);
+    const rmSpy = vi.spyOn(fs, "rm").mockImplementation(async (candidate, options) => {
+      if (String(candidate).includes("paperclip-codex-probe-")) {
+        throw new Error("sk-temp-secret user@example.test /private/probe-home");
+      }
+      return realRm(candidate, options);
+    });
+    try {
+      const result = await testEnvironment({
+        companyId: "company-1",
+        adapterType: "codex_local",
+        config: { engine: "cli", command: "codex" },
+        executionTarget: null,
+      });
+
+      expect(result.checks).toContainEqual(
+        expect.objectContaining({
+          code: "codex_hello_probe_cleanup_failed",
+          level: "error",
+        }),
+      );
+      expect(result.checks).not.toContainEqual(
+        expect.objectContaining({ code: "codex_hello_probe_passed" }),
+      );
+      expect(JSON.stringify(result)).not.toMatch(
+        /sk-temp-secret|example\.test|private\/probe-home/,
+      );
+    } finally {
+      rmSpy.mockRestore();
+    }
+  });
+
+  it("removes the local probe root when auth staging fails", async () => {
+    process.env.OPENAI_API_KEY = "sk-test";
+    const realRm = fs.rm.bind(fs);
+    let removedProbeRoot: string | null = null;
+    const writeSpy = vi.spyOn(fs, "writeFile").mockRejectedValueOnce(
+      new Error("sk-stage-secret user@example.test /private/probe-auth"),
+    );
+    const rmSpy = vi.spyOn(fs, "rm").mockImplementation(async (candidate, options) => {
+      if (String(candidate).includes("paperclip-codex-probe-")) {
+        removedProbeRoot = String(candidate);
+      }
+      return realRm(candidate, options);
+    });
+    try {
+      const result = await testEnvironment({
+        companyId: "company-1",
+        adapterType: "codex_local",
+        config: { engine: "cli", command: "codex" },
+        executionTarget: null,
+      });
+
+      expect(result.checks).toContainEqual(
+        expect.objectContaining({ code: "codex_hello_probe_failed", level: "error" }),
+      );
+      expect(result.checks).not.toContainEqual(
+        expect.objectContaining({ code: "codex_hello_probe_cleanup_failed" }),
+      );
+      expect(removedProbeRoot).not.toBeNull();
+      expect(await fs.lstat(removedProbeRoot!).catch(() => null)).toBeNull();
+      expect(JSON.stringify(result)).not.toMatch(
+        /sk-stage-secret|example\.test|private\/probe-auth/,
+      );
+    } finally {
+      writeSpy.mockRestore();
+      rmSpy.mockRestore();
+    }
+  });
+
+  it("reports cleanup failure when failed auth staging leaves a local probe root", async () => {
+    process.env.OPENAI_API_KEY = "sk-test";
+    const realRm = fs.rm.bind(fs);
+    let abandonedProbeRoot: string | null = null;
+    const writeSpy = vi.spyOn(fs, "writeFile").mockRejectedValueOnce(
+      new Error("sk-stage-secret user@example.test /private/probe-auth"),
+    );
+    const rmSpy = vi.spyOn(fs, "rm").mockImplementation(async (candidate, options) => {
+      if (String(candidate).includes("paperclip-codex-probe-")) {
+        abandonedProbeRoot = String(candidate);
+        throw new Error("sk-cleanup-secret user@example.test /private/probe-root");
+      }
+      return realRm(candidate, options);
+    });
+    try {
+      const result = await testEnvironment({
+        companyId: "company-1",
+        adapterType: "codex_local",
+        config: { engine: "cli", command: "codex" },
+        executionTarget: null,
+      });
+
+      expect(result.checks).toContainEqual(
+        expect.objectContaining({
+          code: "codex_hello_probe_cleanup_failed",
+          level: "error",
+        }),
+      );
+      expect(result.checks).not.toContainEqual(
+        expect.objectContaining({ code: "codex_hello_probe_passed" }),
+      );
+      expect(abandonedProbeRoot).not.toBeNull();
+      expect(JSON.stringify(result)).not.toMatch(
+        /sk-stage-secret|sk-cleanup-secret|example\.test|private\//,
+      );
+    } finally {
+      writeSpy.mockRestore();
+      rmSpy.mockRestore();
+      if (abandonedProbeRoot) {
+        await realRm(abandonedProbeRoot, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it("does not expose unexpected or failed CLI output", async () => {
+    const rawEvidence = "sk-failure-secret user@example.test /private/failure/path";
+    const probeResults = [
+      {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: [
+          JSON.stringify({
+            type: "item.completed",
+            item: { type: "agent_message", text: `Not hello ${rawEvidence}` },
+          }),
+          '{"type":"turn.completed","usage":{}}',
+        ].join("\n"),
+        stderr: rawEvidence,
+        pid: 123,
+        startedAt: new Date().toISOString(),
+      },
+      {
+        exitCode: 0,
+        signal: null,
+        timedOut: false,
+        stdout: [
+          JSON.stringify({
+            type: "item.completed",
+            item: { type: "agent_message", text: `Hello. ${rawEvidence}` },
+          }),
+          '{"type":"turn.completed","usage":{}}',
+        ].join("\n"),
+        stderr: rawEvidence,
+        pid: 123,
+        startedAt: new Date().toISOString(),
+      },
+      {
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        stdout: rawEvidence,
+        stderr: rawEvidence,
+        pid: 123,
+        startedAt: new Date().toISOString(),
+      },
+    ];
+
+    for (const probeResult of probeResults) {
+      runAdapterExecutionTargetProcess.mockResolvedValueOnce(probeResult);
+      const result = await testEnvironment({
+        companyId: "company-1",
+        adapterType: "codex_local",
+        config: { engine: "cli", command: "codex" },
+        executionTarget: buildSandboxTarget(),
+        environmentName: "QA sandbox",
+      });
+      expect(result.checks).not.toContainEqual(
+        expect.objectContaining({ code: "codex_hello_probe_passed" }),
+      );
+      expect(JSON.stringify(result)).not.toMatch(/sk-failure-secret|example\.test|private\/failure/);
+    }
+  });
+
+  it("preserves sandbox files while staging 0600 auth over stdin and cleaning the auth root", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-probe-preserve-"));
+    const sandboxWorkspace = path.join(root, "sandbox-workspace");
+    const sandboxDefaultCwd = path.join(root, "sandbox-default");
+    const sandboxBin = path.join(root, "bin");
+    const sentinelPath = path.join(sandboxWorkspace, "operator-data.txt");
+    await fs.mkdir(sandboxWorkspace, { recursive: true });
+    await fs.mkdir(sandboxDefaultCwd, { recursive: true });
+    await fs.mkdir(sandboxBin, { recursive: true });
+    await fs.writeFile(sentinelPath, "keep-this-byte-for-byte\n", "utf8");
+    const fakeCodex = `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const forbidden = ["OPENAI_API_KEY", "CODEX_AUTH_JSON", "_PAPERCLIP_CODEX_AUTH_JSON"];
+const home = process.env.CODEX_HOME || "";
+const authPath = path.join(home, "auth.json");
+const prompt = fs.readFileSync(0, "utf8").trim();
+const failures = [];
+if (!forbidden.every((key) => process.env[key] === undefined)) failures.push("ambient-auth");
+if (path.basename(process.cwd()) !== "workspace") failures.push("workspace-name");
+if (fs.realpathSync(path.dirname(process.cwd())) !== fs.realpathSync(path.dirname(home))) failures.push("workspace-scope");
+if (fs.realpathSync(process.cwd()) === fs.realpathSync(${JSON.stringify(sandboxWorkspace)})) failures.push("operator-workspace");
+if (prompt !== "Reply with exactly Hello. Do not use tools.") failures.push("prompt");
+try {
+  const auth = JSON.parse(fs.readFileSync(authPath, "utf8"));
+  if (typeof auth.OPENAI_API_KEY !== "string") failures.push("auth-shape");
+  if ((fs.statSync(authPath).mode & 0o777) !== 0o600) failures.push("auth-mode");
+} catch {
+  failures.push("auth-read");
+}
+if (failures.length > 0) {
+  process.stdout.write(JSON.stringify({type:"turn.failed",error:{failures}}) + "\\n");
+  process.exit(1);
+}
+process.stdout.write('{"type":"thread.started","thread_id":"thread-1"}\\n');
+process.stdout.write('{"type":"item.completed","item":{"type":"reasoning","text":""}}\\n');
+process.stdout.write('{"type":"item.completed","item":{"type":"agent_message","text":"Hello."}}\\n');
+process.stdout.write('{"type":"turn.completed","usage":{}}\\n');
+`;
+    await fs.writeFile(path.join(sandboxBin, "codex"), fakeCodex, {
+      encoding: "utf8",
+      mode: 0o755,
+    });
+
+    let observedAuthRoot: string | null = null;
+    const observedRuns: Array<Awaited<ReturnType<typeof runChildProcess>>> = [];
+    const runner = {
+      execute: async (input: {
+        command: string;
+        args?: string[];
+        cwd?: string;
+        env?: Record<string, string>;
+        stdin?: string;
+        timeoutMs?: number;
+        onLog?: (stream: "stdout" | "stderr", chunk: string) => Promise<void>;
+      }) => {
+        const command = input.command === "bash" ? "/bin/bash" : input.command;
+        if (input.env?.CODEX_HOME) observedAuthRoot = input.env.CODEX_HOME;
+        const inheritedEnv = Object.fromEntries(
+          Object.entries(process.env).filter((entry): entry is [string, string] =>
+            typeof entry[1] === "string"
+          ),
+        );
+        const result = await runChildProcess("codex-probe-preserve", command, input.args ?? [], {
+          cwd: input.cwd ?? "/",
+          env: {
+            ...inheritedEnv,
+            ...input.env,
+            PATH: `${sandboxBin}:${inheritedEnv.PATH ?? ""}`,
+          },
+          stdin: input.stdin,
+          timeoutSec: Math.max(1, Math.ceil((input.timeoutMs ?? 30_000) / 1000)),
+          graceSec: 5,
+          onLog: input.onLog ?? (async () => {}),
+        });
+        observedRuns.push(result);
+        return result;
+      },
+    };
+    const target: AdapterExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      providerKey: "local-behavioral-fixture",
+      remoteCwd: sandboxDefaultCwd,
+      runner,
+    };
+    const actualExecutionTarget = await vi.importActual<
+      typeof import("@paperclipai/adapter-utils/execution-target")
+    >("@paperclipai/adapter-utils/execution-target");
+    runAdapterExecutionTargetProcess.mockImplementation(
+      actualExecutionTarget.runAdapterExecutionTargetProcess as never,
+    );
+
+    try {
+      const result = await testEnvironment({
+        companyId: "company-1",
+        adapterType: "codex_local",
+        config: {
+          engine: "cli",
+          command: "codex",
+          cwd: sandboxWorkspace,
+          env: { OPENAI_API_KEY: "sk-behavioral" },
+        },
+        executionTarget: target,
+        environmentName: "Behavioral sandbox",
+      });
+
+      expect(observedRuns[0]?.stderr).toBe("");
+      expect(observedRuns[0]?.stdout).toContain('"type":"turn.completed"');
+      expect(result.checks).toContainEqual(
+        expect.objectContaining({ code: "codex_hello_probe_passed", level: "info" }),
+      );
+      expect(observedAuthRoot).toMatch(/^\/tmp\/paperclip-codex-probe-/);
+      await expect(fs.stat(observedAuthRoot!).catch(() => null)).resolves.toBeNull();
+      await expect(fs.readFile(sentinelPath, "utf8")).resolves.toBe(
+        "keep-this-byte-for-byte\n",
+      );
+      await expect(fs.readdir(sandboxWorkspace)).resolves.toEqual(["operator-data.txt"]);
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("omits host Codex secrets from the real local child environment", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-local-env-"));
+    const binDir = path.join(root, "bin");
+    await fs.mkdir(binDir, { recursive: true });
+    const fakeCodex = `#!/usr/bin/env node
+const fs = require("node:fs");
+const path = require("node:path");
+const forbidden = ["OPENAI_API_KEY", "CODEX_API_KEY", "CODEX_AUTH_JSON", "_PAPERCLIP_CODEX_AUTH_JSON"];
+const home = process.env.CODEX_HOME || "";
+const prompt = fs.readFileSync(0, "utf8").trim();
+let valid = forbidden.every((key) => process.env[key] === undefined);
+valid = valid && prompt === "Reply with exactly Hello. Do not use tools.";
+valid = valid && path.basename(process.cwd()) === "workspace";
+valid = valid && fs.realpathSync(process.cwd()) !== fs.realpathSync(${JSON.stringify(root)});
+try {
+  const authPath = path.join(home, "auth.json");
+  const auth = JSON.parse(fs.readFileSync(authPath, "utf8"));
+  valid = valid && auth.OPENAI_API_KEY === "sk-host-secret";
+  valid = valid && (fs.statSync(authPath).mode & 0o777) === 0o600;
+} catch {
+  valid = false;
+}
+if (!valid) {
+  process.stdout.write('{"type":"turn.failed","error":{}}\\n');
+  process.exit(1);
+}
+process.stdout.write('{"type":"thread.started","thread_id":"thread-1"}\\n');
+process.stdout.write('{"type":"item.completed","item":{"type":"agent_message","text":"Hello."}}\\n');
+process.stdout.write('{"type":"turn.completed","usage":{}}\\n');
+`;
+    await fs.writeFile(path.join(binDir, "codex"), fakeCodex, {
+      encoding: "utf8",
+      mode: 0o755,
+    });
+
+    const originalEnv = {
+      PATH: process.env.PATH,
+      OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+      CODEX_API_KEY: process.env.CODEX_API_KEY,
+      CODEX_AUTH_JSON: process.env.CODEX_AUTH_JSON,
+      _PAPERCLIP_CODEX_AUTH_JSON: process.env._PAPERCLIP_CODEX_AUTH_JSON,
+    };
+    process.env.PATH = `${binDir}${path.delimiter}${originalEnv.PATH ?? ""}`;
+    process.env.OPENAI_API_KEY = "sk-host-secret";
+    process.env.CODEX_API_KEY = "sk-host-secondary";
+    process.env.CODEX_AUTH_JSON = "sk-host-auth-json";
+    process.env._PAPERCLIP_CODEX_AUTH_JSON = "sk-host-paperclip-json";
+    const actualExecutionTarget = await vi.importActual<
+      typeof import("@paperclipai/adapter-utils/execution-target")
+    >("@paperclipai/adapter-utils/execution-target");
+    runAdapterExecutionTargetProcess.mockImplementation(
+      actualExecutionTarget.runAdapterExecutionTargetProcess as never,
+    );
+
+    try {
+      const result = await testEnvironment({
+        companyId: "company-1",
+        adapterType: "codex_local",
+        config: {
+          engine: "cli",
+          command: "codex",
+          cwd: root,
+          dangerouslyBypassApprovalsAndSandbox: true,
+          extraArgs: ["--dangerously-bypass-approvals-and-sandbox", "unsafe-local-marker"],
+        },
+        executionTarget: null,
+      });
+
+      expect(result.checks).toContainEqual(
+        expect.objectContaining({ code: "codex_hello_probe_passed", level: "info" }),
+      );
+      const probeCall = executionProcessCalls()[0];
+      expect(probeCall?.[4].cwd).not.toBe(root);
+      expect(path.basename(probeCall?.[4].cwd ?? "")).toBe("workspace");
+      expect(probeCall?.[3]).not.toContain("--dangerously-bypass-approvals-and-sandbox");
+      expect(probeCall?.[3]).not.toContain("unsafe-local-marker");
+      expect(probeCall?.[4].denyEnvironmentKeys).toEqual([
+        "OPENAI_API_KEY",
+        "CODEX_API_KEY",
+        "CODEX_AUTH_JSON",
+        "_PAPERCLIP_CODEX_AUTH_JSON",
+      ]);
+      const authRoot = probeCall?.[4].env.CODEX_HOME;
+      await expect(fs.lstat(authRoot!).catch(() => null)).resolves.toBeNull();
+      expect(JSON.stringify(result)).not.toMatch(
+        /sk-host-secret|sk-host-secondary|sk-host-auth-json|sk-host-paperclip-json/,
+      );
+    } finally {
+      for (const [key, value] of Object.entries(originalEnv)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/adapters/codex-local/src/server/test.ts
+++ b/packages/adapters/codex-local/src/server/test.ts
@@ -6,27 +6,32 @@ import type {
 import {
   asString,
   parseObject,
+  parseJson,
   ensurePathInEnv,
 } from "@paperclipai/adapter-utils/server-utils";
 import {
   ensureAdapterExecutionTargetCommandResolvable,
   ensureAdapterExecutionTargetDirectory,
   maybeRunSandboxInstallCommand,
+  overrideAdapterExecutionTargetRemoteCwd,
   runAdapterExecutionTargetProcess,
   describeAdapterExecutionTarget,
   resolveAdapterExecutionTargetCwd,
-  prepareAdapterExecutionTargetRuntime,
 } from "@paperclipai/adapter-utils/execution-target";
 import fs from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 import { parseCodexJsonl } from "./parse.js";
 import { SANDBOX_INSTALL_COMMAND } from "../index.js";
-import { codexHomeDir, readCodexAuthInfo } from "./quota.js";
+import { readCodexAuthInfo } from "./quota.js";
 import { buildCodexExecArgs } from "./codex-args.js";
 import { prepareManagedCodexHome } from "./codex-home.js";
 import { resolveCodexExecutionEngineForRun, testCodexAcpEnvironment } from "./acp.js";
 import { ADAPTER_AUTH_MISSING_CHECK_CODE } from "./auth-check.js";
+import {
+  classifyCodexProbeAuth,
+  snapshotDurableCodexProbeAuth,
+} from "./codex-probe-auth.js";
 
 function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
   if (checks.some((check) => check.level === "error")) return "fail";
@@ -38,27 +43,132 @@ function isNonEmpty(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
-function firstNonEmptyLine(text: string): string {
-  return (
-    text
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .find(Boolean) ?? ""
+function isCanonicalCodexCommand(command: string): boolean {
+  return command.trim() === "codex";
+}
+
+function inspectCodexProbeProtocol(stdout: string): { valid: boolean; succeeded: boolean } {
+  const safeItemTypes = new Set(["reasoning", "agent_message"]);
+  let valid = true;
+  let threadSeen = false;
+  let turnStarted = false;
+  let helloCount = 0;
+  let successfulTerminalCount = 0;
+  let terminalSeen = false;
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const event = parseJson(line);
+    if (!event || typeof event !== "object" || Array.isArray(event)) {
+      valid = false;
+      continue;
+    }
+    const type = asString(event.type, "");
+    if (!type || terminalSeen) {
+      valid = false;
+      continue;
+    }
+    if (type === "error" || type === "turn.failed") {
+      valid = false;
+      terminalSeen = true;
+      continue;
+    }
+    if (type === "thread.started") {
+      if (threadSeen || helloCount > 0 || !isNonEmpty(event.thread_id)) valid = false;
+      threadSeen = true;
+      continue;
+    }
+    if (type === "turn.started") {
+      if (!threadSeen || turnStarted || helloCount > 0) valid = false;
+      turnStarted = true;
+      continue;
+    }
+    if (type === "item.completed") {
+      if (
+        !threadSeen ||
+        !event.item ||
+        typeof event.item !== "object" ||
+        Array.isArray(event.item)
+      ) {
+        valid = false;
+        continue;
+      }
+      const item = parseObject(event.item);
+      const itemType = asString(item.type, "");
+      if (!safeItemTypes.has(itemType)) {
+        valid = false;
+      } else if (itemType === "agent_message") {
+        helloCount += 1;
+        if (asString(item.text, "").trim() !== "Hello.") valid = false;
+      }
+      continue;
+    }
+    if (type === "item.started" || type === "item.updated") {
+      if (
+        !threadSeen ||
+        !event.item ||
+        typeof event.item !== "object" ||
+        Array.isArray(event.item) ||
+        !safeItemTypes.has(asString(parseObject(event.item).type, ""))
+      ) {
+        valid = false;
+      }
+      continue;
+    }
+    if (type === "turn.completed") {
+      terminalSeen = true;
+      successfulTerminalCount += 1;
+      if (!threadSeen || helloCount !== 1) valid = false;
+      continue;
+    }
+    valid = false;
+  }
+  return {
+    valid,
+    succeeded: valid && helloCount === 1 && successfulTerminalCount === 1,
+  };
+}
+
+const CODEX_PROBE_AUTH_ENV_KEY_NAMES = [
+  "OPENAI_API_KEY",
+  "CODEX_API_KEY",
+  "CODEX_AUTH_JSON",
+  "_PAPERCLIP_CODEX_AUTH_JSON",
+] as const;
+const CODEX_PROBE_AUTH_ENV_KEYS = new Set<string>(CODEX_PROBE_AUTH_ENV_KEY_NAMES);
+const CODEX_PROBE_PREPARATION_CLEANUP_FAILED =
+  "codex_probe_preparation_cleanup_failed";
+
+function stripCodexProbeAuthEnv(env: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(env).filter(([key]) => !CODEX_PROBE_AUTH_ENV_KEYS.has(key.toUpperCase())),
   );
 }
 
-function commandLooksLike(command: string, expected: string): boolean {
-  const base = path.basename(command).toLowerCase();
-  return base === expected || base === `${expected}.cmd` || base === `${expected}.exe`;
-}
-
-function summarizeProbeDetail(stdout: string, stderr: string, parsedError: string | null): string | null {
-  const raw = parsedError?.trim() || firstNonEmptyLine(stderr) || firstNonEmptyLine(stdout);
-  if (!raw) return null;
-  const clean = raw.replace(/\s+/g, " ").trim();
-  const max = 240;
-  return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
-}
+const CODEX_PROBE_HOME_STAGE_SCRIPT = [
+  "set -eu",
+  "umask 077",
+  `node -e '${[
+    'const fs=require("node:fs")',
+    'const path=require("node:path")',
+    'const home=process.env.CODEX_HOME',
+    'const workspace=process.env.PAPERCLIP_CODEX_PROBE_WORKSPACE',
+    'if(!home||!workspace)throw new Error("missing probe paths")',
+    'const root=path.dirname(home)',
+    'fs.mkdirSync(root,{mode:0o700})',
+    'const rootStat=fs.lstatSync(root)',
+    'if(!rootStat.isDirectory()||rootStat.isSymbolicLink())throw new Error("invalid probe root")',
+    'fs.mkdirSync(home,{mode:0o700})',
+    'fs.mkdirSync(workspace,{mode:0o700})',
+    'for(const candidate of [home,workspace]){const stat=fs.lstatSync(candidate);if(!stat.isDirectory()||stat.isSymbolicLink())throw new Error("invalid probe directory")}',
+    'const payload=JSON.parse(fs.readFileSync(0,"utf8"))',
+    'if(payload.authJson!==null&&typeof payload.authJson!=="string")throw new Error("invalid auth payload")',
+    'if(typeof payload.authJson==="string")fs.writeFileSync(path.join(home,"auth.json"),Buffer.from(payload.authJson,"base64"),{mode:0o600,flag:"wx"})',
+  ].join(";")}'`,
+  'cd "$PAPERCLIP_CODEX_PROBE_WORKSPACE"',
+  "unset PAPERCLIP_CODEX_PROBE_WORKSPACE",
+  'printf "%s\\n" "Reply with exactly Hello. Do not use tools." | "$@"',
+].join("; ");
 
 const CODEX_AUTH_REQUIRED_RE =
   /(?:not\s+logged\s+in|login\s+required|authentication\s+required|unauthorized|invalid(?:\s+or\s+missing)?\s+api(?:[_\s-]?key)?|openai[_\s-]?api[_\s-]?key|api[_\s-]?key.*required|please\s+run\s+`?codex\s+login`?)/i;
@@ -73,124 +183,168 @@ async function prepareCodexHelloProbe(input: {
   args: string[];
   env: Record<string, string>;
   probeApiKey: string | null;
+  probeAuthJson: string | null;
 }): Promise<{
   command: string;
   args: string[];
   env: Record<string, string>;
-  cleanup: () => Promise<void>;
+  cwd: string;
+  stdin: string;
+  cleanup: () => Promise<boolean>;
 }> {
-  let preparedRuntime: Awaited<ReturnType<typeof prepareAdapterExecutionTargetRuntime>> | null = null;
-  let preparedRuntimeWorkspaceLocalDir: string | null = null;
-  let probeHomeLocalDir: string | null = null;
+  let probeAuthRootLocalDir: string | null = null;
+  let probeAuthRootRemoteDir: string | null = null;
 
   const cleanup = async () => {
-    await preparedRuntime?.restoreWorkspace().catch(() => {});
-    if (preparedRuntimeWorkspaceLocalDir) {
-      await fs.rm(preparedRuntimeWorkspaceLocalDir, { recursive: true, force: true }).catch(() => {});
+    let succeeded = true;
+    if (probeAuthRootRemoteDir) {
+      const cleanupTarget = input.target?.kind === "remote"
+        ? input.target.transport === "sandbox"
+          ? { ...input.target, remoteCwd: "/tmp" }
+          : {
+              ...input.target,
+              remoteCwd: "/tmp",
+              spec: { ...input.target.spec, remoteCwd: "/tmp" },
+            }
+        : input.target;
+      try {
+        const removal = await runAdapterExecutionTargetProcess(
+          `${input.runId}-cleanup`,
+          cleanupTarget,
+          "rm",
+          ["-rf", "--", probeAuthRootRemoteDir],
+          {
+            cwd: "/tmp",
+            env: {},
+            denyEnvironmentKeys: CODEX_PROBE_AUTH_ENV_KEY_NAMES,
+            timeoutSec: 15,
+            graceSec: 5,
+            onLog: async () => {},
+          },
+        );
+        if (removal.timedOut || (removal.exitCode ?? 1) !== 0) succeeded = false;
+      } catch {
+        succeeded = false;
+      }
+      try {
+        const verification = await runAdapterExecutionTargetProcess(
+          `${input.runId}-cleanup-verify`,
+          cleanupTarget,
+          "sh",
+          ["-c", '[ ! -e "$1" ] && [ ! -L "$1" ]', "sh", probeAuthRootRemoteDir],
+          {
+            cwd: "/tmp",
+            env: {},
+            denyEnvironmentKeys: CODEX_PROBE_AUTH_ENV_KEY_NAMES,
+            timeoutSec: 15,
+            graceSec: 5,
+            onLog: async () => {},
+          },
+        );
+        if (verification.timedOut || (verification.exitCode ?? 1) !== 0) succeeded = false;
+      } catch {
+        succeeded = false;
+      }
     }
-    if (probeHomeLocalDir) {
-      await fs.rm(probeHomeLocalDir, { recursive: true, force: true }).catch(() => {});
+    if (probeAuthRootLocalDir) {
+      try {
+        await fs.rm(probeAuthRootLocalDir, { recursive: true, force: true });
+        const remaining = await fs.lstat(probeAuthRootLocalDir).catch(() => null);
+        if (remaining) succeeded = false;
+      } catch {
+        succeeded = false;
+      }
     }
+    return succeeded;
   };
 
-  if (input.targetIsRemote && !input.probeApiKey) {
+  let authJson: Buffer | null = input.probeApiKey
+    ? Buffer.from(JSON.stringify({ OPENAI_API_KEY: input.probeApiKey }), "utf8")
+      : input.probeAuthJson
+      ? Buffer.from(input.probeAuthJson, "utf8")
+      : null;
+
+  if (authJson && classifyCodexProbeAuth(authJson) !== "api_key") {
+    throw new Error("codex_probe_nonpersistent_subscription_auth_unsupported");
+  }
+
+  if (!authJson && input.targetIsRemote) {
     const managedHome = await prepareManagedCodexHome(process.env, async () => {}, input.companyId, {
       apiKey: null,
     });
-
-    // Upload only the credential/config files the login probe needs, not the
-    // entire managed CODEX_HOME. A real managed home accumulates hundreds of MB
-    // of session/state history (`sessions/`, `state_*.sqlite`, …); tarring and
-    // streaming all of it into the sandbox made the environment Test probe take
-    // many minutes and look like it hung. The hello probe only needs auth.
-    probeHomeLocalDir = await fs.mkdtemp(
-      path.join(os.tmpdir(), `paperclip-codex-probe-home-${input.runId}-`),
-    );
-    let seededAuth = false;
-    for (const file of ["auth.json", "config.toml"]) {
-      // `fs.readFile` follows the managed home's `auth.json` symlink into the
-      // host's `~/.codex`, so we copy the resolved bytes as a plain file.
-      const contents = await fs.readFile(path.join(managedHome, file)).catch(() => null);
-      if (contents) {
-        await fs.writeFile(path.join(probeHomeLocalDir, file), contents);
-        if (file === "auth.json") seededAuth = true;
+    const authSnapshot = await snapshotDurableCodexProbeAuth(managedHome).catch((error) => {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw error;
+    });
+    authJson = authSnapshot?.bytes ?? null;
+    if (authSnapshot) {
+      if (authSnapshot.kind === "subscription") {
+        throw new Error("codex_probe_remote_subscription_auth_unsupported");
+      }
+      if (authSnapshot.kind === "unsupported") {
+        throw new Error("codex_probe_auth_format_unsupported");
       }
     }
-
-    // When the host has no Codex credentials to seed, don't override CODEX_HOME.
-    // Pointing Codex at an empty uploaded home would mask any login already
-    // baked into the sandbox (e.g. a captured custom-image snapshot); leaving
-    // CODEX_HOME unset lets the probe exercise that in-sandbox login instead.
-    if (!seededAuth) {
-      return {
-        command: input.command,
-        args: input.args,
-        env: { ...input.env },
-        cleanup,
-      };
-    }
-
-    preparedRuntimeWorkspaceLocalDir = await fs.mkdtemp(
-      path.join(os.tmpdir(), `paperclip-codex-envtest-${input.runId}-`),
-    );
-    preparedRuntime = await prepareAdapterExecutionTargetRuntime({
-      runId: input.runId,
-      target: input.target,
-      adapterKey: "codex",
-      workspaceLocalDir: preparedRuntimeWorkspaceLocalDir,
-      // Pass `input.cwd` as the base (not a pre-built per-run subdir).
-      // `prepareRemoteManagedRuntime` itself appends
-      // `.paperclip-runtime/runs/<runId>/workspace` to whatever it gets, so
-      // pre-building a per-run path here would double-nest the run ID.
-      workspaceRemoteDir: input.cwd,
-      installCommand: SANDBOX_INSTALL_COMMAND,
-      detectCommand: input.command,
-      assets: [
-        {
-          key: "home",
-          localDir: probeHomeLocalDir,
-          followSymlinks: true,
-        },
-      ],
-    });
-
-    return {
-      command: input.command,
-      args: input.args,
-      env: preparedRuntime.assetDirs.home
-        ? { ...input.env, CODEX_HOME: preparedRuntime.assetDirs.home }
-        : { ...input.env },
-      cleanup,
-    };
   }
 
-  if (input.probeApiKey) {
-    const probeHome = input.targetIsRemote
-      ? path.posix.join(input.cwd, ".paperclip-runtime", "codex", `probe-home-${input.runId}`)
-      : path.join(os.tmpdir(), `paperclip-codex-probe-${input.runId}`);
+  const sanitizedEnv = stripCodexProbeAuthEnv(input.env);
+  if (input.targetIsRemote) {
+    const probeRoot = path.posix.join("/tmp", `paperclip-codex-probe-${input.runId}`);
+    const probeHome = path.posix.join(probeRoot, "home");
+    const probeWorkspace = path.posix.join(probeRoot, "workspace");
+    probeAuthRootRemoteDir = probeRoot;
     return {
       command: "sh",
       args: [
         "-c",
-        'set -e; mkdir -p "$CODEX_HOME"; umask 077; printf "%s" "$_PAPERCLIP_CODEX_AUTH_JSON" > "$CODEX_HOME/auth.json"; unset _PAPERCLIP_CODEX_AUTH_JSON; trap \'rm -rf "$CODEX_HOME"\' EXIT INT TERM; "$0" "$@"',
+        CODEX_PROBE_HOME_STAGE_SCRIPT,
+        "paperclip-codex-probe",
         input.command,
         ...input.args,
       ],
       env: {
-        ...input.env,
+        ...sanitizedEnv,
         CODEX_HOME: probeHome,
-        _PAPERCLIP_CODEX_AUTH_JSON: JSON.stringify({ OPENAI_API_KEY: input.probeApiKey }),
+        PAPERCLIP_CODEX_PROBE_WORKSPACE: probeWorkspace,
       },
+      cwd: input.cwd,
+      stdin: JSON.stringify({
+        authJson: authJson?.toString("base64") ?? null,
+      }),
       cleanup,
     };
   }
 
-  return {
-    command: input.command,
-    args: input.args,
-    env: { ...input.env },
-    cleanup,
-  };
+  const probeRoot = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-probe-"));
+  probeAuthRootLocalDir = probeRoot;
+  try {
+    const probeWorkspace = path.join(probeRoot, "workspace");
+    await fs.mkdir(probeWorkspace, { mode: 0o700 });
+    let probeEnv = sanitizedEnv;
+    if (authJson) {
+      const probeHome = path.join(probeRoot, "home");
+      await fs.mkdir(probeHome, { mode: 0o700 });
+      await fs.writeFile(path.join(probeHome, "auth.json"), authJson, {
+        mode: 0o600,
+        flag: "wx",
+      });
+      probeEnv = { ...sanitizedEnv, CODEX_HOME: probeHome };
+    }
+    return {
+      command: input.command,
+      args: input.args,
+      env: probeEnv,
+      cwd: probeWorkspace,
+      stdin: "Reply with exactly Hello. Do not use tools.",
+      cleanup,
+    };
+  } catch (error) {
+    const cleanupSucceeded = await cleanup().catch(() => false);
+    if (!cleanupSucceeded) {
+      throw new Error(CODEX_PROBE_PREPARATION_CLEANUP_FAILED);
+    }
+    throw error;
+  }
 }
 
 export async function testEnvironment(
@@ -204,14 +358,13 @@ export async function testEnvironment(
     return testCodexAcpEnvironment(ctx);
   }
 
-  const checks: AdapterEnvironmentCheck[] = [];
+  let checks: AdapterEnvironmentCheck[] = [];
   if (!engineSelection.explicit && engineSelection.fallbackReason) {
     checks.push({
       code: "codex_acp_default_fallback",
       level: "warn",
       message: "Codex ACP default is unavailable; testing the Codex CLI fallback lane.",
-      detail: engineSelection.fallbackReason,
-      hint: "Fix the ACP prerequisite to use the default ACP lane, or set engine=cli to pin the CLI lane.",
+      hint: "Fix the ACP prerequisite to use the default ACP lane, or explicitly select the CLI lane.",
     });
   }
   const config = parseObject(ctx.config);
@@ -220,6 +373,9 @@ export async function testEnvironment(
   const targetIsRemote = target?.kind === "remote";
   const targetIsSandbox = target?.kind === "remote" && target.transport === "sandbox";
   const cwd = resolveAdapterExecutionTargetCwd(target, asString(config.cwd, ""), process.cwd());
+  const cwdBoundTarget = targetIsSandbox && target
+    ? { ...target, remoteCwd: cwd }
+    : target;
   const targetLabel = targetIsRemote
     ? ctx.environmentName ?? describeAdapterExecutionTarget(target)
     : null;
@@ -229,12 +385,12 @@ export async function testEnvironment(
     checks.push({
       code: "codex_environment_target",
       level: "info",
-      message: `Probing inside environment: ${targetLabel}`,
+      message: "Probing inside the selected execution environment.",
     });
   }
 
   try {
-    await ensureAdapterExecutionTargetDirectory(runId, target, cwd, {
+    await ensureAdapterExecutionTargetDirectory(runId, cwdBoundTarget, cwd, {
       cwd,
       env: {},
       createIfMissing: true,
@@ -242,14 +398,13 @@ export async function testEnvironment(
     checks.push({
       code: "codex_cwd_valid",
       level: "info",
-      message: `Working directory is valid: ${cwd}`,
+      message: "Working directory is valid.",
     });
-  } catch (err) {
+  } catch {
     checks.push({
       code: "codex_cwd_invalid",
       level: "error",
-      message: err instanceof Error ? err.message : "Invalid working directory",
-      detail: cwd,
+      message: "Working directory is invalid or inaccessible.",
     });
   }
 
@@ -258,41 +413,71 @@ export async function testEnvironment(
   for (const [key, value] of Object.entries(envConfig)) {
     if (typeof value === "string") env[key] = value;
   }
-  const runtimeEnv = ensurePathInEnv({ ...process.env, ...env });
+  const inheritedEnv = Object.fromEntries(
+    Object.entries(process.env).filter((entry): entry is [string, string] =>
+      typeof entry[1] === "string"
+    ),
+  );
+  const sanitizedProbeEnv = stripCodexProbeAuthEnv(env);
+  const runtimeEnv = ensurePathInEnv(stripCodexProbeAuthEnv({ ...inheritedEnv, ...env }));
   const installCheck = await maybeRunSandboxInstallCommand({
     runId,
-    target,
+    target: cwdBoundTarget,
     adapterKey: "codex",
     installCommand: SANDBOX_INSTALL_COMMAND,
     detectCommand: command,
-    env,
+    env: sanitizedProbeEnv,
   });
-  if (installCheck) checks.push(installCheck);
+  if (installCheck) {
+    checks.push({
+      code: installCheck.code,
+      level: installCheck.level,
+      message:
+        installCheck.level === "warn"
+          ? "Codex installation check needs attention."
+          : "Codex installation check completed.",
+      ...(installCheck.level === "warn"
+        ? { hint: "Verify that the Codex CLI is installed in the selected sandbox." }
+        : {}),
+    });
+  }
   try {
-    await ensureAdapterExecutionTargetCommandResolvable(command, target, cwd, runtimeEnv);
+    await ensureAdapterExecutionTargetCommandResolvable(command, cwdBoundTarget, cwd, runtimeEnv);
     checks.push({
       code: "codex_command_resolvable",
       level: "info",
-      message: `Command is executable: ${command}`,
+      message: "Codex command is executable.",
     });
-  } catch (err) {
+  } catch {
     checks.push({
       code: "codex_command_unresolvable",
       level: "error",
-      message: err instanceof Error ? err.message : "Command is not executable",
-      detail: command,
+      message: "Codex command is not executable.",
     });
   }
 
-  const configOpenAiKey = env.OPENAI_API_KEY;
-  const hostOpenAiKey = targetIsRemote ? undefined : process.env.OPENAI_API_KEY;
-  if (isNonEmpty(configOpenAiKey) || isNonEmpty(hostOpenAiKey)) {
-    const source = isNonEmpty(configOpenAiKey) ? "adapter config env" : "server environment";
+  const configAuthJson = isNonEmpty(env.CODEX_AUTH_JSON)
+    ? env.CODEX_AUTH_JSON
+    : isNonEmpty(env._PAPERCLIP_CODEX_AUTH_JSON)
+      ? env._PAPERCLIP_CODEX_AUTH_JSON
+      : null;
+  const configApiKey = isNonEmpty(env.OPENAI_API_KEY)
+    ? env.OPENAI_API_KEY
+    : isNonEmpty(env.CODEX_API_KEY)
+      ? env.CODEX_API_KEY
+      : null;
+  const hostApiKey = targetIsRemote
+    ? null
+    : isNonEmpty(process.env.OPENAI_API_KEY)
+      ? process.env.OPENAI_API_KEY
+      : isNonEmpty(process.env.CODEX_API_KEY)
+        ? process.env.CODEX_API_KEY
+        : null;
+  if (configAuthJson || configApiKey || hostApiKey) {
     checks.push({
       code: "codex_openai_api_key_present",
       level: "info",
       message: "OPENAI_API_KEY is set for Codex authentication.",
-      detail: `Detected in ${source}.`,
     });
   } else if (!targetIsRemote) {
     // Local-only auth file check. On remote targets, the probe will surface
@@ -304,7 +489,6 @@ export async function testEnvironment(
         code: "codex_native_auth_present",
         level: "info",
         message: "Codex is authenticated via its own auth configuration.",
-        detail: codexAuth.email ? `Logged in as ${codexAuth.email}.` : `Credentials found in ${path.join(codexHome ?? codexHomeDir(), "auth.json")}.`,
       });
     } else {
       checks.push({
@@ -319,17 +503,24 @@ export async function testEnvironment(
   const canRunProbe =
     checks.every((check) => check.code !== "codex_cwd_invalid" && check.code !== "codex_command_unresolvable");
   if (canRunProbe) {
-    if (!commandLooksLike(command, "codex")) {
+    if (!isCanonicalCodexCommand(command)) {
       checks.push({
         code: "codex_hello_probe_skipped_custom_command",
-        level: "info",
+        level: "warn",
         message: "Skipped hello probe because command is not `codex`.",
-        detail: command,
         hint: "Use the `codex` CLI command to run the automatic login and installation probe.",
       });
     } else {
       const execArgs = buildCodexExecArgs(
-        { ...config, fastMode: false },
+        {
+          ...config,
+          fastMode: false,
+          search: false,
+          dangerouslyBypassApprovalsAndSandbox: false,
+          dangerouslyBypassSandbox: false,
+          extraArgs: [],
+          args: [],
+        },
         { skipGitRepoCheck: targetIsSandbox },
       );
       const args = execArgs.args;
@@ -337,7 +528,7 @@ export async function testEnvironment(
         checks.push({
           code: "codex_fast_mode_unsupported_model",
           level: "warn",
-          message: execArgs.fastModeIgnoredReason,
+          message: "Codex Fast mode is unavailable for the selected model.",
           hint: "Switch the agent model to GPT-5.4 or enter a manual model ID to enable Codex Fast mode.",
         });
       }
@@ -352,100 +543,145 @@ export async function testEnvironment(
 
       // Codex CLI (>= 0.122) ignores the OPENAI_API_KEY env var and only reads
       // credentials from $CODEX_HOME/auth.json. When we have a key available,
-      // wrap the probe with a shell that materializes a per-run auth.json so
-      // the CLI can authenticate. The key content is passed via env (not on
-      // the command line) to avoid leaking it into process listings.
-      const probeApiKey = isNonEmpty(configOpenAiKey)
-        ? configOpenAiKey
-        : isNonEmpty(hostOpenAiKey)
-          ? hostOpenAiKey
-          : null;
-      const preparedProbe = await prepareCodexHelloProbe({
-        runId,
-        companyId: ctx.companyId,
-        target,
-        targetIsRemote,
-        cwd,
-        command,
-        args,
-        env,
-        probeApiKey,
-      });
+      // materialize a per-run auth.json from stdin. Credential bytes never
+      // enter argv or a child environment.
+      const probeAuthJson = configAuthJson;
+      const probeApiKey = probeAuthJson ? null : configApiKey ?? hostApiKey;
+      const probeCheckStart = checks.length;
+      let preparedProbe: Awaited<ReturnType<typeof prepareCodexHelloProbe>> | null = null;
+      let cleanupSucceeded = true;
       try {
-        const probe = await runAdapterExecutionTargetProcess(
+          preparedProbe = await prepareCodexHelloProbe({
           runId,
-          target,
-          preparedProbe.command,
-          preparedProbe.args,
-          {
-            cwd,
-            env: preparedProbe.env,
-            timeoutSec: 45,
-            graceSec: 5,
-            stdin: "Respond with hello.",
-            onLog: async () => {},
-          },
-        );
-        const parsed = parseCodexJsonl(probe.stdout);
-        const detail = summarizeProbeDetail(probe.stdout, probe.stderr, parsed.errorMessage);
-        const authEvidence = `${parsed.errorMessage ?? ""}\n${probe.stdout}\n${probe.stderr}`.trim();
+          companyId: ctx.companyId,
+          target: cwdBoundTarget,
+          targetIsRemote,
+          cwd,
+          command,
+          args,
+          env,
+          probeApiKey,
+          probeAuthJson,
+        });
+          cleanupSucceeded = false;
+          try {
+          const probeExecutionTarget = targetIsRemote
+            ? overrideAdapterExecutionTargetRemoteCwd(cwdBoundTarget, preparedProbe.cwd)
+            : cwdBoundTarget;
+          const probe = await runAdapterExecutionTargetProcess(
+            runId,
+            probeExecutionTarget,
+            preparedProbe.command,
+            preparedProbe.args,
+            {
+              cwd: preparedProbe.cwd,
+              env: preparedProbe.env,
+              denyEnvironmentKeys: CODEX_PROBE_AUTH_ENV_KEY_NAMES,
+              timeoutSec: 45,
+              graceSec: 5,
+              stdin: preparedProbe.stdin,
+              onLog: async () => {},
+            },
+          );
+          const parsed = parseCodexJsonl(probe.stdout);
+          const protocol = inspectCodexProbeProtocol(probe.stdout);
+          const authEvidence = `${parsed.errorMessage ?? ""}\n${probe.stdout}\n${probe.stderr}`.trim();
 
-        if (probe.timedOut) {
-          checks.push({
-            code: "codex_hello_probe_timed_out",
-            level: "warn",
-            message: "Codex hello probe timed out.",
-            hint: "Retry the probe. If this persists, verify Codex can run `Respond with hello` from this directory manually.",
-          });
-        } else if ((probe.exitCode ?? 1) === 0) {
-          const summary = parsed.summary.trim();
-          const hasHello = /\bhello\b/i.test(summary);
-          checks.push({
-            code: hasHello ? "codex_hello_probe_passed" : "codex_hello_probe_unexpected_output",
-            level: hasHello ? "info" : "warn",
-            message: hasHello
-              ? "Codex hello probe succeeded."
-              : "Codex probe ran but did not return `hello` as expected.",
-            ...(summary ? { detail: summary.replace(/\s+/g, " ").trim().slice(0, 240) } : {}),
-            ...(hasHello
-              ? {}
-              : {
-                  hint: "Try the probe manually (`codex exec --json -` then prompt: Respond with hello) to inspect full output.",
-                }),
-          });
-        } else if (CODEX_AUTH_REQUIRED_RE.test(authEvidence)) {
-          checks.push({
-            code: "codex_hello_probe_auth_required",
-            level: "warn",
-            message: "Codex CLI is installed, but authentication is not ready.",
-            ...(detail ? { detail } : {}),
-            hint: probeApiKey
-              ? "OPENAI_API_KEY was provided but Codex still rejected the request. Verify the key is valid for the OpenAI Responses API (e.g. `curl -H \"Authorization: Bearer $OPENAI_API_KEY\" https://api.openai.com/v1/models`), or run `codex login` and seed `~/.codex/auth.json`."
-              : "Codex CLI does not read OPENAI_API_KEY from the environment; set OPENAI_API_KEY in this adapter's config (so Paperclip writes it to `$CODEX_HOME/auth.json`) or run `codex login` on the host first.",
-          });
-          if (targetIsSandbox) {
-            // Emit the neutral canonical check so the user interface can decide
-            // login eligibility from a stable code. The user interface does not
-            // read the message text or the top-level status.
+          if (probe.timedOut) {
             checks.push({
-              code: ADAPTER_AUTH_MISSING_CHECK_CODE,
+              code: "codex_hello_probe_timed_out",
               level: "warn",
-              message: "This environment has no ready authentication for this adapter.",
-              ...(detail ? { detail } : {}),
-              hint: "Provide credentials for this adapter, or start login in the environment.",
+              message: "Codex hello probe timed out.",
+              hint: "Retry the probe. If this persists, verify Codex can reply with exactly `Hello.` from this directory manually.",
+            });
+          } else if (
+            (probe.exitCode ?? 1) === 0 &&
+            protocol.succeeded &&
+            !parsed.errorMessage
+          ) {
+            const summary = parsed.summary.trim();
+            const hasHello = summary === "Hello.";
+            checks.push({
+              code: hasHello ? "codex_hello_probe_passed" : "codex_hello_probe_unexpected_output",
+              level: hasHello ? "info" : "warn",
+              message: hasHello
+                ? "Codex hello probe succeeded."
+                : "Codex probe ran but did not return `hello` as expected.",
+              ...(hasHello ? { detail: "Hello." } : {}),
+              ...(hasHello
+                ? {}
+                : {
+                    hint: "Try the probe manually (`codex exec --json -` then prompt: Reply with exactly Hello.) to inspect full output.",
+                  }),
+            });
+          } else if (!protocol.valid) {
+            checks.push({
+              code: "codex_hello_probe_failed",
+              level: "error",
+              message: "Codex hello probe failed.",
+              hint: "Retry the live test after verifying the selected Codex CLI installation.",
+            });
+          } else if ((probe.exitCode ?? 1) !== 0 && CODEX_AUTH_REQUIRED_RE.test(authEvidence)) {
+            checks.push({
+              code: "codex_hello_probe_auth_required",
+              level: "warn",
+              message: "Codex CLI is installed, but authentication is not ready.",
+              hint: probeApiKey
+                ? "OPENAI_API_KEY was provided but Codex still rejected the request. Verify the key is valid for the OpenAI Responses API (e.g. `curl -H \"Authorization: Bearer $OPENAI_API_KEY\" https://api.openai.com/v1/models`), or run `codex login` and seed `~/.codex/auth.json`."
+                : "Codex CLI does not read OPENAI_API_KEY from the environment; set OPENAI_API_KEY in this adapter's config (so Paperclip writes it to `$CODEX_HOME/auth.json`) or run `codex login` on the host first.",
+            });
+            if (targetIsSandbox) {
+              checks.push({
+                code: ADAPTER_AUTH_MISSING_CHECK_CODE,
+                level: "warn",
+                message: "This environment has no ready authentication for this adapter.",
+                hint: "Provide credentials for this adapter, or start login in the environment.",
+              });
+            }
+          } else {
+            checks.push({
+              code: "codex_hello_probe_failed",
+              level: "error",
+              message: "Codex hello probe failed.",
+              hint: "Run `codex exec --json -` manually in this working directory and prompt `Reply with exactly Hello.` to debug.",
             });
           }
-        } else {
+        } catch {
           checks.push({
             code: "codex_hello_probe_failed",
             level: "error",
             message: "Codex hello probe failed.",
-            ...(detail ? { detail } : {}),
-            hint: "Run `codex exec --json -` manually in this working directory and prompt `Respond with hello` to debug.",
+            hint: "Retry the live test after verifying the selected Codex CLI installation.",
+          });
+        } finally {
+          cleanupSucceeded = await preparedProbe.cleanup().catch(() => false);
+        }
+      } catch (error) {
+        if (!preparedProbe) {
+          if (
+            error instanceof Error &&
+            error.message === CODEX_PROBE_PREPARATION_CLEANUP_FAILED
+          ) {
+            cleanupSucceeded = false;
+          }
+          checks.push({
+            code: "codex_hello_probe_failed",
+            level: "error",
+            message: "Codex hello probe failed.",
+            hint: "Retry the live test after verifying the selected Codex CLI installation.",
           });
         }
-      } finally {
-        await preparedProbe.cleanup();
+      }
+      if (!cleanupSucceeded) {
+        checks = [
+          ...checks.slice(0, probeCheckStart),
+          {
+            code: "codex_hello_probe_cleanup_failed",
+            level: "error",
+            message: "Codex replied, but environment cleanup did not complete safely.",
+            hint: "Retry the live test after checking the selected environment's runtime health.",
+          },
+        ];
       }
     }
   }

--- a/ui/src/components/CodexLiveProofResult.test.tsx
+++ b/ui/src/components/CodexLiveProofResult.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+
+import { act, type ReactElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CodexLiveProofResult } from "./CodexLiveProofResult";
+
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let root: ReturnType<typeof createRoot> | null = null;
+let container: HTMLDivElement | null = null;
+
+afterEach(() => {
+  if (root) act(() => root?.unmount());
+  root = null;
+  container?.remove();
+  container = null;
+  vi.restoreAllMocks();
+});
+
+function render(element: ReactElement) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => root?.render(element));
+  return container;
+}
+
+function recentLiveResult() {
+  return {
+    adapterType: "codex_local",
+    status: "pass",
+    testedAt: new Date().toISOString(),
+    checks: [
+      {
+        code: "codex_hello_probe_passed",
+        level: "info",
+        message: "Raw probe message should stay hidden.",
+        detail: "token=secret-value /Users/person/private user@example.com",
+        hint: "Raw hint should stay hidden.",
+      },
+    ],
+  };
+}
+
+describe("CodexLiveProofResult", () => {
+  it("renders a neutral prompt before the first test", () => {
+    const node = render(<CodexLiveProofResult result={null} />);
+    expect(node.textContent).toContain("A fresh live reply is required");
+    expect(node.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it("renders a polite, canonical live reply without raw probe output", () => {
+    const result = recentLiveResult();
+    vi.spyOn(Date.prototype, "toLocaleString").mockReturnValue("localized date and time");
+    const node = render(<CodexLiveProofResult result={result} />);
+    const status = node.querySelector('[role="status"]');
+    const timestamp = status?.querySelector("time");
+
+    expect(status?.getAttribute("aria-live")).toBe("polite");
+    expect(status?.textContent).toContain("Live reply verified");
+    expect(status?.textContent).toContain("Hello.");
+    expect(timestamp?.getAttribute("dateTime")).toBe(result.testedAt);
+    expect(timestamp?.textContent).toBe("localized date and time");
+    expect(status?.textContent).not.toContain("secret-value");
+    expect(status?.textContent).not.toContain("/Users/person/private");
+    expect(status?.textContent).not.toContain("user@example.com");
+    expect(status?.textContent).not.toContain("Raw probe message");
+    expect(status?.textContent).not.toContain("Raw hint");
+  });
+
+  it("renders allowlisted warnings without raw warning fields", () => {
+    const result = {
+      ...recentLiveResult(),
+      status: "warn",
+      checks: [
+        ...recentLiveResult().checks,
+        {
+          code: "codex_fast_mode_unsupported_model",
+          level: "warn",
+          message: "token=secret-value /Users/person/private",
+          hint: "user@example.com",
+        },
+      ],
+    };
+    const node = render(<CodexLiveProofResult result={result} />);
+    const warnings = node.querySelector('[aria-label="Codex connection warnings"]');
+
+    expect(warnings?.textContent).toContain("Codex Fast mode is unavailable");
+    expect(warnings?.textContent).not.toContain("secret-value");
+    expect(warnings?.textContent).not.toContain("user@example.com");
+  });
+
+  it.each([
+    ["failed", { ...recentLiveResult(), status: "fail" }],
+    ["malformed", { detail: "token=secret-value /Users/person/private" }],
+  ])("renders a safe alert for a %s result", (_name, result) => {
+    const node = render(<CodexLiveProofResult result={result} />);
+    const alert = node.querySelector('[role="alert"]');
+
+    expect(alert?.textContent).toContain("Live reply not verified");
+    expect(alert?.textContent).not.toContain("secret-value");
+    expect(alert?.textContent).not.toContain("/Users/person/private");
+  });
+});

--- a/ui/src/components/CodexLiveProofResult.tsx
+++ b/ui/src/components/CodexLiveProofResult.tsx
@@ -1,0 +1,50 @@
+import type { CSSProperties } from "react";
+import { evaluateCodexLiveProof } from "./codex-live-proof";
+
+export function CodexLiveProofResult({ result }: { result: unknown }) {
+  if (result === null || result === undefined) {
+    return (
+      <div className="rounded-md border border-border bg-muted/20 px-2.5 py-2 text-(length:--text-micro) text-muted-foreground">
+        A fresh live reply is required before this Codex agent can be hired.
+      </div>
+    );
+  }
+
+  const proof = evaluateCodexLiveProof(result);
+  if (!proof.valid) {
+    return (
+      <div
+        role="alert"
+        className="rounded-md border border-destructive/30 bg-destructive/10 px-2.5 py-2 text-(length:--text-micro) text-destructive"
+      >
+        <div className="font-medium">Live reply not verified</div>
+        <p className="mt-1">{proof.reason}</p>
+        <p className="mt-1 opacity-90">Run the Codex connection test again before continuing.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="status-chip rounded-md border px-2.5 py-2 text-(length:--text-micro)"
+      style={{ "--sc": "var(--status-task-done)" } as CSSProperties}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-medium">Live reply verified</span>
+        <time dateTime={proof.testedAt} className="text-(length:--text-nano) opacity-80">
+          {new Date(proof.testedAt).toLocaleString()}
+        </time>
+      </div>
+      <p className="mt-1 font-medium">{proof.detail}</p>
+      {proof.warnings.length > 0 && (
+        <ul aria-label="Codex connection warnings" className="mt-2 list-disc space-y-1 pl-4">
+          {proof.warnings.map((warning) => (
+            <li key={warning}>{warning}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/OnboardingWizard.test.tsx
+++ b/ui/src/components/OnboardingWizard.test.tsx
@@ -912,6 +912,229 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
     });
   });
 
+  describe("hire gate: fresh Codex live proof", () => {
+    const SANDBOX_ENVIRONMENT = {
+      id: "env-codex-sandbox",
+      driver: "sandbox" as const,
+      status: "active" as const,
+      config: { provider: "fixture" },
+      metadata: {},
+    };
+    const CODEX_CONFIG = {
+      engine: "acp",
+      model: "gpt-5.6-sol",
+      env: { OPENAI_API_KEY: { type: "plain", value: "sk-config-secret" } },
+    };
+
+    function codexLiveResult(testedAt = new Date().toISOString()) {
+      return {
+        adapterType: "codex_local",
+        status: "pass" as const,
+        checks: [
+          {
+            code: "codex_hello_probe_passed",
+            level: "info" as const,
+            message: "raw provider message sk-result-secret user@example.test /private/worktree",
+            detail: "raw provider detail sk-result-secret",
+          },
+        ],
+        testedAt,
+      };
+    }
+
+    async function openCodexConnectStep() {
+      mockCompany.companies = [{ id: "company-new", name: "Initech", issuePrefix: "INI" }];
+      mockCompany.loading = false;
+      mockCompaniesApi.list.mockResolvedValue(mockCompany.companies);
+      mockAdapterRegistry.list = [{ type: "claude_local" }, { type: "codex_local" }];
+      mockAdapterBuild.buildAdapterConfig.mockReturnValue(CODEX_CONFIG);
+      mockEnvironmentsApi.list.mockResolvedValue([SANDBOX_ENVIRONMENT]);
+      mockInstanceSettingsApi.get.mockResolvedValue({ defaultEnvironmentId: SANDBOX_ENVIRONMENT.id });
+      mockInstanceSettingsApi.getExperimental.mockResolvedValue({ enableManagedSandboxOnly: false });
+      mockAgentsApi.getAdapterAuthSignal.mockResolvedValue({ status: "present" });
+      window.localStorage.setItem(
+        ONBOARDING_STORAGE_KEY,
+        JSON.stringify({
+          step: 4,
+          onboardingPath: "create",
+          companyName: "Initech",
+          agentName: "Ada",
+          createdCompanyId: "company-new",
+          adapterType: "codex_local",
+        }),
+      );
+
+      const { root, queryClient } = render();
+      await act(async () => {
+        root.render(
+          <QueryClientProvider client={queryClient}>
+            <OnboardingWizard />
+          </QueryClientProvider>,
+        );
+      });
+      for (let i = 0; i < 5; i++) await flushReact();
+      expect(document.body.textContent).toContain("Codex live connection");
+
+      const findButton = (match: (text: string) => boolean) =>
+        [...document.body.querySelectorAll("button")].find((button) =>
+          match(button.textContent?.trim() ?? ""),
+        ) as HTMLButtonElement | undefined;
+      const clickButton = async (match: (text: string) => boolean) => {
+        const button = findButton(match);
+        expect(button).toBeDefined();
+        await act(async () => {
+          button!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        });
+        await flushReact();
+      };
+      return { root, queryClient, findButton, clickButton };
+    }
+
+    it("binds one fresh proof to the exact company, config, and environment before one hire", async () => {
+      mockAgentsApi.testEnvironment.mockResolvedValue(codexLiveResult());
+      const { root, findButton, clickButton } = await openCodexConnectStep();
+
+      expect(findButton((text) => text.startsWith("Connect"))?.disabled).toBe(true);
+      expect(document.body.textContent).toContain("A fresh live reply is required");
+
+      await clickButton((text) => text === "Test now");
+
+      expect(mockAgentsApi.testEnvironment).toHaveBeenCalledWith(
+        "company-new",
+        "codex_local",
+        {
+          adapterConfig: CODEX_CONFIG,
+          environmentId: SANDBOX_ENVIRONMENT.id,
+        },
+      );
+      expect(findButton((text) => text.startsWith("Connect"))?.disabled).toBe(false);
+      expect(document.body.textContent).toContain("Live reply verified");
+      expect(document.body.textContent).toContain("Hello.");
+      expect(document.body.textContent).not.toMatch(/sk-result-secret|example\.test|private\/worktree/);
+
+      // The instance default is mutable global state. Model an out-of-band
+      // operator change after the proof: the hire must still carry the target
+      // captured by the proof instead of inheriting whatever default exists
+      // when the agent's first run starts.
+      mockInstanceSettingsApi.get.mockResolvedValue({ defaultEnvironmentId: "env-changed-later" });
+
+      const connect = findButton((text) => text.startsWith("Connect"))!;
+      await act(async () => {
+        connect.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        connect.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      await flushReact();
+
+      expect(mockAgentsApi.testEnvironment).toHaveBeenCalledTimes(1);
+      expect(mockAgentsApi.hire).toHaveBeenCalledTimes(1);
+      const hireArgs = mockAgentsApi.hire.mock.calls[0] as unknown[];
+      expect(hireArgs[0]).toBe("company-new");
+      expect(
+        hireArgs[1] as {
+          adapterType: string;
+          adapterConfig: unknown;
+          defaultEnvironmentId: string;
+        },
+      ).toMatchObject({
+        adapterType: "codex_local",
+        adapterConfig: CODEX_CONFIG,
+        defaultEnvironmentId: SANDBOX_ENVIRONMENT.id,
+      });
+
+      await act(async () => root.unmount());
+    });
+
+    it("keeps Connect closed for an expired proof and opens only after a fresh retry", async () => {
+      mockAgentsApi.testEnvironment
+        .mockResolvedValueOnce(codexLiveResult(new Date(Date.now() - 5 * 60_000 - 1).toISOString()))
+        .mockResolvedValueOnce(codexLiveResult());
+      const { root, findButton, clickButton } = await openCodexConnectStep();
+
+      await clickButton((text) => text === "Test now");
+      expect(findButton((text) => text.startsWith("Connect"))?.disabled).toBe(true);
+      expect(document.body.textContent).toContain("connection proof has expired");
+      expect(mockAgentsApi.hire).not.toHaveBeenCalled();
+
+      await clickButton((text) => text === "Test now");
+      expect(findButton((text) => text.startsWith("Connect"))?.disabled).toBe(false);
+      expect(mockAgentsApi.testEnvironment).toHaveBeenCalledTimes(2);
+
+      await act(async () => root.unmount());
+    });
+
+    it("keeps Codex request failures canonical and closed", async () => {
+      mockAgentsApi.testEnvironment.mockRejectedValue(
+        new Error("sk-server-secret user@example.test /private/server/stderr"),
+      );
+      const { root, findButton, clickButton } = await openCodexConnectStep();
+
+      await clickButton((text) => text === "Test now");
+
+      expect(document.body.textContent).toContain("Codex connection test failed");
+      expect(document.body.textContent).not.toMatch(/sk-server-secret|example\.test|private\/server/);
+      expect(findButton((text) => text.startsWith("Connect"))?.disabled).toBe(true);
+      expect(mockAgentsApi.hire).not.toHaveBeenCalled();
+
+      await act(async () => root.unmount());
+    });
+
+    it("never renders raw Codex checks, paths, or manual debug commands", async () => {
+      mockAgentsApi.testEnvironment.mockResolvedValue({
+        ...codexLiveResult(),
+        status: "fail",
+        checks: [
+          {
+            code: "codex_hello_probe_failed",
+            level: "error",
+            message: "sk-server-secret user@example.test /private/server/stderr",
+            detail: "/private/effective/codex exec --json -",
+            hint: "Run /Users/operator/bin/codex manually",
+          },
+        ],
+      });
+      const { root, findButton, clickButton } = await openCodexConnectStep();
+
+      await clickButton((text) => text === "Test now");
+
+      expect(document.body.textContent).toContain("Live reply not verified");
+      expect(document.body.textContent).not.toContain("Manual debug");
+      expect(document.body.textContent).not.toContain("exec --json");
+      expect(document.body.textContent).not.toMatch(
+        /sk-server-secret|example\.test|private\/server|private\/effective|Users\/operator/,
+      );
+      expect(findButton((text) => text.startsWith("Connect"))?.disabled).toBe(true);
+
+      await act(async () => root.unmount());
+    });
+
+    it("ignores an in-flight Codex result after the adapter binding changes", async () => {
+      let resolveProbe: (result: ReturnType<typeof codexLiveResult>) => void = () => {};
+      mockAgentsApi.testEnvironment.mockReturnValue(
+        new Promise((resolve) => {
+          resolveProbe = resolve;
+        }),
+      );
+      const { root, findButton, clickButton } = await openCodexConnectStep();
+
+      const testButton = findButton((text) => text === "Test now")!;
+      await act(async () => {
+        testButton.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      });
+      await clickButton((text) => text.startsWith("Advanced settings"));
+      await clickButton((text) => text === "claude_local");
+      await act(async () => resolveProbe(codexLiveResult()));
+      await flushReact();
+      await clickButton((text) => text === "codex_local");
+
+      expect(document.body.textContent).toContain("A fresh live reply is required");
+      expect(document.body.textContent).not.toContain("Live reply verified");
+      expect(findButton((text) => text.startsWith("Connect"))?.disabled).toBe(true);
+      expect(mockAgentsApi.hire).not.toHaveBeenCalled();
+
+      await act(async () => root.unmount());
+    });
+  });
+
   it("re-syncs a restored draft once companies resolve asynchronously (companies start empty/loading)", async () => {
     // Regression for the initializer-only restore bug: the inner wizard's
     // ~20 useState(saved?.x ?? default) initializers only read `saved` on

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -89,6 +89,12 @@ import { FooterNav } from "./onboarding/FooterNav";
 import { OnboardingHeading } from "./onboarding/OnboardingPrimitives";
 import { DEFAULT_AGENT_ROLE } from "../lib/onboarding-agent-role";
 import { capsuleHeroMotion } from "./onboarding/onboarding-motion";
+import { CodexLiveProofResult } from "./CodexLiveProofResult";
+import {
+  createCodexLiveProofScope,
+  evaluateCodexLiveProof,
+  getCodexLiveProofExpiryMs,
+} from "./codex-live-proof";
 import { Badge } from "@/components/ui/badge";
 import {
   Building2,
@@ -479,10 +485,13 @@ function OnboardingWizardInner({
   const [command, setCommand] = useState((saved?.command as string) ?? "");
   const [args, setArgs] = useState((saved?.args as string) ?? "");
   const [url, setUrl] = useState((saved?.url as string) ?? "");
-  const [adapterEnvResult, setAdapterEnvResult] =
+  const [adapterEnvTestResult, setAdapterEnvTestResult] =
     useState<AdapterEnvironmentTestResult | null>(null);
+  const [adapterEnvProofScope, setAdapterEnvProofScope] = useState<string | null>(null);
   const [adapterEnvError, setAdapterEnvError] = useState<string | null>(null);
   const [adapterEnvLoading, setAdapterEnvLoading] = useState(false);
+  const adapterEnvRequestIdRef = useRef(0);
+  const [, forceCodexProofExpiryRender] = useState(0);
   const [forceUnsetAnthropicApiKey, setForceUnsetAnthropicApiKey] =
     useState(false);
   const [unsetAnthropicLoading, setUnsetAnthropicLoading] = useState(false);
@@ -944,12 +953,37 @@ function OnboardingWizardInner({
 
   useEffect(() => {
     if (step !== 4) return;
-    setAdapterEnvResult(null);
+    adapterEnvRequestIdRef.current += 1;
+    setAdapterEnvTestResult(null);
+    setAdapterEnvProofScope(null);
     adapterEnvResultAppliedStoredLoginRef.current = false;
     setAdapterEnvError(null);
-  }, [step, adapterType, model, command, args, url]);
+    setAdapterEnvLoading(false);
+  }, [step, createdCompanyId, adapterType, cwd, model, command, args, url]);
+
+  const currentCodexProofScope = createCodexLiveProofScope({
+    companyId: createdCompanyId,
+    adapterType,
+    adapterConfig: buildAdapterConfig(),
+    environmentId: resolvedLoginEnvironmentId,
+  });
+  const adapterEnvResult =
+    adapterType !== "codex_local" || adapterEnvProofScope === currentCodexProofScope
+      ? adapterEnvTestResult
+      : null;
+  useEffect(() => {
+    if (adapterType !== "codex_local") return;
+    const expiresAt = getCodexLiveProofExpiryMs(adapterEnvResult);
+    if (expiresAt === null) return;
+    const timeout = window.setTimeout(
+      () => forceCodexProofExpiryRender((revision) => revision + 1),
+      Math.max(0, expiresAt - Date.now() + 1),
+    );
+    return () => window.clearTimeout(timeout);
+  }, [adapterType, adapterEnvResult]);
 
   const selectedModel = (adapterModels ?? []).find((m) => m.id === model);
+  const codexLiveProof = evaluateCodexLiveProof(adapterEnvResult);
   const hasAnthropicApiKeyOverrideCheck =
     adapterEnvResult?.checks.some(
       (check) =>
@@ -1023,7 +1057,9 @@ function OnboardingWizardInner({
     setCommand("");
     setArgs("");
     setUrl("");
-    setAdapterEnvResult(null);
+    adapterEnvRequestIdRef.current += 1;
+    setAdapterEnvTestResult(null);
+    setAdapterEnvProofScope(null);
     adapterEnvResultAppliedStoredLoginRef.current = false;
     setAdapterEnvError(null);
     setAdapterEnvLoading(false);
@@ -1192,7 +1228,14 @@ function OnboardingWizardInner({
       );
       return null;
     }
+    const requestId = adapterEnvRequestIdRef.current + 1;
+    adapterEnvRequestIdRef.current = requestId;
+    const companyId = createdCompanyId;
+    const testedAdapterType = adapterType;
+    const adapterConfig = adapterConfigOverride ?? buildAdapterConfig();
     setAdapterEnvLoading(true);
+    setAdapterEnvTestResult(null);
+    setAdapterEnvProofScope(null);
     setAdapterEnvError(null);
     try {
       // Probe the environment a real run would use, so the Test matches a real
@@ -1206,8 +1249,8 @@ function OnboardingWizardInner({
       try {
         const [list, generalSettings, experimentalSettings] = await Promise.all([
           queryClient.ensureQueryData({
-            queryKey: queryKeys.environments.list(createdCompanyId),
-            queryFn: () => environmentsApi.list(createdCompanyId),
+            queryKey: queryKeys.environments.list(companyId),
+            queryFn: () => environmentsApi.list(companyId),
           }),
           queryClient.ensureQueryData({
             queryKey: queryKeys.instance.settings,
@@ -1222,9 +1265,11 @@ function OnboardingWizardInner({
         settings = generalSettings;
         managedSandboxOnly = experimentalSettings?.enableManagedSandboxOnly === true;
       } catch {
-        setAdapterEnvError(
-          "Could not load environment settings to determine which environment to test in. Retry the test.",
-        );
+        if (adapterEnvRequestIdRef.current === requestId) {
+          setAdapterEnvError(
+            "Could not load environment settings to determine which environment to test in. Retry the test.",
+          );
+        }
         return null;
       }
       // Mirror the server run-time resolution, including the managed-sandbox-only
@@ -1245,23 +1290,40 @@ function OnboardingWizardInner({
         visibleEnvironmentIds: environmentList.map((environment) => environment.id),
       });
       const result = await agentsApi.testEnvironment(
-        createdCompanyId,
-        adapterType,
+        companyId,
+        testedAdapterType,
         {
-          adapterConfig: adapterConfigOverride ?? buildAdapterConfig(),
+          adapterConfig,
           environmentId,
         }
       );
-      setAdapterEnvResult(result);
+      if (adapterEnvRequestIdRef.current !== requestId) return null;
+      setAdapterEnvTestResult(result);
+      setAdapterEnvProofScope(
+        createCodexLiveProofScope({
+          companyId,
+          adapterType: testedAdapterType,
+          adapterConfig,
+          environmentId,
+        }),
+      );
       adapterEnvResultAppliedStoredLoginRef.current = appliedStoredClaudeLoginBinding;
       return result;
     } catch (err) {
-      setAdapterEnvError(
-        err instanceof Error ? err.message : "Adapter environment test failed"
-      );
+      if (adapterEnvRequestIdRef.current === requestId) {
+        setAdapterEnvError(
+          testedAdapterType === "codex_local"
+            ? "Codex connection test failed. Retry after checking the selected environment."
+            : err instanceof Error
+              ? err.message
+              : "Adapter environment test failed"
+        );
+      }
       return null;
     } finally {
-      setAdapterEnvLoading(false);
+      if (adapterEnvRequestIdRef.current === requestId) {
+        setAdapterEnvLoading(false);
+      }
     }
   }
 
@@ -1520,7 +1582,29 @@ function OnboardingWizardInner({
           }
         : baseAdapterConfig;
 
-      if (isLocalAdapter) {
+      let provenCodexEnvironmentId: string | null = null;
+      if (adapterType === "codex_local") {
+        // Codex is the one onboarding adapter whose hire requires an explicit,
+        // fresh live LLM reply. `adapterEnvResult` is already filtered by the
+        // exact company, adapter config, and resolved environment scope above,
+        // so a changed or in-flight configuration fails closed here.
+        const currentProof = evaluateCodexLiveProof(adapterEnvResult);
+        if (!currentProof.valid) {
+          setError(currentProof.reason);
+          return;
+        }
+        // Pin the agent to the environment covered by that proof. Leaving the
+        // agent default unset would make its first run resolve the *current*
+        // instance default instead; an operator changing that default between
+        // Test and hire could therefore move the run to an untested target.
+        // A valid `adapterEnvResult` above is scoped to
+        // `resolvedLoginEnvironmentId`, so this is the exact tested id.
+        if (!resolvedLoginEnvironmentId) {
+          setError("Codex did not resolve an environment that can be bound to this agent.");
+          return;
+        }
+        provenCodexEnvironmentId = resolvedLoginEnvironmentId;
+      } else if (isLocalAdapter) {
         // A cached result is reusable only when it tested the same
         // configuration the hire below sends, and only when it does not
         // block the hire — see blocksAgentCreate. With the "Test now" card
@@ -1563,6 +1647,9 @@ function OnboardingWizardInner({
         role: agentRole,
         adapterType,
         adapterConfig: hireAdapterConfig,
+        ...(provenCodexEnvironmentId
+          ? { defaultEnvironmentId: provenCodexEnvironmentId }
+          : {}),
         ...(shouldApplyStoredClaudeLogin ? { applyStoredClaudeLogin: true } : {}),
         runtimeConfig: buildNewAgentRuntimeConfig()
       });
@@ -1694,7 +1781,12 @@ function OnboardingWizardInner({
       }
       else if (step === 2 && companyName.trim() && companyGoal.trim()) handleConfirmMission();
       else if (step === 3 && agentName.trim()) setStep(4);
-      else if (step === 4 && agentName.trim() && !missionUnresolvedForHire)
+      else if (
+        step === 4 &&
+        agentName.trim() &&
+        !missionUnresolvedForHire &&
+        (adapterType !== "codex_local" || codexLiveProof.valid)
+      )
         handleGiveHeartbeat();
       else if (step === 5) handleLaunchToDashboard();
     }
@@ -2372,23 +2464,46 @@ function OnboardingWizardInner({
                       way to judge one — and the agent's model is changeable
                       later, where its work gives the choice meaning. */}
 
-                  {/* The environment check runs without being shown: Connect
-                      probes the adapter before hiring (see handleGiveHeartbeat)
-                      and blocks the hire on a fail. The idle card — probe
-                      explainer plus a "Test now" button — is gone from this
-                      step, so this block renders only when a probe has actually
-                      found something: the checks the blocking error tells the
-                      customer to fix have to be visible somewhere. */}
-                  {isLocalAdapter && (adapterEnvError || (adapterEnvResult && adapterEnvResult.status !== "pass")) && (
+                  {/* Other local adapters keep the implicit Connect-time
+                      environment check. Codex requires a deliberate live LLM
+                      reply before Connect, so only that adapter restores the
+                      visible Test action and proof receipt. */}
+                  {isLocalAdapter &&
+                    (adapterType === "codex_local" ||
+                      adapterEnvError ||
+                      (adapterEnvResult && adapterEnvResult.status !== "pass")) && (
                     <div className="space-y-2 rounded-md border border-border p-3">
-                      {adapterEnvError && (
-                        <div className="rounded-md border border-destructive/30 bg-destructive/10 px-2.5 py-2 text-(length:--text-micro) text-destructive">
-                          {adapterEnvError}
+                      {adapterType === "codex_local" && (
+                        <div className="flex items-center justify-between gap-2">
+                          <div>
+                            <p className="text-xs font-medium">Codex live connection</p>
+                            <p className="text-(length:--text-nano) text-muted-foreground">
+                              Runs the selected configuration and verifies a fresh Hello reply.
+                            </p>
+                          </div>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            className="h-7 px-2.5 text-xs"
+                            disabled={adapterEnvLoading}
+                            onClick={() => void runAdapterEnvironmentTest()}
+                          >
+                            {adapterEnvLoading ? "Testing..." : "Test now"}
+                          </Button>
                         </div>
                       )}
 
-                      {adapterEnvResult &&
-                      adapterEnvResult.status === "pass" ? (
+                      {adapterEnvError && (
+                        <div className="rounded-md border border-destructive/30 bg-destructive/10 px-2.5 py-2 text-(length:--text-micro) text-destructive">
+                          {adapterType === "codex_local"
+                            ? "Codex connection test failed. Retry after checking the selected environment."
+                            : adapterEnvError}
+                        </div>
+                      )}
+
+                      {adapterType === "codex_local" ? (
+                        <CodexLiveProofResult result={adapterEnvResult} />
+                      ) : adapterEnvResult && adapterEnvResult.status === "pass" ? (
                         <div className="space-y-2 animate-in fade-in slide-in-from-bottom-1 duration-300">
                           {/* Use the shared status-chip helper with the done
                               status hue, so the pass banner derives its fill,
@@ -2433,7 +2548,9 @@ function OnboardingWizardInner({
                         </div>
                       )}
 
-                      {adapterEnvResult && adapterEnvResult.status === "fail" && (
+                      {adapterType !== "codex_local" &&
+                        adapterEnvResult &&
+                        adapterEnvResult.status === "fail" && (
                         <div className="rounded-md border border-border/70 bg-muted/20 px-2.5 py-2 text-(length:--text-micro) space-y-1.5">
                           <p className="font-medium">Manual debug</p>
                           <p className="text-muted-foreground font-mono break-all">
@@ -2549,7 +2666,10 @@ function OnboardingWizardInner({
                     step === 3
                       ? !agentName.trim()
                       : step === 4
-                        ? loading || adapterEnvLoading || missionUnresolvedForHire
+                        ? loading ||
+                          adapterEnvLoading ||
+                          missionUnresolvedForHire ||
+                          (adapterType === "codex_local" && !codexLiveProof.valid)
                         : loading || launchStateIncomplete
                   }
                   onPrimary={() => {
@@ -2624,7 +2744,8 @@ function OnboardingWizardInner({
                         !agentName.trim() ||
                         loading ||
                         adapterEnvLoading ||
-                        missionUnresolvedForHire
+                        missionUnresolvedForHire ||
+                        (adapterType === "codex_local" && !codexLiveProof.valid)
                       }
                       onClick={handleGiveHeartbeat}
                     >

--- a/ui/src/components/codex-live-proof.test.ts
+++ b/ui/src/components/codex-live-proof.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from "vitest";
+import {
+  createCodexLiveProofScope,
+  evaluateCodexLiveProof,
+  getCodexLiveProofExpiryMs,
+} from "./codex-live-proof";
+
+const NOW = Date.parse("2026-08-31T12:00:00.000Z");
+
+function liveResult(overrides: Record<string, unknown> = {}) {
+  return {
+    adapterType: "codex_local",
+    status: "pass",
+    testedAt: new Date(NOW).toISOString(),
+    checks: [
+      {
+        code: "codex_hello_probe_passed",
+        level: "info",
+        message: "Raw probe message should stay hidden.",
+        detail: "token=secret-value /Users/person/private user@example.com",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("evaluateCodexLiveProof", () => {
+  it.each(["pass", "warn"])("accepts a recent %s result with the exact live proof check", (status) => {
+    expect(evaluateCodexLiveProof(liveResult({ status }), NOW)).toEqual({
+      valid: true,
+      testedAt: "2026-08-31T12:00:00.000Z",
+      detail: "Hello.",
+      warnings: [],
+    });
+  });
+
+  it("normalizes warning checks without exposing server text", () => {
+    const proof = evaluateCodexLiveProof(
+      liveResult({
+        status: "warn",
+        checks: [
+          { code: "codex_hello_probe_passed", level: "info", message: "ok" },
+          {
+            code: "codex_fast_mode_unsupported_model",
+            level: "warn",
+            message: "token=secret-value /Users/person/private",
+            hint: "user@example.com",
+          },
+          { code: "future_warning_code", level: "warn", message: "another-secret" },
+        ],
+      }),
+      NOW,
+    );
+
+    expect(proof).toEqual({
+      valid: true,
+      testedAt: "2026-08-31T12:00:00.000Z",
+      detail: "Hello.",
+      warnings: [
+        "Codex Fast mode is unavailable for the selected model.",
+        "Codex reported an additional warning. Review the server-side test details.",
+      ],
+    });
+    expect(JSON.stringify(proof)).not.toContain("secret-value");
+    expect(JSON.stringify(proof)).not.toContain("user@example.com");
+  });
+
+  it.each([
+    ["non-object result", null, "Codex did not return a valid connection result."],
+    ["failed status", liveResult({ status: "fail" }), "Codex did not pass the live connection test."],
+    [
+      "different adapter",
+      liveResult({ adapterType: "claude_local" }),
+      "Codex returned a result for a different adapter.",
+    ],
+    ["unknown status", liveResult({ status: "ok" }), "Codex did not pass the live connection test."],
+    ["non-array checks", liveResult({ checks: {} }), "Codex returned invalid connection checks."],
+    [
+      "malformed check",
+      liveResult({ checks: [{ code: "codex_hello_probe_passed", level: "info" }] }),
+      "Codex returned invalid connection checks.",
+    ],
+    [
+      "error check",
+      liveResult({
+        checks: [
+          { code: "codex_hello_probe_passed", level: "info", message: "ok" },
+          { code: "codex_cwd_invalid", level: "error", message: "invalid" },
+        ],
+      }),
+      "Codex reported a connection error.",
+    ],
+    [
+      "near-match proof code",
+      liveResult({ checks: [{ code: "codex_hello_probe_passed_extra", level: "info", message: "ok" }] }),
+      "Codex did not verify a live reply.",
+    ],
+    [
+      "runtime scaffold only",
+      liveResult({ checks: [{ code: "codex_acp_runtime_scaffold", level: "info", message: "ready" }] }),
+      "Codex did not verify a live reply.",
+    ],
+    [
+      "non-info proof check",
+      liveResult({ checks: [{ code: "codex_hello_probe_passed", level: "warn", message: "not proven" }] }),
+      "Codex did not verify a live reply.",
+    ],
+    [
+      "stale proof",
+      liveResult({ testedAt: new Date(NOW - 5 * 60_000 - 1).toISOString() }),
+      "The Codex connection proof has expired.",
+    ],
+    [
+      "far-future proof",
+      liveResult({ testedAt: new Date(NOW + 60_001).toISOString() }),
+      "The Codex connection proof has an invalid timestamp.",
+    ],
+    [
+      "invalid timestamp",
+      liveResult({ testedAt: "not-a-date" }),
+      "The Codex connection proof has an invalid timestamp.",
+    ],
+  ])("rejects %s", (_name, result, reason) => {
+    expect(evaluateCodexLiveProof(result, NOW)).toEqual({ valid: false, reason });
+  });
+
+  it.each([
+    "codex_hello_probe_timed_out",
+    "codex_hello_probe_unexpected_output",
+    "codex_hello_probe_auth_required",
+  ])("rejects a contradictory %s warning", (code) => {
+    expect(
+      evaluateCodexLiveProof(
+        liveResult({
+          status: "warn",
+          checks: [
+            { code: "codex_hello_probe_passed", level: "info", message: "ok" },
+            { code, level: "warn", message: "not actually successful" },
+          ],
+        }),
+        NOW,
+      ),
+    ).toEqual({
+      valid: false,
+      reason: "Codex reported an unsuccessful live reply.",
+    });
+  });
+
+  it("accepts timestamps exactly on the freshness boundaries", () => {
+    expect(
+      evaluateCodexLiveProof(
+        liveResult({ testedAt: new Date(NOW - 5 * 60_000).toISOString() }),
+        NOW,
+      ).valid,
+    ).toBe(true);
+    expect(
+      evaluateCodexLiveProof(
+        liveResult({ testedAt: new Date(NOW + 60_000).toISOString() }),
+        NOW,
+      ).valid,
+    ).toBe(true);
+  });
+});
+
+describe("createCodexLiveProofScope", () => {
+  it("binds proof to company, adapter, environment, and canonicalized config", () => {
+    const left = createCodexLiveProofScope({
+      companyId: "company-1",
+      adapterType: "codex_local",
+      environmentId: "sandbox-1",
+      adapterConfig: { model: "gpt-5", nested: { b: 2, a: 1 } },
+    });
+    const same = createCodexLiveProofScope({
+      companyId: "company-1",
+      adapterType: "codex_local",
+      environmentId: "sandbox-1",
+      adapterConfig: { nested: { a: 1, b: 2 }, model: "gpt-5" },
+    });
+
+    expect(left).toBe(same);
+    expect(
+      createCodexLiveProofScope({
+        companyId: "company-1",
+        adapterType: "codex_local",
+        environmentId: "sandbox-2",
+        adapterConfig: { model: "gpt-5", nested: { a: 1, b: 2 } },
+      }),
+    ).not.toBe(left);
+    expect(
+      createCodexLiveProofScope({
+        companyId: "company-2",
+        adapterType: "codex_local",
+        environmentId: "sandbox-1",
+        adapterConfig: { model: "gpt-5", nested: { a: 1, b: 2 } },
+      }),
+    ).not.toBe(left);
+    expect(
+      createCodexLiveProofScope({
+        companyId: "company-1",
+        adapterType: "codex_local",
+        environmentId: "sandbox-1",
+        adapterConfig: { model: "gpt-5.1", nested: { a: 1, b: 2 } },
+      }),
+    ).not.toBe(left);
+  });
+
+  it("fails closed without a Codex company scope", () => {
+    expect(
+      createCodexLiveProofScope({
+        companyId: null,
+        adapterType: "codex_local",
+        environmentId: null,
+        adapterConfig: {},
+      }),
+    ).toBeNull();
+    expect(
+      createCodexLiveProofScope({
+        companyId: "company-1",
+        adapterType: "claude_local",
+        environmentId: null,
+        adapterConfig: {},
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("getCodexLiveProofExpiryMs", () => {
+  it("returns the exact five-minute expiry for a valid proof timestamp", () => {
+    expect(getCodexLiveProofExpiryMs(liveResult(), NOW)).toBe(NOW + 5 * 60_000);
+  });
+
+  it("fails closed for invalid results instead of scheduling unsafe timers", () => {
+    expect(getCodexLiveProofExpiryMs(null, NOW)).toBeNull();
+    expect(getCodexLiveProofExpiryMs(liveResult({ testedAt: "invalid" }), NOW)).toBeNull();
+    expect(
+      getCodexLiveProofExpiryMs(
+        liveResult({ testedAt: new Date(NOW + 60_001).toISOString() }),
+        NOW,
+      ),
+    ).toBeNull();
+  });
+});

--- a/ui/src/components/codex-live-proof.ts
+++ b/ui/src/components/codex-live-proof.ts
@@ -1,0 +1,140 @@
+const LIVE_PROOF_TTL_MS = 5 * 60_000;
+const CLOCK_SKEW_TOLERANCE_MS = 60_000;
+const LIVE_PROOF_CODE = "codex_hello_probe_passed";
+const BLOCKING_WARNING_CODES = new Set([
+  "codex_hello_probe_timed_out",
+  "codex_hello_probe_unexpected_output",
+  "codex_hello_probe_auth_required",
+]);
+
+const SAFE_WARNING_LABELS: Record<string, string> = {
+  codex_acp_default_fallback:
+    "Codex ACP was unavailable, so the live test used the CLI lane.",
+  codex_openai_api_key_missing:
+    "No Codex authentication source was detected before the live probe.",
+  codex_fast_mode_unsupported_model:
+    "Codex Fast mode is unavailable for the selected model.",
+  codex_hello_probe_timed_out: "The Codex hello probe timed out.",
+  codex_hello_probe_unexpected_output:
+    "The Codex hello probe returned unexpected output.",
+  codex_hello_probe_auth_required:
+    "Codex reported that authentication is required.",
+};
+
+const GENERIC_SAFE_WARNING =
+  "Codex reported an additional warning. Review the server-side test details.";
+
+export type CodexLiveProof =
+  | { valid: true; testedAt: string; detail: "Hello."; warnings: string[] }
+  | { valid: false; reason: string };
+
+type RuntimeCheck = {
+  code: string;
+  level: "info" | "warn" | "error";
+  message: string;
+  detail?: string | null;
+  hint?: string | null;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((entry) => canonicalize(entry));
+  if (!isRecord(value)) return value;
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([, entry]) => entry !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => [key, canonicalize(entry)]),
+  );
+}
+
+export function createCodexLiveProofScope(input: {
+  companyId: string | null;
+  adapterType: string;
+  adapterConfig: Record<string, unknown>;
+  environmentId: string | null;
+}): string | null {
+  if (!input.companyId || input.adapterType !== "codex_local") return null;
+  try {
+    return JSON.stringify(canonicalize(input));
+  } catch {
+    return null;
+  }
+}
+
+export function getCodexLiveProofExpiryMs(
+  result: unknown,
+  now = Date.now(),
+): number | null {
+  const proof = evaluateCodexLiveProof(result, now);
+  if (!proof.valid) return null;
+  const testedAtMs = Date.parse(proof.testedAt);
+  return Number.isFinite(testedAtMs) ? testedAtMs + LIVE_PROOF_TTL_MS : null;
+}
+
+function isOptionalNullableString(value: unknown): value is string | null | undefined {
+  return value === undefined || value === null || typeof value === "string";
+}
+
+function isRuntimeCheck(value: unknown): value is RuntimeCheck {
+  if (!isRecord(value)) return false;
+  return (
+    typeof value.code === "string" &&
+    (value.level === "info" || value.level === "warn" || value.level === "error") &&
+    typeof value.message === "string" &&
+    isOptionalNullableString(value.detail) &&
+    isOptionalNullableString(value.hint)
+  );
+}
+
+export function evaluateCodexLiveProof(result: unknown, now = Date.now()): CodexLiveProof {
+  if (!isRecord(result)) {
+    return { valid: false, reason: "Codex did not return a valid connection result." };
+  }
+  if (result.adapterType !== "codex_local") {
+    return { valid: false, reason: "Codex returned a result for a different adapter." };
+  }
+  if (result.status !== "pass" && result.status !== "warn") {
+    return { valid: false, reason: "Codex did not pass the live connection test." };
+  }
+  if (!Array.isArray(result.checks) || !result.checks.every(isRuntimeCheck)) {
+    return { valid: false, reason: "Codex returned invalid connection checks." };
+  }
+  if (result.checks.some((check) => check.level === "error")) {
+    return { valid: false, reason: "Codex reported a connection error." };
+  }
+  if (
+    result.checks.some(
+      (check) => check.level === "warn" && BLOCKING_WARNING_CODES.has(check.code),
+    )
+  ) {
+    return { valid: false, reason: "Codex reported an unsuccessful live reply." };
+  }
+  if (!result.checks.some((check) => check.code === LIVE_PROOF_CODE && check.level === "info")) {
+    return { valid: false, reason: "Codex did not verify a live reply." };
+  }
+  if (typeof result.testedAt !== "string") {
+    return { valid: false, reason: "The Codex connection proof has an invalid timestamp." };
+  }
+
+  const testedAtMs = Date.parse(result.testedAt);
+  if (!Number.isFinite(testedAtMs) || testedAtMs > now + CLOCK_SKEW_TOLERANCE_MS) {
+    return { valid: false, reason: "The Codex connection proof has an invalid timestamp." };
+  }
+  if (now - testedAtMs > LIVE_PROOF_TTL_MS) {
+    return { valid: false, reason: "The Codex connection proof has expired." };
+  }
+
+  const warnings = Array.from(
+    new Set(
+      result.checks
+        .filter((check) => check.level === "warn")
+        .map((check) => SAFE_WARNING_LABELS[check.code] ?? GENERIC_SAFE_WARNING),
+    ),
+  );
+  return { valid: true, testedAt: result.testedAt, detail: "Hello.", warnings };
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app that people use to manage AI agents for work.
> - The `codex_local` adapter connects Paperclip to a local Codex installation.
> - The current setup check can pass without a fresh LLM response from the selected adapter configuration.
> - A stale or broad result can let onboarding hire an agent that has not proved the current Codex connection.
> - Shared Codex authentication and unsafe execution defaults also increase the effect of a false positive.
> - This pull request adds a strict and scoped `Hello.` proof before both onboarding flows can hire the agent.
> - The benefit is a current connection proof with bounded credentials, an empty workspace, no tools, and fail-closed cleanup.

## Linked Issues or Issue Description

Refs #3946

## What Changed

- Add a typed Codex live proof. Bind it to the company, adapter configuration, and environment.
- Require one exact `Hello.` agent message and one successful terminal event.
- Reject command, file, MCP, and tool events during the probe.
- Use an empty temporary workspace for each probe.
- Stage API-key authentication in an isolated temporary Codex home.
- Use the durable local Codex home for native subscription authentication.
- Reject remote and inline subscription probes before execution. This avoids unsafe token rotation across a crash boundary.
- Remove inherited credential variables from local and remote probe environments.
- Set ACP probe permissions to deny all requests.
- Block both onboarding hire paths when the proof is absent, stale, mismatched, malformed, or unsafe.
- Render only fixed diagnostic text in the onboarding result.

## Verification

- `pnpm --filter @paperclipai/adapter-utils test`
- `pnpm --filter @paperclipai/adapter-codex-local test`
- `pnpm --filter @paperclipai/ui exec vitest run src/components/OnboardingWizard.test.tsx src/components/CodexLiveProofResult.test.tsx src/components/codex-live-proof.test.ts`
- `pnpm --filter @paperclipai/adapter-utils typecheck`
- `pnpm --filter @paperclipai/adapter-codex-local typecheck`
- `pnpm --filter @paperclipai/ui typecheck`
- `pnpm --filter @paperclipai/adapter-utils build`
- `pnpm --filter @paperclipai/adapter-codex-local build`
- `pnpm --filter @paperclipai/ui build`
- `pnpm check:tokens`
- `git diff --check`

All listed checks passed before the final rebase with Node.js 24.19.0. The repository requires Node.js 24.11.0 or later.

## Risks

- The probe is stricter than the current setup check. Existing custom output can now fail closed.
- Remote and inline subscription probes are not supported by this change. API-key probes remain supported in those environments.
- The proof confirms connectivity at one time. It does not prove the exact model because current Codex event data does not provide that claim.
- The change does not rotate or copy a live subscription token. A reviewer must approve a durable remote authentication design before that path can be enabled.
- This is a draft. Project coordination and all upstream review gates are still required before merge.

## Model Used

OpenAI Codex on a GPT-5 family model. The desktop host did not expose a more precise deployment ID. The run used tool calls and local code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
