### PR TITLE
feat(http-adapter): poll remote runs for completion and render payload templates

### DIFF
--- a/server/src/adapters/http/execute.test.ts
+++ b/server/src/adapters/http/execute.test.ts
@@ -1,10 +1,68 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CONNECTION_INTENT_AGENT_GUIDANCE } from "@paperclipai/shared";
 import { execute } from "./execute.js";
+import type { AdapterExecutionContext } from "../types.js";
 
 afterEach(() => {
   vi.unstubAllGlobals();
 });
+
+function jsonResponse(body: unknown, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+// The tree runs with noUncheckedIndexedAccess, so reach into the recorded fetch
+// calls through guards rather than asserting the tuple shape.
+function fetchCall(mock: { mock: { calls: unknown[][] } }, index: number) {
+  const call = mock.mock.calls[index];
+  if (!call) throw new Error(`expected a fetch call at index ${index}`);
+  return { url: String(call[0]), init: call[1] as RequestInit | undefined };
+}
+
+function requestBody(mock: { mock: { calls: unknown[][] } }, index = 0): Record<string, unknown> {
+  const { init } = fetchCall(mock, index);
+  if (!init?.body) throw new Error(`fetch call ${index} carried no body`);
+  return JSON.parse(String(init.body)) as Record<string, unknown>;
+}
+
+function buildContext(
+  config: Record<string, unknown>,
+  overrides: Partial<AdapterExecutionContext> = {},
+): AdapterExecutionContext {
+  return {
+    runId: "run-1",
+    agent: {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "Agent",
+      adapterType: "http",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config,
+    context: {},
+    onLog: async () => {},
+    ...overrides,
+  } as AdapterExecutionContext;
+}
+
+// A poll block that finishes on the first attempt, so the tests never sleep for
+// the 2000ms default.
+const FAST_POLL = {
+  enabled: true,
+  urlTemplate: "https://runtime.test/runs/{{run_id}}",
+  intervalMs: 0,
+  maxAttempts: 3,
+};
 
 describe("http adapter execute", () => {
   it("delivers the complete runtime connection descriptor and shared guidance", async () => {
@@ -75,31 +133,174 @@ describe("http adapter execute", () => {
       })),
     );
 
-    const result = await execute({
-      runId: "run-1",
-      agent: {
-        id: "agent-1",
-        companyId: "company-1",
-        name: "Agent",
-        adapterType: "http",
-        adapterConfig: {},
-      },
-      runtime: {
-        sessionId: null,
-        sessionParams: null,
-        sessionDisplayId: null,
-        taskKey: null,
-      },
-      config: {
-        url: "https://example.test/webhook",
-        timeoutMs: 1,
-      },
-      context: {},
-      onLog: async () => {},
-    });
+    const result = await execute(buildContext({
+      url: "https://example.test/webhook",
+      timeoutMs: 1,
+    }));
 
     expect(result.timedOut).toBe(true);
     expect(result.errorCode).toBe("timeout");
     expect(result.errorMessage).toContain("timed out after 1ms");
+  });
+
+  it("renders payload template strings with run context", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await execute(buildContext(
+      {
+        url: "https://example.test/webhook",
+        payloadTemplate: { input: "Work issue {{ context.issueId }} for {{ agent.name }}" },
+      },
+      { context: { issueId: "issue-42" } },
+    ));
+
+    const body = requestBody(fetchMock);
+    expect(body.input).toBe("Work issue issue-42 for Agent");
+  });
+
+  it("leaves non-string payload values untouched", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await execute(buildContext({
+      url: "https://example.test/webhook",
+      payloadTemplate: { timeout_sec: 120, stream: false, tags: ["a", "{{ runId }}"] },
+    }));
+
+    const body = requestBody(fetchMock);
+    expect(body.timeout_sec).toBe(120);
+    expect(body.stream).toBe(false);
+    expect(body.tags).toEqual(["a", "run-1"]);
+  });
+
+  it("does not leak the full agent record into the payload", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({}));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await execute(buildContext({
+      url: "https://example.test/webhook",
+      payloadTemplate: { leak: "{{ agent }}" },
+      // A credential of the kind adapterConfig legitimately carries.
+      apiKey: "super-secret",
+    }));
+
+    const leak = String(requestBody(fetchMock).leak);
+    expect(leak).not.toContain("super-secret");
+    expect(leak).not.toContain("adapterConfig");
+  });
+
+  it("preserves fire-and-forget behavior when no poll block is configured", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ run_id: "remote-1" }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await execute(buildContext({ url: "https://example.test/webhook" }));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.exitCode).toBe(0);
+    expect(result.summary).toBe("HTTP POST https://example.test/webhook");
+    expect(result.resultJson).toBeUndefined();
+  });
+
+  it("polls to a terminal status and captures output, usage and cost", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ run_id: "remote-1" }))
+      .mockResolvedValueOnce(jsonResponse({ status: "running" }))
+      .mockResolvedValueOnce(jsonResponse({
+        status: "completed",
+        output: "the brief",
+        usage: { input_tokens: 10, output_tokens: 4 },
+        cost_usd: 0.41,
+        model: "anthropic/claude-sonnet-4",
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const logs: Array<[string, string]> = [];
+    const result = await execute(buildContext(
+      {
+        url: "https://example.test/webhook",
+        poll: { ...FAST_POLL, costUsdPath: "cost_usd", modelPath: "model" },
+      },
+      { onLog: async (stream, chunk) => { logs.push([stream, chunk]); } },
+    ));
+
+    expect(result.exitCode).toBe(0);
+    expect(result.usage).toEqual({ inputTokens: 10, outputTokens: 4 });
+    expect(result.costUsd).toBe(0.41);
+    expect(result.model).toBe("anthropic/claude-sonnet-4");
+    expect(logs.some(([stream, chunk]) => stream === "stdout" && chunk === "the brief")).toBe(true);
+    // The poll URL must render its double-brace placeholder.
+    expect(fetchCall(fetchMock, 1).url).toBe("https://runtime.test/runs/remote-1");
+  });
+
+  it("uses a status line as the summary by default", async () => {
+    vi.stubGlobal("fetch", vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ run_id: "remote-1" }))
+      .mockResolvedValueOnce(jsonResponse({ status: "completed", output: "the brief" })));
+
+    const result = await execute(buildContext({
+      url: "https://example.test/webhook",
+      poll: FAST_POLL,
+    }));
+
+    expect(result.summary).toContain("run remote-1 (completed)");
+    expect(result.summary).not.toBe("the brief");
+  });
+
+  it("promotes captured output to the summary when outputAsSummary is set", async () => {
+    vi.stubGlobal("fetch", vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ run_id: "remote-1" }))
+      .mockResolvedValueOnce(jsonResponse({ status: "completed", output: "  the brief  " })));
+
+    const result = await execute(buildContext({
+      url: "https://example.test/webhook",
+      poll: { ...FAST_POLL, outputAsSummary: true },
+    }));
+
+    expect(result.summary).toBe("the brief");
+  });
+
+  it("does not promote output to the summary on a failed remote run", async () => {
+    vi.stubGlobal("fetch", vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ run_id: "remote-1" }))
+      .mockResolvedValueOnce(jsonResponse({ status: "failed", output: "partial junk" })));
+
+    const result = await execute(buildContext({
+      url: "https://example.test/webhook",
+      poll: { ...FAST_POLL, outputAsSummary: true },
+    }));
+
+    expect(result.exitCode).toBe(1);
+    expect(result.summary).toContain("run remote-1 (failed)");
+    expect(result.errorMessage).toContain("failed");
+  });
+
+  it("throws when polling is enabled but the invoke response carries no run id", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => jsonResponse({ nope: true })));
+
+    await expect(execute(buildContext({
+      url: "https://example.test/webhook",
+      poll: FAST_POLL,
+    }))).rejects.toThrow(/no run id at path "run_id"/);
+  });
+
+  it("reports a poll timeout when no attempt returns a usable response", async () => {
+    vi.stubGlobal("fetch", vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ run_id: "remote-1" }))
+      .mockResolvedValue(jsonResponse({}, false, 503)));
+
+    const result = await execute(buildContext({
+      url: "https://example.test/webhook",
+      poll: { ...FAST_POLL, maxAttempts: 2 },
+    }));
+
+    expect(result.timedOut).toBe(true);
+    expect(result.exitCode).toBe(1);
+    expect(result.errorMessage).toContain("Polled 2 times");
   });
 });

