### PR TITLE
fix(tools): use toolkits.enable, not toolkits.enabled, in Composio session requests

### DIFF
--- a/server/src/services/composio.test.ts
+++ b/server/src/services/composio.test.ts
@@ -120,7 +120,7 @@ describe("Composio REST client", () => {
         body: {
           user_id: "user-1",
           mcp: true,
-          toolkits: { enabled: ["github"] },
+          toolkits: { enable: ["github"] },
           tools: { github: { enable: ["GITHUB_LIST_REPOS"] } },
           auth_configs: { github: "ac_1" },
           connected_accounts: { github: ["ca_1"] },

--- a/server/src/services/composio.ts
+++ b/server/src/services/composio.ts
@@ -199,7 +199,7 @@ export function createComposioClient(options: ComposioClientOptions): ComposioCl
         body: JSON.stringify({
           user_id: userId,
           mcp: options.mcp,
-          ...(options.toolkits ? { toolkits: { enabled: options.toolkits } } : {}),
+          ...(options.toolkits ? { toolkits: { enable: options.toolkits } } : {}),
           ...(options.tools ? { tools: options.tools } : {}),
           ...(options.authConfigs ? { auth_configs: options.authConfigs } : {}),
           ...(options.connectedAccounts ? { connected_accounts: options.connectedAccounts } : {}),


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Tool connections let Paperclip broker third-party APIs (like Composio) for agents; Composio itself brokers many toolkits (Gmail, GitHub, Google Ads, ...) behind one project API key
> - Actually calling a Composio-brokered tool requires Paperclip to mint a short-lived Composio "tool router" MCP session per toolkit connection
> - That session-minting call was silently sending the wrong field name for the toolkit allowlist, so it always failed with a 400 from Composio's API — breaking every Composio toolkit, not just one
> - This pull request corrects the field name (`enable`, not `enabled`) to match Composio's actual v3.1 API contract
> - The benefit is that Composio-brokered toolkits (verified end-to-end with a real Google Ads connection: auth config, OAuth consent, connected account, session) become usable again instead of failing with an opaque `composio_request_failed` error

## Linked Issues or Issue Description

Fixes: #12628

Related (not a duplicate): #11894 adds the Composio API key connection type and its UI gallery entry (still open/unmerged) — separate, larger feature-scope PR. This PR is a narrow bugfix for the session-minting call in the Composio client that already exists on `master`, independent of that PR's scope.

## What Changed

- `server/src/services/composio.ts`: `createSession()` now sends `toolkits: { enable: [...] }` instead of `toolkits: { enabled: [...] }` in the `POST /tool_router/session` request body, matching Composio's actual v3.1 API.
- `server/src/services/composio.test.ts`: updated the unit test's expected serialized request body to match.

## Verification

- Reproduced the failure directly against the live Composio v3.1 API using a real project API key: `POST https://backend.composio.dev/api/v3.1/tool_router/session` with `toolkits: {enabled: ["googleads"]}` returns `400 {"errors":["Error in payload.toolkits: Invalid input"]}`.
- Same request with `toolkits: {enable: ["googleads"]}` succeeds and returns a working `session_id` + MCP session URL.
- End-to-end: connected a Composio parent app, created a custom (bring-your-own-OAuth) auth config for the `googleads` toolkit, completed the OAuth consent flow (connected account shows `ACTIVE` in Composio) — session-minting was the only remaining failure, and this fix resolves it.
- `npm test -- composio.test.ts` (updated expectation) covers the corrected request shape at the unit level.
- All CI checks green (typecheck, server/workspace test suites, e2e, build, security scans).

## Risks

Low risk. One-field rename in a single outbound request body; no schema/migration changes, no behavioral change to any other code path. The old value (`enabled`) was never accepted by Composio's API, so there is no backward-compatibility concern — every caller was already broken.

## Model Used

Claude Sonnet 5 (`claude-sonnet-5`), running in Claude Code (Anthropic's CLI agent). Used for root-causing (reading the Paperclip source, reproducing the failure against Composio's live API with direct HTTP calls to isolate the exact field-name defect) and for authoring this fix and its PR description. No extended-thinking mode; standard tool-use (reading source, running `curl` against the Composio API, editing files, `git`/`gh` for branch/PR creation).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (`fix/composio-toolkits-enable-field`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (n/a — no user-facing docs describe this internal request payload)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (Greptile's only flagged issue was this incomplete description, now addressed; will re-trigger)
- [x] I will address all Greptile and reviewer comments before requesting merge