### PR TITLE
fix(tool-gateway): stop mapping application-level tools/call errors to raw HTTP 404/400 on the named MCP gateway

### DIFF
--- a/server/src/__tests__/tool-gateway.test.ts
+++ b/server/src/__tests__/tool-gateway.test.ts
@@ -830,6 +830,85 @@ describeEmbeddedPostgres("tool gateway acceptance", () => {
     }
   });
 
+  it("never surfaces a raw HTTP 404/400 for an application-level tools/call error on the named MCP gateway", async () => {
+    // The MCP Streamable HTTP spec reserves HTTP 404 ("session not found") and
+    // 400 ("server not initialized") for transport-level session state. This
+    // gateway route has no mcp-session-id concept at all (bearer-token-per-
+    // request), so any ToolGatewayHttpError surfacing one of those statuses
+    // here is always an application-level failure (bad tool name, missing
+    // args) — never a dead session. A spec-compliant client (Claude Code)
+    // that sees a raw 404 reconnects/reports "session expired" regardless of
+    // the JSON-RPC body, misreporting an ordinary tool error as a broken
+    // session and abandoning an otherwise-healthy one. Regression for a real
+    // production incident: an agent's `run_tool` calls with an unresolvable
+    // (or malformed) target tool name all failed as `MCP server "ai-1mcp"
+    // session expired` even though the gateway connection itself was fine.
+    const company = await createCompany(db);
+    const [profile] = await db.insert(toolProfiles).values({
+      companyId: company.id,
+      profileKey: `named-gateway-404-${randomUUID()}`,
+      name: `Named gateway 404 regression`,
+      defaultAction: "allow",
+    }).returning();
+    const gateway = createTestToolGatewayService(db);
+    const created = await gateway.createNamedGateway({
+      companyId: company.id,
+      body: { name: "External reader", profileId: profile.id },
+    });
+    const token = await gateway.createNamedGatewayToken({
+      companyId: company.id,
+      gatewayId: created.id,
+      body: { name: "Cursor", clientLabel: "Cursor desktop", ownerNote: "QA fixture token" },
+    });
+
+    const app = createGatewayRouteApp(db, gateway);
+
+    // Direct tools/call with an unresolvable tool name (findToolForSession's
+    // 404 "tool_not_found").
+    const unresolvable = await request(app)
+      .post(`/api/tool-gateway/gateways/${created.id}/mcp`)
+      .set("authorization", `Bearer ${token.token}`)
+      .send({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "does-not-exist-in-any-catalog", arguments: {} },
+      });
+    expect(unresolvable.status).toBe(200);
+    expect(unresolvable.body.error.data.reasonCode).toBe("tool_not_found");
+
+    // The virtual run_tool wrapper with an unresolvable target (virtualRunToolInput
+    // -> findToolForSession's 404), the exact shape an agent hits when it guesses
+    // a short tool name instead of the fully-qualified catalog name.
+    const runToolUnresolvable = await request(app)
+      .post(`/api/tool-gateway/gateways/${created.id}/mcp`)
+      .set("authorization", `Bearer ${token.token}`)
+      .send({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: { name: "run_tool", arguments: { tool: "crw-1mcp-crw-search", arguments: { query: "test" } } },
+      });
+    expect(runToolUnresolvable.status).toBe(200);
+    expect(runToolUnresolvable.body.error.data.reasonCode).toBe("tool_not_found");
+
+    // A bare "run_tool" call in a company with no on-demand remote tools
+    // connected doesn't even expose the virtual run_tool wrapper — same
+    // findToolForSession 404 as any other unresolvable name, still never a
+    // raw HTTP 404.
+    const runToolMissingTarget = await request(app)
+      .post(`/api/tool-gateway/gateways/${created.id}/mcp`)
+      .set("authorization", `Bearer ${token.token}`)
+      .send({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: { name: "run_tool", arguments: {} },
+      });
+    expect(runToolMissingTarget.status).toBe(200);
+    expect(runToolMissingTarget.body.error.data.reasonCode).toBe("tool_not_found");
+  });
+
   it("omits archived gateways from listNamedGateways", async () => {
     const company = await createCompany(db);
     const [profile] = await db.insert(toolProfiles).values({

--- a/server/src/routes/tool-gateway.ts
+++ b/server/src/routes/tool-gateway.ts
@@ -204,7 +204,21 @@ async function handleMcpGatewayProtocol(
   } catch (err) {
     if (err instanceof ToolGatewayHttpError) {
       const id = (req.body as { id?: unknown } | undefined)?.id ?? null;
-      res.status(err.status).json({
+      // HTTP 404 and 400 carry reserved meaning under the MCP Streamable HTTP
+      // transport spec ("session not found" / "server not initialized"), and
+      // spec-compliant clients (e.g. Claude Code) act on the raw HTTP status
+      // directly - reconnecting or reporting "session expired" - without
+      // reading the JSON-RPC body. This endpoint is a stateless bearer-token
+      // gateway with no mcp-session-id concept at all, so a ToolGatewayHttpError
+      // with one of those statuses (e.g. "tool not found", "invalid_parameters")
+      // is always an ordinary application-level failure here, never an actual
+      // dead session. Passing it through as a raw 404/400 made spec-compliant
+      // clients misreport routine tool errors (a bad tool name, missing args)
+      // as a broken session - confusing agents into abandoning otherwise-fine
+      // sessions. Surface those as a normal JSON-RPC error on HTTP 200 instead;
+      // genuine transport-auth failures (401/403) are unaffected.
+      const httpStatus = err.status === 404 || err.status === 400 ? 200 : err.status;
+      res.status(httpStatus).json({
         jsonrpc: "2.0",
         id,
         error: { code: err.status >= 500 ? -32603 : -32000, message: err.message, data: { reasonCode: err.reasonCode, ...err.details } },


### PR DESCRIPTION
## Thinking Path

> - Paperclip's named MCP gateway (`/api/tool-gateway/gateways/:gatewayId/mcp`) is a bearer-token-authenticated JSON-RPC endpoint that external MCP clients — including Claude Code CLI itself, for `claude_local` agent runs — connect to directly
> - `handleMcpGatewayProtocol` catches `ToolGatewayHttpError` and reuses its `.status` field verbatim as the raw HTTP response status for every `tools/call` failure
> - The MCP Streamable HTTP transport spec reserves two HTTP status codes with protocol-level meaning that spec-compliant clients act on directly, without reading the JSON-RPC body: 404 means "session not found, reinitialize" and 400 means "server not initialized"
> - This endpoint has no `mcp-session-id` concept at all — it's stateless, bearer-token-per-request — so a `ToolGatewayHttpError` with status 404 or 400 here is always an ordinary application-level failure (e.g. "tool not found", "run_tool requires a target tool name"), never an actual dead session
> - A spec-compliant client receiving that raw 404/400 doesn't inspect the JSON-RPC error body first — it acts on the HTTP status and reports/behaves as if the session died, discarding an otherwise-completely-healthy connection
> - This pull request stops passing those two specific statuses through as raw HTTP codes for `tools/call`, surfacing them instead as an ordinary JSON-RPC error on HTTP 200 (transport-auth failures — 401 revoked/invalid token, 403 policy denial — are untouched, since those aren't spec-reserved codes)

## Linked Issues or Issue Description

No existing issue — describing inline (bug), reproduced end-to-end against a live deployment:

**What happened:** An agent's tool calls through the named MCP gateway intermittently, and sometimes entirely, fail with a client-reported `MCP server "<gateway-name>" session expired`, even though `tools/list` on the exact same connection keeps succeeding throughout — i.e. the connection/session is demonstrably healthy.

**Root cause:** Traced end-to-end against a real running agent (Claude Code CLI, `claude_local` adapter) hitting this exact endpoint. The agent called the gateway's virtual `run_tool` wrapper with a tool name that didn't resolve in the catalog (a short/guessed name instead of the fully-qualified one `tools/list` returns). Server-side, `findToolForSession` correctly throws a `ToolGatewayHttpError(404, 'Tool "..." not found', "tool_not_found")` — a completely ordinary "bad argument" condition. `handleMcpGatewayProtocol`'s catch block turned that into a raw HTTP 404 response. Claude Code, being spec-compliant, read the HTTP 404 and reported it as a session failure rather than a bad-tool-name error — the JSON-RPC body's actual `tool_not_found` reason code was never surfaced to the user/agent, only the misleading client-side "session expired" framing. Confirmed by reading the paperclip server's own access logs directly against the timestamps in the agent's transcript: every one of the failing calls got HTTP 404 from *this* route, and the downstream MCP aggregator's own logs show no corresponding request or error at all for that window — the failure never left this server.

**Expected:** An unresolvable tool name (or any other ordinary `tools/call` application error) is reported as exactly that — a JSON-RPC tool error — not misreported as a dead session that discards the whole connection.

**Repro:** Call `tools/call` on a named gateway with a tool name that doesn't exist in that gateway's catalog (or call the virtual `run_tool` wrapper with an unresolvable target). Before: HTTP 404 with the tool-not-found reason buried in a body a spec-compliant client won't read before acting on the status code. After: HTTP 200 with the same JSON-RPC error body, correctly interpretable as an ordinary tool error.

_Dedup search: no open PR touches `handleMcpGatewayProtocol`'s error-status mapping. No duplicate found._

## What Changed

- `server/src/routes/tool-gateway.ts`, `handleMcpGatewayProtocol`'s catch block: when a caught `ToolGatewayHttpError` has `status === 404` or `status === 400`, respond with HTTP 200 (still carrying the same JSON-RPC `error` object, including `reasonCode`) instead of passing the raw status through. Every other status (401, 403, 429, 5xx) is unaffected — those don't carry MCP-spec-reserved meaning at this stateless, bearer-token-only endpoint.
- Added a regression test exercising exactly the failure shape hit in production: an unresolvable direct tool name, the virtual `run_tool` wrapper with an unresolvable target, and a bare `run_tool` call with no on-demand tools connected — all now assert HTTP 200 with `reasonCode: "tool_not_found"` instead of a raw 404.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/tool-gateway.test.ts` → 62/62 passing, including the new regression test and the pre-existing named-gateway auth/revocation tests (401/403 paths unchanged).
- `tsc --noEmit`: no new errors in either changed file (this checkout has pre-existing, unrelated typecheck failures elsewhere from a stale local `@paperclipai/plugin-sdk` build — none touch these files).
- Traced end-to-end against a live deployment: read the paperclip server's own access logs and the agent's raw session transcript side by side, confirmed the exact request/response pair (agent's `run_tool` call → server's `POST .../mcp 404` with `reasonCode: "tool_not_found"` in the body → Claude Code's `MCP server "..." session expired` report), confirming this route — not the downstream MCP aggregator, which showed no corresponding request in its own logs for that window — is where the misleading status originates.

## Risks

Low risk. Only two specific HTTP status values are affected, both remapped to 200 with the JSON-RPC error preserved verbatim (callers reading `reasonCode`/`error.data` see no behavior change; only callers relying on the raw HTTP status code for these two cases would need to switch to reading the JSON-RPC body, which is the spec-correct behavior anyway). No schema/migration changes.

## Model Used

Claude Sonnet 5 (`claude-sonnet-5`), via Claude Code — root-caused by correlating a real agent's raw session transcript against the paperclip server's own access logs and the downstream MCP aggregator's logs for the same time window, live against a production deployment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change (`fix/...`) and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (none required — internal error-mapping behavior)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