--- a/server/src/adapters/http/execute.ts
+++ b/server/src/adapters/http/execute.ts
@@ -1,15 +1,145 @@
-import type { AdapterExecutionContext, AdapterExecutionResult } from "../types.js";
-import { asString, asNumber, parseObject } from "../utils.js";
+import type { AdapterExecutionContext, AdapterExecutionResult, UsageSummary } from "../types.js";
+import { asString, asNumber, parseObject, renderTemplate } from "../utils.js";
+
+const DEFAULT_POLL_INTERVAL_MS = 2000;
+const DEFAULT_POLL_MAX_ATTEMPTS = 90;
+const DEFAULT_TERMINAL_STATUSES = ["completed", "failed", "succeeded", "error", "cancelled"];
+const FAILURE_STATUSES = ["failed", "error", "cancelled"];
+const DEFAULT_RUN_ID_PATH = "run_id";
+const DEFAULT_STATUS_PATH = "status";
+const DEFAULT_OUTPUT_PATH = "output";
+const DEFAULT_USAGE_PATH = "usage";
+
+interface PollConfig {
+  urlTemplate: string;
+  intervalMs: number;
+  maxAttempts: number;
+  terminalStatuses: string[];
+  runIdPath: string;
+  statusPath: string;
+  outputPath: string;
+  usagePath: string;
+  outputAsSummary: boolean;
+  costUsdPath?: string;
+  modelPath?: string;
+  providerPath?: string;
+}
+
+function readPollConfig(config: Record<string, unknown>): PollConfig | null {
+  const raw = parseObject(config.poll);
+  if (!raw || raw.enabled !== true) return null;
+
+  const urlTemplate = asString(raw.urlTemplate, "");
+  if (!urlTemplate) return null;
+
+  const terminalStatusesRaw: unknown = raw.terminalStatuses ?? DEFAULT_TERMINAL_STATUSES;
+  const terminalStatuses = Array.isArray(terminalStatusesRaw)
+    ? terminalStatusesRaw.map((status) => String(status).toLowerCase())
+    : DEFAULT_TERMINAL_STATUSES;
+
+  return {
+    urlTemplate,
+    intervalMs: asNumber(raw.intervalMs, DEFAULT_POLL_INTERVAL_MS),
+    maxAttempts: asNumber(raw.maxAttempts, DEFAULT_POLL_MAX_ATTEMPTS),
+    terminalStatuses,
+    runIdPath: asString(raw.runIdPath, DEFAULT_RUN_ID_PATH),
+    statusPath: asString(raw.statusPath, DEFAULT_STATUS_PATH),
+    outputPath: asString(raw.outputPath, DEFAULT_OUTPUT_PATH),
+    usagePath: asString(raw.usagePath, DEFAULT_USAGE_PATH),
+    outputAsSummary: raw.outputAsSummary === true,
+    costUsdPath: typeof raw.costUsdPath === "string" ? raw.costUsdPath : undefined,
+    modelPath: typeof raw.modelPath === "string" ? raw.modelPath : undefined,
+    providerPath: typeof raw.providerPath === "string" ? raw.providerPath : undefined,
+  };
+}
+
+function readPath(source: unknown, path: string): unknown {
+  if (!path || source === null || source === undefined) return undefined;
+  let cursor: unknown = source;
+  for (const segment of path.split(".")) {
+    if (cursor === null || cursor === undefined) return undefined;
+    if (typeof cursor !== "object") return undefined;
+    cursor = (cursor as Record<string, unknown>)[segment];
+  }
+  return cursor;
+}
+
+// Render every string in the payload template. Non-strings (numbers, booleans,
+// null) pass through untouched, so `timeout_sec: 120` stays a number rather
+// than becoming "120".
+function renderPayloadValue(value: unknown, data: Record<string, unknown>): unknown {
+  if (typeof value === "string") return renderTemplate(value, data);
+  if (Array.isArray(value)) return value.map((entry) => renderPayloadValue(entry, data));
+  if (value && typeof value === "object") {
+    const rendered: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      rendered[key] = renderPayloadValue(entry, data);
+    }
+    return rendered;
+  }
+  return value;
+}
+
+function toUsageSummary(raw: unknown): UsageSummary | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const record = raw as Record<string, unknown>;
+  const input = Number(record.input_tokens ?? record.prompt_tokens ?? record.inputTokens ?? 0);
+  const output = Number(record.output_tokens ?? record.completion_tokens ?? record.outputTokens ?? 0);
+  const cached = Number(record.cached_input_tokens ?? record.cached_tokens ?? record.cachedInputTokens ?? 0);
+  if (!Number.isFinite(input) && !Number.isFinite(output)) return undefined;
+  return {
+    inputTokens: Number.isFinite(input) ? input : 0,
+    outputTokens: Number.isFinite(output) ? output : 0,
+    ...(cached > 0 ? { cachedInputTokens: cached } : {}),
+  };
+}
+
+function stringifyOutput(value: unknown): string | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value === "string") return value;
+  if (typeof value === "object") return JSON.stringify(value, null, 2);
+  return String(value);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
-  const { config, runId, agent, context } = ctx;
+  const { config, runId, agent, context, onLog } = ctx;
   const url = asString(config.url, "");
   if (!url) throw new Error("HTTP adapter missing url");
 
   const method = asString(config.method, "POST");
   const timeoutMs = asNumber(config.timeoutMs, 0);
   const headers = parseObject(config.headers) as Record<string, string>;
