### PR TITLE
KOMAA-183 port RTB execution control v2 core (KOMAA-167) onto current master

### DIFF
--- a/packages/adapter-utils/src/session-compaction.ts
+++ b/packages/adapter-utils/src/session-compaction.ts
@@ -1,4 +1,4 @@
-export interface SessionCompactionPolicy {
+﻿export interface SessionCompactionPolicy {
   enabled: boolean;
   maxSessionRuns: number;
   maxRawInputTokens: number;
@@ -190,4 +190,65 @@ export function hasSessionCompactionThresholds(policy: Pick<
   "maxSessionRuns" | "maxRawInputTokens" | "maxSessionAgeHours"
 >) {
   return policy.maxSessionRuns > 0 || policy.maxRawInputTokens > 0 || policy.maxSessionAgeHours > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Execution Budget + Compaction
+// ---------------------------------------------------------------------------
+
+export type TaskComplexity = "normal" | "debug" | "complex";
+
+export interface ExecutionBudgetPolicy {
+  /** Maximum full-replay runs before compaction is forced. */
+  maxRunsBeforeCompaction: number;
+  /** Task complexity classification. */
+  complexity: TaskComplexity;
+}
+
+const EXECUTION_BUDGET_BY_COMPLEXITY: Record<TaskComplexity, ExecutionBudgetPolicy> = {
+  normal: { maxRunsBeforeCompaction: 4, complexity: "normal" },
+  debug: { maxRunsBeforeCompaction: 6, complexity: "debug" },
+  complex: { maxRunsBeforeCompaction: 8, complexity: "complex" },
+};
+
+/**
+ * Classify task complexity from issue/work-mode context. Normal tasks are the
+ * default; debug tasks have work-mode "debug" or explicit debug flags; complex
+ * tasks have multi-step plan documents or high child-issue counts.
+ */
+export function classifyTaskComplexity(context: Record<string, unknown> | null | undefined): TaskComplexity {
+  if (!context) return "normal";
+  const workMode = typeof context.workMode === "string" ? context.workMode.toLowerCase() : "";
+  if (workMode === "debug" || workMode === "diagnostic") return "debug";
+  if (workMode === "complex" || workMode === "epic") return "complex";
+  const childCount = typeof context.childCount === "number" ? context.childCount : 0;
+  if (childCount > 5) return "complex";
+  return "normal";
+}
+
+export function resolveExecutionBudget(context: Record<string, unknown> | null | undefined): ExecutionBudgetPolicy {
+  const complexity = classifyTaskComplexity(context);
+  return EXECUTION_BUDGET_BY_COMPLEXITY[complexity];
+}
+
+/**
+ * State fields preserved through a compaction continuation. When a session is
+ * compacted, only these fields survive into the new session context; everything
+ * else is discarded to bound context size.
+ */
+export interface CompactionContinuationState {
+  /** Objective: what the task is trying to achieve. */
+  objective: string | null;
+  /** Key decisions made so far. */
+  decisions: string[];
+  /** Files changed so far in this session. */
+  changedFiles: string[];
+  /** Test results / status. */
+  tests: string | null;
+  /** Current blockers. */
+  blockers: string[];
+  /** Concrete next action for the continuation. */
+  nextAction: string | null;
+  /** Run IDs from prior runs in this session (for traceability). */
+  priorRunIds: string[];
 }

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -1,7 +1,9 @@
-// ---------------------------------------------------------------------------
+﻿// ---------------------------------------------------------------------------
 // Minimal adapter-facing interfaces (no drizzle dependency)
 // ---------------------------------------------------------------------------
 
+import type { CompactionDecision, FirstModelTokenTelemetry, ToolSchemaTelemetry } from "@paperclipai/shared";
+import type { RuntimePromptSectionSelection } from "./context-economy-wiring.js";
 import type { SshRemoteExecutionSpec } from "./ssh.js";
 import type { AdapterExecutionTarget } from "./execution-target.js";
 import type { RuntimeStatusSink } from "./runtime-progress.js";
@@ -74,6 +76,33 @@ export type AdapterExecutionErrorFamily =
   | "refresh_token_expired"
   | "refresh_token_invalidated";
 
+/**
+ * Structured per-run telemetry counters derived from adapter output events.
+ * Persisted on the heartbeat run record for observability, budget
+ * classification, and compaction decisions. Counters are computed deterministically
+ * from the adapter event stream (e.g. OpenCode JSONL); they are never estimated.
+ */
+export interface AdapterRunTelemetry {
+  /** Total tool invocations observed in the run output. */
+  toolCalls: number;
+  /** Tool invocations that ended in error status. */
+  failedToolCalls: number;
+  /** Adapter-reported retry count (e.g. session unknown retry). */
+  retryCount: number;
+  /** Tool invocations classified as search/grep/glob/read. */
+  searchCalls: number;
+  /** Tool invocations classified as file read operations. */
+  fileReads: number;
+  /** Tool invocations classified as file write/edit operations. */
+  fileWrites: number;
+  /** Tool invocations classified as test execution. */
+  testCalls: number;
+  /** Wall-clock ms from first event to first file-write tool call. */
+  timeToFirstWriteMs: number | null;
+  /** Wall-clock ms from first event to first test tool call. */
+  timeToFirstTestMs: number | null;
+}
+
 export interface AdapterExecutionResult {
   exitCode: number | null;
   signal: string | null;
@@ -88,7 +117,7 @@ export interface AdapterExecutionResult {
    * How `usage` totals are scoped. "per_run" means the tokens cover only this
    * execution; "session_cumulative" means they are running totals for the
    * persisted session, and the server must delta consecutive runs. Absent
-   * means unknown — the server applies its legacy session-delta heuristic.
+   * means unknown ÔÇö the server applies its legacy session-delta heuristic.
    */
   usageBasis?: "per_run" | "session_cumulative" | null;
   /**
@@ -120,6 +149,14 @@ export interface AdapterExecutionResult {
    */
   referencedProjectStagingFailures?: Array<{ projectId: string; error: string }>;
   summary?: string | null;
+  /**
+   * Structured per-run telemetry derived from adapter output events. Adapters
+   * that parse structured stdout (e.g. OpenCode JSONL) populate this with
+   * deterministic counters and timestamps; the server persists these into the
+   * heartbeat run record for observability and budget classification. Absent
+   * when the adapter does not emit structured telemetry events.
+   */
+  runTelemetry?: AdapterRunTelemetry | null;
   clearSession?: boolean;
   question?: {
     prompt: string;
@@ -131,6 +168,30 @@ export interface AdapterExecutionResult {
   } | null;
   /** Present only for a persisted native-mode run; legacy adapters omit it. */
   nativeFinalization?: NativeFinalizationResult;
+  /**
+   * Paperclip context-economy diagnostics for this run: narrowed managed-MCP
+   * set, derived tool-schema telemetry, first-model token telemetry, the
+   * Paperclip-controlled prompt-section selection, and the context-budget /
+   * compaction decision. Absent on runs where the control plane did not request
+   * economy instrumentation.
+   */
+  runContextDiagnostics?: RunContextDiagnostics | null;
+}
+
+/**
+ * Structured context-economy diagnostics surfaced on the execution result so the
+ * Paperclip control plane can persist them per run without re-deriving from the
+ * agent runtime.
+ */
+export interface RunContextDiagnostics {
+  mcpNarrowing?: {
+    droppedUnauthorized: string[];
+    droppedInactive: string[];
+  } | null;
+  tools?: ToolSchemaTelemetry | null;
+  firstModelTokens?: FirstModelTokenTelemetry | null;
+  promptSections?: RuntimePromptSectionSelection | null;
+  compaction?: CompactionDecision | null;
 }
 
 export interface AdapterSessionCodec {
@@ -358,7 +419,7 @@ export interface HireApprovedHookResult {
 }
 
 // ---------------------------------------------------------------------------
-// Quota window types — used by adapters that can report provider quota/rate-limit state
+// Quota window types ÔÇö used by adapters that can report provider quota/rate-limit state
 // ---------------------------------------------------------------------------
 
 /** a single rate-limit or usage window returned by a provider quota API */
@@ -391,7 +452,7 @@ export interface ProviderQuotaResult {
 }
 
 // ---------------------------------------------------------------------------
-// Adapter config schema — declarative UI config for external adapters
+// Adapter config schema ÔÇö declarative UI config for external adapters
 // ---------------------------------------------------------------------------
 
 export interface ConfigFieldOption {
@@ -410,7 +471,7 @@ export interface ConfigFieldSchema {
   hint?: string;
   required?: boolean;
   group?: string;
-  /** Optional metadata — not rendered, but available to custom UI logic */
+  /** Optional metadata ÔÇö not rendered, but available to custom UI logic */
   meta?: Record<string, unknown>;
 }
 
@@ -492,7 +553,7 @@ export interface ServerAdapterModule {
    * Optional: return a declarative config schema so the UI can render
    * adapter-specific form fields without shipping React components.
    * Dynamic options (e.g. scanning a profiles directory) should be
-   * resolved inside this method — the caller receives a fully hydrated schema.
+   * resolved inside this method ÔÇö the caller receives a fully hydrated schema.
    */
   getConfigSchema?: () => Promise<AdapterConfigSchema> | AdapterConfigSchema;
 
@@ -501,7 +562,7 @@ export interface ServerAdapterModule {
   //
   // These allow adapter plugins to declare what "local" capabilities they
   // support, replacing hardcoded type lists in the server and UI.
-  // All flags are optional — when undefined, the server falls back to
+  // All flags are optional ÔÇö when undefined, the server falls back to
   // legacy hardcoded lists for built-in adapters.
   // ---------------------------------------------------------------------------
 

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -1,4 +1,4 @@
-import fs from "node:fs/promises";
+﻿import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -130,8 +130,8 @@ export async function ensureRemoteOpenCodeModelConfiguredAndAvailable(input: {
   );
 
   // The remote availability probe is a best-effort pre-flight guard, not a gate.
-  // If `opencode models` itself cannot run on the target — timeout, transient CLI
-  // error, provider hiccup — do NOT abort the run. The real invocation is
+  // If `opencode models` itself cannot run on the target ÔÇö timeout, transient CLI
+  // error, provider hiccup ÔÇö do NOT abort the run. The real invocation is
   // authoritative, so a probe that can't execute must never be fatal. (Previously
   // these threw and crashed runs mid-flight, losing the agent's work + disposition.)
   if (probe.timedOut) {
@@ -708,6 +708,23 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           stderr: attempt.proc.stderr,
         },
         summary: attempt.parsed.summary,
+        // Structured per-run telemetry derived from OpenCode JSONL events. Always
+        // present when the adapter emits parseable events; mapped to the
+        // adapter-facing AdapterRunTelemetry shape (engine capability
+        // `supportedObservability` must be non-null for the acceptance contract).
+        runTelemetry: attempt.parsed.telemetry
+          ? {
+              toolCalls: attempt.parsed.telemetry.toolCalls,
+              failedToolCalls: attempt.parsed.telemetry.failedToolCalls,
+              retryCount: attempt.parsed.telemetry.retryCount,
+              searchCalls: attempt.parsed.telemetry.searchCalls,
+              fileReads: attempt.parsed.telemetry.fileReads,
+              fileWrites: attempt.parsed.telemetry.fileWrites,
+              testCalls: attempt.parsed.telemetry.testCalls,
+              timeToFirstWriteMs: attempt.parsed.telemetry.timeToFirstWriteMs,
+              timeToFirstTestMs: attempt.parsed.telemetry.timeToFirstTestMs,
+            }
+          : null,
         clearSession: Boolean(clearSessionOnMissingSession && !attempt.parsed.sessionId),
       };
     };

--- a/packages/adapters/opencode-local/src/server/parse.test.ts
+++ b/packages/adapters/opencode-local/src/server/parse.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+﻿import { describe, expect, it } from "vitest";
 import { parseOpenCodeJsonl, isOpenCodeUnknownSessionError } from "./parse.js";
 
 describe("parseOpenCodeJsonl", () => {
@@ -73,5 +73,47 @@ describe("parseOpenCodeJsonl", () => {
     expect(isOpenCodeUnknownSessionError("Session not found: s_123", "")).toBe(true);
     expect(isOpenCodeUnknownSessionError("", "unknown session id")).toBe(true);
     expect(isOpenCodeUnknownSessionError("all good", "")).toBe(false);
+  });
+
+  it("tracks structured telemetry counters", () => {
+    const base = { sessionID: "s1" };
+    const t0 = "2026-01-01T00:00:00.000Z";
+    const t1 = "2026-01-01T00:00:01.000Z";
+    const t2 = "2026-01-01T00:00:02.000Z";
+    const t3 = "2026-01-01T00:00:03.000Z";
+    const t4 = "2026-01-01T00:00:04.000Z";
+    const stdout = [
+      JSON.stringify({ ...base, type: "step_start", ts: t0 }),
+      JSON.stringify({ ...base, type: "tool_use", ts: t1, part: { tool: "grep", state: { status: "completed" } } }),
+      JSON.stringify({ ...base, type: "tool_use", ts: t2, part: { tool: "write", state: { status: "completed" } } }),
+      JSON.stringify({ ...base, type: "tool_use", ts: t3, part: { tool: "bash", state: { status: "error", error: "fail" } } }),
+      JSON.stringify({ ...base, type: "tool_use", ts: t4, part: { tool: "vitest", state: { status: "completed" } } }),
+    ].join("\n");
+
+    const parsed = parseOpenCodeJsonl(stdout);
+    const t = parsed.telemetry;
+    expect(t.toolCalls).toBe(4);
+    expect(t.failedToolCalls).toBe(1);
+    expect(t.searchCalls).toBe(1);
+    expect(t.fileWrites).toBe(1);
+    expect(t.bashCalls).toBe(1);
+    expect(t.testCalls).toBe(1);
+    expect(t.stepCount).toBe(1);
+    expect(t.timeToFirstWriteMs).toBe(2000);
+    expect(t.timeToFirstTestMs).toBe(4000);
+    expect(t.firstEventAt).toBe(t0);
+    expect(t.lastEventAt).toBe(t4);
+  });
+
+  it("returns null timeToFirstWriteMs when no write tools used", () => {
+    const stdout = [
+      JSON.stringify({ sessionID: "s1", type: "tool_use", ts: "2026-01-01T00:00:00.000Z", part: { tool: "grep", state: { status: "completed" } } }),
+    ].join("\n");
+
+    const parsed = parseOpenCodeJsonl(stdout);
+    expect(parsed.telemetry.timeToFirstWriteMs).toBeNull();
+    expect(parsed.telemetry.timeToFirstTestMs).toBeNull();
+    expect(parsed.telemetry.toolCalls).toBe(1);
+    expect(parsed.telemetry.searchCalls).toBe(1);
   });
 });

--- a/packages/adapters/opencode-local/src/server/parse.ts
+++ b/packages/adapters/opencode-local/src/server/parse.ts
@@ -1,4 +1,4 @@
-import { asNumber, asString, parseJson, parseObject } from "@paperclipai/adapter-utils/server-utils";
+﻿import { asNumber, asString, parseJson, parseObject } from "@paperclipai/adapter-utils/server-utils";
 
 function errorText(value: unknown): string {
   if (typeof value === "string") return value;
@@ -19,6 +19,37 @@ function errorText(value: unknown): string {
   }
 }
 
+const SEARCH_TOOL_PATTERNS = /^(grep|glob|rg|find|search|webfetch|web_search|codesearch)/i;
+const FILE_WRITE_TOOL_PATTERNS = /^(write|edit|create_file|write_file|str_replace_editor)/i;
+const FILE_READ_TOOL_PATTERNS = /^(read|view|cat|head|less|file_read)/i;
+const TEST_TOOL_PATTERNS = /^(test|pytest|vitest|jest|mocha|npm\s+test|run_test|run_tests)/i;
+const BASH_TOOL_PATTERNS = /^(bash|shell|exec|run_command|terminal|powershell)/i;
+
+function classifyToolName(toolName: string): "search" | "fileWrite" | "fileRead" | "test" | "bash" | "other" {
+  if (SEARCH_TOOL_PATTERNS.test(toolName)) return "search";
+  if (FILE_WRITE_TOOL_PATTERNS.test(toolName)) return "fileWrite";
+  if (FILE_READ_TOOL_PATTERNS.test(toolName)) return "fileRead";
+  if (TEST_TOOL_PATTERNS.test(toolName)) return "test";
+  if (BASH_TOOL_PATTERNS.test(toolName)) return "bash";
+  return "other";
+}
+
+export interface OpenCodeTelemetry {
+  toolCalls: number;
+  failedToolCalls: number;
+  retryCount: number;
+  searchCalls: number;
+  fileReads: number;
+  fileWrites: number;
+  testCalls: number;
+  bashCalls: number;
+  timeToFirstWriteMs: number | null;
+  timeToFirstTestMs: number | null;
+  firstEventAt: string | null;
+  lastEventAt: string | null;
+  stepCount: number;
+}
+
 export function parseOpenCodeJsonl(stdout: string) {
   let sessionId: string | null = null;
   const messages: string[] = [];
@@ -31,6 +62,26 @@ export function parseOpenCodeJsonl(stdout: string) {
   };
   let costUsd = 0;
 
+  const telemetry: OpenCodeTelemetry = {
+    toolCalls: 0,
+    failedToolCalls: 0,
+    retryCount: 0,
+    searchCalls: 0,
+    fileReads: 0,
+    fileWrites: 0,
+    testCalls: 0,
+    bashCalls: 0,
+    timeToFirstWriteMs: null,
+    timeToFirstTestMs: null,
+    firstEventAt: null,
+    lastEventAt: null,
+    stepCount: 0,
+  };
+
+  let firstEventTs: number | null = null;
+  let firstWriteTs: number | null = null;
+  let firstTestTs: number | null = null;
+
   for (const rawLine of stdout.split(/\r?\n/)) {
     const line = rawLine.trim();
     if (!line) continue;
@@ -42,11 +93,21 @@ export function parseOpenCodeJsonl(stdout: string) {
     if (currentSessionId) sessionId = currentSessionId;
 
     const type = asString(event.type, "");
+    const eventTs = typeof event.ts === "string" ? Date.parse(event.ts) : NaN;
+    if (Number.isFinite(eventTs)) {
+      if (firstEventTs === null) firstEventTs = eventTs;
+      telemetry.lastEventAt = new Date(eventTs).toISOString();
+    }
 
     if (type === "text") {
       const part = parseObject(event.part);
       const text = asString(part.text, "").trim();
       if (text) messages.push(text);
+      continue;
+    }
+
+    if (type === "step_start") {
+      telemetry.stepCount += 1;
       continue;
     }
 
@@ -63,8 +124,30 @@ export function parseOpenCodeJsonl(stdout: string) {
 
     if (type === "tool_use") {
       const part = parseObject(event.part);
+      const toolName = asString(part.tool, "tool");
       const state = parseObject(part.state);
-      if (asString(state.status, "") === "error") {
+      const status = asString(state.status, "");
+      const category = classifyToolName(toolName);
+
+      telemetry.toolCalls += 1;
+      if (category === "search") telemetry.searchCalls += 1;
+      if (category === "fileRead") telemetry.fileReads += 1;
+      if (category === "fileWrite") {
+        telemetry.fileWrites += 1;
+        if (firstWriteTs === null && Number.isFinite(eventTs)) {
+          firstWriteTs = eventTs;
+        }
+      }
+      if (category === "test") {
+        telemetry.testCalls += 1;
+        if (firstTestTs === null && Number.isFinite(eventTs)) {
+          firstTestTs = eventTs;
+        }
+      }
+      if (category === "bash") telemetry.bashCalls += 1;
+
+      if (status === "error") {
+        telemetry.failedToolCalls += 1;
         const text = asString(state.error, "").trim();
         if (text) toolErrors.push(text);
       }
@@ -78,6 +161,16 @@ export function parseOpenCodeJsonl(stdout: string) {
     }
   }
 
+  if (firstEventTs !== null) {
+    telemetry.firstEventAt = new Date(firstEventTs).toISOString();
+  }
+  if (firstWriteTs !== null && firstEventTs !== null) {
+    telemetry.timeToFirstWriteMs = firstWriteTs - firstEventTs;
+  }
+  if (firstTestTs !== null && firstEventTs !== null) {
+    telemetry.timeToFirstTestMs = firstTestTs - firstEventTs;
+  }
+
   return {
     sessionId,
     summary: messages.join("\n\n").trim(),
@@ -85,6 +178,7 @@ export function parseOpenCodeJsonl(stdout: string) {
     costUsd,
     errorMessage: errors.length > 0 ? errors.join("\n") : null,
     toolErrors,
+    telemetry,
   };
 }
 

--- a/server/src/services/rtb-execution-control.test.ts
+++ b/server/src/services/rtb-execution-control.test.ts
@@ -1,0 +1,222 @@
+﻿import { describe, expect, it } from "vitest";
+import {
+  buildCompactContinuationPrompt,
+  decideWatchdogTick,
+  deriveStructuredRunMetrics,
+  evaluateRunBudget,
+  MAX_AUTO_RECOVERIES,
+  MAX_COMPACT_CONTINUATION_CHARS,
+  RUN_BUDGET_BY_PROFILE,
+  shouldOpenNewMetaIssue,
+  type RunTelemetryEvent,
+} from "./rtb-execution-control.js";
+
+describe("decideWatchdogTick ÔÇö RTB no-meta-issue + bounded lifecycle (KOMAA-166 A/B, acceptance #2/#3)", () => {
+  it("idle / not_applicable => no model, no meta-issue, no action", () => {
+    const decision = decideWatchdogTick({
+      severity: "ok",
+      priorRecoveryCount: 0,
+      livenessProgress: false,
+      openMetaIssueExists: false,
+    });
+    expect(decision.invokeModel).toBe(false);
+    expect(decision.createMetaIssue).toBe(false);
+    expect(decision.action).toBe("none");
+  });
+
+  it("suspicious tick => zero model invocations, zero new meta-issue (state-only)", () => {
+    const decision = decideWatchdogTick({
+      severity: "suspicious",
+      priorRecoveryCount: 0,
+      livenessProgress: false,
+      openMetaIssueExists: false,
+    });
+    expect(decision.invokeModel).toBe(false);
+    expect(decision.createMetaIssue).toBe(false);
+    expect(decision.action).toBe("state_only");
+  });
+
+  it("3 consecutive suspicious ticks for the same source => 0 meta-issues, 0 model, no duplicates", () => {
+    let openMetaIssueExists = false;
+    for (let tick = 0; tick < 3; tick += 1) {
+      const decision = decideWatchdogTick({
+        severity: "suspicious",
+        priorRecoveryCount: 0,
+        livenessProgress: false,
+        openMetaIssueExists,
+      });
+      expect(decision.invokeModel).toBe(false);
+      expect(decision.createMetaIssue).toBe(false);
+    }
+    // Idempotency guard: while no meta-issue exists the guard *permits* opening
+    // the first one, but the RTB default (allowMetaIssue=false) means
+    // decideWatchdogTick never requests it. Once one exists, the guard refuses a
+    // duplicate — so across the 3 ticks we never open a second meta-issue.
+    expect(shouldOpenNewMetaIssue(false)).toBe(true);
+    expect(shouldOpenNewMetaIssue(true)).toBe(false);
+  });
+
+  it("critical with confirmed liveness => single bounded recovery, no meta-issue by default", () => {
+    const decision = decideWatchdogTick({
+      severity: "critical",
+      priorRecoveryCount: 0,
+      livenessProgress: true,
+      openMetaIssueExists: false,
+    });
+    expect(decision.action).toBe("recover");
+    expect(decision.invokeModel).toBe(false);
+    expect(decision.createMetaIssue).toBe(false);
+  });
+
+  it("critical without liveness => terminalize (bounded lifecycle)", () => {
+    const decision = decideWatchdogTick({
+      severity: "critical",
+      priorRecoveryCount: 0,
+      livenessProgress: false,
+      openMetaIssueExists: false,
+    });
+    expect(decision.action).toBe("terminalize");
+    expect(decision.createMetaIssue).toBe(false);
+  });
+
+  it("critical after MAX_AUTO_RECOVERIES => terminalize, never a second recovery", () => {
+    const decision = decideWatchdogTick({
+      severity: "critical",
+      priorRecoveryCount: MAX_AUTO_RECOVERIES,
+      livenessProgress: true,
+      openMetaIssueExists: false,
+    });
+    expect(decision.action).toBe("terminalize");
+    expect(decision.invokeModel).toBe(false);
+  });
+
+  it("recovery budget is exactly one (max 1 automatic recovery)", () => {
+    expect(MAX_AUTO_RECOVERIES).toBe(1);
+  });
+});
+
+describe("shouldOpenNewMetaIssue ÔÇö idempotent meta-issue guard (acceptance #3)", () => {
+  it("returns false when a meta-issue is already open for the source", () => {
+    expect(shouldOpenNewMetaIssue(true)).toBe(false);
+  });
+  it("returns true only when no meta-issue exists and legacy path is taken", () => {
+    expect(shouldOpenNewMetaIssue(false)).toBe(true);
+  });
+});
+
+describe("evaluateRunBudget ÔÇö mechanical model-call budget + compaction (KOMAA-166 C, acceptance #4)", () => {
+  it("within budget => no compaction", () => {
+    const result = evaluateRunBudget({ modelCalls: RUN_BUDGET_BY_PROFILE.normal });
+    expect(result.exceeded).toBe(false);
+    expect(result.strategy).toBe("within");
+  });
+
+  it("over budget with small cached replay => compact continuation", () => {
+    const result = evaluateRunBudget({ modelCalls: RUN_BUDGET_BY_PROFILE.normal + 1, cachedInputTokens: 10_000 });
+    expect(result.exceeded).toBe(true);
+    expect(result.strategy).toBe("compact");
+  });
+
+  it("over budget with huge cached replay => fork instead of full replay", () => {
+    const result = evaluateRunBudget({
+      modelCalls: RUN_BUDGET_BY_PROFILE.normal + 1,
+      cachedInputTokens: 3_000_000,
+    });
+    expect(result.exceeded).toBe(true);
+    expect(result.strategy).toBe("fork");
+  });
+
+  it("debug/complex profiles use their own limits", () => {
+    expect(evaluateRunBudget({ modelCalls: 5 }, "debug").exceeded).toBe(false);
+    expect(evaluateRunBudget({ modelCalls: 7 }, "complex").exceeded).toBe(false);
+    expect(evaluateRunBudget({ modelCalls: 9 }, "complex").exceeded).toBe(true);
+  });
+});
+
+describe("buildCompactContinuationPrompt ÔÇö bounded continuation context (acceptance #4)", () => {
+  const ctx = {
+    objective: "Ship RTB execution control",
+    decisions: ["A1", "A2"],
+    changedFiles: ["server/src/services/rtb-execution-control.ts"],
+    tests: ["rtb-execution-control.test.ts"],
+    blockers: ["none"],
+    nextAction: "Wire decideWatchdogTick into recovery service",
+    runtimeIds: { runId: "run_123", workspaceId: "ws_456" },
+  };
+
+  it("preserves objective/decisions/files/tests/blockers/next action and runtime ids", () => {
+    const prompt = buildCompactContinuationPrompt(ctx);
+    expect(prompt).toContain("OBJECTIVE:");
+    expect(prompt).toContain("DECISIONS:");
+    expect(prompt).toContain("CHANGED FILES:");
+    expect(prompt).toContain("TESTS:");
+    expect(prompt).toContain("BLOCKERS:");
+    expect(prompt).toContain("NEXT ACTION:");
+    expect(prompt).toContain("RUNTIME IDS:");
+    expect(prompt).toContain("run_123");
+  });
+
+  it("is always bounded to MAX_COMPACT_CONTINUATION_CHARS", () => {
+    const huge = { ...ctx, objective: "x".repeat(10_000), decisions: ["y".repeat(10_000)] };
+    const prompt = buildCompactContinuationPrompt(huge);
+    expect(prompt.length).toBeLessThanOrEqual(MAX_COMPACT_CONTINUATION_CHARS);
+    expect(prompt).toContain("[truncated to bounded size]");
+  });
+});
+
+describe("deriveStructuredRunMetrics ÔÇö persisted structured telemetry (KOMAA-166 D, acceptance #5)", () => {
+  const start = 1_000_000;
+  const events: RunTelemetryEvent[] = [
+    { eventType: "tool_call", timestamp: start + 100, ok: true },
+    { eventType: "tool_call", timestamp: start + 200, ok: false },
+    { eventType: "tool_call", timestamp: start + 300, ok: true },
+    { eventType: "tool_error", timestamp: start + 350 },
+    { eventType: "retry", timestamp: start + 400 },
+    { eventType: "retry", timestamp: start + 450 },
+    { eventType: "search", timestamp: start + 500 },
+    { eventType: "file_read", timestamp: start + 600 },
+    { eventType: "file_read", timestamp: start + 650 },
+    { eventType: "file_write", timestamp: start + 1000 },
+    { eventType: "test", timestamp: start + 2000 },
+    { eventType: "model_call", timestamp: start + 50 },
+  ];
+
+  it("derives all required counters/timestamps non-null and consistent with events", () => {
+    const metrics = deriveStructuredRunMetrics({
+      events,
+      runStartedAt: start,
+      usage: { inputTokens: 10 },
+      durationMs: 5000,
+      provider: "opencode_local",
+      model: "mimo-v2.5",
+    });
+
+    expect(metrics.toolCalls).toBe(3);
+    expect(metrics.failedToolCalls).toBe(2); // one tool_call ok:false + one tool_error
+    expect(metrics.retryCount).toBe(2);
+    expect(metrics.searchCalls).toBe(1);
+    expect(metrics.fileReads).toBe(2);
+    expect(metrics.fileWrites).toBe(1);
+    expect(metrics.testCalls).toBe(1);
+    expect(metrics.timeToFirstWriteMs).toBe(1000);
+    expect(metrics.timeToFirstTestMs).toBe(2000);
+    expect(metrics.derived).toBe(true);
+    expect(metrics.unsupported).toEqual([]);
+    expect(metrics.provider).toBe("opencode_local");
+    expect(metrics.model).toBe("mimo-v2.5");
+    expect(metrics.usage).toEqual({ inputTokens: 10 });
+    expect(metrics.durationMs).toBe(5000);
+  });
+
+  it("reports null timestamps when no write/test events occurred (never estimated)", () => {
+    const metrics = deriveStructuredRunMetrics({
+      events: [{ eventType: "tool_call", timestamp: start + 10, ok: true }],
+      runStartedAt: start,
+    });
+    expect(metrics.toolCalls).toBe(1);
+    expect(metrics.timeToFirstWriteMs).toBeNull();
+    expect(metrics.timeToFirstTestMs).toBeNull();
+    expect(metrics.derived).toBe(true);
+    expect(metrics.unsupported).toEqual([]);
+  });
+});

--- a/server/src/services/rtb-execution-control.ts
+++ b/server/src/services/rtb-execution-control.ts
@@ -1,0 +1,383 @@
+﻿/**
+ * RTB execution control ÔÇö bounded lifecycle, compaction, and structured telemetry.
+ *
+ * This module implements the decision logic required by KOMAA-166 (P0 RTB
+ * EXECUTION CONTROL) as pure, framework-free functions so they can be unit
+ * tested with fault injection and wired into the heartbeat/recovery paths
+ * without changing existing call-site types.
+ *
+ * It deliberately does NOT create meta-issues (stale_active_run_evaluation /
+ * issue_productivity_review) for the RTB default: detection updates persisted
+ * watchdog/execution state and emits an event/comment only when needed. A new
+ * issue is created only for an independent deliverable or via the explicit
+ * opt-in legacy path.
+ */
+
+export type RunBudgetProfile = "normal" | "debug" | "complex";
+
+/** Per-source-issue model-call budget guardrails (KOMAA-166 C). */
+export const RUN_BUDGET_BY_PROFILE: Readonly<Record<RunBudgetProfile, number>> = {
+  normal: 4,
+  debug: 6,
+  complex: 8,
+};
+
+export const DEFAULT_RUN_BUDGET_PROFILE: RunBudgetProfile = "normal";
+
+/** Maximum automatic recovery continuations for a single silent/stalled run. */
+export const MAX_AUTO_RECOVERIES = 1;
+
+/** If cached-input replay exceeds this, fork instead of compact (KOMAA-166 C). */
+export const COMPACT_FORK_CACHED_INPUT_THRESHOLD = 2_000_000;
+
+/** Output-silence thresholds in ms (KOMAA-166 B). */
+export const DEFAULT_SUSPICION_THRESHOLD_MS = 60 * 60 * 1000;
+export const DEFAULT_CRITICAL_THRESHOLD_MS = 4 * 60 * 60 * 1000;
+
+/** Bounded size for a compacted continuation prompt (KOMAA-166 C). */
+export const MAX_COMPACT_CONTINUATION_CHARS = 4000;
+
+export type WatchdogSeverity = "ok" | "suspicious" | "critical" | "not_applicable";
+
+export type WatchdogAction =
+  | "none" // ok / not_applicable: do nothing
+  | "state_only" // suspicious: persisted state/event only, no model, no meta-issue
+  | "terminalize" // critical + no progress / budget exhausted: cancel run
+  | "recover"; // critical + liveness confirmed: single bounded recovery
+
+export interface WatchdogTickInput {
+  severity: WatchdogSeverity;
+  /** Automatic recovery continuations already performed for this run. */
+  priorRecoveryCount: number;
+  /** Process/orphan liveness still shows the run making progress. */
+  livenessProgress: boolean;
+  /** An open meta-issue (stale_active_run_evaluation / issue_productivity_review) already exists for the source. */
+  openMetaIssueExists: boolean;
+  /** Opt-in legacy path; RTB default is false (no meta-issue churn). */
+  allowMetaIssue?: boolean;
+}
+
+export interface WatchdogDecision {
+  severity: WatchdogSeverity;
+  invokeModel: boolean;
+  createMetaIssue: boolean;
+  action: WatchdogAction;
+  reason: string;
+}
+
+/**
+ * Decide what a single watchdog tick should do for a run.
+ *
+ * Invariants (KOMAA-166 A/B, acceptance #2/#3):
+ *  - ok / not_applicable => no model, no meta-issue.
+ *  - suspicious => persisted state only; zero model invocations, zero new meta-issue.
+ *  - critical => at most ONE automatic recovery; otherwise terminalize.
+ *  - meta-issue creation is disabled by default (RTB no-meta-issue churn).
+ */
+export function decideWatchdogTick(input: WatchdogTickInput): WatchdogDecision {
+  const { severity, priorRecoveryCount, livenessProgress, openMetaIssueExists, allowMetaIssue } = input;
+
+  if (severity === "ok" || severity === "not_applicable") {
+    return {
+      severity,
+      invokeModel: false,
+      createMetaIssue: false,
+      action: "none",
+      reason: "within thresholds or not applicable",
+    };
+  }
+
+  if (severity === "suspicious") {
+    return {
+      severity,
+      invokeModel: false,
+      createMetaIssue: false,
+      action: "state_only",
+      reason: "suspicious: persisted state/event only; no model, no meta-issue",
+    };
+  }
+
+  // severity === "critical"
+  if (priorRecoveryCount >= MAX_AUTO_RECOVERIES) {
+    return {
+      severity,
+      invokeModel: false,
+      createMetaIssue: false,
+      action: "terminalize",
+      reason: "critical: automatic recovery budget exhausted; terminalize run",
+    };
+  }
+
+  if (!livenessProgress) {
+    return {
+      severity,
+      invokeModel: false,
+      createMetaIssue: false,
+      action: "terminalize",
+      reason: "critical: no process liveness/progress; terminalize run",
+    };
+  }
+
+  const createMetaIssue = Boolean(allowMetaIssue) && !openMetaIssueExists;
+  return {
+    severity,
+    invokeModel: false,
+    createMetaIssue,
+    action: "recover",
+    reason: createMetaIssue
+      ? "critical: liveness confirmed; single bounded recovery + legacy meta-issue"
+      : "critical: liveness confirmed; single bounded recovery, no meta-issue",
+  };
+}
+
+/**
+ * Idempotency guard for meta-issue creation (KOMAA-166 A, acceptance #3).
+ * Never open a new stale_active_run_evaluation / issue_productivity_review when
+ * one is already open for the same source.
+ */
+export function shouldOpenNewMetaIssue(openMetaIssueExists: boolean): boolean {
+  return !openMetaIssueExists;
+}
+
+export type BudgetStrategy = "within" | "compact" | "fork" | "block";
+
+export interface RunBudgetUsage {
+  modelCalls: number;
+  /** Cached-input tokens of the latest replay; used to pick fork vs compact. */
+  cachedInputTokens?: number;
+}
+
+export interface BudgetEvaluation {
+  profile: RunBudgetProfile;
+  limit: number;
+  used: number;
+  exceeded: boolean;
+  strategy: BudgetStrategy;
+  reason: string;
+}
+
+/**
+ * Evaluate the per-source-issue model-call budget (KOMAA-166 C, acceptance #4).
+ * On breach, choose a compact (bounded) or fork continuation instead of a full
+ * replay. Never silently launches another unbounded heartbeat.
+ */
+export function evaluateRunBudget(
+  usage: RunBudgetUsage,
+  profile: RunBudgetProfile = DEFAULT_RUN_BUDGET_PROFILE,
+): BudgetEvaluation {
+  const limit = RUN_BUDGET_BY_PROFILE[profile];
+  const used = usage.modelCalls;
+
+  if (used <= limit) {
+    return { profile, limit, used, exceeded: false, strategy: "within", reason: "within budget" };
+  }
+
+  const cached = usage.cachedInputTokens ?? 0;
+  const strategy: BudgetStrategy = cached > COMPACT_FORK_CACHED_INPUT_THRESHOLD ? "fork" : "compact";
+  return {
+    profile,
+    limit,
+    used,
+    exceeded: true,
+    strategy,
+    reason: `model-call budget exceeded (${used}/${limit}); ${strategy} continuation`,
+  };
+}
+
+export interface ContinuationContext {
+  objective: string;
+  decisions: string[];
+  changedFiles: string[];
+  tests: string[];
+  blockers: string[];
+  nextAction: string;
+  runtimeIds?: Record<string, string>;
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}\nÔÇŽ[truncated]` : value;
+}
+
+/**
+ * Build a bounded continuation prompt that preserves only the objective,
+ * decisions, changed files, tests, blockers, next action and essential runtime
+ * IDs (KOMAA-166 C, acceptance #4). The result is always truncated to
+ * MAX_COMPACT_CONTINUATION_CHARS so a continuation never replays the full
+ * multi-million-token context.
+ */
+export function buildCompactContinuationPrompt(ctx: ContinuationContext): string {
+  const sections: string[] = [];
+  sections.push(`OBJECTIVE:\n${truncate(ctx.objective, 800)}`);
+  sections.push(`DECISIONS:\n${ctx.decisions.map((d) => `- ${d}`).join("\n") || "- (none)"}`);
+  sections.push(`CHANGED FILES:\n${ctx.changedFiles.map((f) => `- ${f}`).join("\n") || "- (none)"}`);
+  sections.push(`TESTS:\n${ctx.tests.map((t) => `- ${t}`).join("\n") || "- (none)"}`);
+  sections.push(`BLOCKERS:\n${ctx.blockers.map((b) => `- ${b}`).join("\n") || "- (none)"}`);
+  sections.push(`NEXT ACTION:\n${ctx.nextAction}`);
+  if (ctx.runtimeIds && Object.keys(ctx.runtimeIds).length > 0) {
+    sections.push(`RUNTIME IDS:\n${Object.entries(ctx.runtimeIds).map(([k, v]) => `- ${k}=${v}`).join("\n")}`);
+  }
+
+  let out = sections.join("\n\n");
+  const suffix = "\nÔÇŽ[truncated to bounded size]";
+  if (out.length > MAX_COMPACT_CONTINUATION_CHARS) {
+    out = `${out.slice(0, Math.max(0, MAX_COMPACT_CONTINUATION_CHARS - suffix.length))}${suffix}`;
+  }
+  return out;
+}
+
+export type RunTelemetryEventType =
+  | "tool_call"
+  | "tool_result"
+  | "tool_error"
+  | "search"
+  | "file_read"
+  | "file_write"
+  | "test"
+  | "retry"
+  | "model_call";
+
+export interface RunTelemetryEvent {
+  eventType: RunTelemetryEventType;
+  /** Epoch milliseconds. */
+  timestamp: number;
+  /** Success flag for tool_call / tool_result style events. */
+  ok?: boolean;
+}
+
+export interface StructuredRunMetrics {
+  toolCalls: number;
+  failedToolCalls: number;
+  retryCount: number;
+  searchCalls: number;
+  fileReads: number;
+  fileWrites: number;
+  testCalls: number;
+  timeToFirstWriteMs: number | null;
+  timeToFirstTestMs: number | null;
+  usage: Record<string, unknown> | null;
+  durationMs: number | null;
+  provider: string | null;
+  model: string | null;
+  /** True when counters were derived from persisted events rather than estimated. */
+  derived: boolean;
+  /** Fields the engine does not support, each with a reason. */
+  unsupported: string[];
+}
+
+export interface DeriveTelemetryInput {
+  events: RunTelemetryEvent[];
+  /** Epoch milliseconds when the run started. */
+  runStartedAt: number;
+  usage?: Record<string, unknown> | null;
+  durationMs?: number | null;
+  provider?: string | null;
+  model?: string | null;
+}
+
+/**
+ * Derive structured execution telemetry from persisted run events
+ * (KOMAA-166 D, acceptance #5). Counters are computed from the event stream and
+ * are never estimated. `usage`/`duration`/`provider`/`model` are passed through
+ * from the existing public run metrics.
+ */
+export function deriveStructuredRunMetrics(input: DeriveTelemetryInput): StructuredRunMetrics {
+  const { events, runStartedAt } = input;
+
+  let toolCalls = 0;
+  let failedToolCalls = 0;
+  let retryCount = 0;
+  let searchCalls = 0;
+  let fileReads = 0;
+  let fileWrites = 0;
+  let testCalls = 0;
+  let firstWriteTs: number | null = null;
+  let firstTestTs: number | null = null;
+
+  for (const e of events) {
+    switch (e.eventType) {
+      case "tool_call":
+        toolCalls += 1;
+        if (e.ok === false) failedToolCalls += 1;
+        break;
+      case "tool_error":
+        failedToolCalls += 1;
+        break;
+      case "retry":
+        retryCount += 1;
+        break;
+      case "search":
+        searchCalls += 1;
+        break;
+      case "file_read":
+        fileReads += 1;
+        break;
+      case "file_write":
+        fileWrites += 1;
+        if (firstWriteTs === null) firstWriteTs = e.timestamp;
+        break;
+      case "test":
+        testCalls += 1;
+        if (firstTestTs === null) firstTestTs = e.timestamp;
+        break;
+      case "tool_result":
+      case "model_call":
+      default:
+        break;
+    }
+  }
+
+  return {
+    toolCalls,
+    failedToolCalls,
+    retryCount,
+    searchCalls,
+    fileReads,
+    fileWrites,
+    testCalls,
+    timeToFirstWriteMs: firstWriteTs === null ? null : firstWriteTs - runStartedAt,
+    timeToFirstTestMs: firstTestTs === null ? null : firstTestTs - runStartedAt,
+    usage: input.usage ?? null,
+    durationMs: input.durationMs ?? null,
+    provider: input.provider ?? null,
+    model: input.model ?? null,
+    derived: true,
+    unsupported: [],
+  };
+}
+
+/**
+ * Map a persisted `heartbeat_run_events` row into a normalized telemetry event.
+ * Returns null for rows that do not carry a recognized telemetry signal, so a
+ * missing adapter mapping degrades gracefully instead of corrupting metrics.
+ */
+export function normalizeHeartbeatRunEvent(row: {
+  eventType: string;
+  payload?: Record<string, unknown> | null;
+  createdAt: Date | string | number;
+}): RunTelemetryEvent | null {
+  const timestamp =
+    row.createdAt instanceof Date
+      ? row.createdAt.getTime()
+      : typeof row.createdAt === "string" || typeof row.createdAt === "number"
+        ? new Date(row.createdAt).getTime()
+        : NaN;
+  if (Number.isNaN(timestamp)) return null;
+
+  const type = row.eventType;
+  const payload = row.payload ?? {};
+
+  switch (type) {
+    case "tool_call":
+    case "tool_error":
+    case "tool_result":
+    case "search":
+    case "file_read":
+    case "file_write":
+    case "test":
+    case "retry":
+    case "model_call":
+      return { eventType: type, timestamp, ok: payload.ok === false ? false : undefined };
+    default:
+      return null;
+  }
+}


### PR DESCRIPTION
Ports the proven KOMAA-167 RTB execution control mechanisms onto current master (isolated worktree from origin/master 1955b0e2d).

- server/src/services/rtb-execution-control.ts (+test): framework-free decideWatchdogTick / evaluateRunBudget / buildCompactContinuationPrompt / deriveStructuredRunMetrics / normalizeHeartbeatRunEvent (RTB no-meta-issue default, bounded lifecycle, structured telemetry). 17/17 unit tests pass in source branch.
- packages/adapter-utils/src/session-compaction.ts: port ExecutionBudgetPolicy, classifyTaskComplexity, resolveExecutionBudget, CompactionContinuationState.
- packages/adapter-utils/src/types.ts: add AdapterRunTelemetry interface and runTelemetry field on AdapterExecutionResult.
- packages/adapters/opencode-local/src/server/parse.ts: parse structured OpenCode JSONL telemetry.
- execute.ts: wire parsed runTelemetry into AdapterExecutionResult.

Verification: node checks pass, decideWatchdogTick suspicious=>state_only no model no meta-issue.

Remaining activation (watchdog meta-issue suppression wiring, worktree lease/liveness, durable reconciliation, budget activation, supportedObservability) documented for next atomic step.

Fixes KOMAA-183 (partial core port, isolated worktree, no direct write to main).