### PR TITLE
refactor(docker): declare the build stage's C toolchain explicitly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,13 @@ WORKDIR /app
 # version-pinned, checksum-verified installer and let the runner's own
 # rust-toolchain.toml choose the compiler — one pin, owned by the runner
 # package, shared by CI and image builds alike.
+#
+# The C toolchain is explicit: apt's cargo used to pull gcc in as a
+# dependency, and rustup does not — without it every build script dies on
+# "linker `cc` not found".
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends gcc libc6-dev pkg-config \
+  && rm -rf /var/lib/apt/lists/*
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The Docker images compile the Rust runner (paperclip-runnerd) during the build stage
> - The previous change replaced apt's cargo/rustc with a pinned rustup install
> - apt's cargo package pulled gcc in as a dependency; rustup does not install a C toolchain
> - Every master docker build now fails with "linker `cc` not found" in the build scripts
> - This pull request installs gcc, libc6-dev, and pkg-config explicitly in the build stage
> - The benefit is that the build stage declares its own C toolchain instead of inheriting one by accident

## Linked Issues or Issue Description

**What happened?**

Master `docker.yml` builds fail in `pnpm --filter @paperclipai/server build`: cargo build scripts (`libc`, `quote`, `proc-macro2`) die with `` error: linker `cc` not found ``, and the job exits with code 101.

**Expected behavior**

Master docker builds compile the runner and publish images.

**Steps to reproduce**

1. Run the `docker.yml` workflow on current `master`.
2. Observe the `build-and-push` job fail with the linker error above.

**Paperclip version or commit**

`master` after commit `317394456` (the rustup change); example failing run: docker.yml on `86ebdf842`.

## What Changed

- The build stage installs `gcc`, `libc6-dev`, and `pkg-config` explicitly, with a comment recording why: the old apt cargo brought gcc in as a dependency and the pinned rustup install does not.

## Verification

- Replicated the build stage's exact package sequence in `node:24-trixie-slim` — base-stage packages only (which include no compiler), then this new line, then the pinned, checksum-verified rustup install: the runner compiles (`Finished release`) with `rustc 1.97.1` and `cc 14.2.0`.
- Note: `docker.yml` triggers only on master pushes, so a PR run cannot exercise the image build itself; the container replication above is the pre-merge check. No test files: build-infrastructure fix (`fix:` on the Dockerfile only).

## Risks

- Low risk. Three packages added to the build stage only; the production stage is unchanged.

## Model Used

- Claude Fable 5 (`claude-fable-5`), Anthropic — Claude Code harness, extended thinking + tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details