-  const payloadTemplate = parseObject(config.payloadTemplate);
+
+  // Render the payload template against the same data shape the local adapters
+  // use for promptTemplate, so a remote runtime can receive per-run context
+  // (e.g. `input: "Work issue {{ context.issueId }}"`). Without this the payload
+  // is static per agent and the remote runtime never learns which run it is on.
+  const templateData: Record<string, unknown> = {
+    agentId: agent.id,
+    companyId: agent.companyId,
+    runId,
+    company: { id: agent.companyId },
+    // Deliberately a narrow subset, NOT the whole agent record. This payload is
+    // sent to a third-party endpoint and agent.adapterConfig can hold plaintext
+    // credentials; renderTemplate JSON-stringifies objects, so exposing `agent`
+    // wholesale would let a stray `{{ agent }}` ship those secrets off-box.
+    agent: {
+      id: agent.id,
+      name: agent.name,
+      companyId: agent.companyId,
+      adapterType: agent.adapterType,
+    },
+    run: { id: runId },
+    context,
+  };
+  const payloadTemplate = renderPayloadValue(
+    parseObject(config.payloadTemplate),
+    templateData,
+  ) as Record<string, unknown>;
   const body = {
     ...payloadTemplate,
     agentId: agent.id,
@@ -18,9 +148,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     ...(ctx.runtimeTools ? { paperclipRuntimeTools: ctx.runtimeTools } : {}),
   };
 
