### PR TITLE
fix(recovery): treat a dependency-blocked continuation as a wait, not a strand

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -4223,7 +4223,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const heartbeat = heartbeatService(db);
     const result = await heartbeat.reconcileStrandedAssignedIssues();
 
-    expect(result.waitingOnReviewResolved).toBe(1);
+    expect(result.deliberateWaitResolved).toBe(1);
     expect(result.escalated).toBe(0);
     expect(result.issueIds).toEqual([issueId]);
 
@@ -4323,7 +4323,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const heartbeat = heartbeatService(db);
     const result = await heartbeat.reconcileStrandedAssignedIssues();
 
-    expect(result.waitingOnReviewResolved).toBe(1);
+    expect(result.deliberateWaitResolved).toBe(1);
     expect(result.escalated).toBe(0);
     expect(result.issueIds).toEqual([issueId]);
 
@@ -4365,7 +4365,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const heartbeat = heartbeatService(db);
     const result = await heartbeat.reconcileStrandedAssignedIssues();
 
-    expect(result.waitingOnReviewResolved).toBe(0);
+    expect(result.deliberateWaitResolved).toBe(0);
     expect(result.continuationRequeued).toBe(1);
     expect(result.dispositionRepairRequeued).toBe(1);
     expect(result.escalated).toBe(0);
@@ -4927,6 +4927,104 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       resolutionNote: "owner_not_invokable",
     });
     expect(repairWakeups).toHaveLength(0);
