### PR TITLE
fix(tools): fall back to the parent API key when Composio omits mcp.headers.x-api-key

### DIFF
--- a/server/src/services/composio-session-manager.test.ts
+++ b/server/src/services/composio-session-manager.test.ts
@@ -1,0 +1,179 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  companies,
+  companySecretBindings,
+  companySecrets,
+  companySecretVersions,
+  createDb,
+  secretAccessEvents,
+  toolApplications,
+  toolConnections,
+} from "@paperclipai/db";
+import { eq } from "drizzle-orm";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "../__tests__/helpers/embedded-postgres.js";
+import { createComposioSessionManager } from "./composio-session-manager.js";
+import { secretService } from "./secrets.js";
+import type { ComposioClient } from "./composio.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describeEmbeddedPostgres("composio session manager", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-composio-session-manager-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await db.delete(secretAccessEvents);
+    await db.delete(companySecretBindings);
+    await db.delete(companySecretVersions);
+    await db.delete(companySecrets);
+    await db.delete(toolConnections);
+    await db.delete(toolApplications);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function createComposioParentAndChild(companyId: string) {
+    const secrets = secretService(db);
+    const apiKey = await secrets.create(companyId, {
+      name: `Composio test key ${randomUUID().slice(0, 8)}`,
+      key: `tool_app.${randomUUID()}.credentials_apiKey`,
+      provider: "local_encrypted",
+      value: "composio-test-key",
+    });
+    const [application] = await db.insert(toolApplications).values({
+      companyId,
+      name: "Composio",
+      type: "mcp_http",
+      status: "active",
+    }).returning();
+    const [parent] = await db.insert(toolConnections).values({
+      companyId,
+      applicationId: application!.id,
+      name: "Composio",
+      uid: `composio/${randomUUID()}`,
+      transport: "rest_api",
+      authKind: "api_key",
+      status: "active",
+      enabled: true,
+      config: { sourceTemplateKey: "composio" },
+      transportConfig: { sourceTemplateKey: "composio" },
+      credentialSecretRefs: [{
+        secretId: apiKey.id,
+        versionSelector: "latest",
+        configPath: "credentials.apiKey",
+        required: true,
+        label: "Composio API key",
+      }],
+    }).returning();
+    const [child] = await db.insert(toolConnections).values({
+      companyId,
+      applicationId: application!.id,
+      name: "Google Ads (via Composio)",
+      uid: `composio/googleads/${randomUUID()}`,
+      transport: "mcp_remote",
+      authKind: "none",
+      status: "active",
+      enabled: true,
+      config: {
+        provider: "composio",
+        parentConnectionId: parent!.id,
+        toolkitSlug: "googleads",
+        connectedAccountId: "ca_test",
+      },
+      transportConfig: {},
+    }).returning();
+    return { parent: parent!, child: child! };
+  }
+
+  function fakeComposioClient(mcpHeaders?: Record<string, string>): ComposioClient {
+    return {
+      validateApiKey: vi.fn(async () => undefined),
+      listToolkits: vi.fn(async () => ({ items: [] })),
+      listAuthConfigs: vi.fn(async () => ({ items: [] })),
+      createConnectLink: vi.fn(async () => ({ link_token: "link", redirect_url: "https://composio.test/link", expires_at: new Date().toISOString() })),
+      listConnectedAccounts: vi.fn(async () => ({ items: [] })),
+      deleteConnectedAccount: vi.fn(async () => undefined),
+      createSession: vi.fn(async () => ({
+        session_id: `session-${randomUUID()}`,
+        mcp: { url: "https://composio.test/mcp", ...(mcpHeaders ? { headers: mcpHeaders } : {}) },
+      })),
+      resumeSession: vi.fn(async () => ({ session_id: "session", mcp: { url: "https://composio.test/mcp" } })),
+    };
+  }
+
+  it("excludes Composio's own meta-tools from the toolkit-scoped allowlist", async () => {
+    const [company] = await db.insert(companies).values({
+      name: `Composio session test ${randomUUID()}`,
+      issuePrefix: `CS${randomUUID().slice(0, 6).toUpperCase()}`,
+    }).returning();
+    const { child } = await createComposioParentAndChild(company!.id);
+    const client = fakeComposioClient();
+    const manager = createComposioSessionManager(db, { composioClientFactory: () => client });
+
+    // Regression guard for #12643: COMPOSIO_SEARCH_TOOLS et al. belong to the
+    // "composio" toolkit itself, not to whichever child toolkit is calling
+    // them, and Composio's API rejects scoping them under a child's own
+    // allowlist. Every Composio child's catalog is made up entirely of these
+    // meta-tools, so without this filter every real tool call would fail.
+    await manager.ensureSession(child.id, {
+      tools: ["COMPOSIO_SEARCH_TOOLS", "GOOGLEADS_LIST_ACCESSIBLE_CUSTOMERS"],
+    });
+
+    expect(client.createSession).toHaveBeenCalledWith(
+      `paperclip:${company!.id}`,
+      expect.objectContaining({
+        tools: { googleads: { enable: ["GOOGLEADS_LIST_ACCESSIBLE_CUSTOMERS"] } },
+      }),
+    );
+  });
+
+  it("falls back to the parent's own API key when Composio omits mcp.headers.x-api-key", async () => {
+    const [company] = await db.insert(companies).values({
+      name: `Composio session test ${randomUUID()}`,
+      issuePrefix: `CS${randomUUID().slice(0, 6).toUpperCase()}`,
+    }).returning();
+    const { child } = await createComposioParentAndChild(company!.id);
+    // Regression guard for #12631: Composio's tool_router/session response
+    // does not always include an x-api-key entry under mcp.headers, but the
+    // returned MCP endpoint still requires one on every call.
+    const client = fakeComposioClient(undefined);
+    const manager = createComposioSessionManager(db, { composioClientFactory: () => client });
+
+    const session = await manager.ensureSession(child.id, { tools: ["GOOGLEADS_LIST_ACCESSIBLE_CUSTOMERS"] });
+
+    expect(session.headers["x-api-key"]).toBe("composio-test-key");
+
+    const [persistedChild] = await db.select().from(toolConnections).where(eq(toolConnections.id, child.id));
+    expect(persistedChild!.credentialSecretRefs).toEqual(
+      expect.arrayContaining([expect.objectContaining({ label: "Composio MCP x-api-key header" })]),
+    );
+  });
+
+  it("keeps an explicit Composio-supplied x-api-key header instead of overriding it", async () => {
+    const [company] = await db.insert(companies).values({
+      name: `Composio session test ${randomUUID()}`,
+      issuePrefix: `CS${randomUUID().slice(0, 6).toUpperCase()}`,
+    }).returning();
+    const { child } = await createComposioParentAndChild(company!.id);
+    const client = fakeComposioClient({ "x-api-key": "composio-issued-session-key" });
+    const manager = createComposioSessionManager(db, { composioClientFactory: () => client });
+
+    const session = await manager.ensureSession(child.id, { tools: ["GOOGLEADS_LIST_ACCESSIBLE_CUSTOMERS"] });
+
+    expect(session.headers["x-api-key"]).toBe("composio-issued-session-key");
+  });
+});

