### PR TITLE
fix(tools): promote Composio broker connections out of draft after a healthy connect

### DIFF
--- a/server/src/__tests__/tool-access-service.test.ts
+++ b/server/src/__tests__/tool-access-service.test.ts
@@ -3851,6 +3851,38 @@ describeEmbeddedPostgres("tool access service", () => {
     await expect(service.getConnection(child.id)).resolves.toMatchObject({ status: "archived", enabled: false });
   });
 
+  it("activates the Composio broker connection and application on a healthy connect, with the mcp_http type its mcp_remote children need", async () => {
+    const company = await createCompany(db);
+    const client = fakeComposioClient(() => "ACTIVE");
+    const service = createTestToolAccessService(db, { composioClientFactory: () => client });
+
+    const connected = await service.connectGalleryApp(company.id, {
+      galleryKey: "composio",
+      connectionMethodKey: "api-key",
+      name: "Composio",
+      credentialValues: { "credentials.apiKey": "composio-test-key" },
+    }, { actorType: "user", actorId: "board" });
+
+    // Regression guard for #12633/#12634: connectGalleryApp's Composio branch
+    // used to return right after a successful health check without ever
+    // promoting either row out of "draft", and the application's `type` was
+    // derived from the broker's own ("rest_api") transport rather than the
+    // "mcp_remote" transport its children actually use -- both of which made
+    // every Composio child connection's tools permanently invisible to
+    // connectedMcpToolsForCompany() (it requires an active application whose
+    // type is (mcp_http, mcp_remote) or (mcp_stdio, local_stdio)).
+    expect(client.validateApiKey).toHaveBeenCalled();
+    expect(connected.connection).toMatchObject({ status: "active", enabled: true });
+    expect(connected.application).toMatchObject({ status: "active", type: "mcp_http" });
+
+    const [persistedConnection] = await db.select().from(toolConnections)
+      .where(eq(toolConnections.id, connected.connectionId));
+    const [persistedApplication] = await db.select().from(toolApplications)
+      .where(eq(toolApplications.id, connected.application.id));
+    expect(persistedConnection).toMatchObject({ status: "active", enabled: true });
+    expect(persistedApplication).toMatchObject({ status: "active", type: "mcp_http" });
+  });
+
   it("returns server-derived create capabilities for a non-manager member", async () => {
     const company = await createCompany(db);
     const app = createRouteApp(db, boardSessionActor(company.id, "member"));

--- a/server/src/services/tool-access.ts
+++ b/server/src/services/tool-access.ts
@@ -8964,11 +8964,25 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
         throw error;
       }
       if (galleryEntry?.slug === COMPOSIO_GALLERY_KEY) {
+        // The Composio broker connection has no tools of its own — only its
+        // per-toolkit children do — so it never goes through refreshCatalog
+        // below, and (unlike the OAuth callback paths above) nothing else on
+        // this route ever promotes it out of "draft". Left there, every
+        // Composio child connection's tools stay permanently invisible to the
+        // tool gateway, which requires an active application row
+        // (connectedMcpToolsForCompany filters on toolApplications.status =
+        // "active"). The health check above already confirmed the API key
+        // works, so promote both rows now.
+        await db.update(toolConnections).set({ status: "active", enabled: true, updatedAt: now() })
+          .where(eq(toolConnections.id, connectionRow.id));
+        await db.update(toolApplications).set({ status: "active", updatedAt: now() })
+          .where(eq(toolApplications.id, applicationRow.id));
         const [application] = await db.select().from(toolApplications).where(eq(toolApplications.id, applicationRow.id));
+        const [activatedConnection] = await db.select().from(toolConnections).where(eq(toolConnections.id, connectionRow.id));
         return {
-          connectionId: health.connection.id,
+          connectionId: activatedConnection.id,
           application: toApplication(application),
-          connection: health.connection,
+          connection: toConnection(activatedConnection),
           catalog: [],
           actions: { readOnly: [], canMakeChanges: [] },
           suggestedDefaults: recommendedDefaultsForApp(galleryEntry, method?.key),

--- a/server/src/services/tool-access.ts
+++ b/server/src/services/tool-access.ts
@@ -8973,9 +8973,18 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
         // (connectedMcpToolsForCompany filters on toolApplications.status =
         // "active"). The health check above already confirmed the API key
         // works, so promote both rows now.
+        //
+        // The application row was also inserted with `type` derived from the
+        // *broker's own* transport ("rest_api" -> "mcp_stdio"), but every
+        // Composio child connection is "mcp_remote". The tool gateway's
+        // connectedMcpToolsForCompany() only accepts the pairings
+        // (mcp_remote, mcp_http) or (local_stdio, mcp_stdio) — "mcp_stdio"
+        // here matches neither, and silently excludes every one of this
+        // application's children regardless of the status fix above. Correct
+        // it to "mcp_http" to match the transport its children actually use.
         await db.update(toolConnections).set({ status: "active", enabled: true, updatedAt: now() })
           .where(eq(toolConnections.id, connectionRow.id));
-        await db.update(toolApplications).set({ status: "active", updatedAt: now() })
+        await db.update(toolApplications).set({ status: "active", type: "mcp_http", updatedAt: now() })
           .where(eq(toolApplications.id, applicationRow.id));
         const [application] = await db.select().from(toolApplications).where(eq(toolApplications.id, applicationRow.id));
         const [activatedConnection] = await db.select().from(toolConnections).where(eq(toolConnections.id, connectionRow.id));


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - A Composio broker connection has no tools of its own — it exists to spawn per-toolkit child connections, which are what agents actually call
> - Even with #12628 and #12631 fixed (session-minting and MCP auth), a fully healthy, end-to-end Composio child connection still couldn't be called — every tool call 404'd with `tool_not_found`
> - The gap turned out to be two separate field mismatches in the same code path: `connectGalleryApp()`'s Composio branch never promotes the broker connection out of `"draft"`, *and* it inserts the broker's `toolApplications.type` using logic that doesn't fit Composio's parent/child transport split
> - Both are invisible from the UI/API surface (`healthStatus: "ok"` the whole time) — only `connectedMcpToolsForCompany()`'s DB-level join filter, which every real tool call goes through, actually cares about either field
> - This pull request corrects both, right where the health check already confirms the connection works
> - The benefit is that a Composio toolkit connection is actually usable end-to-end, not just "healthy-looking" in the UI

## Linked Issues or Issue Description

Fixes: #12633
Refs: #12628, #12631 (prerequisite fixes — these bugs are the third and fourth blockers found in the same end-to-end Composio flow; each one only became reachable after fixing the last)

Related (not a duplicate): #11894 adds the Composio API key connection type and its UI gallery entry (still open) — separate feature-scope PR.

## What Changed

- `server/src/services/tool-access.ts`, `connectGalleryApp()`, in the `galleryEntry?.slug === COMPOSIO_GALLERY_KEY` branch, after `checkConnectionHealth` succeeds:
  1. Promote `toolConnections` (`status: "active", enabled: true`) and `toolApplications` (`status: "active"`) for the broker connection — every other connection method already reaches this state downstream (OAuth callback, or `refreshCatalog()` for generic non-OAuth methods); the Composio branch returned early and never did.
  2. Also correct `toolApplications.type` to `"mcp_http"`. It was inserted using `type: transport === "mcp_remote" ? "mcp_http" : "mcp_stdio"` derived from the *broker's own* transport (`"rest_api"` for the API-key method) → `"mcp_stdio"`. But every Composio child connection is `"mcp_remote"`, and `connectedMcpToolsForCompany()` (`tool-gateway.ts`) only accepts the pairings `(mcp_remote, mcp_http)` or `(local_stdio, mcp_stdio)` between a connection and its application — `"mcp_stdio"` matches neither half for an `"mcp_remote"` child, silently excluding every one of that application's children regardless of the status fix.

## Verification

- Confirmed via the live API on a real instance: a Composio broker connection's `status` stays `"draft"` indefinitely even after `checkConnectionHealth` reports `healthStatus: "ok"`, and its `toolApplications.type` is `"mcp_stdio"`.
- Confirmed a real Google Ads Composio child connection (already fixed for #12628/#12631: `ACTIVE` connected account, `healthStatus: "ok"`, `"Tool catalog refreshed."`, 22 catalog entries) still returns `{"error":"Tool \"...\" not found","reasonCode":"tool_not_found"}` from `POST /tool-connections/:id/test-calls` for every tool name in its own catalog, with the broker still `"draft"`/`"mcp_stdio"`.
- Traced both fields to the exact `eligibleRows`/status filters in `connectedMcpToolsForCompany()`.
- The only existing Composio test fixture (`createComposioParentAndChild`) inserts its rows with `status: "active"` and no `toolApplications.type` mismatch, bypassing `connectGalleryApp()` — so no existing test exercises this path; noted as a risk below.
- All CI checks green (typecheck, server/workspace test suites, e2e, build, security scans) as of the first commit; re-verifying after the second.

## Risks

Low-to-moderate. The change only affects the Composio connect path (`galleryEntry?.slug === COMPOSIO_GALLERY_KEY`), and only promotes status/corrects type further along the same lifecycle every other connection type already reaches automatically — no new states, no schema change. The main risk is test coverage: no existing automated test exercises `connectGalleryApp()`'s Composio branch (the fixture bypasses it), so this fix is verified against a live instance/API rather than a unit test. A reviewer may reasonably want a regression test added for this branch before merge — happy to add one if pointed at the right test harness/mocking pattern for `connectGalleryApp()` (the existing Composio tests only cover child-connection behavior via directly-inserted fixtures, not the connect flow itself).

## Model Used

Claude Sonnet 5 (`claude-sonnet-5`), running in Claude Code (Anthropic's CLI agent). Found while continuing end-to-end verification after #12628 and #12631: once those cleared session-minting and MCP auth, this was the next failure in the chain (draft status), and immediately after fixing that, a second, related failure in the same branch (wrong application type) surfaced on retest. Both root-caused by reading `connectGalleryApp()` and `connectedMcpToolsForCompany()` and confirming via direct API calls against a live instance. No extended-thinking mode; standard tool-use (reading source, API calls against a live Paperclip + Composio instance, editing files, `git`/`gh` for branch/PR creation).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (`fix/composio-application-activation`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable (no existing test harness exercises `connectGalleryApp()`'s Composio branch — see Risks; open to adding one)
- [ ] I have updated relevant documentation to reflect my changes (n/a — internal connection-lifecycle behavior, no user-facing docs describe it)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (will address any feedback)
- [x] I will address all Greptile and reviewer comments before requesting merge