### PR TITLE
fix(tool-access): mark catalog entries removed when they drop out of an upstream refresh

### DIFF
--- a/packages/shared/src/types/tool-access.ts
+++ b/packages/shared/src/types/tool-access.ts
@@ -917,6 +917,7 @@ export interface ToolCatalogRefreshResult {
   catalog: ToolCatalogEntry[];
   discoveredCount: number;
   quarantinedCount: number;
+  removedCount: number;
 }
 
 export type ToolAppAttentionReason =

--- a/server/src/__tests__/tool-access-service.test.ts
+++ b/server/src/__tests__/tool-access-service.test.ts
@@ -1896,6 +1896,104 @@ describeEmbeddedPostgres("tool access service", () => {
     expect(stillBlocked!.status).toBe("disabled");
   });
 
+  it("marks a catalog entry removed once its upstream tool disappears from a refresh, instead of leaving it active forever", async () => {
+    // Regression for a real production incident: 1mcp renamed a downstream
+    // client (crw -> scrape), so its tools started listing under new names
+    // (scrape_1mcp_crw_search) while the old ones (crw_1mcp_crw_search)
+    // stopped appearing in any future tools/list response. Nothing here ever
+    // revisited rows for tools that dropped out of the descriptor list, so
+    // the stale entry sat "active" indefinitely - agents kept discovering and
+    // calling it, and every call failed at the transport layer against a
+    // target that no longer resolved, sitting right next to the real,
+    // working tool with a near-identical name.
+    const company = await createCompany(db);
+    const service = createTestToolAccessService(db);
+    mockToolsList([
+      {
+        name: "crw_1mcp_crw_search",
+        description: "Search the web.",
+        inputSchema: { type: "object", properties: { query: { type: "string" } } },
+        annotations: { readOnlyHint: true },
+      },
+      {
+        name: "stable_tool",
+        description: "Unrelated tool that stays.",
+        inputSchema: { type: "object", properties: {} },
+        annotations: { readOnlyHint: true },
+      },
+    ]);
+
+    const connection = await service.createConnection(company.id, {
+      name: "Remote fixture",
+      transport: "mcp_remote",
+      config: { url: "https://fixture.example/mcp" },
+      enabled: true,
+      status: "active",
+    });
+    const firstRefresh = await service.refreshCatalog(connection.id, { actorType: "user", actorId: "board" });
+    expect(firstRefresh.discoveredCount).toBe(2);
+    expect(firstRefresh.removedCount).toBe(0);
+    expect(firstRefresh.catalog).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ toolName: "crw_1mcp_crw_search", status: "active" }),
+        expect.objectContaining({ toolName: "stable_tool", status: "active" }),
+      ]),
+    );
+
+    // Simulate the rename: the next refresh's upstream tools/list only
+    // returns the tool under its new name, plus the unrelated stable tool.
+    mockToolsList([
+      {
+        name: "scrape_1mcp_crw_search",
+        description: "Search the web.",
+        inputSchema: { type: "object", properties: { query: { type: "string" } } },
+        annotations: { readOnlyHint: true },
+      },
+      {
+        name: "stable_tool",
+        description: "Unrelated tool that stays.",
+        inputSchema: { type: "object", properties: {} },
+        annotations: { readOnlyHint: true },
+      },
+    ]);
+    const secondRefresh = await service.refreshCatalog(connection.id);
+
+    expect(secondRefresh.discoveredCount).toBe(2);
+    expect(secondRefresh.removedCount).toBe(1);
+    expect(secondRefresh.catalog).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ toolName: "scrape_1mcp_crw_search", status: "active" }),
+        expect.objectContaining({ toolName: "stable_tool", status: "active" }),
+      ]),
+    );
+
+    const staleEntry = await db
+      .select()
+      .from(toolCatalogEntries)
+      .where(and(eq(toolCatalogEntries.connectionId, connection.id), eq(toolCatalogEntries.toolName, "crw_1mcp_crw_search")));
+    expect(staleEntry).toHaveLength(1);
+    expect(staleEntry[0]).toMatchObject({ status: "removed" });
+
+    // A third refresh where the old name never reappears must not keep
+    // re-touching (or re-counting) an already-removed entry.
+    mockToolsList([
+      {
+        name: "scrape_1mcp_crw_search",
+        description: "Search the web.",
+        inputSchema: { type: "object", properties: { query: { type: "string" } } },
+        annotations: { readOnlyHint: true },
+      },
+      {
+        name: "stable_tool",
+        description: "Unrelated tool that stays.",
+        inputSchema: { type: "object", properties: {} },
+        annotations: { readOnlyHint: true },
+      },
+    ]);
+    const thirdRefresh = await service.refreshCatalog(connection.id);
+    expect(thirdRefresh.removedCount).toBe(0);
+  });
+
   it("sends the MCP Streamable HTTP Accept header and decodes an SSE catalog response", async () => {
     const company = await createCompany(db);
     const service = createTestToolAccessService(db);

--- a/server/src/services/tool-access.ts
+++ b/server/src/services/tool-access.ts
@@ -5491,6 +5491,31 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
     const normalizedTransportConfig = refreshOptions.enableAllByDefault
       ? { ...connection.transportConfig, quarantineNewEntries: false }
       : connection.transportConfig;
+
+    // Entries that existed before this refresh but weren't in this refresh's
+    // descriptor list no longer exist upstream (renamed, removed, or the
+    // upstream connection's tool naming changed - e.g. 1mcp relabeling a
+    // downstream client). Left untouched, a stale row stays "active" forever:
+    // agents keep discovering and calling it (it still passes every policy
+    // check, since nothing here ever revisits it), and every call fails at
+    // the transport layer against a target that no longer resolves - the
+    // real, live tools sit right next to a landmine with an identical-looking
+    // name. Mark them "removed" so every status="active" query (discovery,
+    // policy, catalog listings) stops surfacing them, without touching genuine
+    // quarantine/disable state on tools that are still present upstream.
+    const freshNames = new Set(descriptors.map((descriptor) => descriptor.name));
+    const staleEntries = existingRows.filter(
+      (entry) => !freshNames.has(entry.toolName) && entry.status !== "removed",
+    );
+    let removedCount = 0;
+    for (const stale of staleEntries) {
+      await db
+        .update(toolCatalogEntries)
+        .set({ status: "removed", updatedAt: refreshedAt })
+        .where(eq(toolCatalogEntries.id, stale.id));
+      removedCount += 1;
+    }
+
     const [updatedConnection] = await db
       .update(toolConnections)
       .set({
@@ -5540,7 +5565,7 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
       connectionId: connection.id,
       action: "tool_connection.catalog_refresh",
       outcome: "success",
-      details: { discoveredCount: descriptors.length, quarantinedCount },
+      details: { discoveredCount: descriptors.length, quarantinedCount, removedCount },
       actor,
     });
 
@@ -5549,6 +5574,7 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
       catalog: updatedEntries,
       discoveredCount: descriptors.length,
       quarantinedCount,
+      removedCount,
     };
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip caches a discovered catalog of tools per remote MCP connection in `tool_catalog_entries`, refreshed periodically by `refreshCatalog()` against the connection's live `tools/list`
> - The sync loop in `refreshCatalog()` walks the fresh descriptor list and inserts new rows or updates existing ones by matching `toolName` — but it never looks the other way: an existing row whose `toolName` simply isn't in this refresh's descriptor list is left completely untouched
> - A downstream MCP server renaming or removing a tool (the concrete case: an aggregator relabeling a downstream client, so `crw_search` becomes `scrape_search`) makes the *old* name permanently absent from every future refresh — but the row for it is still sitting there with `status: "active"`, indistinguishable from a real, currently-callable tool
> - Every consumer (discovery, policy decisions, catalog listings) filters on `status = "active"`, so that stale row keeps surfacing to agents as if it were live, and every call against it fails at the transport layer with whatever error the downstream server gives for an unresolvable target
> - `toolCatalogEntries.status` already has a `"removed"` value in its type (`TOOL_CATALOG_ENTRY_STATUSES`) — defined, but never actually set anywhere in the codebase
> - This pull request makes `refreshCatalog()` mark any entry that dropped out of the fresh descriptor list `"removed"`, so the existing `status = "active"` filters everywhere else make it disappear on their own, with no other code changes needed

## Linked Issues or Issue Description

No existing issue — describing inline (bug), root-caused against a live production incident:

**What happened:** An agent kept getting a tool name back from `search_tools`/catalog discovery, calling it with that exact name, and it always failed — with the aggregator reporting "Unknown client" for the prefix in that name.

**Root cause:** The downstream aggregator had renamed a client (`crw` → `scrape`) at some point. Its tools started listing under the new prefix in every subsequent refresh; the old-prefixed rows never got touched again by any refresh, so they sat `status: "active"` indefinitely, side-by-side with the correctly-renamed rows for the same underlying tool. Confirmed directly: querying the connection's cached catalog turned up both `crw_1mcp_crw_search` (stale, dead) and `scrape_1mcp_crw_search` (live) as two separate `active` entries for what is really one tool.

**Expected:** A tool that stops appearing in a connection's live `tools/list` stops being discoverable/callable through Paperclip once the catalog has refreshed past that point — the same way a genuinely deleted or disabled tool already does.

**Repro:** Refresh a connection's catalog with tool `A` present, then refresh again with `A` absent from the descriptor list (renamed or removed upstream). Before: the catalog entry for `A` stays `status: "active"` forever. After: it flips to `status: "removed"` on the refresh where it first disappears, and stays that way (a `removed` entry never gets re-touched, only entries still absent and not yet marked).

_Dedup search: no open PR touches `refreshCatalog`'s stale-entry handling. No duplicate found._

## What Changed

- `server/src/services/tool-access.ts`, `refreshCatalog()`: after syncing the fresh descriptor list, build the set of tool names it contains, then mark any existing entry whose `toolName` isn't in that set (and isn't already `"removed"`) as `status: "removed"`. Quarantine/disable state on tools that are still present upstream is untouched — this only affects rows for tools that are no longer in the live catalog at all.
- Threaded a `removedCount` through `ToolCatalogRefreshResult` and the `tool_connection.catalog_refresh` audit event, alongside the existing `discoveredCount`/`quarantinedCount`, for observability.
- Added a regression test modeling the exact production scenario (a downstream tool renamed between two refreshes): asserts the old-named entry flips to `removed`, the new-named entry and an unrelated stable tool stay `active`, and a further refresh where the old name never reappears doesn't keep re-touching (or re-counting) the already-removed row.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/tool-access-service.test.ts` → 204/204 passing, including the new regression test and the existing quarantine-refresh test (unaffected — that test's assertions use `arrayContaining`, so they never depended on the absence of dropped-out entries).
- `tsc --noEmit`: no new errors in any changed file (this checkout has pre-existing, unrelated typecheck failures elsewhere from a stale local `@paperclipai/plugin-sdk` build; none touch these files).
- Verified against the live incident data: the connection's cached catalog held both the stale and live entries for the same renamed tool before a manual fix; confirmed the new logic would have caught and marked the stale one on its very next refresh.

## Risks

Low risk, additive only. `"removed"` was already a first-class status value in the type system with no prior producer; every consumer already filters on `status = "active"` for discovery, policy, and listings, so newly-removed entries simply stop appearing there, the same as any other non-active status already does. No entry that's still present upstream is touched. No schema/migration changes (the `removed` status value already existed in the column's type).

## Model Used

Claude Sonnet 5 (`claude-sonnet-5`), via Claude Code — root-caused by directly querying a live connection's cached catalog and cross-referencing it against the aggregator's own error logs for a real, currently-failing production incident.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change (`fix/...`) and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (none required — internal catalog-sync behavior)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