--- a/server/src/services/composio-session-manager.test.ts
+++ b/server/src/services/composio-session-manager.test.ts
@@ -79,6 +79,13 @@ describeEmbeddedPostgres("composio session manager", () => {
         label: "Composio API key",
       }],
     }).returning();
+    await db.insert(companySecretBindings).values({
+      companyId,
+      secretId: apiKey.id,
+      targetType: "tool_connection",
+      targetId: parent!.id,
+      configPath: "credentials.apiKey",
+    });
     const [child] = await db.insert(toolConnections).values({
       companyId,
       applicationId: application!.id,

--- a/server/src/services/composio-session-manager.ts
+++ b/server/src/services/composio-session-manager.ts
@@ -170,11 +170,19 @@ export function createComposioSessionManager(db: Db, options: ComposioSessionMan
       return resolveCached(child, cached);
     }
 
+    // Composio's session-scoped meta-tools (COMPOSIO_SEARCH_TOOLS,
+    // COMPOSIO_MULTI_EXECUTE_TOOL, ...) belong to the "composio" toolkit
+    // itself, not to config.toolkitSlug. Composio's API rejects a request
+    // that tries to scope one of them under a child toolkit's own allowlist
+    // ("Tool slugs in config.tools must be configured under their owning
+    // toolkit"), so only toolkit-owned tool names go into `tools.enable`;
+    // the meta-tools stay implicitly available via tool_router_tools.
+    const toolkitScopedTools = tools.filter((tool) => !tool.startsWith("COMPOSIO_"));
     const client = options.composioClientFactory?.(apiKey) ?? createComposioClient({ apiKey });
     const session = await client.createSession(`paperclip:${child.companyId}`, {
       mcp: true,
       toolkits: [config.toolkitSlug],
-      ...(tools.length > 0 ? { tools: { [config.toolkitSlug]: { enable: tools } } } : {}),
+      ...(toolkitScopedTools.length > 0 ? { tools: { [config.toolkitSlug]: { enable: toolkitScopedTools } } } : {}),
       ...(config.connectedAccountId ? { connectedAccounts: { [config.toolkitSlug]: [config.connectedAccountId] } } : {}),
     });
     if (!session.mcp?.url) throw unprocessable("Composio did not return a hosted MCP URL.", { code: "composio_session_invalid" });

--- a/server/src/services/composio-session-manager.ts
+++ b/server/src/services/composio-session-manager.ts
@@ -187,9 +187,18 @@ export function createComposioSessionManager(db: Db, options: ComposioSessionMan
       configPath: `${prefix}.url`,
       value: session.mcp.url,
     });
+    // Composio's tool_router/session response does not always echo back an
+    // x-api-key entry in mcp.headers, but the returned MCP endpoint still
+    // requires one on every call ("API key is required...", HTTP 401). Fall
+    // back to the parent connection's own project API key so a session with
+    // no explicit auth headers from Composio is still callable.
+    const mcpHeaders = { ...(session.mcp.headers ?? {}) };
+    if (!Object.keys(mcpHeaders).some((name) => name.toLowerCase() === "x-api-key")) {
+      mcpHeaders["x-api-key"] = apiKey;
+    }
     const priorHeaders = new Map((cached?.headerRefs ?? []).map((ref) => [ref.name.toLowerCase(), ref]));
     const headerRefs: SessionRef[] = [];
-    for (const [name, value] of Object.entries(session.mcp.headers ?? {})) {
+    for (const [name, value] of Object.entries(mcpHeaders)) {
       headerRefs.push(await createOrRotateRef({
         child,
         cached: priorHeaders.get(name.toLowerCase()),


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Composio-brokered toolkit connections work by minting a short-lived hosted MCP session per toolkit, then calling that session's MCP endpoint to discover and execute tools
> - Even after #12628 fixes session-minting itself, two further bugs in the same `mint()` function still blocked every real Composio tool call end-to-end
> - First: the MCP endpoint requires an `x-api-key` header on every call, but Composio's session-creation response doesn't reliably echo one back — Paperclip only ever trusted whatever (possibly empty) headers Composio returned
> - Second: a Composio child connection's entire tool catalog is Composio's own session-level meta-tools (`COMPOSIO_SEARCH_TOOLS` etc.), which belong to the `composio` toolkit itself — but every real tool call scoped them under the *child's* own toolkit allowlist, which Composio's API rejects outright
> - This pull request fixes both, in the same function, so a Composio toolkit connection is actually usable end-to-end
> - The benefit is real: verified against a live Google Ads connection, both the meta-tool discovery call and the actual `GOOGLEADS_LIST_ACCESSIBLE_CUSTOMERS` execution now succeed and return real customer data

## Linked Issues or Issue Description

Fixes: #12631, #12643
Refs: #12628 (prerequisite — session creation has to succeed before either of these bugs is even reachable), #12633 (a third, independent bug in the same end-to-end chain, fixed separately in #12634)

Related (not a duplicate): #11894 adds the Composio API key connection type and UI gallery entry (still open) — separate feature-scope PR, unrelated to this session/execution-layer code.

## What Changed

- `server/src/services/composio-session-manager.ts`, `mint()`:
  1. Builds an `mcpHeaders` object that starts from `session.mcp.headers ?? {}` and adds `x-api-key: <resolved parent API key>` only when Composio's response didn't already include an `x-api-key` entry (checked case-insensitively). The existing per-header secret-ref caching/rotation logic is unchanged — it now just iterates over `mcpHeaders` instead of the raw Composio response.
  2. Filters out Composio's own meta-tool names (`COMPOSIO_*`) before building the toolkit-scoped `tools.enable` allowlist sent to Composio — they stay implicitly available via the session's `tool_router_tools` regardless of this field, and scoping them under a child toolkit's own allowlist is explicitly rejected by Composio's API.

## Verification

- **x-api-key fallback:** reproduced against the live Composio v3.1 API — `POST /tool_router/session` for a real (`googleads`) connected account returns `mcp: {type, url}` with no `headers` key; calling that session's MCP endpoint (`tools/list`) with only standard MCP headers returns `HTTP 401`; the same call with `x-api-key: <project key>` added returns `HTTP 200` with the full tool list.
- **Meta-tool scoping:** reproduced directly — `POST /tool_router/session` with `tools: {googleads: {enable: ["COMPOSIO_SEARCH_TOOLS"]}}` returns `HTTP 400 {"error":{"message":"Tool slugs in config.tools must be configured under their owning toolkit: COMPOSIO_SEARCH_TOOLS under \"googleads\" belongs to \"composio\".",...}}`; omitting `COMPOSIO_*` names from that field succeeds.
- **Full end-to-end, on a live instance, with this fix plus #12628/#12633/#12634 all applied:** a real Google Ads Composio child connection successfully executes `POST /tool-connections/:id/test-calls` for both `COMPOSIO_SEARCH_TOOLS` and, via `COMPOSIO_MULTI_EXECUTE_TOOL`, the actual `GOOGLEADS_LIST_ACCESSIBLE_CUSTOMERS` tool — returning real customer account resource names (`customers/9513180980`, etc.). This is the last of five bugs found while getting one real Composio toolkit working end-to-end from zero; with all five applied together, it works.
- No existing unit tests cover `composio-session-manager.ts` (none exist for this file); verification here is against the live Composio API and a live Paperclip instance rather than a mocked unit test, consistent with how both defects were found.

## Risks

Low risk for both changes. The header fallback is purely additive — when Composio *does* return its own header, behavior is unchanged. The meta-tool filter only removes names Composio would reject anyway; toolkit-owned tool names are unaffected. Neither changes any other code path.

## Model Used

Claude Sonnet 5 (`claude-sonnet-5`), running in Claude Code (Anthropic's CLI agent). Both bugs found while doing a full end-to-end verification of a real Composio toolkit connection (Google Ads) from a clean start — each one only became reachable after fixing the previous blocker in the chain (#12628 → this PR's first bug → #12633/#12634 → this PR's second bug), root-caused each time by reading `composio-session-manager.ts` and reproducing the exact Composio API error directly via `curl` before writing the fix. No extended-thinking mode; standard tool-use (reading source, API calls against a live Paperclip + Composio instance, editing files, `git`/`gh` for branch/PR creation).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (`fix/composio-session-mcp-headers-x-api-key`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable (no existing test file for `composio-session-manager.ts`; verified against the live API and a live end-to-end run instead — see Verification)
- [ ] I have updated relevant documentation to reflect my changes (n/a — no user-facing docs describe this internal session-header/scoping behavior)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (will address any feedback)
- [x] I will address all Greptile and reviewer comments before requesting merge