### PR TITLE
fix(server): redact agent profile configuration by default

### DIFF
--- a/packages/shared/src/validators/agent.ts
+++ b/packages/shared/src/validators/agent.ts
@@ -133,6 +133,9 @@ export const updateAgentSchema = objectWithoutDefaults(
   .partial()
   .extend({
     permissions: z.never().optional(),
+    literalRedactedConfigPaths: z.array(z.array(z.string().min(1)).min(2)).max(100).optional().describe(
+      "Configuration paths where a redaction marker is intentional literal data, not an unchanged placeholder.",
+    ),
     preserveRedactedConfigValues: z.boolean().optional().describe(
       "Treat response redaction markers in adapterConfig/runtimeConfig as unchanged values during this update.",
     ),

--- a/packages/shared/src/validators/agent.ts
+++ b/packages/shared/src/validators/agent.ts
@@ -133,6 +133,9 @@ export const updateAgentSchema = objectWithoutDefaults(
   .partial()
   .extend({
     permissions: z.never().optional(),
+    preserveRedactedConfigValues: z.boolean().optional().describe(
+      "Treat response redaction markers in adapterConfig/runtimeConfig as unchanged values during this update.",
+    ),
     replaceAdapterConfig: z.boolean().optional(),
     status: z.enum(AGENT_STATUSES).optional(),
     spentMonthlyCents: z.number().int().nonnegative().optional(),

--- a/server/src/__tests__/agent-instructions-routes.test.ts
+++ b/server/src/__tests__/agent-instructions-routes.test.ts
@@ -823,4 +823,34 @@ describe("agent instructions bundle routes", () => {
       expect.any(Object),
     );
   });
+
+  it("persists a literal marker at a new path during placeholder-preserving UI updates", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent(),
+      adapterConfig: { model: "old-model" },
+    });
+
+    const res = await requestApp(await createApp(), (baseUrl) => request(baseUrl)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111?companyId=company-1")
+      .send({
+        preserveRedactedConfigValues: true,
+        replaceAdapterConfig: true,
+        adapterConfig: {
+          model: "***REDACTED***",
+          newSetting: "***REDACTED***",
+        },
+      }));
+
+    expect(res.status).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        adapterConfig: expect.objectContaining({
+          model: "old-model",
+          newSetting: "***REDACTED***",
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
 });

--- a/server/src/__tests__/agent-instructions-routes.test.ts
+++ b/server/src/__tests__/agent-instructions-routes.test.ts
@@ -853,4 +853,26 @@ describe("agent instructions bundle routes", () => {
       expect.any(Object),
     );
   });
+
+  it("persists a literal marker at an existing path when that path is explicitly escaped", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent(),
+      adapterConfig: { command: "stored-command" },
+    });
+
+    const res = await requestApp(await createApp(), (baseUrl) => request(baseUrl)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111?companyId=company-1")
+      .send({
+        literalRedactedConfigPaths: [["adapterConfig", "command"]],
+        preserveRedactedConfigValues: true,
+        adapterConfig: { command: "***REDACTED***" },
+      }));
+
+    expect(res.status).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({ adapterConfig: expect.objectContaining({ command: "***REDACTED***" }) }),
+      expect.any(Object),
+    );
+  });
 });

--- a/server/src/__tests__/agent-instructions-routes.test.ts
+++ b/server/src/__tests__/agent-instructions-routes.test.ts
@@ -758,11 +758,52 @@ describe("agent instructions bundle routes", () => {
 
     expect(res.status, JSON.stringify(res.body)).toBe(200);
     expect(res.body.adapterConfig).toMatchObject({
-      command: "codex --profile engineer",
+      command: "***REDACTED***",
     });
     expect(res.body.adapterConfig.instructionsBundleMode).toBeUndefined();
     expect(res.body.adapterConfig.instructionsRootPath).toBeUndefined();
     expect(res.body.adapterConfig.instructionsEntryFile).toBeUndefined();
     expect(res.body.adapterConfig.instructionsFilePath).toBeUndefined();
+  });
+
+  it("preserves stored values when a redacted configuration response is round-tripped", async () => {
+    mockAgentService.getById.mockResolvedValue({
+      ...makeAgent(),
+      adapterConfig: {
+        model: "old-model",
+        env: { TOKEN: { type: "plain", value: "stored-secret" } },
+      },
+      runtimeConfig: {
+        heartbeat: { enabled: true },
+      },
+    });
+
+    const res = await requestApp(await createApp(), (baseUrl) => request(baseUrl)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111?companyId=company-1")
+      .send({
+        replaceAdapterConfig: true,
+        adapterConfig: {
+          model: "new-model",
+          env: { TOKEN: { type: "plain", value: "***REDACTED***" } },
+        },
+        runtimeConfig: {
+          heartbeat: { enabled: "***REDACTED***" },
+        },
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        adapterConfig: expect.objectContaining({
+          model: "new-model",
+          env: { TOKEN: { type: "plain", value: "stored-secret" } },
+        }),
+        runtimeConfig: {
+          heartbeat: { enabled: true },
+        },
+      }),
+      expect.any(Object),
+    );
   });
 });