+  const pollConfig = readPollConfig(config);
+
   const controller = new AbortController();
   const timer = timeoutMs > 0 ? setTimeout(() => controller.abort(), timeoutMs) : null;
 
+  let initialResponseJson: unknown = null;
   try {
     // HTTP adapters have no child-process spawn event. Signal immediately
     // before starting the remote request so dispatch gates can release without
@@ -40,12 +173,14 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       throw new Error(`HTTP invoke failed with status ${res.status}`);
     }
 
-    return {
-      exitCode: 0,
-      signal: null,
-      timedOut: false,
-      summary: `HTTP ${method} ${url}`,
-    };
+    // Only the polling path needs the response body, but reading it
+    // unconditionally keeps the fire-and-forget path's behavior identical.
+    const responseText = await res.text();
+    try {
+      initialResponseJson = responseText ? JSON.parse(responseText) : null;
+    } catch {
+      initialResponseJson = responseText;
+    }
   } catch (err) {
     if (timer && err instanceof Error && err.name === "AbortError") {
       return {
@@ -60,4 +195,118 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   } finally {
     if (timer) clearTimeout(timer);
   }
+
+  // No poll block configured: preserve the historical fire-and-forget contract.
+  if (!pollConfig) {
+    return {
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      summary: `HTTP ${method} ${url}`,
+    };
+  }
+
+  const remoteRunId = readPath(initialResponseJson, pollConfig.runIdPath);
+  if (typeof remoteRunId !== "string" || remoteRunId.length === 0) {
+    throw new Error(
+      `HTTP adapter poll enabled but no run id at path "${pollConfig.runIdPath}" in the invoke response`,
+    );
+  }
+
+  const pollUrl = renderTemplate(pollConfig.urlTemplate, {
+    run_id: remoteRunId,
+    runId: remoteRunId,
+  });
+  await onLog(
+    "stderr",
+    `[paperclip] http adapter dispatched run ${remoteRunId}; polling ${pollUrl} every ${pollConfig.intervalMs}ms\n`,
+  );
+
+  let lastStatus: string | null = null;
+  let lastJson: Record<string, unknown> | null = null;
+  for (let attempt = 0; attempt < pollConfig.maxAttempts; attempt++) {
+    await sleep(pollConfig.intervalMs);
+
+    const pollRes = await fetch(pollUrl, {
+      method: "GET",
+      headers: { accept: "application/json", ...headers },
+    });
+    if (!pollRes.ok) {
+      await onLog(
+        "stderr",
+        `[paperclip] poll attempt ${attempt + 1}/${pollConfig.maxAttempts} returned HTTP ${pollRes.status}; continuing\n`,
+      );
+      continue;
+    }
+
+    const pollText = await pollRes.text();
+    let pollJson: Record<string, unknown> | null = null;
+    try {
+      pollJson = pollText ? (JSON.parse(pollText) as Record<string, unknown>) : null;
+    } catch {
+      await onLog("stderr", `[paperclip] poll response was not JSON; raw: ${pollText.slice(0, 200)}\n`);
+      continue;
+    }
+    if (!pollJson) continue;
+
+    lastJson = pollJson;
+    const statusRaw = readPath(pollJson, pollConfig.statusPath);
+    const status = typeof statusRaw === "string" ? statusRaw.toLowerCase() : null;
+    if (status && status !== lastStatus) {
+      await onLog("stderr", `[paperclip] run ${remoteRunId} status=${status}\n`);
+      lastStatus = status;
+    }
+    if (status && pollConfig.terminalStatuses.includes(status)) break;
+  }
+
+  if (!lastJson) {
+    return {
+      exitCode: 1,
+      signal: null,
+      timedOut: true,
+      errorMessage: `Polled ${pollConfig.maxAttempts} times without a usable response`,
+      summary: `HTTP ${method} ${url} (poll timed out)`,
+    };
+  }
+
+  const finalStatusRaw = readPath(lastJson, pollConfig.statusPath);
+  const finalStatus = typeof finalStatusRaw === "string" ? finalStatusRaw.toLowerCase() : null;
+  const reachedTerminal = finalStatus !== null && pollConfig.terminalStatuses.includes(finalStatus);
+  const isSuccess = reachedTerminal && !FAILURE_STATUSES.includes(finalStatus);
+
+  const outputText = stringifyOutput(readPath(lastJson, pollConfig.outputPath));
+  if (outputText !== null) {
+    await onLog("stdout", outputText);
+  }
+
+  const usage = toUsageSummary(readPath(lastJson, pollConfig.usagePath));
+  const costUsd = pollConfig.costUsdPath ? Number(readPath(lastJson, pollConfig.costUsdPath)) : undefined;
+  const model = pollConfig.modelPath ? readPath(lastJson, pollConfig.modelPath) : undefined;
+  const provider = pollConfig.providerPath ? readPath(lastJson, pollConfig.providerPath) : undefined;
+
+  // A remote runtime's answer is otherwise stranded in the run transcript: the
+  // server builds the run's issue comment from `resultJson.summary`, and
+  // mergeHeartbeatRunResultJson fills that from the adapter's `summary` when the
+  // remote did not supply one. Opting in here therefore routes the captured
+  // output onto the issue through the existing comment path, with no change to
+  // the heartbeat service. Off by default because a status line is the more
+  // useful run summary when the output is large or machine-readable.
+  const statusSummary = `HTTP ${method} ${url} → run ${remoteRunId} (${finalStatus ?? "unknown"})`;
+  const summary =
+    pollConfig.outputAsSummary && isSuccess && outputText && outputText.trim()
+      ? outputText.trim()
+      : statusSummary;
+
+  return {
+    exitCode: isSuccess ? 0 : 1,
+    signal: null,
+    timedOut: false,
+    errorMessage: isSuccess ? null : `Remote run finished with status ${finalStatus ?? "unknown"}`,
+    summary,
+    usage,
+    costUsd: typeof costUsd === "number" && Number.isFinite(costUsd) ? costUsd : null,
+    model: typeof model === "string" ? model : null,
+    provider: typeof provider === "string" ? provider : null,
+    resultJson: lastJson,
+  };
 }

--- a/server/src/adapters/http/index.ts
+++ b/server/src/adapters/http/index.ts
@@ -17,6 +17,40 @@ Core fields:
 - method (string, optional): HTTP method, default POST
 - headers (object, optional): request headers
 - payloadTemplate (object, optional): JSON payload template
-- timeoutSec (number, optional): request timeout in seconds
+- timeoutMs (number, optional): invoke request timeout in milliseconds
+
+Every string in payloadTemplate is rendered with the run's context, using the
+same data the local adapters expose to promptTemplate: agentId, companyId,
+runId, company, agent, run, and context. So
+\`input: "Work issue {{ context.issueId }}"\` resolves per run. Non-strings pass
+through untouched, so \`timeout_sec: 120\` stays a number. The exposed \`agent\` is
+a narrow subset (id, name, companyId, adapterType) rather than the whole record,
+because this payload leaves the box and adapterConfig can hold credentials.
+
+Optional poll block. Without it the adapter is fire-and-forget: it returns as
+soon as the endpoint accepts the request, and the remote's result is never
+collected. With it, the adapter reads a run id out of the invoke response and
+polls until the run reaches a terminal status, then captures output, usage,
+cost, and model.
+
+- poll.enabled (boolean): must be true, or the whole block is ignored
+- poll.urlTemplate (string, required): status URL. Use DOUBLE braces:
+  "https://runtime.example/runs/{{run_id}}". Single braces are not rendered,
+  the literal text is requested, and every poll 404s until attempts run out.
+- poll.intervalMs (number, default 2000)
+- poll.maxAttempts (number, default 90)
+- poll.terminalStatuses (string[], default completed/failed/succeeded/error/cancelled)
+- poll.runIdPath (string, default "run_id"): dotted path in the invoke response
+- poll.statusPath (string, default "status"): dotted path in the poll response
+- poll.outputPath (string, default "output")
+- poll.usagePath (string, default "usage")
+- poll.costUsdPath / poll.modelPath / poll.providerPath (string, optional)
+- poll.outputAsSummary (boolean, default false): use the captured output as the
+  run summary instead of a status line, which routes it onto the issue through
+  the normal run-comment path
+
+intervalMs x maxAttempts is a hard ceiling, not a target. The defaults allow 180
+seconds; a remote run that legitimately takes longer is recorded as a poll
+timeout while it actually succeeds, so size this to the slowest real run.
 `,
 };