+  });
+
+  it("waits on the open child instead of escalating a dependency-gated process-loss retry", async () => {
+    // HIV-2762 / HIV-2740: the child died, the process-loss retry hit the dependency
+    // gate, and `issue_dependencies_blocked` used to be classified non-retryable — so the
+    // parent was reassigned to the recovery owner and its provider session abandoned
+    // while the child was still running. It must become an ordinary dependency wait.
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "cancelled",
+      retryReason: "issue_continuation_needed",
+      runErrorCode: "issue_dependencies_blocked",
+      runError:
+        "Cancelled because issue dependencies are still blocked; Paperclip will wake the assignee when blockers resolve",
+    });
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    const openChildId = randomUUID();
+
+    await db.insert(issues).values([
+      {
+        id: openChildId,
+        companyId,
+        parentId: issueId,
+        title: "Delegated child still running",
+        status: "in_progress",
+        priority: "medium",
+        issueNumber: 30,
+        identifier: `${issuePrefix}-30`,
+      },
+    ]);
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.deliberateWaitResolved).toBe(1);
+    expect(result.escalated).toBe(0);
+
+    const parent = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(parent?.status).toBe("blocked");
+    // The assignee keeps the issue, so the blockers-resolved wake resumes its task session.
+    expect(parent?.assigneeAgentId).toBe(agentId);
+    await expect(sourceBlockerIssueIds(companyId, issueId)).resolves.toEqual([openChildId]);
+
+    // No stranded-recovery action/issue, so nothing is handed to the recovery owner.
+    const recoveryIssues = await db
+      .select()
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "stranded_issue_recovery")));
+    expect(recoveryIssues).toHaveLength(0);
+
+    const comments = await db.select().from(issueComments).where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.body).toContain(`${issuePrefix}-30`);
+    expect(comments[0]?.body).toContain("continue automatically");
+    expect(comments[0]?.body).not.toContain("issue_dependencies_blocked");
+    expect(comments[0]?.metadata).toMatchObject({
+      sections: [expect.objectContaining({
+        rows: expect.arrayContaining([
+          expect.objectContaining({ label: "Cause", value: "continuation_dependencies_blocked" }),
+        ]),
+      })],
+    });
+
+    const activity = await db.select().from(activityLog).where(eq(activityLog.entityId, issueId));
+    expect(
+      activity.some(
+        (event) =>
+          event.action === "issue.updated" &&
+          (event.details as { source?: string } | null)?.source ===
+            "recovery.reconcile_continuation_dependencies_blocked",
+      ),
+    ).toBe(true);
+  });
+
+  it("requeues a continuation instead of escalating when a dependency hold has no open blocker", async () => {
+    // Stale hold: the gate said blocked but nothing is actually open. That is a resume
+    // candidate, not a terminal failure — the old non-retryable classification escalated it.
+    // `retryReason: null` models the HIV-2740 shape: the cancelled run was a process-loss
+    // retry, not an automatic continuation recovery, so no attempt cap has been spent yet.
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "cancelled",
+      retryReason: null,
+      runErrorCode: "issue_dependencies_blocked",
+      runError: "Cancelled because issue dependencies are still blocked",
+    });
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.deliberateWaitResolved).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.continuationRequeued).toBe(1);
+
+    const parent = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(parent?.status).toBe("in_progress");
+    expect(parent?.assigneeAgentId).toBe(agentId);
+    await expect(sourceBlockerIssueIds(companyId, issueId)).resolves.toEqual([]);
   });
 
   it("clears the detached warning when the run reports activity again", async () => {
@@ -6329,7 +6427,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const result = await heartbeat.reconcileStrandedAssignedIssues();
 
     expect(result.continuationRequeued).toBe(0);
-    expect(result.waitingOnReviewResolved).toBe(0);
+    expect(result.deliberateWaitResolved).toBe(0);
     expect(result.escalated).toBe(1);
     expect(result.issueIds).toContain(issueId);
 

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -390,14 +390,37 @@ const NON_RETRYABLE_CONTINUATION_ERROR_CODES = new Set<string>([
   "budget_blocked",
   "budget_exhausted",
   "issue_paused",
-  "issue_dependencies_blocked",
 ]);
 
-// A continuation cancelled with this code is a *deliberate wait* (the latest run
-// reported it was parked for review/approval), not a lost execution path. When the
-// issue has a real waiting target we convert it into a normal dependency wait rather
-// than escalating it as stranded.
+// A continuation cancelled with one of these codes is a *deliberate wait*, not a lost
+// execution path: something the issue is legitimately waiting for stopped the run on
+// purpose. When the issue has a real waiting target we convert it into a normal
+// dependency wait rather than escalating it as stranded.
+//
+// `issue_dependencies_blocked` belongs here and not in the non-retryable set above.
+// Waiting on an open child is the most ordinary reason a continuation stops, and
+// classifying it as "cannot retry" strands the issue: the owner is dropped, the
+// provider session is never resumed, and the work restarts from scratch under whoever
+// picks up the escalation. The wait already knows when it ends -- the child closing --
+// so there is nothing to escalate.
+type ContinuationDeliberateWait = { label: string; because: string };
+
 const CONTINUATION_WAITING_ON_REVIEW_ERROR_CODE = "issue_continuation_waiting_on_review";
+const CONTINUATION_DEPENDENCIES_BLOCKED_ERROR_CODE = "issue_dependencies_blocked";
+
+const CONTINUATION_WAITING_ON_REVIEW_WAIT: ContinuationDeliberateWait = {
+  label: "continuation_waiting_on_review",
+  because: "because the latest run reported it was waiting for review/approval",
+};
+const CONTINUATION_DEPENDENCIES_BLOCKED_WAIT: ContinuationDeliberateWait = {
+  label: "continuation_dependencies_blocked",
+  because: "because its continuation run was held back while that work is still open",
+};
+
+const CONTINUATION_DELIBERATE_WAITS = new Map<string, ContinuationDeliberateWait>([
+  [CONTINUATION_WAITING_ON_REVIEW_ERROR_CODE, CONTINUATION_WAITING_ON_REVIEW_WAIT],
+  [CONTINUATION_DEPENDENCIES_BLOCKED_ERROR_CODE, CONTINUATION_DEPENDENCIES_BLOCKED_WAIT],
+]);
 const INTERACTION_CONTINUATION_REQUEUE_MAX_ATTEMPTS = 3;
 
 const CONTINUATION_RECOVERY_TRANSIENT_MAX_ATTEMPTS = 3;
@@ -529,7 +552,7 @@ type ContinuationRetryClassification = {
 
 export function classifyContinuationFailure(latestRun: LatestIssueRun): ContinuationRetryClassification {
   const errorCode = readNonEmptyString(latestRun?.errorCode);
-  if (errorCode === CONTINUATION_WAITING_ON_REVIEW_ERROR_CODE) {
+  if (errorCode && CONTINUATION_DELIBERATE_WAITS.has(errorCode)) {
     return {
       kind: "deliberate_wait_without_target",
       maxAttempts: DISPOSITION_REPAIR_MAX_ATTEMPTS,
@@ -2481,6 +2504,13 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
   }
 
   async function resolveContinuationWaitingOnReview(issue: typeof issues.$inferSelect) {
+    return resolveContinuationDeliberateWait(issue, CONTINUATION_WAITING_ON_REVIEW_WAIT);
+  }
+
+  async function resolveContinuationDeliberateWait(
+    issue: typeof issues.$inferSelect,
+    cause: ContinuationDeliberateWait,
+  ) {
     const [existingBlockers, openChildren] = await Promise.all([
       existingUnresolvedBlockerIssues(issue.companyId, issue.id),
       openChildIssues(issue),
@@ -2496,7 +2526,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       issue.id,
       `This task is waiting on ${waitingOn} to finish. ` +
         "It will continue automatically when that work is done — there's nothing you need to do. " +
-        "(It was paused because the latest run reported it was waiting for review/approval; " +
+        `(It was paused ${cause.because}; ` +
         "Paperclip turned that into a normal dependency wait instead of flagging it as stuck.)",
       {},
       {
@@ -2507,7 +2537,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           sections: [{
             title: "Recovery",
             rows: [
-              { type: "key_value", label: "Cause", value: "continuation_waiting_on_review" },
+              { type: "key_value", label: "Cause", value: cause.label },
               { type: "key_value", label: "Previous status", value: issue.status },
               {
                 type: "key_value",
@@ -2532,7 +2562,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         identifier: issue.identifier,
         status: "blocked",
         previousStatus: issue.status,
-        source: "recovery.reconcile_continuation_waiting_on_review",
+        source: `recovery.reconcile_${cause.label}`,
         blockedByIssueIds,
       },
     });
@@ -3569,7 +3599,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       successfulRunHandoffEscalated: 0,
       reviewParticipantRequeued: 0,
       escalated: 0,
-      waitingOnReviewResolved: 0,
+      deliberateWaitResolved: 0,
       providerQuotaMonitored: 0,
       recentProgressExempted: 0,
       operatorCancelExempted: 0,
@@ -3825,7 +3855,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           ) {
             const resolved = await resolveContinuationWaitingOnReview(issue);
             if (resolved) {
-              result.waitingOnReviewResolved += 1;
+              result.deliberateWaitResolved += 1;
               result.issueIds.push(issue.id);
               continue;
             }
@@ -3848,7 +3878,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           if (consecutive >= INTERACTION_CONTINUATION_REQUEUE_MAX_ATTEMPTS && latestPostResolutionRun) {
             const resolved = await resolveContinuationWaitingOnReview(issue);
             if (resolved) {
-              result.waitingOnReviewResolved += 1;
+              result.deliberateWaitResolved += 1;
               result.issueIds.push(issue.id);
               continue;
             }
@@ -4220,10 +4250,13 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       if (isUnsuccessfulTerminalIssueRun(latestRun)) {
         const classification = classifyContinuationFailure(latestRun);
 
-        if (classification.errorCode === CONTINUATION_WAITING_ON_REVIEW_ERROR_CODE) {
-          const resolved = await resolveContinuationWaitingOnReview(issue);
+        const deliberateWait = classification.errorCode
+          ? CONTINUATION_DELIBERATE_WAITS.get(classification.errorCode)
+          : undefined;
+        if (deliberateWait) {
+          const resolved = await resolveContinuationDeliberateWait(issue, deliberateWait);
           if (resolved) {
-            result.waitingOnReviewResolved += 1;
+            result.deliberateWaitResolved += 1;
             result.issueIds.push(issue.id);
             continue;
           }


### PR DESCRIPTION
### The problem

A continuation cancelled with `issue_dependencies_blocked` is classified non-retryable, alongside `agent_not_invokable`, `budget_exhausted` and `issue_paused`.

That is the wrong reading of the code. Waiting on an open child is the most ordinary reason a continuation stops, and it is a *deliberate wait with a known end* — the child closing — not a lost execution path. Nothing about it says "this issue can never make progress again", which is what the non-retryable set means.

The consequences are all of the expensive kind:

- the issue is taken from its assignee and escalated,
- its provider session is never resumed,
- whoever picks up the escalation restarts the same work from scratch,
- and the child it was waiting for is still running the whole time.

### The fix

`issue_continuation_waiting_on_review` already had exactly the right handling for this shape — convert it into a normal dependency wait when there is a real waiting target, escalate only when there is not — but hard-coded for that one error code.

This generalises the single case into a small table of deliberate waits and puts the dependency code in it. Each entry carries the phrasing for the comment the issue receives and the label used in the comment metadata and the activity record, so a reader can still tell the two waits apart.

`resolveContinuationWaitingOnReview` stays as a thin wrapper over the parameterised resolver, so the two legacy review-park call sites are untouched and every existing comment string, metadata value and activity source on the review path is byte-identical. Only the general classification branch becomes table-driven.

### What is deliberately not changed

The two genuine termination guards stay exactly as they are — a continuation that makes no progress still stops, and repeated crashes still stop. This only removes the case where the issue was strandable while a healthy dependency was simply not finished yet.

### Tests

Two new cases over the process-loss path in `heartbeat-process-recovery.test.ts`:

- child still open → the issue becomes a normal dependency wait and keeps its assignee;
- dependency hold with no open blocker → the continuation is requeued, not escalated.

The existing `waitingOnReviewResolved` counter is renamed `deliberateWaitResolved` since it now counts both kinds.

`server/src/__tests__/heartbeat-process-recovery.test.ts`: **122 passed (122)** on current `master`.

### Provenance

Found in production: an issue waiting on a child was escalated away from its owner and restarted from scratch, repeatedly. The equivalent change has been running in our downstream deployment since 2026-09-01 and is live now.