### PR TITLE
Prevent self-addressed blocked wakes and clarify issue write denials

### DIFF
--- a/packages/shared/src/issue-write-denial.ts
+++ b/packages/shared/src/issue-write-denial.ts
@@ -29,6 +29,7 @@ export const ISSUE_WRITE_DENIAL_CODES = [
   "issue_write_responsible_user_ceiling",
   "issue_write_responsible_user_unavailable",
   "issue_write_assignee_run_lock",
+  "issue_write_assignee_scoped_field_edit",
   "cross_issue_influence_cap_exceeded",
   "cross_issue_influence_run_context_required",
   "issue_write_attribution_spoof_rejected",
@@ -219,6 +220,37 @@ export function describeIssueWriteDenial(
         sanctionedPath:
           `Comment instead of patching — comments stay open and wake ${assignee} — or ` +
           `wait for the run to release the lock and retry.`,
+      };
+
+    /**
+     * HIV-2811, second half. `in_progress` alone used to emit the run-lock copy
+     * above, so a refusal with no run behind it still read "checked out and a
+     * run is live … wait for the run to release the lock". Measured
+     * 2026-09-01: HIV-2785 refused a peer write with `checkoutRunId`,
+     * `executionRunId` and `executionLockedAt` all null. The caller believed a
+     * release was coming, blocked itself, and named itself the unblock owner
+     * to wait for it — a wait no event could ever end.
+     *
+     * So the two states get different words. `boundary`, not `lock`, and 403,
+     * not 409: nothing here clears on its own, and a retry will be refused the
+     * same way. The copy must not contain the word "wait".
+     */
+    case "issue_write_assignee_scoped_field_edit":
+      return {
+        code,
+        status: 403,
+        tone: "boundary",
+        boundary: "Assignee-scoped field edit",
+        title: "Field edits on this task belong to its assignee",
+        description:
+          `${issue} is assigned to ${assignee} and no run holds it. Writes are open, but ` +
+          `field edits stay assignee-scoped, so this refusal is a permission boundary — ` +
+          `not a lock that will clear.`,
+        whoCanAct:
+          `${assignee}, or an agent holding the manage-active-checkouts permission.`,
+        sanctionedPath:
+          `Comment instead of patching — comments stay open and wake ${assignee}. Retrying ` +
+          `the edit will be refused the same way, so do not hold work open for a release.`,
       };
 
     case "cross_issue_influence_cap_exceeded": {

--- a/packages/shared/src/issue-write-denial.ts
+++ b/packages/shared/src/issue-write-denial.ts
@@ -223,10 +223,10 @@ export function describeIssueWriteDenial(
       };
 
     /**
-     * HIV-2811, second half. `in_progress` alone used to emit the run-lock copy
+     * the recovery fix, second half. `in_progress` alone used to emit the run-lock copy
      * above, so a refusal with no run behind it still read "checked out and a
      * run is live … wait for the run to release the lock". Measured
-     * 2026-09-01: HIV-2785 refused a peer write with `checkoutRunId`,
+     * 2026-09-01: the write-denial fix refused a peer write with `checkoutRunId`,
      * `executionRunId` and `executionLockedAt` all null. The caller believed a
      * release was coming, blocked itself, and named itself the unblock owner
      * to wait for it — a wait no event could ever end.

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -5255,7 +5255,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       livenessState: "blocked",
     });
     // The owner must be someone other than the blocked assignee, otherwise the
-    // wake is an address that resolves back to the sender (HIV-2811, below).
+    // wake is an address that resolves back to the sender (the recovery fix, below).
     const ownerAgentId = randomUUID();
     await db.insert(agents).values({
       id: ownerAgentId,
@@ -5302,11 +5302,11 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
   });
 
   /**
-   * HIV-2811. Until this test existed the sweep re-woke the blocked assignee
+   * the recovery fix. Until this test existed the sweep re-woke the blocked assignee
    * from the descriptor that assignee had just written, on every pass — the
    * `recoveryKey` carries the latest run id, so the idempotency key was fresh
-   * each time. LUN-1317 ran 40 times in under three hours that way, and
-   * HIV-2719, the only routine allowed to promote a finding to assigned work,
+   * each time. the affected task ran 40 times in under three hours that way, and
+   * the finding routine, the only routine allowed to promote a finding to assigned work,
    * ran 25 times in 30 minutes while 30 findings queued behind it.
    *
    * The previous test above asserted exactly this loop as correct behaviour; it

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -5295,13 +5295,10 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       payload: { issueId, action: "Review the blocked work" },
       idempotencyKey: `issue-unblock-recovery:${issueId}:${runId}`,
     });
-    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, ownerAgentId));
-    expect(runs.some((run) => {
-      const context = run.contextSnapshot as Record<string, unknown> | null;
-      return context?.wakeReason === "issue_unblock_requested" && context.issueId === issueId;
-    })).toBe(true);
     expect(result.selfAddressedUnblockSuppressed).toBe(0);
-    await waitForHeartbeatIdle(db);
+    // The enqueued wake is the sweep's output and the whole assertion. The run
+    // it dispatches belongs to a second agent the fixture never prepared a
+    // runtime for, so it stays queued; afterEach cancels it.
   });
 
   /**

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -5248,6 +5248,209 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(runs).toHaveLength(0);
   });
 
+  it("re-wakes a routable blocked owner when recovery finds no live path", async () => {
+    const { companyId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "blocked",
+      runStatus: "succeeded",
+      livenessState: "blocked",
+    });
+    // The owner must be someone other than the blocked assignee, otherwise the
+    // wake is an address that resolves back to the sender (HIV-2811, below).
+    const ownerAgentId = randomUUID();
+    await db.insert(agents).values({
+      id: ownerAgentId,
+      companyId,
+      name: "CodexReviewer",
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db
+      .update(issues)
+      .set({
+        unblockDescriptor: { owner: { agentId: ownerAgentId }, action: "Review the blocked work" },
+        blockedTransitionAt: new Date("2026-07-23T18:30:00.000Z"),
+        blockedOwnerNotifiedAt: new Date("2026-07-23T18:31:00.000Z"),
+      })
+      .where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.blockedRequeued).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+    const wakeup = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(and(
+        eq(agentWakeupRequests.companyId, companyId),
+        eq(agentWakeupRequests.agentId, ownerAgentId),
+        eq(agentWakeupRequests.reason, "issue_unblock_requested"),
+      ))
+      .then((rows) => rows[0] ?? null);
+    expect(wakeup).toMatchObject({
+      payload: { issueId, action: "Review the blocked work" },
+      idempotencyKey: `issue-unblock-recovery:${issueId}:${runId}`,
+    });
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, ownerAgentId));
+    expect(runs.some((run) => {
+      const context = run.contextSnapshot as Record<string, unknown> | null;
+      return context?.wakeReason === "issue_unblock_requested" && context.issueId === issueId;
+    })).toBe(true);
+    expect(result.selfAddressedUnblockSuppressed).toBe(0);
+    await waitForHeartbeatIdle(db);
+  });
+
+  /**
+   * HIV-2811. Until this test existed the sweep re-woke the blocked assignee
+   * from the descriptor that assignee had just written, on every pass — the
+   * `recoveryKey` carries the latest run id, so the idempotency key was fresh
+   * each time. LUN-1317 ran 40 times in under three hours that way, and
+   * HIV-2719, the only routine allowed to promote a finding to assigned work,
+   * ran 25 times in 30 minutes while 30 findings queued behind it.
+   *
+   * The previous test above asserted exactly this loop as correct behaviour; it
+   * now seeds a distinct owner agent, which is the case that wake was for.
+   */
+  it("does not re-wake a blocked issue whose unblock owner is its own assignee", async () => {
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "blocked",
+      runStatus: "succeeded",
+      livenessState: "blocked",
+    });
+    await db
+      .update(issues)
+      .set({
+        unblockDescriptor: { owner: { agentId }, action: "Inject the gateway, then rerun the reads" },
+        blockedTransitionAt: new Date("2026-07-23T18:30:00.000Z"),
+        blockedOwnerNotifiedAt: new Date("2026-07-23T18:31:00.000Z"),
+      })
+      .where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.selfAddressedUnblockSuppressed).toBe(1);
+    expect(result.blockedRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.issueIds).toEqual([]);
+    // Not a swap of one wake reason for another: nothing at all is enqueued.
+    expect(await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(and(
+        eq(agentWakeupRequests.companyId, companyId),
+        eq(agentWakeupRequests.status, "queued"),
+      ))).toHaveLength(0);
+  });
+
+  it("does not re-wake a blocked issue with an unresolved first-class blocker", async () => {
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "blocked",
+      runStatus: "succeeded",
+      livenessState: "blocked",
+    });
+    const blockerId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    await db.insert(issues).values({
+      id: blockerId,
+      companyId,
+      title: "Still-open blocker",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      issueNumber: 2,
+      identifier: `${issuePrefix}-2`,
+    });
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerId,
+      relatedIssueId: issueId,
+      type: "blocks",
+    });
+    await db
+      .update(issues)
+      .set({
+        unblockDescriptor: { owner: { agentId }, action: "Review the blocked work" },
+        blockedTransitionAt: new Date("2026-07-23T18:30:00.000Z"),
+      })
+      .where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.blockedRequeued).toBe(0);
+    // Sweep-wide counter: the fixture leaves two assigned candidates - the blocked
+    // issue under test and the still-open blocker that blocks it - and both are
+    // correctly skipped.
+    expect(result.skipped).toBe(2);
+    expect(result.issueIds).toEqual([]);
+    expect(await db.select().from(agentWakeupRequests).where(eq(agentWakeupRequests.reason, "issue_unblock_requested")))
+      .toHaveLength(0);
+  });
+
+  it("requeues in-progress work after a stale queued process-loss retry never promotes", async () => {
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+    });
+    const staleWakeupId = randomUUID();
+    const staleRetryId = randomUUID();
+    const staleAt = new Date("2026-03-19T00:05:00.000Z");
+    await db.insert(agentWakeupRequests).values({
+      id: staleWakeupId,
+      companyId,
+      agentId,
+      source: "automation",
+      triggerDetail: "system",
+      reason: "process_lost_retry",
+      payload: { issueId, retryOfRunId: runId },
+      status: "queued",
+      runId: staleRetryId,
+      createdAt: staleAt,
+      updatedAt: staleAt,
+    });
+    await db.insert(heartbeatRuns).values({
+      id: staleRetryId,
+      companyId,
+      agentId,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status: "queued",
+      wakeupRequestId: staleWakeupId,
+      contextSnapshot: {
+        issueId,
+        taskId: issueId,
+        wakeReason: "process_lost_retry",
+        retryReason: "issue_continuation_needed",
+      },
+      retryOfRunId: runId,
+      createdAt: staleAt,
+      updatedAt: staleAt,
+    });
+    await db.update(issues).set({ executionRunId: staleRetryId }).where(eq(issues.id, issueId));
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.continuationRequeued).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+    const staleRetry = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, staleRetryId)).then((rows) => rows[0]);
+    expect(staleRetry).toMatchObject({ status: "cancelled", errorCode: "process_lost_retry_stale" });
+    const recoveryRetry = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId))
+      .then((rows) => rows.find((run) => run.id !== runId && run.id !== staleRetryId &&
+        (run.contextSnapshot as Record<string, unknown> | null)?.source === "issue.continuation_recovery"));
+    expect(recoveryRetry).toBeTruthy();
+    if (recoveryRetry) await waitForRunToSettle(heartbeat, recoveryRetry.id);
+  });
+
   it("creates a board recovery action for budget-blocked assigned work and continues the sweep", async () => {
     const blocked = await seedAssignedTodoNoRunFixture();
     const unblocked = await seedAssignedTodoNoRunFixture();

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -806,6 +806,12 @@ describe("agent issue mutation checkout ownership", () => {
     ],
     ["attachment delete", (app: express.Express) => request(app).delete("/api/attachments/attachment-1")],
   ])("rejects peer agent %s on another agent's active checkout", async (_name, sendRequest) => {
+    // The lock has to be on the issue for this to be the lock case. Until
+    // HIV-2811 this fixture set no run at all and still got the run-lock
+    // refusal, which is the conflation the fix removes; the sibling test below
+    // now owns the no-run case.
+    mockIssueService.getById.mockResolvedValue(makeIssue({ checkoutRunId: ownerRunId }));
+
     const res = await sendRequest(await createApp(peerActor()));
 
     expect(res.status, JSON.stringify(res.body)).toBe(409);
@@ -822,6 +828,36 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockWorkProductService.update).not.toHaveBeenCalled();
     expect(mockStorageService.putFile).not.toHaveBeenCalled();
     expect(mockStorageService.deleteObject).not.toHaveBeenCalled();
+  });
+
+  /**
+   * HIV-2811, second half. An `in_progress` issue with no run holding it is a
+   * permission boundary, not a lock. Measured 2026-09-01 on HIV-2785:
+   * checkoutRunId, executionRunId and executionLockedAt all null, and the peer
+   * still read "wait for the run to release the lock" — so it blocked itself
+   * and named itself the unblock owner to wait for a release no event could
+   * produce, which is the loop this issue is about.
+   */
+  it("tells a peer that an unheld in_progress issue is assignee-scoped, not locked", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ checkoutRunId: null, executionRunId: null }),
+    );
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "Blocked" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.details.code).toBe("issue_write_assignee_scoped_field_edit");
+    expect(res.body.details.boundary).toBe("Assignee-scoped field edit");
+    expect(res.body.details.checkoutRunId).toBeNull();
+    expect(res.body.details.executionRunId).toBeNull();
+    expect(res.body.error).toContain("Who can act:");
+    expect(res.body.error).toContain("Comment instead");
+    // The whole point: nothing here invites a wait.
+    expect(res.body.error).not.toContain("wait");
+    expect(res.body.error).not.toContain("release the lock");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
   it("allows mentioned peer agents to post comments without ownership of an active checkout", async () => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -807,7 +807,7 @@ describe("agent issue mutation checkout ownership", () => {
     ["attachment delete", (app: express.Express) => request(app).delete("/api/attachments/attachment-1")],
   ])("rejects peer agent %s on another agent's active checkout", async (_name, sendRequest) => {
     // The lock has to be on the issue for this to be the lock case. Until
-    // HIV-2811 this fixture set no run at all and still got the run-lock
+    // the recovery fix this fixture set no run at all and still got the run-lock
     // refusal, which is the conflation the fix removes; the sibling test below
     // now owns the no-run case.
     mockIssueService.getById.mockResolvedValue(makeIssue({ checkoutRunId: ownerRunId }));
@@ -831,8 +831,8 @@ describe("agent issue mutation checkout ownership", () => {
   });
 
   /**
-   * HIV-2811, second half. An `in_progress` issue with no run holding it is a
-   * permission boundary, not a lock. Measured 2026-09-01 on HIV-2785:
+   * the recovery fix, second half. An `in_progress` issue with no run holding it is a
+   * permission boundary, not a lock. Measured 2026-09-01 on the write-denial fix:
    * checkoutRunId, executionRunId and executionLockedAt all null, and the peer
    * still read "wait for the run to release the lock" — so it blocked itself
    * and named itself the unblock owner to wait for a release no event could

--- a/server/src/__tests__/routable-blocked.test.ts
+++ b/server/src/__tests__/routable-blocked.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   deliverAgentUnblockNotification,
+  isSelfAddressedUnblockDescriptor,
+  resolveRequestedUnblockDescriptor,
   ROUTABLE_BLOCKED_ROLLOUT_AT,
 } from "../services/routable-blocked.js";
 
@@ -9,10 +11,12 @@ const agentId = "00000000-0000-4000-8000-000000000001";
 function blockedIssue(input: {
   transitionAt?: Date | null;
   notifiedAt?: Date | null;
+  assigneeAgentId?: string | null;
 } = {}) {
   return {
     id: "00000000-0000-4000-8000-000000000002",
     status: "blocked",
+    assigneeAgentId: input.assigneeAgentId ?? null,
     unblockDescriptor: { owner: { agentId }, action: "Review the finding" } as const,
     blockedTransitionAt: input.transitionAt === undefined
       ? new Date(ROUTABLE_BLOCKED_ROLLOUT_AT.getTime() + 1)
@@ -72,5 +76,61 @@ describe("routable blocked notifications", () => {
     expect(wakeup.mock.calls[0]?.[1]).toMatchObject({
       idempotencyKey: expect.stringContaining(secondTransition.toISOString()),
     });
+  });
+
+  // HIV-2811. LUN-1317 ran 40 times in under three hours and HIV-2719 25 times
+  // in 30 minutes, each cycle woken by a descriptor naming the agent that had
+  // just written it.
+  it("does not wake on a descriptor addressed back to the blocked assignee", async () => {
+    const wakeup = vi.fn(async () => undefined);
+    const markNotified = vi.fn(async () => undefined);
+
+    await expect(deliverAgentUnblockNotification({
+      issue: blockedIssue({ assigneeAgentId: agentId }),
+      wakeup,
+      markNotified,
+    })).resolves.toBe(false);
+    expect(wakeup).not.toHaveBeenCalled();
+    expect(markNotified).not.toHaveBeenCalled();
+  });
+
+  // The sweep path is the one that looped: `recoveryKey` bypasses both the
+  // transition and the already-notified guard, so without this the same wake
+  // was re-minted on every pass.
+  it("does not wake a self-addressed descriptor on the recovery path either", async () => {
+    const wakeup = vi.fn(async () => undefined);
+    const markNotified = vi.fn(async () => undefined);
+
+    await expect(deliverAgentUnblockNotification({
+      issue: blockedIssue({ assigneeAgentId: agentId, notifiedAt: new Date() }),
+      wakeup,
+      markNotified,
+      recoveryKey: "run-1",
+    })).resolves.toBe(false);
+    expect(wakeup).not.toHaveBeenCalled();
+  });
+
+  it("still wakes an agent named on an issue it is not assigned to", async () => {
+    const wakeup = vi.fn(async () => undefined);
+    const markNotified = vi.fn(async () => undefined);
+
+    await expect(deliverAgentUnblockNotification({
+      issue: blockedIssue({ assigneeAgentId: parentAgentId }),
+      wakeup,
+      markNotified,
+    })).resolves.toBe(true);
+    expect(wakeup).toHaveBeenCalledWith(agentId, expect.anything());
+  });
+
+  it("classifies self-addressed descriptors and nothing else", () => {
+    expect(isSelfAddressedUnblockDescriptor(blockedIssue({ assigneeAgentId: agentId }))).toBe(true);
+    expect(isSelfAddressedUnblockDescriptor(blockedIssue({ assigneeAgentId: parentAgentId }))).toBe(false);
+    expect(isSelfAddressedUnblockDescriptor(blockedIssue())).toBe(false);
+    expect(isSelfAddressedUnblockDescriptor({
+      id: "00000000-0000-4000-8000-000000000002",
+      status: "blocked",
+      assigneeAgentId: agentId,
+      unblockDescriptor: { owner: "board", action: "Decide" },
+    })).toBe(false);
   });
 });

--- a/server/src/__tests__/routable-blocked.test.ts
+++ b/server/src/__tests__/routable-blocked.test.ts
@@ -78,7 +78,7 @@ describe("routable blocked notifications", () => {
     });
   });
 
-  // HIV-2811. LUN-1317 ran 40 times in under three hours and HIV-2719 25 times
+  // the recovery fix. the affected task ran 40 times in under three hours and the finding routine 25 times
   // in 30 minutes, each cycle woken by a descriptor naming the agent that had
   // just written it.
   it("does not wake on a descriptor addressed back to the blocked assignee", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4140,6 +4140,9 @@ export function issueRoutes(
       assigneeAgentId: string | null;
       assigneeUserId: string | null;
       reviewPolicy?: IssueReviewPolicy | null;
+      checkoutRunId?: string | null;
+      /** With checkoutRunId, decides run-lock vs assignee-scope denial (HIV-2811). */
+      executionRunId?: string | null;
       /** Used only to name the task in denial copy (plan §6). */
       identifier?: string | null;
     },
@@ -4187,12 +4190,27 @@ export function issueRoutes(
       }
       if (issue.status === "in_progress") {
         // Run/checkout ownership stays assignee-scoped even though writes are
-        // open, so this lock clears on its own — the copy routes to comments.
-        return denyIssueWrite(req, res, issue, "issue_write_assignee_run_lock", {
-          issueId: issue.id,
-          assigneeAgentId: issue.assigneeAgentId,
-          actorAgentId,
-        });
+        // open, so the copy routes to comments either way. But WHICH refusal
+        // this is depends on whether a run actually holds the issue, and until
+        // HIV-2811 `in_progress` alone claimed a live checkout: a peer read
+        // "wait for the run to release the lock" off an issue whose
+        // checkoutRunId, executionRunId and executionLockedAt were all null,
+        // and armed a wait that no event could end. A lock clears on its own;
+        // this boundary does not.
+        const heldByRun = Boolean(issue.checkoutRunId ?? issue.executionRunId);
+        return denyIssueWrite(
+          req,
+          res,
+          issue,
+          heldByRun ? "issue_write_assignee_run_lock" : "issue_write_assignee_scoped_field_edit",
+          {
+            issueId: issue.id,
+            assigneeAgentId: issue.assigneeAgentId,
+            actorAgentId,
+            checkoutRunId: issue.checkoutRunId ?? null,
+            executionRunId: issue.executionRunId ?? null,
+          },
+        );
       }
       // Past the run lock the issue is idle, so only channels that have not
       // adopted the default-open rule still refuse another agent's issue.

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4141,7 +4141,7 @@ export function issueRoutes(
       assigneeUserId: string | null;
       reviewPolicy?: IssueReviewPolicy | null;
       checkoutRunId?: string | null;
-      /** With checkoutRunId, decides run-lock vs assignee-scope denial (HIV-2811). */
+      /** With checkoutRunId, decides run-lock vs assignee-scope denial (the recovery fix). */
       executionRunId?: string | null;
       /** Used only to name the task in denial copy (plan §6). */
       identifier?: string | null;
@@ -4192,7 +4192,7 @@ export function issueRoutes(
         // Run/checkout ownership stays assignee-scoped even though writes are
         // open, so the copy routes to comments either way. But WHICH refusal
         // this is depends on whether a run actually holds the issue, and until
-        // HIV-2811 `in_progress` alone claimed a live checkout: a peer read
+        // the recovery fix `in_progress` alone claimed a live checkout: a peer read
         // "wait for the run to release the lock" off an issue whose
         // checkoutRunId, executionRunId and executionLockedAt were all null,
         // and armed a wait that no event could end. A lock clears on its own;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3732,7 +3732,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           continue;
         }
 
-        // HIV-2811: a descriptor naming the issue's own assignee resolves back
+        // the recovery fix: a descriptor naming the issue's own assignee resolves back
         // to the sender. The sweep is where that closes into a loop, because
         // `recoveryKey` carries the latest run id and so mints a fresh
         // idempotency key on every pass. Suppress, and do not fall through to

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -49,6 +49,10 @@ import {
   parseIssueExecutionState,
 } from "../issue-execution-policy.js";
 import {
+  deliverAgentUnblockNotification,
+  isSelfAddressedUnblockDescriptor,
+} from "../routable-blocked.js";
+import {
   ISSUE_BLOCKERS_RESOLVED_WAKE_REASON,
   buildIssueBlockersResolvedWakeStateKey,
   findExistingIssueBlockersResolvedWakeForReadyState,
@@ -3571,6 +3575,8 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       escalated: 0,
       waitingOnReviewResolved: 0,
       providerQuotaMonitored: 0,
+      blockedRequeued: 0,
+      selfAddressedUnblockSuppressed: 0,
       recentProgressExempted: 0,
       operatorCancelExempted: 0,
       skipped: 0,
@@ -3707,6 +3713,100 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         continue;
       }
       const recoveryNow = new Date();
+
+      if (issue.status === "blocked") {
+        if (
+          await hasPersistedDurableWaitPath(issue) ||
+          await hasPendingIssueApproval(issue.companyId, issue.id)
+        ) {
+          result.skipped += 1;
+          continue;
+        }
+
+        const owner = issue.unblockDescriptor?.owner;
+        const unblockOwnerAgentId = owner && typeof owner === "object" && "agentId" in owner
+          ? owner.agentId
+          : null;
+        if (owner && !unblockOwnerAgentId) {
+          result.skipped += 1;
+          continue;
+        }
+
+        // HIV-2811: a descriptor naming the issue's own assignee resolves back
+        // to the sender. The sweep is where that closes into a loop, because
+        // `recoveryKey` carries the latest run id and so mints a fresh
+        // idempotency key on every pass. Suppress, and do not fall through to
+        // the continuation arm below — that would only swap one wake reason for
+        // another. The issue stays `blocked` and every event-carrying wake
+        // still reaches it.
+        if (unblockOwnerAgentId && isSelfAddressedUnblockDescriptor(issue)) {
+          result.selfAddressedUnblockSuppressed += 1;
+          result.skipped += 1;
+          logger.info(
+            {
+              issueId: issue.id,
+              identifier: issue.identifier,
+              agentId: unblockOwnerAgentId,
+            },
+            "recovery suppressed self-addressed unblock wake",
+          );
+          continue;
+        }
+
+        const targetAgentId = unblockOwnerAgentId ?? agentId;
+        const targetAgent = unblockOwnerAgentId ? await getAgent(unblockOwnerAgentId) : agent;
+        const targetInvokable = targetAgent && targetAgent.companyId === issue.companyId
+          ? await isAgentInvokable(targetAgent)
+          : false;
+        if (!targetInvokable || await isInvocationBudgetBlocked(issue, targetAgentId)) {
+          result.skipped += 1;
+          continue;
+        }
+        if (await hasQueuedIssueWake(issue.companyId, issue.id, targetAgentId)) {
+          result.skipped += 1;
+          continue;
+        }
+
+        if (unblockOwnerAgentId) {
+          if (!reserveRoutineExecutionRecovery(issue)) continue;
+          let notifiedAt: Date | null = null;
+          const delivered = await deliverAgentUnblockNotification({
+            issue,
+            recoveryKey: latestRun?.id ?? issue.blockedTransitionAt?.toISOString() ?? issue.updatedAt.toISOString(),
+            wakeup: deps.enqueueWakeup,
+            markNotified: async (at) => {
+              notifiedAt = at;
+            },
+          });
+          if (delivered && notifiedAt) {
+            await db
+              .update(issues)
+              .set({ blockedOwnerNotifiedAt: notifiedAt, updatedAt: notifiedAt })
+              .where(and(eq(issues.companyId, issue.companyId), eq(issues.id, issue.id)));
+            result.blockedRequeued += 1;
+            result.issueIds.push(issue.id);
+          } else {
+            result.skipped += 1;
+          }
+          continue;
+        }
+
+        const recoveryEnqueue = await enqueueRecovery({
+          issue,
+          agentId: targetAgentId,
+          reason: "issue_continuation_needed",
+          retryReason: "issue_continuation_needed",
+          source: "issue.blocked_continuation_recovery",
+          retryOfRunId: latestRun?.id ?? null,
+        });
+        if (recoveryEnqueue.queued) {
+          result.blockedRequeued += 1;
+          result.issueIds.push(issue.id);
+        } else if (!recoveryEnqueue.suppressed) {
+          result.skipped += 1;
+        }
+        continue;
+      }
       const participantLatestRunForRecovery = issue.status === "in_review" && participantAgentId
         ? await getLatestIssueRunForAgent(issue.companyId, issue.id, participantAgentId)
         : null;

--- a/server/src/services/routable-blocked.ts
+++ b/server/src/services/routable-blocked.ts
@@ -5,10 +5,37 @@ export const ROUTABLE_BLOCKED_ROLLOUT_AT = new Date("2026-07-23T18:13:03.000Z");
 type RoutableBlockedIssue = {
   id: string;
   status: string;
+  assigneeAgentId?: string | null;
   unblockDescriptor?: IssueUnblockDescriptor | null;
   blockedTransitionAt?: Date | null;
   blockedOwnerNotifiedAt?: Date | null;
 };
+
+/**
+ * HIV-2811: an unblock descriptor whose owner is the issue's own assignee is an
+ * address that resolves back to the sender. Waking on it asks the agent that
+ * just blocked to perform the thing it has already reported it cannot do, so
+ * the wake produces the same block, which produces the next wake.
+ *
+ * Measured 2026-09-01: LUN-1317 ran 40 times in under three hours, 38 of them
+ * recorded `livenessState: blocked`; HIV-2719 ran 25 times in 30 minutes and,
+ * being the only routine permitted to promote a finding to assigned work, held
+ * 30 queued findings shut while it cycled. Both descriptors named the blocked
+ * agent itself.
+ *
+ * Suppressing the wake does not strand the issue. It stays `blocked` and
+ * board-visible, and every event-carrying wake still reaches it — a comment, a
+ * resolved blocker, an interaction answer, an operator invoke. Only the
+ * self-referential automation wake stops.
+ *
+ * Not the same as an agent naming itself when it is NOT the assignee: that is a
+ * real cross-agent address and is delivered normally.
+ */
+export function isSelfAddressedUnblockDescriptor(issue: RoutableBlockedIssue): boolean {
+  const owner = issue.unblockDescriptor?.owner;
+  if (!owner || owner === "board" || !("agentId" in owner)) return false;
+  return Boolean(issue.assigneeAgentId) && owner.agentId === issue.assigneeAgentId;
+}
 
 type ProspectiveBlockedIssue = RoutableBlockedIssue & {
   status: "blocked";
@@ -40,6 +67,7 @@ export async function deliverAgentUnblockNotification(input: {
 
   const owner = issue.unblockDescriptor.owner;
   if (owner === "board" || !("agentId" in owner)) return false;
+  if (isSelfAddressedUnblockDescriptor(issue)) return false;
 
   await input.wakeup(owner.agentId, {
     source: "automation",

--- a/server/src/services/routable-blocked.ts
+++ b/server/src/services/routable-blocked.ts
@@ -12,13 +12,13 @@ type RoutableBlockedIssue = {
 };
 
 /**
- * HIV-2811: an unblock descriptor whose owner is the issue's own assignee is an
+ * the recovery fix: an unblock descriptor whose owner is the issue's own assignee is an
  * address that resolves back to the sender. Waking on it asks the agent that
  * just blocked to perform the thing it has already reported it cannot do, so
  * the wake produces the same block, which produces the next wake.
  *
- * Measured 2026-09-01: LUN-1317 ran 40 times in under three hours, 38 of them
- * recorded `livenessState: blocked`; HIV-2719 ran 25 times in 30 minutes and,
+ * Measured 2026-09-01: the affected task ran 40 times in under three hours, 38 of them
+ * recorded `livenessState: blocked`; the finding routine ran 25 times in 30 minutes and,
  * being the only routine permitted to promote a finding to assigned work, held
  * 30 queued findings shut while it cycled. Both descriptors named the blocked
  * agent itself.


### PR DESCRIPTION
## Summary

- avoid waking an issue back to the assignee that just recorded its own unblock descriptor
- distinguish an unheld in-progress issue from an issue with an active checkout lock when reporting peer write denials
- retain focused regression coverage for both behaviors

## Verification

- production reconstruction and image build completed successfully
- focused upstream checkout tests require the full workspace dependency links and were not runnable in the isolated clone