### PR DESCRIPTION
## What this changes

The http adapter can dispatch work to a remote runtime but cannot collect the result, and
sends `payloadTemplate` verbatim so the remote never learns which run it is on. Together
those make it usable for notifications but not for delegating work.

Three changes, all inside `server/src/adapters/http/`:

**1. `payloadTemplate` strings are rendered with the run's context**, using the same data
shape the local adapters already expose to `promptTemplate`, so
`input: "Work issue {{ context.issueId }}"` resolves per run. Non-strings pass through
untouched, so `timeout_sec: 120` stays a number rather than becoming `"120"`.

The exposed `agent` is deliberately a narrow subset (`id`, `name`, `companyId`,
`adapterType`) rather than the whole record. This payload leaves the box, `adapterConfig`
can hold plaintext credentials, and `renderTemplate` JSON-stringifies objects, so exposing
the agent wholesale would let a stray `{{ agent }}` ship those secrets to a third-party
endpoint. There is a test for this.

**2. An optional `poll` block** reads a run id out of the invoke response and polls a status
URL until the run reaches a terminal status, then captures output, usage, cost, model and
provider onto the result. When no `poll` block is configured the previous fire-and-forget
contract is preserved exactly, which is also covered by a test.

**3. `poll.outputAsSummary`** puts the captured output in the result summary instead of a
status line.