--- a/server/src/__tests__/agent-instructions-routes.test.ts
+++ b/server/src/__tests__/agent-instructions-routes.test.ts
@@ -781,6 +781,7 @@ describe("agent instructions bundle routes", () => {
     const res = await requestApp(await createApp(), (baseUrl) => request(baseUrl)
       .patch("/api/agents/11111111-1111-4111-8111-111111111111?companyId=company-1")
       .send({
+        preserveRedactedConfigValues: true,
         replaceAdapterConfig: true,
         adapterConfig: {
           model: "new-model",
@@ -803,6 +804,22 @@ describe("agent instructions bundle routes", () => {
           heartbeat: { enabled: true },
         },
       }),
+      expect.any(Object),
+    );
+  });
+
+  it("persists a literal redaction marker unless placeholder preservation is requested", async () => {
+    const res = await requestApp(await createApp(), (baseUrl) => request(baseUrl)
+      .patch("/api/agents/11111111-1111-4111-8111-111111111111?companyId=company-1")
+      .send({
+        replaceAdapterConfig: true,
+        adapterConfig: { model: "***REDACTED***" },
+      }));
+
+    expect(res.status).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({ adapterConfig: expect.objectContaining({ model: "***REDACTED***" }) }),
       expect.any(Object),
     );
   });

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -466,7 +466,7 @@ describe.sequential("agent permission routes", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.adapterConfig).toMatchObject({
-      command: "pnpm agent:run",
+      command: "***REDACTED***",
       env: {
         LEGACY_VALUE: { type: "plain", value: "***REDACTED***" },
         PLAIN_VALUE: { type: "plain", value: "***REDACTED***" },
@@ -521,7 +521,7 @@ describe.sequential("agent permission routes", () => {
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(1);
     expect(res.body[0].adapterConfig).toMatchObject({
-      command: "pnpm agent:run",
+      command: "***REDACTED***",
       env: {
         LEGACY_VALUE: { type: "plain", value: "***REDACTED***" },
         PLAIN_VALUE: { type: "plain", value: "***REDACTED***" },

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -484,6 +484,69 @@ describe.sequential("agent permission routes", () => {
     expect(res.body.permissions).toMatchObject({ trustPreset: LOW_TRUST_REVIEW_PRESET });
   }, 20_000);
 
+  // SEC-1790: a missing/null adapterConfig previously short-circuited
+  // redactAgentRowForResponse entirely, returning the raw row (including
+  // runtimeConfig) unredacted.
+  it("still redacts runtimeConfig when adapterConfig is missing or null", async () => {
+    const plaintextValue = "runtime-neutral-value-must-not-leak";
+    mockAgentService.getById.mockResolvedValue({
+      ...baseAgent,
+      adapterConfig: null,
+      runtimeConfig: {
+        heartbeat: { enabled: true },
+        neutralCanary: plaintextValue,
+      },
+    });
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl).get(`/api/agents/${agentId}`));
+
+    expect(res.status).toBe(200);
+    expect(res.body.adapterConfig).toEqual({});
+    expect(res.body.runtimeConfig).toMatchObject({ heartbeat: { enabled: true } });
+    expect(JSON.stringify(res.body)).not.toContain(plaintextValue);
+  }, 20_000);
+
+  // SEC-1790: an adapterConfig present but missing/invalid `env` previously
+  // fell back to the legacy redactEventPayload/sanitizeRecord path, which
+  // preserves scalar values under neutral/unrecognized keys.
+  it("redacts neutral adapterConfig keys when env is missing or invalid", async () => {
+    const plaintextValue = "neutral-adapter-value-must-not-leak";
+    mockAgentService.getById.mockResolvedValue({
+      ...baseAgent,
+      adapterConfig: {
+        command: "pnpm agent:run",
+        neutralCanary: plaintextValue,
+        env: "not-a-plain-object",
+      },
+    });
+
+    const app = await createApp({
+      type: "board",
+      userId: "board-user",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl).get(`/api/agents/${agentId}`));
+
+    expect(res.status).toBe(200);
+    expect(res.body.adapterConfig).toMatchObject({
+      command: "***REDACTED***",
+      neutralCanary: "***REDACTED***",
+      env: "***REDACTED***",
+    });
+    expect(JSON.stringify(res.body)).not.toContain(plaintextValue);
+  }, 20_000);
+
   // TEC-7032 reported the leak against the company agent-list endpoint, which
   // serialises rows directly instead of going through buildAgentDetail.
   it("redacts env values in board GET /api/companies/:companyId/agents responses", async () => {

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -1994,6 +1994,56 @@ describe.sequential("agent permission routes", () => {
       expect(JSON.stringify(res.body)).not.toContain(plaintextValue);
     });
 
+    // SEC-1808: redactAgentAdapterConfig previously returned a non-object
+    // adapterConfig unchanged (fail-open) instead of `{}`, and the `?? {}`
+    // in redactAgentConfiguration only rescues null/undefined, not a
+    // present-but-malformed value such as a raw string.
+    it("redacts a non-object adapterConfig in the single-agent configuration response", async () => {
+      const plaintextValue = "malformed-adapter-config-canary-must-not-leak";
+      mockAgentService.getById.mockResolvedValue({
+        ...baseAgent,
+        adapterConfig: plaintextValue,
+      });
+
+      const app = await createApp({
+        type: "board",
+        userId: "board-user",
+        source: "session",
+        isInstanceAdmin: false,
+        companyIds: [companyId],
+      });
+
+      const res = await request(app).get(`/api/agents/${agentId}/configuration`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.adapterConfig).toEqual({});
+      expect(JSON.stringify(res.body)).not.toContain(plaintextValue);
+    });
+
+    it("redacts a non-object adapterConfig in company configuration-list responses", async () => {
+      const plaintextValue = "malformed-adapter-config-list-canary-must-not-leak";
+      mockAgentService.list.mockResolvedValue([
+        {
+          ...baseAgent,
+          adapterConfig: plaintextValue,
+        },
+      ]);
+
+      const app = await createApp({
+        type: "board",
+        userId: "board-user",
+        source: "session",
+        isInstanceAdmin: false,
+        companyIds: [companyId],
+      });
+
+      const res = await request(app).get(`/api/companies/${companyId}/agent-configurations`);
+
+      expect(res.status).toBe(200);
+      expect(res.body[0].adapterConfig).toEqual({});
+      expect(JSON.stringify(res.body)).not.toContain(plaintextValue);
+    });
+
     it("redacts plaintext env values in configuration revisions", async () => {
       const plaintextValue = "revision-value-must-not-leak";
       mockAgentService.listConfigRevisions.mockResolvedValue([

--- a/server/src/__tests__/low-trust-red-team-routes.test.ts
+++ b/server/src/__tests__/low-trust-red-team-routes.test.ts
@@ -405,8 +405,16 @@ async function seedLowTrustFixture(db: Db) {
     name: "Standard Engineer",
     role: "engineer",
     adapterType: "process",
-    adapterConfig: { token: canaries.agentConfig },
-    runtimeConfig: { env: { SECRET_MARKER: canaries.agentConfig } },
+    adapterConfig: {
+      token: canaries.agentConfig,
+      env: { DISPLAY_NAME: { type: "plain", value: canaries.agentConfig } },
+    },
+    runtimeConfig: {
+      env: {
+        SECRET_MARKER: canaries.agentConfig,
+        BENIGN_LABEL: { type: "plain", value: canaries.agentConfig },
+      },
+    },
     permissions: {},
   }).returning();
   const [cto] = await db.insert(agents).values({
@@ -1068,7 +1076,26 @@ describeEmbeddedPostgres("low-trust red-team HTTP route regression suite", () =>
     const standardActor = agentActor(fixture, fixture.agents.standard.id);
     const standardRes = await request(createApp(db, { ...standardActor, runId: null })).get("/api/agents/me");
     expect(standardRes.status, JSON.stringify(standardRes.body)).toBe(200);
-    expect(JSON.stringify(standardRes.body)).toContain(fixture.canaries.agentConfig);
+    expect(JSON.stringify(standardRes.body)).not.toContain(fixture.canaries.agentConfig);
+    expect(standardRes.body.adapterConfig.token).toBe("***REDACTED***");
+    expect(standardRes.body.runtimeConfig.env.SECRET_MARKER).toBe("***REDACTED***");
+    expect(standardRes.body.adapterConfig.env.DISPLAY_NAME).toEqual({
+      type: "plain",
+      value: "***REDACTED***",
+    });
+    expect(standardRes.body.runtimeConfig.env.BENIGN_LABEL).toEqual({
+      type: "plain",
+      value: "***REDACTED***",
+    });
+
+    const standardSelfByIdRes = await request(createApp(db, { ...standardActor, runId: null }))
+      .get(`/api/agents/${fixture.agents.standard.id}`);
+    expect(standardSelfByIdRes.status, JSON.stringify(standardSelfByIdRes.body)).toBe(200);
+    expect(JSON.stringify(standardSelfByIdRes.body)).not.toContain(fixture.canaries.agentConfig);
+    expect(standardSelfByIdRes.body.adapterConfig.token).toBe("***REDACTED***");
+    expect(standardSelfByIdRes.body.runtimeConfig.env.SECRET_MARKER).toBe("***REDACTED***");
+    expect(standardSelfByIdRes.body.adapterConfig.env.DISPLAY_NAME.value).toBe("***REDACTED***");
+    expect(standardSelfByIdRes.body.runtimeConfig.env.BENIGN_LABEL.value).toBe("***REDACTED***");
 
     const issueScopedLowTrustRes = await request(createApp(db, standardActor)).get("/api/agents/me");
     expect(issueScopedLowTrustRes.status, JSON.stringify(issueScopedLowTrustRes.body)).toBe(200);

--- a/server/src/__tests__/low-trust-red-team-routes.test.ts
+++ b/server/src/__tests__/low-trust-red-team-routes.test.ts
@@ -407,6 +407,7 @@ async function seedLowTrustFixture(db: Db) {
     adapterType: "process",
     adapterConfig: {
       token: canaries.agentConfig,
+      innocuousScalar: canaries.agentConfig,
       env: { DISPLAY_NAME: { type: "plain", value: canaries.agentConfig } },
     },
     runtimeConfig: {
@@ -1078,6 +1079,7 @@ describeEmbeddedPostgres("low-trust red-team HTTP route regression suite", () =>
     expect(standardRes.status, JSON.stringify(standardRes.body)).toBe(200);
     expect(JSON.stringify(standardRes.body)).not.toContain(fixture.canaries.agentConfig);
     expect(standardRes.body.adapterConfig.token).toBe("***REDACTED***");
+    expect(standardRes.body.adapterConfig.innocuousScalar).toBe("***REDACTED***");
     expect(standardRes.body.runtimeConfig.env.SECRET_MARKER).toBe("***REDACTED***");
     expect(standardRes.body.adapterConfig.env.DISPLAY_NAME).toEqual({
       type: "plain",
@@ -1093,6 +1095,7 @@ describeEmbeddedPostgres("low-trust red-team HTTP route regression suite", () =>
     expect(standardSelfByIdRes.status, JSON.stringify(standardSelfByIdRes.body)).toBe(200);
     expect(JSON.stringify(standardSelfByIdRes.body)).not.toContain(fixture.canaries.agentConfig);
     expect(standardSelfByIdRes.body.adapterConfig.token).toBe("***REDACTED***");
+    expect(standardSelfByIdRes.body.adapterConfig.innocuousScalar).toBe("***REDACTED***");
     expect(standardSelfByIdRes.body.runtimeConfig.env.SECRET_MARKER).toBe("***REDACTED***");
     expect(standardSelfByIdRes.body.adapterConfig.env.DISPLAY_NAME.value).toBe("***REDACTED***");
     expect(standardSelfByIdRes.body.runtimeConfig.env.BENIGN_LABEL.value).toBe("***REDACTED***");

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -4,8 +4,10 @@ import {
   PRP_V1_EVENT_TYPES,
   REDACTED_EVENT_VALUE,
   redactAgentAdapterConfig,
+  redactConfigurationPayload,
   redactEventPayload,
   redactSensitiveText,
+  restoreRedactedConfigurationPayload,
   sanitizeRecord,
 } from "../redaction.js";
 

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -43,6 +43,31 @@ describe("redaction", () => {
     }
   });
 
+  it("restores round-tripped redaction markers without discarding intentional edits", () => {
+    const existing = {
+      model: "old-model",
+      env: {
+        TOKEN: { type: "plain", value: "stored-secret" },
+        ITEMS: ["stored-first", "stored-second"],
+      },
+    };
+    const payload = {
+      model: "new-model",
+      env: {
+        TOKEN: { type: "plain", value: REDACTED_EVENT_VALUE },
+        ITEMS: [REDACTED_EVENT_VALUE, "new-second"],
+      },
+    };
+
+    expect(restoreRedactedConfigurationPayload(payload, existing)).toEqual({
+      model: "new-model",
+      env: {
+        TOKEN: { type: "plain", value: "stored-secret" },
+        ITEMS: ["stored-first", "new-second"],
+      },
+    });
+  });
+
   it.each([
     ["secret_ref", "secretId", "secret-id"],
     ["user_secret_ref", "key", "user-secret-key"],

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -68,6 +68,10 @@ describe("redaction", () => {
           type: "plain",
           value: "sk-plain",
         },
+        INNOCUOUS_NAME: {
+          type: "plain",
+          value: "credential-without-a-secret-shaped-key",
+        },
         PAPERCLIP_API_URL: "http://localhost:3100",
       },
     };
@@ -90,6 +94,10 @@ describe("redaction", () => {
         key: "OPENAI_API_KEY",
       },
       OPENAI_API_KEY_PLAIN: {
+        type: "plain",
+        value: REDACTED_EVENT_VALUE,
+      },
+      INNOCUOUS_NAME: {
         type: "plain",
         value: REDACTED_EVENT_VALUE,
       },

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -43,6 +43,39 @@ describe("redaction", () => {
     }
   });
 
+  it.each([
+    ["secret_ref", "secretId", "secret-id"],
+    ["user_secret_ref", "key", "user-secret-key"],
+  ] as const)("omits malformed version payloads from %s bindings", (type, identityKey, identityValue) => {
+    const binding = { type, [identityKey]: identityValue };
+    const result = redactConfigurationPayload({
+      scalar: { ...binding, version: "plaintext-that-must-not-survive" },
+      object: { ...binding, version: { nested: "plaintext-that-must-not-survive" } },
+      array: { ...binding, version: ["plaintext-that-must-not-survive"] },
+    });
+
+    expect(result).toEqual({
+      scalar: binding,
+      object: binding,
+      array: binding,
+    });
+    expect(JSON.stringify(result)).not.toContain("plaintext-that-must-not-survive");
+  });
+
+  it("preserves only supported public secret-reference versions", () => {
+    expect(redactConfigurationPayload({
+      latest: { type: "secret_ref", secretId: "secret-id", version: "latest" },
+      numbered: { type: "user_secret_ref", key: "user-secret-key", version: 2 },
+      zero: { type: "secret_ref", secretId: "secret-id", version: 0 },
+      fractional: { type: "user_secret_ref", key: "user-secret-key", version: 1.5 },
+    })).toEqual({
+      latest: { type: "secret_ref", secretId: "secret-id", version: "latest" },
+      numbered: { type: "user_secret_ref", key: "user-secret-key", version: 2 },
+      zero: { type: "secret_ref", secretId: "secret-id" },
+      fractional: { type: "user_secret_ref", key: "user-secret-key" },
+    });
+  });
+
   it("redacts sensitive keys and nested secret values", () => {
     const input = {
       apiKey: "abc123",

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -129,7 +129,7 @@ describe("redaction", () => {
   });
 
   it.each([
-    ["secret_ref", "secretId", "secret-id"],
+    ["secret_ref", "secretId", "11111111-1111-4111-8111-111111111111"],
     ["user_secret_ref", "key", "user-secret-key"],
   ] as const)("omits malformed version payloads from %s bindings", (type, identityKey, identityValue) => {
     const binding = { type, [identityKey]: identityValue };
@@ -149,14 +149,14 @@ describe("redaction", () => {
 
   it("preserves only supported public secret-reference versions", () => {
     expect(redactConfigurationPayload({
-      latest: { type: "secret_ref", secretId: "secret-id", version: "latest" },
+      latest: { type: "secret_ref", secretId: "11111111-1111-4111-8111-111111111111", version: "latest" },
       numbered: { type: "user_secret_ref", key: "user-secret-key", version: 2 },
-      zero: { type: "secret_ref", secretId: "secret-id", version: 0 },
+      zero: { type: "secret_ref", secretId: "11111111-1111-4111-8111-111111111111", version: 0 },
       fractional: { type: "user_secret_ref", key: "user-secret-key", version: 1.5 },
     })).toEqual({
-      latest: { type: "secret_ref", secretId: "secret-id", version: "latest" },
+      latest: { type: "secret_ref", secretId: "11111111-1111-4111-8111-111111111111", version: "latest" },
       numbered: { type: "user_secret_ref", key: "user-secret-key", version: 2 },
-      zero: { type: "secret_ref", secretId: "secret-id" },
+      zero: { type: "secret_ref", secretId: "11111111-1111-4111-8111-111111111111" },
       fractional: { type: "user_secret_ref", key: "user-secret-key" },
     });
   });
@@ -759,7 +759,7 @@ second-line\" status=401`,
     const plaintextValue = "adapter-env-value-must-not-leak";
 
     const result = redactAgentAdapterConfig({
-      command: "pnpm agent:run",
+      command: REDACTED_EVENT_VALUE,
       env: {
         EXISTING_VALUE: plaintextValue,
         NEW_VALUE: { type: "plain", value: plaintextValue },
@@ -776,7 +776,7 @@ second-line\" status=401`,
     });
 
     expect(result).toEqual({
-      command: "pnpm agent:run",
+      command: REDACTED_EVENT_VALUE,
       env: {
         EXISTING_VALUE: { type: "plain", value: REDACTED_EVENT_VALUE },
         NEW_VALUE: { type: "plain", value: REDACTED_EVENT_VALUE },
@@ -796,7 +796,7 @@ second-line\" status=401`,
 
   it("redacts non-env adapter keys while leaving env binding shapes intact", () => {
     const result = redactAgentAdapterConfig({
-      command: "pnpm agent:run",
+      command: REDACTED_EVENT_VALUE,
       apiKey: "adapter-level-secret",
       env: {
         API_KEY: "env-level-secret",
@@ -806,7 +806,7 @@ second-line\" status=401`,
 
     // Non-env keys still go through the shared payload sanitizer.
     expect(result.apiKey).toBe(REDACTED_EVENT_VALUE);
-    expect(result.command).toBe("pnpm agent:run");
+    expect(result.command).toBe(REDACTED_EVENT_VALUE);
 
     // Env bindings keep their binding shape rather than collapsing to a bare
     // sentinel string, which is what a second sanitizer pass would produce for
@@ -818,8 +818,8 @@ second-line\" status=401`,
   });
 
   it("redacts adapter configs that have no env block", () => {
-    expect(redactAgentAdapterConfig({ command: "pnpm agent:run", apiKey: "secret" })).toEqual({
-      command: "pnpm agent:run",
+    expect(redactAgentAdapterConfig({ command: REDACTED_EVENT_VALUE, apiKey: "secret" })).toEqual({
+      command: REDACTED_EVENT_VALUE,
       apiKey: REDACTED_EVENT_VALUE,
     });
   });

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -43,6 +43,64 @@ describe("redaction", () => {
     }
   });
 
+  it("preserves only path-allowlisted runtime editor metadata", () => {
+    expect(redactConfigurationPayload({
+      heartbeat: {
+        enabled: true,
+        intervalSec: 300,
+        maxTurnContinuation: { enabled: true, maxAttempts: 2, delayMs: 1_000 },
+        neutralCanary: "must-not-survive",
+      },
+      modelProfiles: {
+        cheap: {
+          enabled: true,
+          label: "Cheap",
+          adapterConfig: {
+            model: "public-model-id",
+            provider: "public-provider-id",
+            neutralCanary: "must-not-survive",
+          },
+        },
+      },
+      shadow: { heartbeat: { enabled: "must-not-survive" } },
+    }, "runtime")).toEqual({
+      heartbeat: {
+        enabled: true,
+        intervalSec: 300,
+        maxTurnContinuation: { enabled: true, maxAttempts: 2, delayMs: 1_000 },
+        neutralCanary: REDACTED_EVENT_VALUE,
+      },
+      modelProfiles: {
+        cheap: {
+          enabled: true,
+          label: "Cheap",
+          adapterConfig: {
+            model: "public-model-id",
+            provider: "public-provider-id",
+            neutralCanary: REDACTED_EVENT_VALUE,
+          },
+        },
+      },
+      shadow: { heartbeat: { enabled: REDACTED_EVENT_VALUE } },
+    });
+  });
+
+  it("preserves only top-level allowlisted adapter editor metadata", () => {
+    expect(redactConfigurationPayload({
+      model: "public-model-id",
+      search: true,
+      timeoutSec: 30,
+      command: "must-not-survive",
+      nested: { model: "must-not-survive" },
+    }, "adapter")).toEqual({
+      model: "public-model-id",
+      search: true,
+      timeoutSec: 30,
+      command: REDACTED_EVENT_VALUE,
+      nested: { model: REDACTED_EVENT_VALUE },
+    });
+  });
+
   it("restores round-tripped redaction markers without discarding intentional edits", () => {
     const existing = {
       model: "old-model",

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -103,6 +103,32 @@ describe("redaction", () => {
     });
   });
 
+  it("redacts every element of a malformed array occupying an allowlisted scalar path", () => {
+    const secretValue = "must-not-survive-in-array";
+
+    const adapterResult = redactConfigurationPayload({
+      model: [secretValue, "another-neutral-string"],
+    }, "adapter");
+    expect(adapterResult).toEqual({
+      model: [REDACTED_EVENT_VALUE, REDACTED_EVENT_VALUE],
+    });
+    expect(JSON.stringify(adapterResult)).not.toContain(secretValue);
+
+    const runtimeResult = redactConfigurationPayload({
+      heartbeat: { enabled: [secretValue] },
+    }, "runtime");
+    expect(runtimeResult).toEqual({
+      heartbeat: { enabled: [REDACTED_EVENT_VALUE] },
+    });
+    expect(JSON.stringify(runtimeResult)).not.toContain(secretValue);
+
+    // A scalar (non-array) value at the same allowlisted paths still passes
+    // through untouched — only arrays lose the implicit public-scalar status.
+    expect(redactConfigurationPayload({ model: "public-model-id" }, "adapter")).toEqual({
+      model: "public-model-id",
+    });
+  });
+
   it("restores round-tripped redaction markers without discarding intentional edits", () => {
     const existing = {
       model: "old-model",
@@ -821,6 +847,42 @@ second-line\" status=401`,
     expect(redactAgentAdapterConfig({ command: REDACTED_EVENT_VALUE, apiKey: "secret" })).toEqual({
       command: REDACTED_EVENT_VALUE,
       apiKey: REDACTED_EVENT_VALUE,
+    });
+  });
+
+  // SEC-1790: a missing/invalid `env` shape must deny-by-default through
+  // redactConfigurationPayload rather than fall back to the legacy
+  // sanitizeRecord heuristics, which preserve scalar values under
+  // neutral/unrecognized keys unless they look secret-shaped.
+  it("denies unrecognized adapter keys by default when env is missing or invalid", () => {
+    const neutralValue = "us-east-1";
+
+    expect(redactAgentAdapterConfig({
+      model: "public-model-id",
+      region: neutralValue,
+    })).toEqual({
+      model: "public-model-id",
+      region: REDACTED_EVENT_VALUE,
+    });
+
+    expect(redactAgentAdapterConfig({
+      model: "public-model-id",
+      region: neutralValue,
+      env: "not-a-plain-object",
+    })).toEqual({
+      model: "public-model-id",
+      region: REDACTED_EVENT_VALUE,
+      env: REDACTED_EVENT_VALUE,
+    });
+
+    expect(redactAgentAdapterConfig({
+      model: "public-model-id",
+      region: neutralValue,
+      env: null,
+    })).toEqual({
+      model: "public-model-id",
+      region: REDACTED_EVENT_VALUE,
+      env: null,
     });
   });
 });

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -129,6 +129,22 @@ describe("redaction", () => {
     });
   });
 
+  it("redacts scalars nested under array-of-object elements at an allowlisted path", () => {
+    const secretValue = "must-not-survive-under-array-object";
+
+    // `heartbeat.enabled` is an allowlisted scalar path, but a malformed
+    // array of objects at `heartbeat` must not let `heartbeat[0].enabled`
+    // inherit that public status once object recursion resumes inside the
+    // array — the array's `insideArray` state must propagate to descendants.
+    const runtimeResult = redactConfigurationPayload({
+      heartbeat: [{ enabled: secretValue }],
+    }, "runtime");
+    expect(runtimeResult).toEqual({
+      heartbeat: [{ enabled: REDACTED_EVENT_VALUE }],
+    });
+    expect(JSON.stringify(runtimeResult)).not.toContain(secretValue);
+  });
+
   it("restores round-tripped redaction markers without discarding intentional edits", () => {
     const existing = {
       model: "old-model",

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -1076,21 +1076,32 @@ export function redactConfigurationPayload(
   return redactConfigurationValue(payload, [], surface) as Record<string, unknown>;
 }
 
-function restoreRedactedConfigurationValue(value: unknown, existing: unknown): unknown {
+function restoreRedactedConfigurationValue(
+  value: unknown,
+  existing: unknown,
+  literalPaths: ReadonlySet<string>,
+  path: string[] = [],
+): unknown {
   // A marker can only stand in for a value that actually existed in the
   // response source. At a new path it is ordinary caller-supplied data.
   if (value === REDACTED_EVENT_VALUE) {
+    if (literalPaths.has(JSON.stringify(path))) return value;
     return existing === undefined ? value : existing;
   }
   if (Array.isArray(value)) {
     const existingArray = Array.isArray(existing) ? existing : [];
-    return value.map((entry, index) => restoreRedactedConfigurationValue(entry, existingArray[index]));
+    return value.map((entry, index) => restoreRedactedConfigurationValue(
+      entry,
+      existingArray[index],
+      literalPaths,
+      [...path, String(index)],
+    ));
   }
   if (!isPlainObject(value)) return value;
   const existingRecord = isPlainObject(existing) ? existing : {};
   return Object.fromEntries(Object.entries(value).map(([key, child]) => [
     key,
-    restoreRedactedConfigurationValue(child, existingRecord[key]),
+    restoreRedactedConfigurationValue(child, existingRecord[key], literalPaths, [...path, key]),
   ]));
 }
 
@@ -1102,8 +1113,10 @@ function restoreRedactedConfigurationValue(value: unknown, existing: unknown): u
 export function restoreRedactedConfigurationPayload(
   payload: Record<string, unknown>,
   existing: Record<string, unknown> | null | undefined,
+  literalPaths: readonly (readonly string[])[] = [],
 ): Record<string, unknown> {
-  return restoreRedactedConfigurationValue(payload, existing ?? {}) as Record<string, unknown>;
+  const encodedLiteralPaths = new Set(literalPaths.map((path) => JSON.stringify(path)));
+  return restoreRedactedConfigurationValue(payload, existing ?? {}, encodedLiteralPaths) as Record<string, unknown>;
 }
 
 export function redactSensitiveText(input: string): string {

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -783,7 +783,7 @@ function sanitizeValue(value: unknown): unknown {
     const version = safeSecretVersion(value.version);
     return {
       type: "secret_ref",
-      secretId: value.secretId,
+      secretId: safeSecretReferenceId(value.secretId),
       ...(version === undefined ? {} : { version }),
       ...(value.projectionClass === "unclassified" ||
       value.projectionClass === "class_3_static_lease"
@@ -846,6 +846,10 @@ function isSecretRefBinding(value: unknown): value is {
   );
 }
 
+function safeSecretReferenceId(value: string): string {
+  return SECRET_REFERENCE_ID_RE.test(value) ? value : REDACTED_EVENT_VALUE;
+}
+
 function isUserSecretRefBinding(value: unknown): value is {
   type: "user_secret_ref";
   key: string;
@@ -878,7 +882,7 @@ function redactSecretRefBinding(
 ): { type: "secret_ref"; secretId: string; version?: number | "latest" } {
   return {
     type: value.type,
-    secretId: value.secretId,
+    secretId: safeSecretReferenceId(value.secretId),
     ...(isPublicSecretVersion(value.version) ? { version: value.version } : {}),
   };
 }
@@ -1043,9 +1047,7 @@ export function redactAgentAdapterConfig(
     Object.entries(env).map(([key, value]) => [key, redactAgentEnvBinding(value)]),
   );
 
-  const redactedRest = redactConfigurationPayload(rest, "adapter") ?? {};
-  if (typeof rest.command === "string") redactedRest.command = rest.command;
-  return { ...redactedRest, env: redactedEnv };
+  return { ...(redactConfigurationPayload(rest, "adapter") ?? {}), env: redactedEnv };
 }
 
 function redactConfigurationValue(

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -1092,8 +1092,8 @@ function restoreRedactedConfigurationValue(value: unknown, existing: unknown): u
 
 /**
  * Treat the response-only redaction marker as an unchanged value when a client
- * round-trips configuration. The marker is reserved API syntax; any other
- * value remains an intentional update.
+ * explicitly opts into round-trip restoration. Callers that do not opt in can
+ * persist the marker string literally; every other value is intentional.
  */
 export function restoreRedactedConfigurationPayload(
   payload: Record<string, unknown>,

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -1043,7 +1043,9 @@ export function redactAgentAdapterConfig(
     Object.entries(env).map(([key, value]) => [key, redactAgentEnvBinding(value)]),
   );
 
-  return { ...(redactEventPayload(rest) ?? {}), env: redactedEnv };
+  const redactedRest = redactConfigurationPayload(rest, "adapter") ?? {};
+  if (typeof rest.command === "string") redactedRest.command = rest.command;
+  return { ...redactedRest, env: redactedEnv };
 }
 
 function redactConfigurationValue(

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -972,6 +972,23 @@ export function redactAgentAdapterConfig(
   return { ...(redactEventPayload(rest) ?? {}), env: redactedEnv };
 }
 
+function redactConfigurationValue(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (Array.isArray(value)) return value.map(redactConfigurationValue);
+  if (isSecretRefBinding(value)) return { type: value.type, secretId: value.secretId, version: value.version };
+  if (isUserSecretRefBinding(value)) return { type: value.type, key: value.key, version: value.version };
+  if (isPlainBinding(value)) return { type: value.type, value: REDACTED_EVENT_VALUE };
+  if (!isPlainObject(value)) return REDACTED_EVENT_VALUE;
+  return Object.fromEntries(Object.entries(value).map(([key, child]) => [key, redactConfigurationValue(child)]));
+}
+
+/** Redact executable configuration deny-by-default while retaining its shape. */
+export function redactConfigurationPayload(payload: Record<string, unknown> | null): Record<string, unknown> | null {
+  if (!payload) return null;
+  if (!isPlainObject(payload)) return {};
+  return redactConfigurationValue(payload) as Record<string, unknown>;
+}
+
 export function redactSensitiveText(input: string): string {
   if (!maybeContainsSecretText(input)) return input;
   return redactCommandText(

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -369,6 +369,8 @@ const SECRET_TEXT_HINTS = [
 ] as const;
 export const REDACTED_EVENT_VALUE = "***REDACTED***";
 
+const PUBLIC_CONFIGURATION_SCALAR_KEYS = new Set(["model", "provider"]);
+
 function maybeContainsSecretText(input: string) {
   const lower = input.toLowerCase();
   return (
@@ -996,14 +998,20 @@ export function redactAgentAdapterConfig(
   return { ...(redactEventPayload(rest) ?? {}), env: redactedEnv };
 }
 
-function redactConfigurationValue(value: unknown): unknown {
+function redactConfigurationValue(value: unknown, path: string[] = []): unknown {
   if (value === null || value === undefined) return value;
-  if (Array.isArray(value)) return value.map(redactConfigurationValue);
+  if (Array.isArray(value)) return value.map((entry) => redactConfigurationValue(entry, path));
   if (isSecretRefBinding(value)) return redactSecretRefBinding(value);
   if (isUserSecretRefBinding(value)) return redactUserSecretRefBinding(value);
   if (isPlainBinding(value)) return { type: value.type, value: REDACTED_EVENT_VALUE };
-  if (!isPlainObject(value)) return REDACTED_EVENT_VALUE;
-  return Object.fromEntries(Object.entries(value).map(([key, child]) => [key, redactConfigurationValue(child)]));
+  if (!isPlainObject(value)) {
+    const topLevelKey = path.length === 1 ? path[0] : undefined;
+    return topLevelKey && PUBLIC_CONFIGURATION_SCALAR_KEYS.has(topLevelKey) ? value : REDACTED_EVENT_VALUE;
+  }
+  return Object.fromEntries(Object.entries(value).map(([childKey, child]) => [
+    childKey,
+    redactConfigurationValue(child, [...path, childKey]),
+  ]));
 }
 
 /** Redact executable configuration deny-by-default while retaining its shape. */
@@ -1011,6 +1019,32 @@ export function redactConfigurationPayload(payload: Record<string, unknown> | nu
   if (!payload) return null;
   if (!isPlainObject(payload)) return {};
   return redactConfigurationValue(payload) as Record<string, unknown>;
+}
+
+function restoreRedactedConfigurationValue(value: unknown, existing: unknown): unknown {
+  if (value === REDACTED_EVENT_VALUE) return existing;
+  if (Array.isArray(value)) {
+    const existingArray = Array.isArray(existing) ? existing : [];
+    return value.map((entry, index) => restoreRedactedConfigurationValue(entry, existingArray[index]));
+  }
+  if (!isPlainObject(value)) return value;
+  const existingRecord = isPlainObject(existing) ? existing : {};
+  return Object.fromEntries(Object.entries(value).map(([key, child]) => [
+    key,
+    restoreRedactedConfigurationValue(child, existingRecord[key]),
+  ]));
+}
+
+/**
+ * Treat the response-only redaction marker as an unchanged value when a client
+ * round-trips configuration. The marker is reserved API syntax; any other
+ * value remains an intentional update.
+ */
+export function restoreRedactedConfigurationPayload(
+  payload: Record<string, unknown>,
+  existing: Record<string, unknown> | null | undefined,
+): Record<string, unknown> {
+  return restoreRedactedConfigurationValue(payload, existing ?? {}) as Record<string, unknown>;
 }
 
 export function redactSensitiveText(input: string): string {

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -369,7 +369,56 @@ const SECRET_TEXT_HINTS = [
 ] as const;
 export const REDACTED_EVENT_VALUE = "***REDACTED***";
 
-const PUBLIC_CONFIGURATION_SCALAR_KEYS = new Set(["model", "provider"]);
+export type ConfigurationRedactionSurface = "adapter" | "runtime" | "generic";
+
+const PUBLIC_ADAPTER_CONFIGURATION_SCALAR_KEYS = new Set([
+  "effort",
+  "graceSec",
+  "mode",
+  "model",
+  "modelReasoningEffort",
+  "provider",
+  "reasoningEffort",
+  "search",
+  "timeoutSec",
+  "variant",
+]);
+
+// These are closed, presentation-safe fields consumed by AgentConfigForm.
+// Path checks are exact: a same-named scalar below an unknown object remains
+// redacted, and bindings always take the binding-specific redaction path.
+const PUBLIC_RUNTIME_HEARTBEAT_SCALAR_PATHS = new Set([
+  "heartbeat.cooldownSec",
+  "heartbeat.enabled",
+  "heartbeat.intervalSec",
+  "heartbeat.maxConcurrentRuns",
+  "heartbeat.maxTurnContinuation.delayMs",
+  "heartbeat.maxTurnContinuation.enabled",
+  "heartbeat.maxTurnContinuation.maxAttempts",
+  "heartbeat.wakeOnDemand",
+]);
+
+function isPublicConfigurationScalar(path: string[], surface: ConfigurationRedactionSurface) {
+  if (surface === "adapter") {
+    return path.length === 1 && PUBLIC_ADAPTER_CONFIGURATION_SCALAR_KEYS.has(path[0] ?? "");
+  }
+  if (surface === "runtime") {
+    const joinedPath = path.join(".");
+    if (PUBLIC_RUNTIME_HEARTBEAT_SCALAR_PATHS.has(joinedPath)) return true;
+    if (joinedPath === "debug.providerTrace") return true;
+    return (
+      path.length === 3
+      && path[0] === "modelProfiles"
+      && (path[2] === "enabled" || path[2] === "label")
+    ) || (
+      path.length === 4
+      && path[0] === "modelProfiles"
+      && path[2] === "adapterConfig"
+      && PUBLIC_ADAPTER_CONFIGURATION_SCALAR_KEYS.has(path[3] ?? "")
+    );
+  }
+  return path.length === 1 && (path[0] === "model" || path[0] === "provider");
+}
 
 function maybeContainsSecretText(input: string) {
   const lower = input.toLowerCase();
@@ -998,27 +1047,33 @@ export function redactAgentAdapterConfig(
   return { ...(redactEventPayload(rest) ?? {}), env: redactedEnv };
 }
 
-function redactConfigurationValue(value: unknown, path: string[] = []): unknown {
+function redactConfigurationValue(
+  value: unknown,
+  path: string[] = [],
+  surface: ConfigurationRedactionSurface = "generic",
+): unknown {
   if (value === null || value === undefined) return value;
-  if (Array.isArray(value)) return value.map((entry) => redactConfigurationValue(entry, path));
+  if (Array.isArray(value)) return value.map((entry) => redactConfigurationValue(entry, path, surface));
   if (isSecretRefBinding(value)) return redactSecretRefBinding(value);
   if (isUserSecretRefBinding(value)) return redactUserSecretRefBinding(value);
   if (isPlainBinding(value)) return { type: value.type, value: REDACTED_EVENT_VALUE };
   if (!isPlainObject(value)) {
-    const topLevelKey = path.length === 1 ? path[0] : undefined;
-    return topLevelKey && PUBLIC_CONFIGURATION_SCALAR_KEYS.has(topLevelKey) ? value : REDACTED_EVENT_VALUE;
+    return isPublicConfigurationScalar(path, surface) ? value : REDACTED_EVENT_VALUE;
   }
   return Object.fromEntries(Object.entries(value).map(([childKey, child]) => [
     childKey,
-    redactConfigurationValue(child, [...path, childKey]),
+    redactConfigurationValue(child, [...path, childKey], surface),
   ]));
 }
 
 /** Redact executable configuration deny-by-default while retaining its shape. */
-export function redactConfigurationPayload(payload: Record<string, unknown> | null): Record<string, unknown> | null {
+export function redactConfigurationPayload(
+  payload: Record<string, unknown> | null,
+  surface: ConfigurationRedactionSurface = "generic",
+): Record<string, unknown> | null {
   if (!payload) return null;
   if (!isPlainObject(payload)) return {};
-  return redactConfigurationValue(payload) as Record<string, unknown>;
+  return redactConfigurationValue(payload, [], surface) as Record<string, unknown>;
 }
 
 function restoreRedactedConfigurationValue(value: unknown, existing: unknown): unknown {

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -1077,7 +1077,11 @@ export function redactConfigurationPayload(
 }
 
 function restoreRedactedConfigurationValue(value: unknown, existing: unknown): unknown {
-  if (value === REDACTED_EVENT_VALUE) return existing;
+  // A marker can only stand in for a value that actually existed in the
+  // response source. At a new path it is ordinary caller-supplied data.
+  if (value === REDACTED_EVENT_VALUE) {
+    return existing === undefined ? value : existing;
+  }
   if (Array.isArray(value)) {
     const existingArray = Array.isArray(existing) ? existing : [];
     return value.map((entry, index) => restoreRedactedConfigurationValue(entry, existingArray[index]));

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -814,7 +814,7 @@ function sanitizeValue(value: unknown): unknown {
     };
   }
   if (isPlainBinding(value))
-    return { type: "plain", value: sanitizeValue(value.value) };
+    return { type: "plain", value: REDACTED_EVENT_VALUE };
   if (!isPlainObject(value)) return value;
   return sanitizeRecord(value);
 }
@@ -842,8 +842,7 @@ function isSecretRefBinding(value: unknown): value is {
   if (!isPlainObject(value)) return false;
   return (
     value.type === "secret_ref" &&
-    typeof value.secretId === "string" &&
-    SECRET_REFERENCE_ID_RE.test(value.secretId)
+    typeof value.secretId === "string"
   );
 }
 

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -819,6 +819,30 @@ function isPlainBinding(
   return value.type === "plain" && "value" in value;
 }
 
+function isPublicSecretVersion(value: unknown): value is number | "latest" {
+  return value === "latest" || (typeof value === "number" && Number.isSafeInteger(value) && value > 0);
+}
+
+function redactSecretRefBinding(
+  value: { type: "secret_ref"; secretId: string; version?: unknown },
+): { type: "secret_ref"; secretId: string; version?: number | "latest" } {
+  return {
+    type: value.type,
+    secretId: value.secretId,
+    ...(isPublicSecretVersion(value.version) ? { version: value.version } : {}),
+  };
+}
+
+function redactUserSecretRefBinding(
+  value: { type: "user_secret_ref"; key: string; version?: unknown },
+): { type: "user_secret_ref"; key: string; version?: number | "latest" } {
+  return {
+    type: value.type,
+    key: value.key,
+    ...(isPublicSecretVersion(value.version) ? { version: value.version } : {}),
+  };
+}
+
 function sanitizeCommandArgs(args: unknown[]): unknown[] {
   let redactNext = false;
   return args.map((arg) => {
@@ -975,8 +999,8 @@ export function redactAgentAdapterConfig(
 function redactConfigurationValue(value: unknown): unknown {
   if (value === null || value === undefined) return value;
   if (Array.isArray(value)) return value.map(redactConfigurationValue);
-  if (isSecretRefBinding(value)) return { type: value.type, secretId: value.secretId, version: value.version };
-  if (isUserSecretRefBinding(value)) return { type: value.type, key: value.key, version: value.version };
+  if (isSecretRefBinding(value)) return redactSecretRefBinding(value);
+  if (isUserSecretRefBinding(value)) return redactUserSecretRefBinding(value);
   if (isPlainBinding(value)) return { type: value.type, value: REDACTED_EVENT_VALUE };
   if (!isPlainObject(value)) return REDACTED_EVENT_VALUE;
   return Object.fromEntries(Object.entries(value).map(([key, child]) => [key, redactConfigurationValue(child)]));

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -1081,7 +1081,10 @@ function redactConfigurationValue(
   }
   return Object.fromEntries(Object.entries(value).map(([childKey, child]) => [
     childKey,
-    redactConfigurationValue(child, [...path, childKey], surface),
+    // Preserve `insideArray` through object recursion: a scalar nested under
+    // an array element (e.g. `heartbeat[0].enabled`) must not be mistaken
+    // for the public `heartbeat.enabled` scalar once inside array descent.
+    redactConfigurationValue(child, [...path, childKey], surface, insideArray),
   ]));
 }
 

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -1036,7 +1036,14 @@ export function redactAgentAdapterConfig(
   adapterConfig: Record<string, unknown>,
 ): Record<string, unknown> {
   if (!isPlainObject(adapterConfig)) return adapterConfig;
-  if (!isPlainObject(adapterConfig.env)) return redactEventPayload(adapterConfig) ?? {};
+  // A missing/invalid `env` shape must still deny-by-default through
+  // redactConfigurationPayload, not the legacy redactEventPayload/
+  // sanitizeRecord path, which preserves scalars under neutral/unrecognized
+  // keys and would reintroduce the neutral-key credential exposure this
+  // function exists to close.
+  if (!isPlainObject(adapterConfig.env)) {
+    return redactConfigurationPayload(adapterConfig, "adapter") ?? {};
+  }
 
   // Redact `env` here and sanitize the remaining keys separately, so bindings
   // are never processed twice. `redactAgentEnvBinding` is authoritative for
@@ -1054,14 +1061,23 @@ function redactConfigurationValue(
   value: unknown,
   path: string[] = [],
   surface: ConfigurationRedactionSurface = "generic",
+  insideArray = false,
 ): unknown {
   if (value === null || value === undefined) return value;
-  if (Array.isArray(value)) return value.map((entry) => redactConfigurationValue(entry, path, surface));
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactConfigurationValue(entry, path, surface, true));
+  }
   if (isSecretRefBinding(value)) return redactSecretRefBinding(value);
   if (isUserSecretRefBinding(value)) return redactUserSecretRefBinding(value);
   if (isPlainBinding(value)) return { type: value.type, value: REDACTED_EVENT_VALUE };
   if (!isPlainObject(value)) {
-    return isPublicConfigurationScalar(path, surface) ? value : REDACTED_EVENT_VALUE;
+    // No currently allowlisted path names an array — they all describe a
+    // scalar at that path. A malformed/attacker-influenced array occupying
+    // an otherwise-scalar allowlisted path (e.g. `adapter.model`) must not
+    // let its elements inherit the parent path's public-scalar status.
+    return !insideArray && isPublicConfigurationScalar(path, surface)
+      ? value
+      : REDACTED_EVENT_VALUE;
   }
   return Object.fromEntries(Object.entries(value).map(([childKey, child]) => [
     childKey,

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -1035,7 +1035,10 @@ function redactAgentEnvBinding(value: unknown): unknown {
 export function redactAgentAdapterConfig(
   adapterConfig: Record<string, unknown>,
 ): Record<string, unknown> {
-  if (!isPlainObject(adapterConfig)) return adapterConfig;
+  // A non-plain-object input (malformed/legacy/attacker-influenced data) must
+  // fail closed to `{}`, not pass through unchanged — returning it verbatim
+  // would serialize whatever it contains straight into API responses.
+  if (!isPlainObject(adapterConfig)) return {};
   // A missing/invalid `env` shape must still deny-by-default through
   // redactConfigurationPayload, not the legacy redactEventPayload/
   // sanitizeRecord path, which preserves scalars under neutral/unrecognized

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -109,7 +109,9 @@ import {
 import {
   REDACTED_EVENT_VALUE,
   redactAgentAdapterConfig,
+  redactConfigurationPayload,
   redactEventPayload,
+  restoreRedactedConfigurationPayload,
 } from "../redaction.js";
 import { redactCurrentUserValue } from "../log-redaction.js";
 import {
@@ -2836,7 +2838,14 @@ export function agentRoutes(
     if (!agent.adapterConfig || typeof agent.adapterConfig !== "object") return agent;
     return {
       ...agent,
-      adapterConfig: redactAgentAdapterConfig(agent.adapterConfig as Record<string, unknown>),
+      adapterConfig: redactConfigurationPayload(
+        agent.adapterConfig as Record<string, unknown>,
+        "adapter",
+      ),
+      runtimeConfig: redactConfigurationPayload(
+        (agent as { runtimeConfig?: unknown }).runtimeConfig as Record<string, unknown>,
+        "runtime",
+      ),
     };
   }
 
@@ -2851,8 +2860,8 @@ export function agentRoutes(
       status: agent.status,
       reportsTo: agent.reportsTo,
       adapterType: agent.adapterType,
-      adapterConfig: redactAgentAdapterConfig(agent.adapterConfig),
-      runtimeConfig: redactEventPayload(agent.runtimeConfig),
+      adapterConfig: redactConfigurationPayload(agent.adapterConfig, "adapter") ?? {},
+      runtimeConfig: redactConfigurationPayload(agent.runtimeConfig, "runtime") ?? {},
       permissions: agent.permissions,
       updatedAt: agent.updatedAt,
     };
@@ -2885,7 +2894,7 @@ export function agentRoutes(
     const record = snapshot as Record<string, unknown>;
     return {
       ...record,
-      adapterConfig: redactAgentAdapterConfig(
+      adapterConfig: redactConfigurationPayload(
         typeof record.adapterConfig === "object" && record.adapterConfig !== null
           ? (record.adapterConfig as Record<string, unknown>)
           : {},

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -4667,6 +4667,10 @@ export function agentRoutes(
     // string literally without the server silently reinterpreting it.
     const preserveRedactedConfigValues = patchData.preserveRedactedConfigValues === true;
     delete patchData.preserveRedactedConfigValues;
+    const literalRedactedConfigPaths = Array.isArray(patchData.literalRedactedConfigPaths)
+      ? patchData.literalRedactedConfigPaths as string[][]
+      : [];
+    delete patchData.literalRedactedConfigPaths;
     // The apply-existing flag is not an agent column. The server binds the fixed
     // reference to the owner stored value with no login round trip. Remove it
     // from the patch so it never reaches the update values.
@@ -4679,7 +4683,13 @@ export function agentRoutes(
         return;
       }
       const restoredAdapterConfig = preserveRedactedConfigValues
-        ? restoreRedactedConfigurationPayload(adapterConfig, asRecord(existing.adapterConfig))
+        ? restoreRedactedConfigurationPayload(
+            adapterConfig,
+            asRecord(existing.adapterConfig),
+            literalRedactedConfigPaths
+              .filter(([surface]) => surface === "adapterConfig")
+              .map((path) => path.slice(1)),
+          )
         : adapterConfig;
       assertNoAgentAdapterConfigMutation(req, restoredAdapterConfig);
       const changingInstructionsConfig = adapterConfigTouchesInstructionsConfig(restoredAdapterConfig);
@@ -4707,7 +4717,13 @@ export function agentRoutes(
         return;
       }
       const restoredRuntimeConfig = preserveRedactedConfigValues
-        ? restoreRedactedConfigurationPayload(runtimeConfig, asRecord(existing.runtimeConfig))
+        ? restoreRedactedConfigurationPayload(
+            runtimeConfig,
+            asRecord(existing.runtimeConfig),
+            literalRedactedConfigPaths
+              .filter(([surface]) => surface === "runtimeConfig")
+              .map((path) => path.slice(1)),
+          )
         : runtimeConfig;
       assertProviderTraceSettingTransition(
         req,

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -4879,7 +4879,17 @@ export function agentRoutes(
       details: summarizeAgentUpdateDetails(patchData),
     });
 
-    res.json(redactAgentRowForResponse(agent));
+    res.json(
+      replaceAdapterConfig
+        ? {
+            ...agent,
+            adapterConfig: redactConfigurationPayload(
+              asRecord(agent.adapterConfig) ?? {},
+              "adapter",
+            ),
+          }
+        : redactAgentRowForResponse(agent),
+    );
   });
 
   router.post("/agents/:id/pause", async (req, res) => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2838,9 +2838,8 @@ export function agentRoutes(
     if (!agent.adapterConfig || typeof agent.adapterConfig !== "object") return agent;
     return {
       ...agent,
-      adapterConfig: redactConfigurationPayload(
+      adapterConfig: redactAgentAdapterConfig(
         agent.adapterConfig as Record<string, unknown>,
-        "adapter",
       ),
       runtimeConfig: redactConfigurationPayload(
         (agent as { runtimeConfig?: unknown }).runtimeConfig as Record<string, unknown>,
@@ -2860,7 +2859,7 @@ export function agentRoutes(
       status: agent.status,
       reportsTo: agent.reportsTo,
       adapterType: agent.adapterType,
-      adapterConfig: redactConfigurationPayload(agent.adapterConfig, "adapter") ?? {},
+      adapterConfig: redactAgentAdapterConfig(agent.adapterConfig) ?? {},
       runtimeConfig: redactConfigurationPayload(agent.runtimeConfig, "runtime") ?? {},
       permissions: agent.permissions,
       updatedAt: agent.updatedAt,
@@ -2894,11 +2893,10 @@ export function agentRoutes(
     const record = snapshot as Record<string, unknown>;
     return {
       ...record,
-      adapterConfig: redactConfigurationPayload(
+      adapterConfig: redactAgentAdapterConfig(
         typeof record.adapterConfig === "object" && record.adapterConfig !== null
           ? (record.adapterConfig as Record<string, unknown>)
           : {},
-        "adapter",
       ),
       runtimeConfig: redactConfigurationPayload(
         typeof record.runtimeConfig === "object" && record.runtimeConfig !== null

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -4662,6 +4662,11 @@ export function agentRoutes(
     const patchData = { ...(req.body as Record<string, unknown>) };
     const replaceAdapterConfig = patchData.replaceAdapterConfig === true;
     delete patchData.replaceAdapterConfig;
+    // Profile responses use a visible marker for hidden configuration values.
+    // Restoration is opt-in so an API caller can still persist that same
+    // string literally without the server silently reinterpreting it.
+    const preserveRedactedConfigValues = patchData.preserveRedactedConfigValues === true;
+    delete patchData.preserveRedactedConfigValues;
     // The apply-existing flag is not an agent column. The server binds the fixed
     // reference to the owner stored value with no login round trip. Remove it
     // from the patch so it never reaches the update values.
@@ -4673,10 +4678,9 @@ export function agentRoutes(
         res.status(422).json({ error: "adapterConfig must be an object" });
         return;
       }
-      const restoredAdapterConfig = restoreRedactedConfigurationPayload(
-        adapterConfig,
-        asRecord(existing.adapterConfig),
-      );
+      const restoredAdapterConfig = preserveRedactedConfigValues
+        ? restoreRedactedConfigurationPayload(adapterConfig, asRecord(existing.adapterConfig))
+        : adapterConfig;
       assertNoAgentAdapterConfigMutation(req, restoredAdapterConfig);
       const changingInstructionsConfig = adapterConfigTouchesInstructionsConfig(restoredAdapterConfig);
       if (changingInstructionsConfig) {
@@ -4702,10 +4706,9 @@ export function agentRoutes(
         res.status(422).json({ error: "runtimeConfig must be an object" });
         return;
       }
-      const restoredRuntimeConfig = restoreRedactedConfigurationPayload(
-        runtimeConfig,
-        asRecord(existing.runtimeConfig),
-      );
+      const restoredRuntimeConfig = preserveRedactedConfigValues
+        ? restoreRedactedConfigurationPayload(runtimeConfig, asRecord(existing.runtimeConfig))
+        : runtimeConfig;
       assertProviderTraceSettingTransition(
         req,
         restoredRuntimeConfig,

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -4887,6 +4887,10 @@ export function agentRoutes(
               asRecord(agent.adapterConfig) ?? {},
               "adapter",
             ),
+            runtimeConfig: redactConfigurationPayload(
+              asRecord(agent.runtimeConfig) ?? {},
+              "runtime",
+            ),
           }
         : redactAgentRowForResponse(agent),
     );

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2890,7 +2890,7 @@ export function agentRoutes(
           ? (record.adapterConfig as Record<string, unknown>)
           : {},
       ),
-      runtimeConfig: redactEventPayload(
+      runtimeConfig: redactConfigurationPayload(
         typeof record.runtimeConfig === "object" && record.runtimeConfig !== null
           ? (record.runtimeConfig as Record<string, unknown>)
           : {},

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -4671,12 +4671,16 @@ export function agentRoutes(
         res.status(422).json({ error: "adapterConfig must be an object" });
         return;
       }
-      assertNoAgentAdapterConfigMutation(req, adapterConfig);
-      const changingInstructionsConfig = adapterConfigTouchesInstructionsConfig(adapterConfig);
+      const restoredAdapterConfig = restoreRedactedConfigurationPayload(
+        adapterConfig,
+        asRecord(existing.adapterConfig),
+      );
+      assertNoAgentAdapterConfigMutation(req, restoredAdapterConfig);
+      const changingInstructionsConfig = adapterConfigTouchesInstructionsConfig(restoredAdapterConfig);
       if (changingInstructionsConfig) {
         await assertCanManageInstructionsPath(req, existing);
       }
-      patchData.adapterConfig = adapterConfig;
+      patchData.adapterConfig = restoredAdapterConfig;
     }
 
     // Switching an existing agent ONTO another adapter is a new selection, so
@@ -4696,12 +4700,18 @@ export function agentRoutes(
         res.status(422).json({ error: "runtimeConfig must be an object" });
         return;
       }
+      const restoredRuntimeConfig = restoreRedactedConfigurationPayload(
+        runtimeConfig,
+        asRecord(existing.runtimeConfig),
+      );
+      assertNoAgentRuntimeConfigAdapterConfigMutation(req, restoredRuntimeConfig);
       assertProviderTraceSettingTransition(
         req,
-        runtimeConfig,
+        restoredRuntimeConfig,
         existing.runtimeConfig,
       );
-      requestedRuntimeConfig = runtimeConfig;
+      patchData.runtimeConfig = restoredRuntimeConfig;
+      requestedRuntimeConfig = restoredRuntimeConfig;
     }
     const touchesAdapterConfiguration =
       hasOwn(patchData, "adapterType") ||

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2889,11 +2889,13 @@ export function agentRoutes(
         typeof record.adapterConfig === "object" && record.adapterConfig !== null
           ? (record.adapterConfig as Record<string, unknown>)
           : {},
+        "adapter",
       ),
       runtimeConfig: redactConfigurationPayload(
         typeof record.runtimeConfig === "object" && record.runtimeConfig !== null
           ? (record.runtimeConfig as Record<string, unknown>)
           : {},
+        "runtime",
       ),
       metadata:
         typeof record.metadata === "object" && record.metadata !== null
@@ -4704,7 +4706,6 @@ export function agentRoutes(
         runtimeConfig,
         asRecord(existing.runtimeConfig),
       );
-      assertNoAgentRuntimeConfigAdapterConfigMutation(req, restoredRuntimeConfig);
       assertProviderTraceSettingTransition(
         req,
         restoredRuntimeConfig,

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -4198,7 +4198,7 @@ export function agentRoutes(
       });
     }
 
-    res.status(201).json({ agent, approval });
+    res.status(201).json({ agent: redactAgentProfile(agent), approval });
   });
 
   router.post("/companies/:companyId/agents", validate(createAgentSchema), async (req, res) => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -4209,7 +4209,7 @@ export function agentRoutes(
       });
     }
 
-    res.status(201).json({ agent: redactAgentProfile(agent), approval });
+    res.status(201).json({ agent: redactAgentRowForResponse(agent), approval });
   });
 
   router.post("/companies/:companyId/agents", validate(createAgentSchema), async (req, res) => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -2835,16 +2835,23 @@ export function agentRoutes(
     agent: T,
   ): T {
     if (!agent || typeof agent !== "object") return agent;
-    if (!agent.adapterConfig || typeof agent.adapterConfig !== "object") return agent;
+    // adapterConfig/runtimeConfig are redacted independently of one another's
+    // presence or shape: a missing/null/non-object value must still fail
+    // closed through the deny-by-default redactors below rather than bypass
+    // redaction entirely.
+    const adapterConfig =
+      agent.adapterConfig && typeof agent.adapterConfig === "object"
+        ? (agent.adapterConfig as Record<string, unknown>)
+        : {};
+    const rawRuntimeConfig = (agent as { runtimeConfig?: unknown }).runtimeConfig;
+    const runtimeConfig =
+      rawRuntimeConfig && typeof rawRuntimeConfig === "object"
+        ? (rawRuntimeConfig as Record<string, unknown>)
+        : {};
     return {
       ...agent,
-      adapterConfig: redactAgentAdapterConfig(
-        agent.adapterConfig as Record<string, unknown>,
-      ),
-      runtimeConfig: redactConfigurationPayload(
-        (agent as { runtimeConfig?: unknown }).runtimeConfig as Record<string, unknown>,
-        "runtime",
-      ),
+      adapterConfig: redactAgentAdapterConfig(adapterConfig),
+      runtimeConfig: redactConfigurationPayload(runtimeConfig, "runtime"),
     };
   }
 

--- a/server/src/services/native-runtime/native-question-bridge.test.ts
+++ b/server/src/services/native-runtime/native-question-bridge.test.ts
@@ -58,6 +58,15 @@ describeEmbeddedPostgres("native question bridge", () => {
   let sessionId: string;
   let runnerInstanceId: string;
 
+  function isPostgresDeadlock(error: unknown) {
+    let current = error;
+    for (let depth = 0; depth < 4 && typeof current === "object" && current !== null; depth += 1) {
+      if ("code" in current && (current as { code?: unknown }).code === "40P01") return true;
+      current = "cause" in current ? (current as { cause?: unknown }).cause : undefined;
+    }
+    return false;
+  }
+
   beforeAll(async () => {
     temporary = await startEmbeddedPostgresTestDatabase("paperclip-native-question-");
     db = createDb(temporary.connectionString);
@@ -73,17 +82,25 @@ describeEmbeddedPostgres("native question bridge", () => {
     // TRUNCATE below and can deadlock.
     await drainHeartbeatRunsToQuiescence(db, heartbeat);
     nativeQuestionBridgeInternals.resetForTests();
-    await db.execute(sql.raw(`
-      TRUNCATE TABLE
-        "activity_log",
-        "issue_thread_interactions",
-        "heartbeat_runs",
-        "agent_wakeup_requests",
-        "issues",
-        "agents",
-        "companies"
-      RESTART IDENTITY CASCADE
-    `));
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      try {
+        await db.execute(sql.raw(`
+          TRUNCATE TABLE
+            "activity_log",
+            "issue_thread_interactions",
+            "heartbeat_runs",
+            "agent_wakeup_requests",
+            "issues",
+            "agents",
+            "companies"
+          RESTART IDENTITY CASCADE
+        `));
+        break;
+      } catch (error) {
+        if (!isPostgresDeadlock(error) || attempt === 2) throw error;
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+    }
   });
 
   afterAll(async () => temporary?.cleanup());

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -477,7 +477,11 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
         }
       : overlay;
     if (!isOverlayDirty(nextOverlay)) return;
-    await props.onSave(buildAgentUpdatePatch(props.agent, nextOverlay));
+    const patch = buildAgentUpdatePatch(props.agent, nextOverlay);
+    if (!patch.literalRedactedConfigPaths) {
+      delete patch.preserveRedactedConfigValues;
+    }
+    await props.onSave(patch);
   }, [isCreate, isDirty, overlay, props]);
 
   useEffect(() => {

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -155,6 +155,22 @@ const emptyOverlay: AgentConfigOverlay = {
 /** Stable empty object used as fallback for missing env config to avoid new-object-per-render. */
 const EMPTY_ENV: Record<string, EnvBinding> = {};
 
+function literalEnvMarkerPaths(
+  env: Record<string, EnvBinding>,
+  names: readonly string[],
+): string[][] {
+  return names.flatMap((name) => {
+    const binding = env[name];
+    if (typeof binding === "string") {
+      return binding === "***REDACTED***" ? [["adapterConfig", "env", name]] : [];
+    }
+    if (binding?.type === "plain" && binding.value === "***REDACTED***") {
+      return [["adapterConfig", "env", name, "value"]];
+    }
+    return [];
+  });
+}
+
 export function supportsAdapterModelRefresh(adapterType: string): boolean {
   return adapterType === "claude_local" || adapterType === "codex_local";
 }
@@ -445,6 +461,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
 
   const handleSave = useCallback(async () => {
     if (isCreate) return;
+    const changedEnvNames = environmentVariablesEditorRef.current?.getChangedNames() ?? [];
     const flushedEnv = flushEnvironmentDraft();
     const nextOverlay = flushedEnv
       ? {
@@ -453,6 +470,10 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
             ...overlay.adapterConfig,
             env: flushedEnv,
           },
+          literalRedactedConfigPaths: [
+            ...(overlay.literalRedactedConfigPaths ?? []),
+            ...literalEnvMarkerPaths(flushedEnv, changedEnvNames),
+          ],
         }
       : overlay;
     if (!isOverlayDirty(nextOverlay)) return;
@@ -553,6 +574,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   // existing agent's own page fails to save the binding.
   const handleClaudeLoginStoredEdit = async () => {
     if (isCreate) return;
+    const changedEnvNames = environmentVariablesEditorRef.current?.getChangedNames() ?? [];
     const flushedEnv = flushEnvironmentDraft();
     const baseEnv =
       flushedEnv ??
@@ -561,6 +583,10 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
     const nextOverlay: AgentConfigOverlay = {
       ...overlay,
       adapterConfig: { ...overlay.adapterConfig, env: nextEnv },
+      literalRedactedConfigPaths: [
+        ...(overlay.literalRedactedConfigPaths ?? []),
+        ...literalEnvMarkerPaths(nextEnv, changedEnvNames),
+      ],
     };
     setOverlay(nextOverlay);
     await props.onSave({
@@ -590,6 +616,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
   // pending editor draft first and keep every unrelated binding.
   const handleApplyStoredClaudeLoginEdit = async () => {
     if (isCreate) return;
+    const changedEnvNames = environmentVariablesEditorRef.current?.getChangedNames() ?? [];
     const flushedEnv = flushEnvironmentDraft();
     const baseEnv =
       flushedEnv ??
@@ -598,6 +625,10 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
     const nextOverlay: AgentConfigOverlay = {
       ...overlay,
       adapterConfig: { ...overlay.adapterConfig, env: nextEnv },
+      literalRedactedConfigPaths: [
+        ...(overlay.literalRedactedConfigPaths ?? []),
+        ...literalEnvMarkerPaths(nextEnv, changedEnvNames),
+      ],
     };
     setOverlay(nextOverlay);
     await props.onSave({
@@ -1703,7 +1734,17 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                   onChange={(env) =>
                     isCreate
                       ? set!({ envBindings: env ?? {}, envVars: "" })
-                      : mark("adapterConfig", "env", env)
+                      : setOverlay((prev) => ({
+                          ...prev,
+                          adapterConfig: { ...prev.adapterConfig, env },
+                          literalRedactedConfigPaths: [
+                            ...(prev.literalRedactedConfigPaths ?? []),
+                            ...literalEnvMarkerPaths(
+                              env ?? {},
+                              environmentVariablesEditorRef.current?.getChangedNames() ?? [],
+                            ),
+                          ],
+                        }))
                   }
                 />
               </Field>

--- a/ui/src/components/environment-variables-editor/EnvironmentVariablesEditor.test.tsx
+++ b/ui/src/components/environment-variables-editor/EnvironmentVariablesEditor.test.tsx
@@ -1,11 +1,11 @@
 // @vitest-environment jsdom
 
-import { useState } from "react";
+import { createRef, useState } from "react";
 import { flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CompanySecret, EnvBinding } from "@paperclipai/shared";
-import { EnvironmentVariablesEditor } from "./index";
+import { EnvironmentVariablesEditor, type EnvironmentVariablesEditorHandle } from "./index";
 import { SecretPicker } from "./SecretPicker";
 
 // Radix (DropdownMenu/Popover) relies on Pointer Capture APIs that jsdom omits.
@@ -227,6 +227,29 @@ describe("EnvironmentVariablesEditor", () => {
     saveButton().click();
     await flush();
     expect(onChange).toHaveBeenLastCalledWith({ FOO: { type: "plain", value: "bar" } });
+  });
+
+  it("retains edit intent when a nested masked value returns to its baseline", async () => {
+    const ref = createRef<EnvironmentVariablesEditorHandle>();
+    render(
+      <EnvironmentVariablesEditor
+        ref={ref}
+        value={{ TOKEN: { type: "plain", value: "***REDACTED***" } }}
+        secrets={secrets}
+        onChange={() => {}}
+        onCreateSecret={async () => secrets[0]}
+      />,
+    );
+    const valueInput = container.querySelector<HTMLInputElement>('input[aria-label="Variable value"]')!;
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")!.set!;
+    setter.call(valueInput, "temporary");
+    valueInput.dispatchEvent(new Event("input", { bubbles: true }));
+    await flush();
+    setter.call(valueInput, "***REDACTED***");
+    valueInput.dispatchEvent(new Event("input", { bubbles: true }));
+    await flush();
+
+    expect(ref.current?.getChangedNames()).toContain("TOKEN");
   });
 
   it("flushes unsaved editor changes before an enclosing form submits", async () => {

--- a/ui/src/components/environment-variables-editor/index.tsx
+++ b/ui/src/components/environment-variables-editor/index.tsx
@@ -174,6 +174,10 @@ export const EnvironmentVariablesEditor = forwardRef<EnvironmentVariablesEditorH
   const [touchedNames, setTouchedNames] = useState<ReadonlySet<string>>(
     () => new Set(rowsFromValue(value).map((row) => row.name.trim()).filter(Boolean)),
   );
+  // Tracks edit intent independently from the final value. A masked value may
+  // be edited away and back to ***REDACTED***, which is equal to the committed
+  // baseline but still must be sent as an explicit literal marker.
+  const editIntentNamesRef = useRef<Set<string>>(new Set());
   const [pendingFocus, setPendingFocus] = useState<{ rowId: string; field: "name" | "value" } | null>(null);
 
   useEffect(() => {
@@ -199,6 +203,7 @@ export const EnvironmentVariablesEditor = forwardRef<EnvironmentVariablesEditorH
 
   function adoptExternalValue(nextValue: Record<string, EnvBinding>): EnvRow[] {
     const nextRows = rowsFromValue(nextValue);
+    editIntentNamesRef.current.clear();
     setRows(nextRows);
     touchCommittedNames(nextRows);
     return nextRows;
@@ -228,6 +233,7 @@ export const EnvironmentVariablesEditor = forwardRef<EnvironmentVariablesEditorH
     }
 
     if (matchesPendingSave || draftValueKey === incomingValueKey) {
+      editIntentNamesRef.current.clear();
       touchCommittedNames(rowsRef.current);
       markCommitted(incomingValueKey);
     }
@@ -292,7 +298,12 @@ export const EnvironmentVariablesEditor = forwardRef<EnvironmentVariablesEditorH
 
   useImperativeHandle(ref, () => ({
     flushPendingDraft,
-    getChangedNames: () => [...changeSummary.added, ...changeSummary.changed],
+    getChangedNames: () => [...new Set([
+      ...changeSummary.added,
+      ...changeSummary.changed,
+      ...changeSummary.removed,
+      ...editIntentNamesRef.current,
+    ])],
   }), [changeSummary, flushPendingDraft]);
 
   useEffect(() => {
@@ -332,10 +343,17 @@ export const EnvironmentVariablesEditor = forwardRef<EnvironmentVariablesEditorH
   }
 
   function patchRow(id: string, patch: Partial<EnvRow>) {
-    updateDraft(rows.map((row) => (row.id === id ? { ...row, ...patch } : row)));
+    const row = rows.find((candidate: EnvRow) => candidate.id === id);
+    const nextRow = row ? { ...row, ...patch } : undefined;
+    for (const name of [row?.name.trim(), nextRow?.name.trim()]) {
+      if (name) editIntentNamesRef.current.add(name);
+    }
+    updateDraft(rows.map((candidate: EnvRow) => (candidate.id === id ? nextRow! : candidate)));
   }
 
   function removeRow(id: string) {
+    const name = rows.find((row: EnvRow) => row.id === id)?.name.trim();
+    if (name) editIntentNamesRef.current.add(name);
     updateDraft(rows.filter((row) => row.id !== id));
   }
 
@@ -361,6 +379,7 @@ export const EnvironmentVariablesEditor = forwardRef<EnvironmentVariablesEditorH
     if (pairs.length === 0) return false;
     // Drop the empty row that received the paste, then upsert each pair.
     const working = rows.filter((row) => row.id !== targetRowId).map((row) => ({ ...row }));
+    for (const pair of pairs) editIntentNamesRef.current.add(pair.key);
     for (const { key, value: pairValue } of pairs) {
       const existing = working.find((row) => row.name.trim() === key);
       if (existing) {
@@ -394,6 +413,7 @@ export const EnvironmentVariablesEditor = forwardRef<EnvironmentVariablesEditorH
     target.secretId = secret.id;
     target.version = "latest";
     if (!target.name) target.name = envKeyFromSecretName(secret.name);
+    if (target.name.trim()) editIntentNamesRef.current.add(target.name.trim());
     updateDraft(next);
   }
 
@@ -405,6 +425,7 @@ export const EnvironmentVariablesEditor = forwardRef<EnvironmentVariablesEditorH
 
   function revertDraft() {
     pendingSaveValueKeyRef.current = null;
+    editIntentNamesRef.current.clear();
     lastPropValueKeyRef.current = normalizedEnvKey(value);
     const nextRows = adoptExternalValue(value);
     markCommitted(lastPropValueKeyRef.current, nextRows);

--- a/ui/src/components/environment-variables-editor/index.tsx
+++ b/ui/src/components/environment-variables-editor/index.tsx
@@ -143,6 +143,8 @@ export interface EnvironmentVariablesEditorHandle {
    * action reads parent state. Returns the promoted value when a draft existed.
    */
   flushPendingDraft: () => Record<string, EnvBinding> | null;
+  /** Names whose bindings differ from the committed editor baseline. */
+  getChangedNames: () => string[];
 }
 
 export const EnvironmentVariablesEditor = forwardRef<EnvironmentVariablesEditorHandle, EnvironmentVariablesEditorProps>(function EnvironmentVariablesEditor({
@@ -288,7 +290,10 @@ export const EnvironmentVariablesEditor = forwardRef<EnvironmentVariablesEditorH
     return draftValue ?? {};
   }, [disabled, draftValue, draftValueKey, hasUnsavedChanges, onChange]);
 
-  useImperativeHandle(ref, () => ({ flushPendingDraft }), [flushPendingDraft]);
+  useImperativeHandle(ref, () => ({
+    flushPendingDraft,
+    getChangedNames: () => [...changeSummary.added, ...changeSummary.changed],
+  }), [changeSummary, flushPendingDraft]);
 
   useEffect(() => {
     const form = editorRootRef.current?.closest("form");

--- a/ui/src/lib/agent-config-patch.test.ts
+++ b/ui/src/lib/agent-config-patch.test.ts
@@ -66,6 +66,7 @@ describe("buildAgentUpdatePatch", () => {
     );
 
     expect(patch).toMatchObject({
+      preserveRedactedConfigValues: true,
       runtimeConfig: {
         heartbeat: { enabled: true, intervalSec: 300 },
         debug: { providerTrace: "raw" },
@@ -88,6 +89,7 @@ describe("buildAgentUpdatePatch", () => {
         model: "claude-sonnet-4-6",
         promptTemplate: "Work the issue.",
       },
+      preserveRedactedConfigValues: true,
       replaceAdapterConfig: true,
     });
   });
@@ -107,6 +109,7 @@ describe("buildAgentUpdatePatch", () => {
     );
 
     expect(patch).toEqual({
+      preserveRedactedConfigValues: true,
       runtimeConfig: {
         heartbeat: {
           enabled: true,
@@ -146,6 +149,7 @@ describe("buildAgentUpdatePatch", () => {
         model: "gpt-5.4",
         dangerouslyBypassApprovalsAndSandbox: true,
       },
+      preserveRedactedConfigValues: true,
       replaceAdapterConfig: true,
     });
   });

--- a/ui/src/lib/agent-config-patch.test.ts
+++ b/ui/src/lib/agent-config-patch.test.ts
@@ -154,6 +154,22 @@ describe("buildAgentUpdatePatch", () => {
     });
   });
 
+  it("marks an explicitly edited existing redaction marker as literal data", () => {
+    const agent = makeAgent();
+    agent.adapterConfig = { command: "***REDACTED***" };
+
+    const patch = buildAgentUpdatePatch(
+      agent,
+      makeOverlay({ adapterConfig: { command: "***REDACTED***" } }),
+    );
+
+    expect(patch).toMatchObject({
+      adapterConfig: { command: "***REDACTED***" },
+      literalRedactedConfigPaths: [["adapterConfig", "command"]],
+      preserveRedactedConfigValues: true,
+    });
+  });
+
   it("preserves paperclip skill-sync selections when changing adapter types", () => {
     // Desired skills are adapter-agnostic (company-level selections) but are
     // persisted inside the per-adapter config under `paperclipSkillSync`. A

--- a/ui/src/lib/agent-config-patch.test.ts
+++ b/ui/src/lib/agent-config-patch.test.ts
@@ -170,6 +170,28 @@ describe("buildAgentUpdatePatch", () => {
     });
   });
 
+  it("carries explicit nested literal-marker paths from structured editors", () => {
+    const agent = makeAgent();
+    agent.adapterConfig = {
+      env: { TOKEN: { type: "plain", value: "***REDACTED***" } },
+    };
+
+    const patch = buildAgentUpdatePatch(
+      agent,
+      makeOverlay({
+        adapterConfig: {
+          env: { TOKEN: { type: "plain", value: "***REDACTED***" } },
+        },
+        literalRedactedConfigPaths: [["adapterConfig", "env", "TOKEN", "value"]],
+      }),
+    );
+
+    expect(patch).toMatchObject({
+      literalRedactedConfigPaths: [["adapterConfig", "env", "TOKEN", "value"]],
+      preserveRedactedConfigValues: true,
+    });
+  });
+
   it("preserves paperclip skill-sync selections when changing adapter types", () => {
     // Desired skills are adapter-agnostic (company-level selections) but are
     // persisted inside the per-adapter config under `paperclipSkillSync`. A

--- a/ui/src/lib/agent-config-patch.ts
+++ b/ui/src/lib/agent-config-patch.ts
@@ -1,5 +1,7 @@
 import { ADAPTER_AGNOSTIC_KEYS, type Agent } from "@paperclipai/shared";
 
+const REDACTED_CONFIG_VALUE = "***REDACTED***";
+
 export interface AgentConfigOverlay {
   identity: Record<string, unknown>;
   adapterType?: string;
@@ -79,6 +81,27 @@ export function buildAgentUpdatePatch(agent: Agent, overlay: AgentConfigOverlay)
 
   if (patch.adapterConfig !== undefined || patch.runtimeConfig !== undefined) {
     patch.preserveRedactedConfigValues = true;
+    const literalPaths: string[][] = [];
+    const existingAdapterConfig = (agent.adapterConfig ?? {}) as Record<string, unknown>;
+    for (const [key, value] of Object.entries(overlay.adapterConfig)) {
+      if (value === REDACTED_CONFIG_VALUE && existingAdapterConfig[key] === REDACTED_CONFIG_VALUE) {
+        literalPaths.push(["adapterConfig", key]);
+      }
+    }
+    const existingRuntimeConfig = (agent.runtimeConfig ?? {}) as Record<string, unknown>;
+    const existingHeartbeat = (existingRuntimeConfig.heartbeat ?? {}) as Record<string, unknown>;
+    const existingDebug = (existingRuntimeConfig.debug ?? {}) as Record<string, unknown>;
+    for (const [key, value] of Object.entries(overlay.heartbeat)) {
+      if (value === REDACTED_CONFIG_VALUE && existingHeartbeat[key] === REDACTED_CONFIG_VALUE) {
+        literalPaths.push(["runtimeConfig", "heartbeat", key]);
+      }
+    }
+    for (const [key, value] of Object.entries(overlay.debug)) {
+      if (value === REDACTED_CONFIG_VALUE && existingDebug[key] === REDACTED_CONFIG_VALUE) {
+        literalPaths.push(["runtimeConfig", "debug", key]);
+      }
+    }
+    if (literalPaths.length > 0) patch.literalRedactedConfigPaths = literalPaths;
   }
 
   return patch;

--- a/ui/src/lib/agent-config-patch.ts
+++ b/ui/src/lib/agent-config-patch.ts
@@ -9,6 +9,7 @@ export interface AgentConfigOverlay {
   heartbeat: Record<string, unknown>;
   debug: Record<string, unknown>;
   runtime: Record<string, unknown>;
+  literalRedactedConfigPaths?: string[][];
 }
 
 export function omitUndefinedEntries(value: Record<string, unknown>) {
@@ -81,7 +82,7 @@ export function buildAgentUpdatePatch(agent: Agent, overlay: AgentConfigOverlay)
 
   if (patch.adapterConfig !== undefined || patch.runtimeConfig !== undefined) {
     patch.preserveRedactedConfigValues = true;
-    const literalPaths: string[][] = [];
+    const literalPaths: string[][] = [...(overlay.literalRedactedConfigPaths ?? [])];
     const existingAdapterConfig = (agent.adapterConfig ?? {}) as Record<string, unknown>;
     for (const [key, value] of Object.entries(overlay.adapterConfig)) {
       if (value === REDACTED_CONFIG_VALUE && existingAdapterConfig[key] === REDACTED_CONFIG_VALUE) {
@@ -101,7 +102,11 @@ export function buildAgentUpdatePatch(agent: Agent, overlay: AgentConfigOverlay)
         literalPaths.push(["runtimeConfig", "debug", key]);
       }
     }
-    if (literalPaths.length > 0) patch.literalRedactedConfigPaths = literalPaths;
+    if (literalPaths.length > 0) {
+      patch.literalRedactedConfigPaths = [
+        ...new Map(literalPaths.map((path) => [JSON.stringify(path), path])).values(),
+      ];
+    }
   }
 
   return patch;

--- a/ui/src/lib/agent-config-patch.ts
+++ b/ui/src/lib/agent-config-patch.ts
@@ -77,5 +77,9 @@ export function buildAgentUpdatePatch(agent: Agent, overlay: AgentConfigOverlay)
     Object.assign(patch, overlay.runtime);
   }
 
+  if (patch.adapterConfig !== undefined || patch.runtimeConfig !== undefined) {
+    patch.preserveRedactedConfigValues = true;
+  }
+
   return patch;
 }

--- a/ui/src/pages/Secrets.render.test.tsx
+++ b/ui/src/pages/Secrets.render.test.tsx
@@ -1521,6 +1521,7 @@ describe("Secrets page layout", () => {
         adapterConfig: {
           env: { OPENAI_API_KEY: { type: "secret_ref", secretId: "secret-openai" } },
         },
+        preserveRedactedConfigValues: true,
         replaceAdapterConfig: true,
       },
       "company-1",
@@ -1538,7 +1539,11 @@ describe("Secrets page layout", () => {
 
     expect(mockAgentsApi.update).toHaveBeenCalledWith(
       "agent-reviewer",
-      { adapterConfig: { env: {} }, replaceAdapterConfig: true },
+      {
+        adapterConfig: { env: {} },
+        preserveRedactedConfigValues: true,
+        replaceAdapterConfig: true,
+      },
       "company-1",
     );
 

--- a/ui/src/pages/Secrets.tsx
+++ b/ui/src/pages/Secrets.tsx
@@ -4456,7 +4456,11 @@ function AgentAccessSection({
           : { type: "user_secret_ref", key: reference.definition.key };
       return agentsApi.update(
         agentId,
-        { adapterConfig: { ...adapterConfig, env }, replaceAdapterConfig: true },
+        {
+          adapterConfig: { ...adapterConfig, env },
+          preserveRedactedConfigValues: true,
+          replaceAdapterConfig: true,
+        },
         companyId,
       );
     },
@@ -4483,7 +4487,11 @@ function AgentAccessSection({
       for (const alias of aliases) delete adapterConfig[`${AGENT_ACCESS_CONFIG_PATH_PREFIX}${alias}`];
       return agentsApi.update(
         agentId,
-        { adapterConfig: { ...adapterConfig, env }, replaceAdapterConfig: true },
+        {
+          adapterConfig: { ...adapterConfig, env },
+          preserveRedactedConfigValues: true,
+          replaceAdapterConfig: true,
+        },
         companyId,
       );
     },


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents and their execution settings.
> - The agent API returns profile data to board and agent clients.
> - Agent profiles included raw adapter and runtime configuration.
> - These objects can contain plaintext credentials at any nesting depth.
> - Existing key-name redaction did not protect values under neutral keys.
> - This pull request adds one deny-by-default response boundary for configuration.
> - The benefit is that profile APIs retain configuration shape without returning executable scalar values.

## Linked Issues or Issue Description

**What happened?**

`GET /api/agents/me`, self reads through `GET /api/agents/:id`, and adjacent agent response routes could serialize plaintext values from `adapterConfig` and `runtimeConfig`.

**Expected behavior**

All agent profile response routes must redact configuration scalars at every depth. Secret references may retain non-secret reference metadata.

**Steps to reproduce**

1. Store a synthetic canary in a nested plain binding or a scalar under a neutral key.
2. Read the agent profile as the same agent or an authorized board actor.
3. Observe that the response contains the canary before this change.

**Paperclip version or commit**

Reproduced on the pre-change `master` lineage. The regression test uses synthetic values only.

## What Changed

- Add `redactConfigurationPayload` for deny-by-default recursive configuration redaction.
- Route self, detail, list, create, update, lifecycle, and approval responses through one profile serializer.
- Apply the same policy to configuration and revision snapshots.
- Add synthetic canary tests for neutral keys, nested plain bindings, and both self-profile routes.

## Verification

- `pnpm exec vitest run server/src/__tests__/redaction.test.ts server/src/__tests__/low-trust-red-team-routes.test.ts` passed before the upstream rebase: 2 files and 20 tests.
- After the rebase, `redaction.test.ts` passes 11 tests. The HTTP suite cannot resolve the refreshed `@paperclipai/shared` workspace link in this checkout.
- `pnpm install --frozen-lockfile` is blocked because the upstream patched-dependency configuration and lockfile do not match in this checkout.
- `git diff --check origin/master...HEAD` passes.
- CI must run on the required Node.js 24.11 or later environment.

## Risks

- This change intentionally hides all scalar adapter and runtime configuration values from profile APIs, including values under neutral keys.
- A UI that displays a non-secret configuration scalar from a profile response may now show a redaction marker.
- Runtime secret resolution is unchanged. Agent execution still receives resolved configuration through the internal runtime path.

## Model Used

- OpenAI Codex, `gpt-5.6-sol`, with repository tools and high-reasoning code review.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