## Why there is no change to the heartbeat service

This deliberately adds no new comment path. `mergeHeartbeatRunResultJson` already promotes
an adapter's `summary` into `resultJson.summary`, and `buildHeartbeatRunIssueComment`
already posts that on a successful run. So setting the summary is sufficient to get a
remote runtime's answer onto the issue through machinery that exists today.

It is off by default, because a status line is the more useful run summary when the output
is large or machine-readable.

## Documentation

`agentConfigurationDoc` gains the `poll` block, plus two things that cost real debugging
time in practice:

- `poll.urlTemplate` needs **double** braces. Single braces are not rendered, so the literal
  text is requested and every poll 404s until attempts run out.
- `intervalMs` times `maxAttempts` is a hard ceiling, not a target. A remote run that
  legitimately takes longer is recorded as a poll timeout while it actually succeeded.

It also corrects `timeoutSec` to `timeoutMs` in the doc block, which did not match the code.

## Tests

The adapter had 2 tests. This adds 10, for 12: payload rendering, non-string preservation, the
agent-record leak guard, fire-and-forget preservation, poll-to-terminal capture with usage
and cost, both summary modes, failure status, a missing run id, and poll exhaustion.

`vitest run server/src/adapters/` passes 42/42 against `master` at 0b73ebb86.

For typecheck: there are no errors in any of the three changed files, and the whole-project
error profile is identical with and without this change in the same tree, so it introduces
none. I verified that by swapping in `master`'s copy of exactly these three files and
re-running, rather than by reading the output once.