### PR TITLE
Improve native runner recovery and task interactions

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -747,6 +747,13 @@ non-empty Codex model and otherwise stores the shared `gpt-5.6-sol` default.
 The native execution boundary applies the same default to older runner rows
 whose model is missing or blank.
 
+For native Codex runs, Paperclip passes the resolved execution workspace as
+`PAPERCLIP_WORKSPACE_CWD` and uses it as the provider containment boundary. A
+workspace below the host `HOME` is valid, including the default projectless
+agent workspace. The host `HOME` itself, a directory that contains it, a
+filesystem root, a `CODEX_HOME` overlap, or a canonical path outside the
+assigned workspace is rejected before provider startup.
+
 ## App-Shipped Skills Catalog
 
 The Paperclip app ships a curated catalog of company skills out of the box. The

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -739,6 +739,14 @@ In Vite middleware mode, Paperclip gives HMR a dedicated HTTP server bound to th
 
 When a workspace service runs Paperclip for browser OAuth QA, configure its `expose.urlTemplate` with the canonical URL the browser can reach. Paperclip preserves explicit `PAPERCLIP_PUBLIC_URL` or `BETTER_AUTH_URL` settings; otherwise it uses a valid exposed HTTPS origin (or loopback HTTP) as the managed runtime fallback for Better Auth and `/api/tools/oauth/callback`. Internal service names such as `http://paperclip-dev:<port>` are rejected unless that hostname is genuinely the browser route. Use a unique origin per isolated worktree. See [Execution Workspaces And Runtime Services](../docs/guides/board-operator/execution-workspaces-and-runtime-services.md#browser-reachable-origins-for-oauth-qa) for configuration and verification.
 
+## Paperclip Runner Adapter Conversion
+
+While the native runner supports only Codex, changing an existing agent to
+`paperclip_runner` is supported only from `codex_local`. The conversion keeps a
+non-empty Codex model and otherwise stores the shared `gpt-5.6-sol` default.
+The native execution boundary applies the same default to older runner rows
+whose model is missing or blank.
+
 ## App-Shipped Skills Catalog
 
 The Paperclip app ships a curated catalog of company skills out of the box. The

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -115,9 +115,11 @@ export type {
 export {
   PAPERCLIP_RUNNER_IDLE_TIMEOUT_DEFAULT_MS,
   PAPERCLIP_RUNNER_IDLE_TIMEOUT_MAX_MS,
+  PAPERCLIP_RUNNER_DEFAULT_MODELS,
   PAPERCLIP_RUNNER_PERMISSION_CAPABILITIES,
   isPaperclipRunnerProvider,
   resolvePaperclipRunnerIdleTimeoutMs,
+  resolvePaperclipRunnerModel,
   resolvePaperclipRunnerPermissionMode,
 } from "./paperclip-runner-permissions.js";
 export {

--- a/packages/adapter-utils/src/paperclip-runner-permissions.test.ts
+++ b/packages/adapter-utils/src/paperclip-runner-permissions.test.ts
@@ -8,9 +8,9 @@ import {
 } from "./paperclip-runner-permissions.js";
 
 describe("Paperclip Runner permission defaults", () => {
-  it("defaults Codex to full auto", () => {
+  it("defaults Codex to approval for untrusted operations", () => {
     expect(resolvePaperclipRunnerPermissionMode("codex", undefined)).toBe(
-      "never",
+      "untrusted",
     );
   });
 

--- a/packages/adapter-utils/src/paperclip-runner-permissions.test.ts
+++ b/packages/adapter-utils/src/paperclip-runner-permissions.test.ts
@@ -6,6 +6,12 @@ import {
 } from "./paperclip-runner-permissions.js";
 
 describe("Paperclip Runner permission defaults", () => {
+  it("defaults Codex to full auto", () => {
+    expect(resolvePaperclipRunnerPermissionMode("codex", undefined)).toBe(
+      "never",
+    );
+  });
+
   it("uses interactive defaults for dormant non-Codex providers", () => {
     expect(resolvePaperclipRunnerPermissionMode("opencode", undefined)).toBe(
       "ask",

--- a/packages/adapter-utils/src/paperclip-runner-permissions.test.ts
+++ b/packages/adapter-utils/src/paperclip-runner-permissions.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  PAPERCLIP_RUNNER_DEFAULT_MODELS,
   isPaperclipRunnerProvider,
+  resolvePaperclipRunnerModel,
   resolvePaperclipRunnerPermissionMode,
 } from "./paperclip-runner-permissions.js";
 
@@ -36,5 +38,19 @@ describe("Paperclip Runner permission defaults", () => {
       .toBe("provider-managed");
     expect(resolvePaperclipRunnerPermissionMode("aws_agentcore", "approve-all"))
       .toBe("provider-managed");
+  });
+
+  it("uses the Codex default for missing or blank models", () => {
+    expect(resolvePaperclipRunnerModel("codex", undefined)).toBe(
+      PAPERCLIP_RUNNER_DEFAULT_MODELS.codex,
+    );
+    expect(resolvePaperclipRunnerModel("codex", "   ")).toBe(
+      PAPERCLIP_RUNNER_DEFAULT_MODELS.codex,
+    );
+  });
+
+  it("preserves an explicit Codex model", () => {
+    expect(resolvePaperclipRunnerModel("codex", "gpt-5.5")).toBe("gpt-5.5");
+    expect(resolvePaperclipRunnerModel("codex", "  gpt-5.5  ")).toBe("gpt-5.5");
   });
 });

--- a/packages/adapter-utils/src/paperclip-runner-permissions.ts
+++ b/packages/adapter-utils/src/paperclip-runner-permissions.ts
@@ -16,6 +16,9 @@ export type PaperclipRunnerPermissionMode =
 
 export const PAPERCLIP_RUNNER_IDLE_TIMEOUT_DEFAULT_MS = 300_000;
 export const PAPERCLIP_RUNNER_IDLE_TIMEOUT_MAX_MS = 86_400_000;
+export const PAPERCLIP_RUNNER_DEFAULT_MODELS = {
+  codex: "gpt-5.6-sol",
+} as const;
 
 export interface PaperclipRunnerPermissionOption<TMode extends string = string> {
   value: TMode;
@@ -108,6 +111,15 @@ export function resolvePaperclipRunnerPermissionMode(
   return capability.options.some((option) => option.value === value)
     ? value as PaperclipRunnerPermissionMode
     : capability.defaultMode;
+}
+
+export function resolvePaperclipRunnerModel(
+  provider: keyof typeof PAPERCLIP_RUNNER_DEFAULT_MODELS,
+  value: unknown,
+): string {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : PAPERCLIP_RUNNER_DEFAULT_MODELS[provider];
 }
 
 export function resolvePaperclipRunnerIdleTimeoutMs(value: unknown): number {

--- a/packages/adapter-utils/src/paperclip-runner-permissions.ts
+++ b/packages/adapter-utils/src/paperclip-runner-permissions.ts
@@ -47,7 +47,7 @@ export const PAPERCLIP_RUNNER_PERMISSION_CAPABILITIES = {
   codex: {
     configurable: true,
     configKey: "codexPermissionMode",
-    defaultMode: "untrusted",
+    defaultMode: "never",
     description: "Controls when Codex asks before an operation inside the assigned Paperclip environment.",
     options: [
       { value: "never", label: "Full auto (never ask)", description: "Run without Codex approval pauses." },

--- a/packages/adapter-utils/src/paperclip-runner-permissions.ts
+++ b/packages/adapter-utils/src/paperclip-runner-permissions.ts
@@ -50,7 +50,7 @@ export const PAPERCLIP_RUNNER_PERMISSION_CAPABILITIES = {
   codex: {
     configurable: true,
     configKey: "codexPermissionMode",
-    defaultMode: "never",
+    defaultMode: "untrusted",
     description: "Controls when Codex asks before an operation inside the assigned Paperclip environment.",
     options: [
       { value: "never", label: "Full auto (never ask)", description: "Run without Codex approval pauses." },

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -11,7 +11,10 @@ import {
 } from "./local-process-sandbox.js";
 import { buildSshSpawnTarget, type SshRemoteExecutionSpec } from "./ssh.js";
 import { redactCommandText } from "./command-redaction.js";
-import { PAPERCLIP_RUNNER_PERMISSION_CAPABILITIES } from "./paperclip-runner-permissions.js";
+import {
+  PAPERCLIP_RUNNER_PERMISSION_CAPABILITIES,
+  resolvePaperclipRunnerModel,
+} from "./paperclip-runner-permissions.js";
 import type {
   AdapterRuntimeToolAccess,
   AdapterSkillEntry,
@@ -3093,6 +3096,7 @@ export function normalizePaperclipRunnerAdapterConfig(
     codexPermissionMode: PAPERCLIP_RUNNER_PERMISSION_CAPABILITIES.codex.defaultMode,
     lifecycleMode: "per_turn",
     ...config,
+    model: resolvePaperclipRunnerModel("codex", config.model),
   };
   return normalizePaperclipOperationalSkillPreference(adapterType, next);
 }

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -11,6 +11,7 @@ import {
 } from "./local-process-sandbox.js";
 import { buildSshSpawnTarget, type SshRemoteExecutionSpec } from "./ssh.js";
 import { redactCommandText } from "./command-redaction.js";
+import { PAPERCLIP_RUNNER_PERMISSION_CAPABILITIES } from "./paperclip-runner-permissions.js";
 import type {
   AdapterRuntimeToolAccess,
   AdapterSkillEntry,
@@ -3059,6 +3060,42 @@ export function resolvePaperclipDesiredSkillNames(
  * resolver above.
  */
 export const PAPERCLIP_OPERATIONAL_SKILL_KEY = "paperclipai/paperclip/paperclip";
+
+/**
+ * Native Paperclip Runner sessions receive the control-plane contract through
+ * PRP, so carrying the legacy operational skill into their stored preference
+ * is redundant and invalid. Normalize it away at persistence boundaries.
+ * Legacy adapters remain unchanged because their runtime resolver mounts the
+ * operational skill automatically, including after switching back.
+ */
+export function normalizePaperclipOperationalSkillPreference(
+  adapterType: string,
+  config: Record<string, unknown>,
+): Record<string, unknown> {
+  if (adapterType !== "paperclip_runner") return config;
+  const preference = readPaperclipSkillSyncPreference(config);
+  const desiredSkillEntries = preference.desiredSkillEntries.filter(
+    (entry) => entry.key.trim().toLowerCase() !== PAPERCLIP_OPERATIONAL_SKILL_KEY,
+  );
+  return desiredSkillEntries.length === preference.desiredSkillEntries.length
+    ? config
+    : writePaperclipSkillSyncPreference(config, desiredSkillEntries);
+}
+
+/** Apply the persisted defaults and skill contract for the native runner. */
+export function normalizePaperclipRunnerAdapterConfig(
+  adapterType: string,
+  config: Record<string, unknown>,
+): Record<string, unknown> {
+  if (adapterType !== "paperclip_runner") return config;
+  const next = {
+    provider: "codex",
+    codexPermissionMode: PAPERCLIP_RUNNER_PERMISSION_CAPABILITIES.codex.defaultMode,
+    lifecycleMode: "per_turn",
+    ...config,
+  };
+  return normalizePaperclipOperationalSkillPreference(adapterType, next);
+}
 
 export function resolveLegacyPaperclipDesiredSkillNames(
   config: Record<string, unknown>,

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -3091,13 +3091,15 @@ export function normalizePaperclipRunnerAdapterConfig(
   config: Record<string, unknown>,
 ): Record<string, unknown> {
   if (adapterType !== "paperclip_runner") return config;
-  const next = {
+  const next: Record<string, unknown> = {
     provider: "codex",
     codexPermissionMode: PAPERCLIP_RUNNER_PERMISSION_CAPABILITIES.codex.defaultMode,
     lifecycleMode: "per_turn",
     ...config,
-    model: resolvePaperclipRunnerModel("codex", config.model),
   };
+  if (next.provider === "codex") {
+    next.model = resolvePaperclipRunnerModel("codex", config.model);
+  }
   return normalizePaperclipOperationalSkillPreference(adapterType, next);
 }
 

--- a/packages/adapters/codex-local/src/index.ts
+++ b/packages/adapters/codex-local/src/index.ts
@@ -1,3 +1,7 @@
+import {
+  PAPERCLIP_RUNNER_DEFAULT_MODELS,
+} from "@paperclipai/adapter-utils";
+
 export const type = "codex_local";
 export const label = "Codex";
 
@@ -6,7 +10,7 @@ export const SANDBOX_INSTALL_COMMAND = "npm install -g @openai/codex";
 // Use the concrete `gpt-5.6-sol` slug (Codex's own default for the 5.6 family) rather than the
 // bare `gpt-5.6` alias: OpenAI ships no model metadata for the bare slug, so passing it makes the
 // Codex CLI warn ("Model metadata for `gpt-5.6` not found") and fall back to generic context limits.
-export const DEFAULT_CODEX_LOCAL_MODEL = "gpt-5.6-sol";
+export const DEFAULT_CODEX_LOCAL_MODEL = PAPERCLIP_RUNNER_DEFAULT_MODELS.codex;
 export const DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX = true;
 export const CODEX_LOCAL_FAST_MODE_SUPPORTED_MODELS = [
   "gpt-5.6-sol",

--- a/packages/adapters/codex-local/src/ui/build-config.test.ts
+++ b/packages/adapters/codex-local/src/ui/build-config.test.ts
@@ -136,6 +136,7 @@ describe("buildPaperclipRunnerConfig", () => {
     }));
     expect(config).toMatchObject({
       provider: "codex",
+      model: "gpt-5.4",
       codexPermissionMode: "never",
       lifecycleMode: "per_turn",
     });
@@ -272,6 +273,13 @@ describe("buildPaperclipRunnerConfig", () => {
         [field]: value,
       },
     }))).toThrow("must be an integer between");
+  });
+
+  it("uses the Codex default when no model was selected", () => {
+    expect(buildPaperclipRunnerConfig(makeValues({ model: "" }))).toMatchObject({
+      provider: "codex",
+      model: "gpt-5.6-sol",
+    });
   });
 
   it("bounds warm lifecycle values to the shared safe default", () => {

--- a/packages/adapters/codex-local/src/ui/build-config.test.ts
+++ b/packages/adapters/codex-local/src/ui/build-config.test.ts
@@ -87,7 +87,7 @@ describe("buildPaperclipRunnerConfig", () => {
 
     expect(config).toMatchObject({
       provider: "codex",
-      codexPermissionMode: "untrusted",
+      codexPermissionMode: "never",
       lifecycleMode: "per_turn",
       model: "gpt-5.4",
       timeoutSec: 0,
@@ -136,7 +136,7 @@ describe("buildPaperclipRunnerConfig", () => {
     }));
     expect(config).toMatchObject({
       provider: "codex",
-      codexPermissionMode: "untrusted",
+      codexPermissionMode: "never",
       lifecycleMode: "per_turn",
     });
   });

--- a/packages/adapters/codex-local/src/ui/build-config.test.ts
+++ b/packages/adapters/codex-local/src/ui/build-config.test.ts
@@ -87,7 +87,7 @@ describe("buildPaperclipRunnerConfig", () => {
 
     expect(config).toMatchObject({
       provider: "codex",
-      codexPermissionMode: "never",
+      codexPermissionMode: "untrusted",
       lifecycleMode: "per_turn",
       model: "gpt-5.4",
       timeoutSec: 0,
@@ -137,7 +137,7 @@ describe("buildPaperclipRunnerConfig", () => {
     expect(config).toMatchObject({
       provider: "codex",
       model: "gpt-5.4",
-      codexPermissionMode: "never",
+      codexPermissionMode: "untrusted",
       lifecycleMode: "per_turn",
     });
   });

--- a/packages/adapters/codex-local/src/ui/build-config.ts
+++ b/packages/adapters/codex-local/src/ui/build-config.ts
@@ -1,6 +1,7 @@
 import {
   buildAdapterEnvConfig,
   isPaperclipRunnerProvider,
+  resolvePaperclipRunnerModel,
   resolvePaperclipRunnerIdleTimeoutMs,
   resolvePaperclipRunnerPermissionMode,
   type CreateConfigValues,
@@ -200,6 +201,9 @@ export function buildPaperclipRunnerConfig(v: CreateConfigValues): Record<string
     ...config,
     ...schemaValues,
     provider,
+    ...(provider === "codex"
+      ? { model: resolvePaperclipRunnerModel("codex", config.model) }
+      : {}),
     codexPermissionMode: resolvePaperclipRunnerPermissionMode(
       "codex",
       v.adapterSchemaValues?.codexPermissionMode ?? v.codexPermissionMode,

--- a/packages/paperclip-runner/docs/codex-driver.md
+++ b/packages/paperclip-runner/docs/codex-driver.md
@@ -77,7 +77,10 @@ commands have a separate boundary: an empty-by-default environment with no
 permission profile requesting read-only minimal runtime files, no host-home or
 Codex-home access, and write access to the assigned workspace. The driver
 refuses filesystem-root workspaces, workspaces containing host `HOME`, and any
-workspace overlapping host `CODEX_HOME`.
+workspace overlapping host `CODEX_HOME`. A workspace below host `HOME` is
+valid, but when `PAPERCLIP_WORKSPACE_CWD` is present its canonical path must be
+equal to or below that assigned workspace so sibling and symlink escapes fail
+before provider startup.
 
 The returned sandbox facts remain authoritative. Codex 0.132.0 may inject a
 provider-managed writable root such as `~/.codex/memories` after a first run,

--- a/packages/paperclip-runner/runner/crates/runner-core/src/bin/fake-codex-app-server.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/bin/fake-codex-app-server.rs
@@ -445,6 +445,9 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let require_skill_instructions = args
         .iter()
         .any(|value| value == "--include-skill-instructions");
+    let require_codex_home_auth = args
+        .iter()
+        .any(|value| value == "--require-codex-home-auth");
     let durable_turn_ids = args.iter().any(|value| value == "--durable-turn-ids");
     let emit_tool_call = args.iter().any(|value| value == "--emit-tool-call");
     let replay_completed_tool_call = args
@@ -591,6 +594,17 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 skill_path.display()
             )
             .into());
+        }
+    }
+    if require_codex_home_auth {
+        let auth_path = std::env::var_os("CODEX_HOME")
+            .map(PathBuf::from)
+            .map(|home| home.join("auth.json"))
+            .ok_or("CODEX_HOME is required for the selected auth fixture")?;
+        if !auth_path.is_file() {
+            return Err(
+                format!("Codex auth was not materialized at {}", auth_path.display()).into(),
+            );
         }
     }
     let mut state = load_state(&state_path);

--- a/packages/paperclip-runner/runner/crates/runner-core/src/bin/fake-codex-app-server.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/bin/fake-codex-app-server.rs
@@ -575,6 +575,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let question_before_failed_turn = args
         .iter()
         .any(|value| value == "--question-before-failed-turn");
+    let fail_turn_immediately = args.iter().any(|value| value == "--fail-turn-immediately");
     let reuse_question_id = args.iter().any(|value| value == "--reuse-question-id");
     let pre_response_notification = args
         .iter()
@@ -897,6 +898,20 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 }))?;
                 if fail_after_second_turn_start && turn_start_count == 2 {
                     return Err("configured failure after second turn start".into());
+                } else if fail_turn_immediately {
+                    send(json!({
+                        "method": "turn/completed",
+                        "params": {
+                            "threadId": state.thread_id,
+                            "turn": {
+                                "id": provider_turn_id,
+                                "status": "failed",
+                                "error": {"message": "immediate provider failure"}
+                            }
+                        }
+                    }))?;
+                    state.active_turn_id = None;
+                    save_state(&state_path, &state)?;
                 } else if question_before_failed_turn {
                     send_question(&state)?;
                     send(json!({

--- a/packages/paperclip-runner/runner/crates/runner-core/src/durable/state.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/durable/state.rs
@@ -1131,26 +1131,152 @@ pub(crate) fn redact_text(input: &str) -> String {
     } else {
         (input, false)
     };
-    let normalized = bounded.to_ascii_lowercase();
-    if [
+    let mut redacted = redact_sensitive_text_values(bounded);
+    if truncated {
+        redacted.push_str("…[truncated]");
+    }
+    redacted
+}
+
+fn redact_sensitive_text_values(input: &str) -> String {
+    let normalized = input.to_ascii_lowercase();
+    let bytes = normalized.as_bytes();
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+
+    let is_name_byte = |value: u8| value.is_ascii_alphanumeric() || value == b'_' || value == b'-';
+    let is_value_end = |value: u8| {
+        value.is_ascii_whitespace()
+            || matches!(
+                value,
+                b',' | b';' | b'&' | b'\'' | b'"' | b'`' | b')' | b']' | b'}'
+            )
+    };
+    let value_end = |start: usize| {
+        let mut end = start;
+        while end < bytes.len() && !is_value_end(bytes[end]) {
+            end += 1;
+        }
+        end
+    };
+
+    // Bearer credentials can appear outside a named header in provider errors.
+    for (start, _) in normalized.match_indices("bearer") {
+        let before_is_name = start > 0 && is_name_byte(bytes[start - 1]);
+        let mut value_start = start + "bearer".len();
+        if before_is_name || value_start >= bytes.len() || !bytes[value_start].is_ascii_whitespace()
+        {
+            continue;
+        }
+        while value_start < bytes.len() && bytes[value_start].is_ascii_whitespace() {
+            value_start += 1;
+        }
+        let end = value_end(value_start);
+        if end > value_start {
+            ranges.push((value_start, end));
+        }
+    }
+
+    // Redact only assignment values. Words such as "authorization" in a
+    // provider diagnostic are useful context and are not secrets by themselves.
+    for key in [
         "authorization",
-        "bearer ",
         "api_key",
         "apikey",
-        "password=",
-        "secret=",
-        "ticket=",
-        "token=",
-    ]
-    .iter()
-    .any(|marker| normalized.contains(marker))
-    {
-        "[REDACTED diagnostic containing a sensitive marker]".to_owned()
-    } else if truncated {
-        format!("{bounded}…[truncated]")
-    } else {
-        bounded.to_owned()
+        "password",
+        "secret",
+        "ticket",
+        "token",
+    ] {
+        for (start, _) in normalized.match_indices(key) {
+            let before_is_name = start > 0 && is_name_byte(bytes[start - 1]);
+            let mut separator = start + key.len();
+            if before_is_name || (separator < bytes.len() && is_name_byte(bytes[separator])) {
+                continue;
+            }
+            while separator < bytes.len() && bytes[separator].is_ascii_whitespace() {
+                separator += 1;
+            }
+            if separator >= bytes.len() || !matches!(bytes[separator], b':' | b'=') {
+                continue;
+            }
+            let mut value_start = separator + 1;
+            while value_start < bytes.len() && bytes[value_start].is_ascii_whitespace() {
+                value_start += 1;
+            }
+            let quote = bytes
+                .get(value_start)
+                .copied()
+                .filter(|value| matches!(value, b'\'' | b'"'));
+            if quote.is_some() {
+                value_start += 1;
+            }
+            if key == "authorization" {
+                for scheme in ["bearer", "basic"] {
+                    if !normalized[value_start..].starts_with(scheme) {
+                        continue;
+                    }
+                    let after_scheme = value_start + scheme.len();
+                    if after_scheme >= bytes.len() || !bytes[after_scheme].is_ascii_whitespace() {
+                        continue;
+                    }
+                    value_start = after_scheme;
+                    while value_start < bytes.len() && bytes[value_start].is_ascii_whitespace() {
+                        value_start += 1;
+                    }
+                    break;
+                }
+            }
+            let end = if let Some(quote) = quote {
+                bytes[value_start..]
+                    .iter()
+                    .position(|value| *value == quote)
+                    .map_or(bytes.len(), |offset| value_start + offset)
+            } else if key == "authorization"
+                && !["bearer", "basic"].iter().any(|scheme| {
+                    normalized[separator + 1..]
+                        .trim_start()
+                        .to_ascii_lowercase()
+                        .starts_with(scheme)
+                })
+            {
+                let mut end = value_start;
+                while end < bytes.len() && !matches!(bytes[end], b'\n' | b'\r' | b',' | b';' | b'&')
+                {
+                    end += 1;
+                }
+                end
+            } else {
+                value_end(value_start)
+            };
+            if end > value_start {
+                ranges.push((value_start, end));
+            }
+        }
     }
+
+    if ranges.is_empty() {
+        return input.to_owned();
+    }
+    ranges.sort_unstable();
+    let mut merged: Vec<(usize, usize)> = Vec::with_capacity(ranges.len());
+    for (start, end) in ranges {
+        if let Some((_, previous_end)) = merged.last_mut() {
+            if start <= *previous_end {
+                *previous_end = (*previous_end).max(end);
+                continue;
+            }
+        }
+        merged.push((start, end));
+    }
+    let mut output = String::with_capacity(input.len());
+    let mut cursor = 0;
+    for (start, end) in merged {
+        output.push_str(&input[cursor..start]);
+        output.push_str("[REDACTED]");
+        cursor = end;
+    }
+    output.push_str(&input[cursor..]);
+    output
 }
 
 fn current_timestamp() -> Result<String, DurableRunnerError> {
@@ -1358,6 +1484,38 @@ mod tests {
             sanitized["nested"]["authorizationBoundary"],
             json!("[REDACTED]")
         );
+    }
+
+    #[test]
+    fn diagnostic_redaction_preserves_context_and_removes_only_secret_values() {
+        assert_eq!(
+            redact_text("request failed: authorization service returned 401 Unauthorized"),
+            "request failed: authorization service returned 401 Unauthorized"
+        );
+        assert_eq!(
+            redact_text("401 Unauthorized: Authorization: Bearer secret-value; retry over HTTPS"),
+            "401 Unauthorized: Authorization: Bearer [REDACTED]; retry over HTTPS"
+        );
+        assert_eq!(
+            redact_text("request failed token=secret-value&reason=expired"),
+            "request failed token=[REDACTED]&reason=expired"
+        );
+        assert_eq!(
+            redact_text("Authorization: Basic dXNlcjpwYXNz retry"),
+            "Authorization: Basic [REDACTED] retry"
+        );
+        assert_eq!(
+            redact_text("login failed password=\"two word secret\" status=403"),
+            "login failed password=\"[REDACTED]\" status=403"
+        );
+    }
+
+    #[test]
+    fn diagnostic_redaction_still_bounds_retained_text() {
+        let output = redact_text(&format!("token=secret-value {}", "x".repeat(4_096)));
+        assert!(output.starts_with("token=[REDACTED] "));
+        assert!(output.ends_with("…[truncated]"));
+        assert!(!output.contains("secret-value"));
     }
 
     #[test]

--- a/packages/paperclip-runner/runner/crates/runner-core/src/durable/state.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/durable/state.rs
@@ -1158,6 +1158,10 @@ fn redact_sensitive_text_values(input: &str) -> String {
         }
         end
     };
+    let is_redaction_marker = |start: usize| {
+        normalized[start..].starts_with("[redacted]")
+            || normalized[start..].starts_with("***redacted***")
+    };
 
     // Bearer credentials can appear outside a named header in provider errors.
     for (start, _) in normalized.match_indices("bearer") {
@@ -1169,6 +1173,9 @@ fn redact_sensitive_text_values(input: &str) -> String {
         }
         while value_start < bytes.len() && bytes[value_start].is_ascii_whitespace() {
             value_start += 1;
+        }
+        if is_redaction_marker(value_start) {
+            continue;
         }
         let end = value_end(value_start);
         if end > value_start {
@@ -1225,6 +1232,9 @@ fn redact_sensitive_text_values(input: &str) -> String {
                     }
                     break;
                 }
+            }
+            if is_redaction_marker(value_start) {
+                continue;
             }
             let end = if let Some(quote) = quote {
                 bytes[value_start..]
@@ -1507,6 +1517,23 @@ mod tests {
         assert_eq!(
             redact_text("login failed password=\"two word secret\" status=403"),
             "login failed password=\"[REDACTED]\" status=403"
+        );
+    }
+
+    #[test]
+    fn diagnostic_redaction_is_idempotent() {
+        for input in [
+            "Missing bearer secret-value",
+            "Authorization: Bearer secret-value; retry",
+            "token=secret-value&reason=expired",
+            "password=\"two word secret\" status=403",
+        ] {
+            let once = redact_text(input);
+            assert_eq!(redact_text(&once), once);
+        }
+        assert_eq!(
+            redact_text("Missing bearer [REDACTED]"),
+            "Missing bearer [REDACTED]"
         );
     }
 

--- a/packages/paperclip-runner/runner/crates/runner-core/src/durable/state.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/durable/state.rs
@@ -1216,7 +1216,7 @@ fn redact_sensitive_text_values(input: &str) -> String {
             while value_start < bytes.len() && bytes[value_start].is_ascii_whitespace() {
                 value_start += 1;
             }
-            let quote = bytes
+            let mut quote = bytes
                 .get(value_start)
                 .copied()
                 .filter(|value| matches!(value, b'\'' | b'"'));
@@ -1243,6 +1243,17 @@ fn redact_sensitive_text_values(input: &str) -> String {
                     break;
                 }
                 authorization_value_extends_to_line_end |= !recognized_scheme;
+            }
+            // Authorization schemes can be followed by a quoted credential
+            // even when the assignment value itself is not quoted.
+            if quote.is_none() {
+                quote = bytes
+                    .get(value_start)
+                    .copied()
+                    .filter(|value| matches!(value, b'\'' | b'"'));
+                if quote.is_some() {
+                    value_start += 1;
+                }
             }
             if is_redaction_marker(value_start) {
                 continue;
@@ -1517,6 +1528,12 @@ mod tests {
         assert_eq!(
             redact_text("401 Unauthorized: Authorization: Bearer secret-value; retry over HTTPS"),
             "401 Unauthorized: Authorization: Bearer [REDACTED]; retry over HTTPS"
+        );
+        assert_eq!(
+            redact_text(
+                "Authorization: Bearer \"secret-value\"; Proxy-Authorization: Basic 'credential'"
+            ),
+            "Authorization: Bearer \"[REDACTED]\"; Proxy-Authorization: Basic '[REDACTED]'"
         );
         assert_eq!(
             redact_text("request failed token=secret-value&reason=expired"),

--- a/packages/paperclip-runner/runner/crates/runner-core/src/durable/state.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/durable/state.rs
@@ -1196,8 +1196,12 @@ fn redact_sensitive_text_values(input: &str) -> String {
     ] {
         for (start, _) in normalized.match_indices(key) {
             let before_is_name = start > 0 && is_name_byte(bytes[start - 1]);
+            let is_sensitive_name_suffix =
+                start > 0 && bytes[start - 1] == b'_' && key != "authorization";
             let mut separator = start + key.len();
-            if before_is_name || (separator < bytes.len() && is_name_byte(bytes[separator])) {
+            if (before_is_name && !is_sensitive_name_suffix)
+                || (separator < bytes.len() && is_name_byte(bytes[separator]))
+            {
                 continue;
             }
             while separator < bytes.len() && bytes[separator].is_ascii_whitespace() {
@@ -1517,6 +1521,10 @@ mod tests {
         assert_eq!(
             redact_text("login failed password=\"two word secret\" status=403"),
             "login failed password=\"[REDACTED]\" status=403"
+        );
+        assert_eq!(
+            redact_text("OPENAI_API_KEY=secret-value access_token=other-secret"),
+            "OPENAI_API_KEY=[REDACTED] access_token=[REDACTED]"
         );
     }
 

--- a/packages/paperclip-runner/runner/crates/runner-core/src/durable/state.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/durable/state.rs
@@ -1196,8 +1196,10 @@ fn redact_sensitive_text_values(input: &str) -> String {
     ] {
         for (start, _) in normalized.match_indices(key) {
             let before_is_name = start > 0 && is_name_byte(bytes[start - 1]);
-            let is_sensitive_name_suffix =
-                start > 0 && bytes[start - 1] == b'_' && key != "authorization";
+            let is_sensitive_name_suffix = before_is_name
+                && key != "authorization"
+                && (matches!(bytes[start - 1], b'_' | b'-')
+                    || matches!(key, "apikey" | "password" | "secret" | "ticket" | "token"));
             let mut separator = start + key.len();
             if (before_is_name && !is_sensitive_name_suffix)
                 || (separator < bytes.len() && is_name_byte(bytes[separator]))
@@ -1525,6 +1527,12 @@ mod tests {
         assert_eq!(
             redact_text("OPENAI_API_KEY=secret-value access_token=other-secret"),
             "OPENAI_API_KEY=[REDACTED] access_token=[REDACTED]"
+        );
+        assert_eq!(
+            redact_text(
+                "openai_api_key=first-secret openaiApiKey=second-secret clientSecret=third-secret refreshToken=fourth-secret"
+            ),
+            "openai_api_key=[REDACTED] openaiApiKey=[REDACTED] clientSecret=[REDACTED] refreshToken=[REDACTED]"
         );
     }
 

--- a/packages/paperclip-runner/runner/crates/runner-core/src/durable/state.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/durable/state.rs
@@ -1201,6 +1201,11 @@ fn redact_sensitive_text_values(input: &str) -> String {
             if separator < bytes.len() && is_name_byte(bytes[separator]) {
                 continue;
             }
+            // Serialized diagnostics commonly quote object keys before the
+            // assignment separator: {"access_token":"..."}.
+            if separator < bytes.len() && matches!(bytes[separator], b'\'' | b'"') {
+                separator += 1;
+            }
             while separator < bytes.len() && bytes[separator].is_ascii_whitespace() {
                 separator += 1;
             }
@@ -1540,6 +1545,12 @@ mod tests {
                 "proxyAuthorization: Bearer first-secret; ProxyAuthorization: Basic second-secret"
             ),
             "proxyAuthorization: Bearer [REDACTED]; ProxyAuthorization: Basic [REDACTED]"
+        );
+        assert_eq!(
+            redact_text(
+                r#"{"proxyAuthorization":"Bearer first-secret","access_token":"second-secret"}"#
+            ),
+            r#"{"proxyAuthorization":"Bearer [REDACTED]","access_token":"[REDACTED]"}"#
         );
     }
 

--- a/packages/paperclip-runner/runner/crates/runner-core/src/durable/state.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/durable/state.rs
@@ -1197,9 +1197,9 @@ fn redact_sensitive_text_values(input: &str) -> String {
         for (start, _) in normalized.match_indices(key) {
             let before_is_name = start > 0 && is_name_byte(bytes[start - 1]);
             let is_sensitive_name_suffix = before_is_name
-                && key != "authorization"
                 && (matches!(bytes[start - 1], b'_' | b'-')
-                    || matches!(key, "apikey" | "password" | "secret" | "ticket" | "token"));
+                    || (key != "authorization"
+                        && matches!(key, "apikey" | "password" | "secret" | "ticket" | "token")));
             let mut separator = start + key.len();
             if (before_is_name && !is_sensitive_name_suffix)
                 || (separator < bytes.len() && is_name_byte(bytes[separator]))
@@ -1533,6 +1533,12 @@ mod tests {
                 "openai_api_key=first-secret openaiApiKey=second-secret clientSecret=third-secret refreshToken=fourth-secret"
             ),
             "openai_api_key=[REDACTED] openaiApiKey=[REDACTED] clientSecret=[REDACTED] refreshToken=[REDACTED]"
+        );
+        assert_eq!(
+            redact_text(
+                "Proxy-Authorization: Basic dXNlcjpwYXNz; proxy_authorization=Bearer other-secret"
+            ),
+            "Proxy-Authorization: Basic [REDACTED]; proxy_authorization=Bearer [REDACTED]"
         );
     }
 

--- a/packages/paperclip-runner/runner/crates/runner-core/src/durable/state.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/durable/state.rs
@@ -1248,10 +1248,19 @@ fn redact_sensitive_text_values(input: &str) -> String {
                 continue;
             }
             let end = if let Some(quote) = quote {
-                bytes[value_start..]
-                    .iter()
-                    .position(|value| *value == quote)
-                    .map_or(bytes.len(), |offset| value_start + offset)
+                let mut end = value_start;
+                let mut escaped = false;
+                while end < bytes.len() {
+                    if bytes[end] == quote && !escaped {
+                        break;
+                    }
+                    escaped = bytes[end] == b'\\' && !escaped;
+                    if bytes[end] != b'\\' {
+                        escaped = false;
+                    }
+                    end += 1;
+                }
+                end
             } else if authorization_value_extends_to_line_end {
                 let mut end = value_start;
                 while end < bytes.len() && !matches!(bytes[end], b'\n' | b'\r') {
@@ -1526,6 +1535,10 @@ mod tests {
         assert_eq!(
             redact_text("login failed password=\"two word secret\" status=403"),
             "login failed password=\"[REDACTED]\" status=403"
+        );
+        assert_eq!(
+            redact_text(r#"login failed password="pa\"ss" status=403"#),
+            r#"login failed password="[REDACTED]" status=403"#
         );
         assert_eq!(
             redact_text("OPENAI_API_KEY=secret-value access_token=other-secret"),

--- a/packages/paperclip-runner/runner/crates/runner-core/src/durable/state.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/durable/state.rs
@@ -1195,15 +1195,10 @@ fn redact_sensitive_text_values(input: &str) -> String {
         "token",
     ] {
         for (start, _) in normalized.match_indices(key) {
-            let before_is_name = start > 0 && is_name_byte(bytes[start - 1]);
-            let is_sensitive_name_suffix = before_is_name
-                && (matches!(bytes[start - 1], b'_' | b'-')
-                    || (key != "authorization"
-                        && matches!(key, "apikey" | "password" | "secret" | "ticket" | "token")));
             let mut separator = start + key.len();
-            if (before_is_name && !is_sensitive_name_suffix)
-                || (separator < bytes.len() && is_name_byte(bytes[separator]))
-            {
+            // Match the full sensitive name or a compound identifier that ends
+            // with it (for example OPENAI_API_KEY or proxyAuthorization).
+            if separator < bytes.len() && is_name_byte(bytes[separator]) {
                 continue;
             }
             while separator < bytes.len() && bytes[separator].is_ascii_whitespace() {
@@ -1539,6 +1534,12 @@ mod tests {
                 "Proxy-Authorization: Basic dXNlcjpwYXNz; proxy_authorization=Bearer other-secret"
             ),
             "Proxy-Authorization: Basic [REDACTED]; proxy_authorization=Bearer [REDACTED]"
+        );
+        assert_eq!(
+            redact_text(
+                "proxyAuthorization: Bearer first-secret; ProxyAuthorization: Basic second-secret"
+            ),
+            "proxyAuthorization: Bearer [REDACTED]; ProxyAuthorization: Basic [REDACTED]"
         );
     }
 

--- a/packages/paperclip-runner/runner/crates/runner-core/src/durable/state.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/durable/state.rs
@@ -1223,8 +1223,10 @@ fn redact_sensitive_text_values(input: &str) -> String {
             if quote.is_some() {
                 value_start += 1;
             }
+            let mut authorization_value_extends_to_line_end = false;
             if key == "authorization" {
-                for scheme in ["bearer", "basic"] {
+                let mut recognized_scheme = false;
+                for scheme in ["bearer", "basic", "digest"] {
                     if !normalized[value_start..].starts_with(scheme) {
                         continue;
                     }
@@ -1236,8 +1238,11 @@ fn redact_sensitive_text_values(input: &str) -> String {
                     while value_start < bytes.len() && bytes[value_start].is_ascii_whitespace() {
                         value_start += 1;
                     }
+                    recognized_scheme = true;
+                    authorization_value_extends_to_line_end = scheme == "digest";
                     break;
                 }
+                authorization_value_extends_to_line_end |= !recognized_scheme;
             }
             if is_redaction_marker(value_start) {
                 continue;
@@ -1247,17 +1252,9 @@ fn redact_sensitive_text_values(input: &str) -> String {
                     .iter()
                     .position(|value| *value == quote)
                     .map_or(bytes.len(), |offset| value_start + offset)
-            } else if key == "authorization"
-                && !["bearer", "basic"].iter().any(|scheme| {
-                    normalized[separator + 1..]
-                        .trim_start()
-                        .to_ascii_lowercase()
-                        .starts_with(scheme)
-                })
-            {
+            } else if authorization_value_extends_to_line_end {
                 let mut end = value_start;
-                while end < bytes.len() && !matches!(bytes[end], b'\n' | b'\r' | b',' | b';' | b'&')
-                {
+                while end < bytes.len() && !matches!(bytes[end], b'\n' | b'\r') {
                     end += 1;
                 }
                 end
@@ -1519,6 +1516,12 @@ mod tests {
         assert_eq!(
             redact_text("Authorization: Basic dXNlcjpwYXNz retry"),
             "Authorization: Basic [REDACTED] retry"
+        );
+        assert_eq!(
+            redact_text(
+                "Authorization: Digest username=\"u\", nonce=\"secret\", response=\"credential\""
+            ),
+            "Authorization: Digest [REDACTED]"
         );
         assert_eq!(
             redact_text("login failed password=\"two word secret\" status=403"),

--- a/packages/paperclip-runner/runner/crates/runner-core/src/provider_backend.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/provider_backend.rs
@@ -2351,6 +2351,7 @@ impl CodexCommandExecutor {
             "driver": state.config.driver,
             "providerSessionId": state.thread_id,
             "activeProviderTurnId": state.active_provider_turn_id,
+            "cwd": state.config.cwd,
         })))
     }
 

--- a/packages/paperclip-runner/runner/crates/runner-core/src/provider_events.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/provider_events.rs
@@ -675,6 +675,29 @@ pub fn normalize_codex_notification(method: &str, params: &Value) -> Vec<Normali
                     payload,
                 );
             } else {
+                let mut payload = json!({
+                    "provider": "codex",
+                    "itemId": item_id,
+                    "kind": bounded_text(item_type, 160),
+                    "status": provider_status(string(provider_item.get("status")), completed),
+                    "channel": if item_type == "agentMessage" && provider_phase == "final_answer" {
+                        "final"
+                    } else if item_type == "agentMessage" {
+                        "progress"
+                    } else {
+                        "detail"
+                    },
+                    "text": provider_item.get("text").and_then(Value::as_str).map(|value| bounded_text(value, MAX_TEXT_CHARS)),
+                });
+                if !provider_phase.is_empty() {
+                    payload
+                        .as_object_mut()
+                        .expect("item payload is an object")
+                        .insert(
+                            "providerPhase".to_owned(),
+                            Value::String(bounded_text(provider_phase, 160)),
+                        );
+                }
                 push(
                     &mut events,
                     if completed {
@@ -687,25 +710,7 @@ pub fn normalize_codex_notification(method: &str, params: &Value) -> Vec<Normali
                     } else {
                         EventPriority::P2
                     },
-                    json!({
-                        "provider": "codex",
-                        "itemId": item_id,
-                        "kind": bounded_text(item_type, 160),
-                        "status": provider_status(string(provider_item.get("status")), completed),
-                        "channel": if item_type == "agentMessage" && provider_phase == "final_answer" {
-                            "final"
-                        } else if item_type == "agentMessage" {
-                            "progress"
-                        } else {
-                            "detail"
-                        },
-                        "providerPhase": if provider_phase.is_empty() {
-                            Value::Null
-                        } else {
-                            Value::String(bounded_text(provider_phase, 160))
-                        },
-                        "text": provider_item.get("text").and_then(Value::as_str).map(|value| bounded_text(value, MAX_TEXT_CHARS)),
-                    }),
+                    payload,
                 );
             }
         }
@@ -1256,6 +1261,17 @@ mod tests {
         );
         assert_eq!(commentary[0].payload["channel"], "progress");
         assert_eq!(commentary[0].payload["providerPhase"], "commentary");
+
+        let legacy = normalize_codex_notification(
+            "item/completed",
+            &json!({"item": {
+                "id": "msg-legacy",
+                "type": "agentMessage",
+                "status": "completed",
+                "text": "Legacy response.",
+            }}),
+        );
+        assert!(legacy[0].payload.get("providerPhase").is_none());
     }
 
     #[test]

--- a/packages/paperclip-runner/runner/crates/runner-core/src/provider_events.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/provider_events.rs
@@ -371,6 +371,32 @@ fn bounded_text(value: &str, max_chars: usize) -> String {
     redact_text(value).chars().take(max_chars).collect()
 }
 
+fn codex_terminal_error(params: &Value, event_type: &str) -> Value {
+    if event_type != "turn.failed" {
+        return Value::Null;
+    }
+    let error = [
+        "/turn/error",
+        "/turn/failure",
+        "/turn/reason",
+        "/turn/message",
+        "/error",
+        "/failure",
+        "/reason",
+        "/message",
+    ]
+    .into_iter()
+    .find_map(|pointer| params.pointer(pointer).filter(|value| !value.is_null()));
+    match error {
+        Some(Value::String(message)) => Value::String(bounded_text(message, MAX_TEXT_CHARS)),
+        Some(value) => sanitize_value(value),
+        None => json!({
+            "code": "provider_terminal_error_missing",
+            "message": "Codex reported a failed turn without error details",
+        }),
+    }
+}
+
 fn string(value: Option<&Value>) -> &str {
     value.and_then(Value::as_str).unwrap_or("")
 }
@@ -494,6 +520,7 @@ pub fn normalize_codex_notification(method: &str, params: &Value) -> Vec<Normali
                     "provider": "codex",
                     "providerTurnId": params.pointer("/turn/id").or_else(|| params.get("turnId")).and_then(Value::as_str),
                     "status": provider_status(status, true),
+                    "error": codex_terminal_error(params, event_type),
                 }),
             );
         }
@@ -1192,10 +1219,23 @@ mod tests {
     fn maps_terminal_and_usage_events_at_priority_zero() {
         let terminal = normalize_codex_notification(
             "turn/completed",
-            &json!({"turn": {"id": "provider-turn", "status": "failed"}}),
+            &json!({"turn": {
+                "id": "provider-turn",
+                "status": "failed",
+                "error": {
+                    "message": "provider rejected the turn",
+                    "accessToken": "secret-value",
+                },
+            }}),
         );
         assert_eq!(terminal[0].event_type, "turn.failed");
         assert_eq!(terminal[0].priority, EventPriority::P0);
+        assert_eq!(
+            terminal[0].payload["error"]["message"],
+            "provider rejected the turn"
+        );
+        assert_eq!(terminal[0].payload["error"]["accessToken"], "[REDACTED]");
+        assert!(!terminal[0].payload.to_string().contains("secret-value"));
         for (method, expected) in [
             ("turn/failed", "turn.failed"),
             ("turn/cancelled", "turn.cancelled"),
@@ -1205,6 +1245,12 @@ mod tests {
                 normalize_codex_notification(method, &json!({"turnId": "provider-turn"}));
             assert_eq!(terminal[0].event_type, expected);
             assert_eq!(terminal[0].priority, EventPriority::P0);
+            if method == "turn/failed" {
+                assert_eq!(
+                    terminal[0].payload["error"]["code"],
+                    "provider_terminal_error_missing"
+                );
+            }
         }
 
         let usage = normalize_codex_notification(

--- a/packages/paperclip-runner/runner/crates/runner-core/src/provider_events.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/src/provider_events.rs
@@ -633,6 +633,7 @@ pub fn normalize_codex_notification(method: &str, params: &Value) -> Vec<Normali
             let provider_item = item(params);
             let item_id = stable_id(string(provider_item.get("id")), "codex-item");
             let item_type = string(provider_item.get("type"));
+            let provider_phase = string(provider_item.get("phase"));
             let completed = method == "item/completed";
             if matches!(item_type, "commandExecution" | "mcpToolCall") {
                 let mut payload = json!({
@@ -691,7 +692,18 @@ pub fn normalize_codex_notification(method: &str, params: &Value) -> Vec<Normali
                         "itemId": item_id,
                         "kind": bounded_text(item_type, 160),
                         "status": provider_status(string(provider_item.get("status")), completed),
-                        "channel": if item_type == "agentMessage" { "progress" } else { "detail" },
+                        "channel": if item_type == "agentMessage" && provider_phase == "final_answer" {
+                            "final"
+                        } else if item_type == "agentMessage" {
+                            "progress"
+                        } else {
+                            "detail"
+                        },
+                        "providerPhase": if provider_phase.is_empty() {
+                            Value::Null
+                        } else {
+                            Value::String(bounded_text(provider_phase, 160))
+                        },
                         "text": provider_item.get("text").and_then(Value::as_str).map(|value| bounded_text(value, MAX_TEXT_CHARS)),
                     }),
                 );
@@ -1213,6 +1225,37 @@ mod tests {
         assert_eq!(events[0].payload["outputTruncated"], true);
         assert_eq!(events[0].payload["outputBytes"], 32);
         assert!(!events[0].payload.to_string().contains("top-secret"));
+    }
+
+    #[test]
+    fn maps_codex_final_answer_as_final_agent_message() {
+        let final_answer = normalize_codex_notification(
+            "item/completed",
+            &json!({"item": {
+                "id": "msg-final",
+                "type": "agentMessage",
+                "phase": "final_answer",
+                "status": "completed",
+                "text": "2 + 2 is 4.",
+            }}),
+        );
+        assert_eq!(final_answer[0].event_type, "item.completed");
+        assert_eq!(final_answer[0].payload["channel"], "final");
+        assert_eq!(final_answer[0].payload["providerPhase"], "final_answer");
+        assert_eq!(final_answer[0].payload["text"], "2 + 2 is 4.");
+
+        let commentary = normalize_codex_notification(
+            "item/completed",
+            &json!({"item": {
+                "id": "msg-progress",
+                "type": "agentMessage",
+                "phase": "commentary",
+                "status": "completed",
+                "text": "I am checking the result.",
+            }}),
+        );
+        assert_eq!(commentary[0].payload["channel"], "progress");
+        assert_eq!(commentary[0].payload["providerPhase"], "commentary");
     }
 
     #[test]

--- a/packages/paperclip-runner/runner/crates/runner-core/tests/acpx_event_payload.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/tests/acpx_event_payload.rs
@@ -380,7 +380,7 @@ fn decodes_terminal_and_redacts_diagnostic_payloads() {
     assert!(matches!(
         decoded,
         AcpxEventPayload::Diagnostic { message, .. }
-            if message == "[REDACTED diagnostic containing a sensitive marker]"
+            if message == "Authorization: Bearer [REDACTED]"
     ));
 }
 

--- a/packages/paperclip-runner/runner/crates/runner-core/tests/codex_provider.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/tests/codex_provider.rs
@@ -57,6 +57,42 @@ fn provider_config(directory: &Path, switches: &[&str]) -> CodexProviderConfig {
     }
 }
 
+#[test]
+fn provider_receives_the_isolated_codex_auth_home() {
+    let directory = temporary_directory("isolated-auth-home");
+    fs::write(directory.join("auth.json"), r#"{"auth_mode":"apikey"}"#)
+        .expect("write isolated Codex auth fixture");
+
+    // Run this assertion in a dedicated subprocess because environment
+    // mutation is process-global and Rust executes tests concurrently.
+    let test_binary = std::env::current_exe().expect("resolve current test binary");
+    let status = std::process::Command::new(test_binary)
+        .arg("provider_receives_isolated_codex_auth_home_subprocess")
+        .arg("--exact")
+        .arg("--ignored")
+        .arg("--nocapture")
+        .env("PAPERCLIP_CODEX_AUTH_TEST_HOME", &directory)
+        .env("HOME", &directory)
+        .env("CODEX_HOME", &directory)
+        .status()
+        .expect("run isolated auth-home assertion");
+    assert!(status.success());
+    fs::remove_dir_all(directory).expect("remove Codex integration-test directory");
+}
+
+#[test]
+#[ignore = "subprocess helper for provider_receives_the_isolated_codex_auth_home"]
+fn provider_receives_isolated_codex_auth_home_subprocess() {
+    let Some(directory) = std::env::var_os("PAPERCLIP_CODEX_AUTH_TEST_HOME").map(PathBuf::from)
+    else {
+        return;
+    };
+    let config = provider_config(&directory, &["--require-codex-home-auth"]);
+    let mut provider = CodexProvider::start(&config, None)
+        .expect("Codex provider should read auth from the isolated CODEX_HOME");
+    provider.shutdown().expect("stop fake Codex provider");
+}
+
 fn task_context_tool() -> AuthorizedTool {
     AuthorizedTool {
         operation_id: "get_task_context".to_owned(),

--- a/packages/paperclip-runner/runner/crates/runner-core/tests/codex_provider.rs
+++ b/packages/paperclip-runner/runner/crates/runner-core/tests/codex_provider.rs
@@ -1734,6 +1734,7 @@ fn durable_ambiguous_start_recovers_a_distinct_active_replacement_after_process_
         .expect("reconcile active replacement turn");
     assert_eq!(snapshot.result["status"], "turn_active");
     assert_eq!(snapshot.result["activeProviderTurnId"], "provider-turn-2");
+    assert_eq!(snapshot.result["cwd"], config.cwd);
     let persisted_recovered: Value = serde_json::from_slice(
         &fs::read(directory.join("codex-provider-state.json"))
             .expect("read recovered provider state"),

--- a/packages/paperclip-runner/src/backends/codex-native-backend.ts
+++ b/packages/paperclip-runner/src/backends/codex-native-backend.ts
@@ -10,6 +10,8 @@ import { HarnessDriverBackend } from "./harness-driver-backend.js";
 import { nativeSystemInstructions, nativeTaskConstraints } from "./runtime-context.js";
 
 export interface CodexNativeSessionBackendOptions {
+  /** Effective provider environment, including the assigned workspace boundary. */
+  environment?: NodeJS.ProcessEnv;
   runnerInstanceId?: string;
   onSpawn?: (meta: {
     pid: number;
@@ -127,6 +129,7 @@ function createTransportBackedNativeSessionBackend(
     transportFactory: options.transportFactory,
     dynamicTools: options.dynamicTools,
     dynamicToolHandler: options.dynamicToolHandler,
+    environment: options.environment,
     driverIdentity,
     capabilities: isCodex
       ? {}

--- a/packages/paperclip-runner/src/backends/native-backend-factory.ts
+++ b/packages/paperclip-runner/src/backends/native-backend-factory.ts
@@ -98,6 +98,7 @@ export function createNativeSessionBackend(
     onSpawn: options.onSpawn,
     dynamicTools: options.dynamicTools,
     dynamicToolHandler: options.dynamicToolHandler,
+    environment: options.environment,
     transportFactory: options.codexTransportFactory,
   });
 }

--- a/packages/paperclip-runner/src/backends/runtime-context.test.ts
+++ b/packages/paperclip-runner/src/backends/runtime-context.test.ts
@@ -10,7 +10,10 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import type { NativeExecutionInput } from "../contracts/native-execution.js";
-import { nativeSystemInstructions } from "./runtime-context.js";
+import {
+  nativeSystemInstructions,
+  nativeTaskConstraints,
+} from "./runtime-context.js";
 
 const temporaryRoots: string[] = [];
 
@@ -39,6 +42,20 @@ describe("native runtime context files", () => {
 
     expect(nativeSystemInstructions(runtimeInput(bundleRoot, "AGENTS.md")))
       .toContain("Stay inside the bundle.");
+  });
+
+  it("requires semantic completion before the final assistant response", () => {
+    const constraints = nativeTaskConstraints(
+      {} as unknown as NativeExecutionInput,
+    ).join("\n");
+
+    expect(constraints).toContain(
+      "Invoke paperclip_finish or paperclip_block exactly once before writing",
+    );
+    expect(constraints).toContain("do not call another tool");
+    expect(constraints).not.toContain(
+      "final response exactly once before invoking",
+    );
   });
 
   it("rejects traversal and symlink escapes from the bundle root", () => {

--- a/packages/paperclip-runner/src/backends/runtime-context.ts
+++ b/packages/paperclip-runner/src/backends/runtime-context.ts
@@ -26,7 +26,7 @@ export function nativeSystemInstructions(input: NativeExecutionInput): string {
 
 export function nativeTaskConstraints(input: NativeExecutionInput): string[] {
   const finalResponseConstraint =
-    "Write the complete user-facing final response exactly once before invoking paperclip_finish or paperclip_block. Treat that semantic completion tool as the last action and do not emit a trailing acknowledgement.";
+    "Invoke paperclip_finish or paperclip_block exactly once before writing the complete user-facing final response. After the semantic tool succeeds, write that response exactly once and do not call another tool.";
   if (!("runtimeContext" in input)) {
     return [
       "Do not discover or invoke skills.",

--- a/packages/paperclip-runner/src/drivers/codex/codex-app-server-driver.recovery.test.ts
+++ b/packages/paperclip-runner/src/drivers/codex/codex-app-server-driver.recovery.test.ts
@@ -72,6 +72,42 @@ describe("Codex app-server Codex driver", () => {
     expect((await recovery?.session?.snapshot())?.activeTurnId).toBe("turn-1");
   });
 
+  it("rejects a recovered provider thread outside the assigned workspace", async () => {
+    const first = new FakeCodexTransport();
+    const second = new FakeCodexTransport();
+    second.readResponse = {
+      thread: {
+        id: "thread-1",
+        sessionId: "provider-session-1",
+        cwd: "/tmp",
+        turns: [{ id: "turn-1", status: "inProgress", items: [] }],
+      },
+    };
+    const driver = makeDriver([first, second], {
+      environment: {
+        PATH: "/bin",
+        HOME: "/isolated/home",
+        CODEX_HOME: "/isolated/codex",
+        PAPERCLIP_WORKSPACE_CWD: WORKSPACE,
+      },
+    });
+    const original = await driver.openSession({
+      runId: "run-recover-outside-workspace",
+      normalizedSessionId: "normalized-recover-outside-workspace",
+      workingDirectory: WORKSPACE,
+    });
+    await original.startTurn({ message: { role: "user", text: "Work." } });
+    const snapshot = await original.snapshot();
+    await original.close({ reason: "transport lost" });
+
+    await expect(driver.recoverSession?.(snapshot)).resolves.toEqual({
+      recovered: false,
+      reason: expect.stringContaining(
+        "Codex working directory is outside the assigned workspace",
+      ),
+    });
+  });
+
   it("ignores an old terminal turn when the persisted active turn is still running", async () => {
     const first = new FakeCodexTransport();
     const second = new FakeCodexTransport();

--- a/packages/paperclip-runner/src/drivers/codex/codex-boundaries.test.ts
+++ b/packages/paperclip-runner/src/drivers/codex/codex-boundaries.test.ts
@@ -56,6 +56,12 @@ describe("Codex value and workspace boundaries", () => {
         }),
       ).toBe(realpathSync.native(ordinaryHomeWorkspace));
       expect(() =>
+        validateCodexWorkingDirectory(protectedHomeDirectory, {
+          HOME: hostHome,
+          CODEX_HOME: codexHome,
+        }),
+      ).toThrow("cannot overlap sensitive host HOME state");
+      expect(() =>
         validateCodexWorkingDirectory(join(workspaceRoot, "future-run"), {
           PAPERCLIP_WORKSPACE_CWD: workspaceRoot,
         }),
@@ -75,7 +81,7 @@ describe("Codex value and workspace boundaries", () => {
           HOME: hostHome,
           PAPERCLIP_WORKSPACE_CWD: workspaceRoot,
         }),
-      ).toThrow("outside the assigned workspace");
+      ).toThrow("cannot overlap sensitive host HOME state");
       expect(() =>
         validateCodexWorkingDirectory(outside, {
           PAPERCLIP_WORKSPACE_CWD: workspaceRoot,

--- a/packages/paperclip-runner/src/drivers/codex/codex-boundaries.test.ts
+++ b/packages/paperclip-runner/src/drivers/codex/codex-boundaries.test.ts
@@ -20,19 +20,21 @@ import {
 } from "./codex-boundaries.js";
 
 describe("Codex value and workspace boundaries", () => {
-  it("accepts only an assigned non-root workspace that does not contain host state", () => {
+  it("accepts assigned workspaces below HOME while rejecting host-state and containment escapes", () => {
     const fixture = mkdtempSync(join(tmpdir(), "paperclip-codex-boundaries-"));
     try {
-      const workspaceRoot = join(fixture, "workspaces");
-      const workspace = join(workspaceRoot, "run-1");
-      const outside = join(fixture, "outside");
       const hostRoot = join(fixture, "host");
       const hostHome = join(hostRoot, "home");
+      const workspaceRoot = join(hostHome, ".paperclip", "workspaces");
+      const workspace = join(workspaceRoot, "run-1");
+      const ordinaryHomeWorkspace = join(hostHome, "projects", "app");
+      const outside = join(fixture, "outside");
       const protectedHomeDirectory = join(hostHome, ".ssh");
       const codexHome = join(fixture, "codex-home");
       const codexWorkspace = join(codexHome, "run");
       for (const directory of [
         workspace,
+        ordinaryHomeWorkspace,
         outside,
         protectedHomeDirectory,
         codexWorkspace,
@@ -47,6 +49,12 @@ describe("Codex value and workspace boundaries", () => {
           PAPERCLIP_WORKSPACE_CWD: workspaceRoot,
         }),
       ).toBe(realpathSync.native(workspace));
+      expect(
+        validateCodexWorkingDirectory(ordinaryHomeWorkspace, {
+          HOME: hostHome,
+          CODEX_HOME: codexHome,
+        }),
+      ).toBe(realpathSync.native(ordinaryHomeWorkspace));
       expect(() =>
         validateCodexWorkingDirectory(join(workspaceRoot, "future-run"), {
           PAPERCLIP_WORKSPACE_CWD: workspaceRoot,
@@ -60,8 +68,14 @@ describe("Codex value and workspace boundaries", () => {
         validateCodexWorkingDirectory(hostRoot, { HOME: hostHome }),
       ).toThrow("cannot contain the host HOME");
       expect(() =>
-        validateCodexWorkingDirectory(protectedHomeDirectory, { HOME: hostHome }),
-      ).toThrow("cannot overlap the host HOME");
+        validateCodexWorkingDirectory(hostHome, { HOME: hostHome }),
+      ).toThrow("cannot contain the host HOME");
+      expect(() =>
+        validateCodexWorkingDirectory(protectedHomeDirectory, {
+          HOME: hostHome,
+          PAPERCLIP_WORKSPACE_CWD: workspaceRoot,
+        }),
+      ).toThrow("outside the assigned workspace");
       expect(() =>
         validateCodexWorkingDirectory(outside, {
           PAPERCLIP_WORKSPACE_CWD: workspaceRoot,

--- a/packages/paperclip-runner/src/drivers/codex/codex-boundaries.test.ts
+++ b/packages/paperclip-runner/src/drivers/codex/codex-boundaries.test.ts
@@ -49,10 +49,17 @@ describe("Codex value and workspace boundaries", () => {
           PAPERCLIP_WORKSPACE_CWD: workspaceRoot,
         }),
       ).toBe(realpathSync.native(workspace));
+      expect(() =>
+        validateCodexWorkingDirectory(ordinaryHomeWorkspace, {
+          HOME: hostHome,
+          CODEX_HOME: codexHome,
+        }),
+      ).toThrow("inside the host HOME requires an assigned workspace");
       expect(
         validateCodexWorkingDirectory(ordinaryHomeWorkspace, {
           HOME: hostHome,
           CODEX_HOME: codexHome,
+          PAPERCLIP_WORKSPACE_CWD: join(hostHome, "projects"),
         }),
       ).toBe(realpathSync.native(ordinaryHomeWorkspace));
       expect(() =>

--- a/packages/paperclip-runner/src/drivers/codex/codex-boundaries.ts
+++ b/packages/paperclip-runner/src/drivers/codex/codex-boundaries.ts
@@ -60,6 +60,7 @@ export function validateCodexWorkingDirectory(
   if (resolved === parse(resolved).root) {
     throw new Error("Codex working directory cannot be a filesystem root");
   }
+  const configuredRoot = environment.PAPERCLIP_WORKSPACE_CWD;
   const hostHome = canonicalConfiguredPath(environment.HOME);
   if (hostHome && pathContains(resolved, hostHome)) {
     throw new Error("Codex working directory cannot contain the host HOME");
@@ -74,6 +75,15 @@ export function validateCodexWorkingDirectory(
       "Codex working directory cannot overlap sensitive host HOME state",
     );
   }
+  if (
+    hostHome &&
+    pathContains(hostHome, resolved) &&
+    (configuredRoot === undefined || configuredRoot.trim().length === 0)
+  ) {
+    throw new Error(
+      "Codex working directory inside the host HOME requires an assigned workspace",
+    );
+  }
   const codexHome = canonicalConfiguredPath(environment.CODEX_HOME);
   if (codexHome) {
     if (
@@ -83,7 +93,6 @@ export function validateCodexWorkingDirectory(
       throw new Error("Codex working directory cannot overlap host CODEX_HOME");
     }
   }
-  const configuredRoot = environment.PAPERCLIP_WORKSPACE_CWD;
   if (configuredRoot !== undefined && configuredRoot.trim().length > 0) {
     const root = canonicalConfiguredPath(configuredRoot)!;
     const pathFromRoot = relative(root, resolved);

--- a/packages/paperclip-runner/src/drivers/codex/codex-boundaries.ts
+++ b/packages/paperclip-runner/src/drivers/codex/codex-boundaries.ts
@@ -55,9 +55,6 @@ export function validateCodexWorkingDirectory(
   if (hostHome && pathContains(resolved, hostHome)) {
     throw new Error("Codex working directory cannot contain the host HOME");
   }
-  if (hostHome && pathContains(hostHome, resolved)) {
-    throw new Error("Codex working directory cannot overlap the host HOME");
-  }
   const codexHome = canonicalConfiguredPath(environment.CODEX_HOME);
   if (codexHome) {
     if (

--- a/packages/paperclip-runner/src/drivers/codex/codex-boundaries.ts
+++ b/packages/paperclip-runner/src/drivers/codex/codex-boundaries.ts
@@ -18,6 +18,15 @@ import { redactCodexDiagnostic } from "./app-server-transport.js";
 
 const MAX_RETAINED_CODEX_PAYLOAD_BYTES = 64 * 1024;
 const MAX_RETAINED_CODEX_STRING_CHARS = 32 * 1024;
+const SENSITIVE_HOST_HOME_DIRECTORIES = [
+  ".aws",
+  ".azure",
+  ".codex",
+  ".config/gcloud",
+  ".gnupg",
+  ".kube",
+  ".ssh",
+] as const;
 
 function record(value: unknown): Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -54,6 +63,16 @@ export function validateCodexWorkingDirectory(
   const hostHome = canonicalConfiguredPath(environment.HOME);
   if (hostHome && pathContains(resolved, hostHome)) {
     throw new Error("Codex working directory cannot contain the host HOME");
+  }
+  if (
+    hostHome &&
+    SENSITIVE_HOST_HOME_DIRECTORIES.some((directory) =>
+      pathContains(resolve(hostHome, directory), resolved),
+    )
+  ) {
+    throw new Error(
+      "Codex working directory cannot overlap sensitive host HOME state",
+    );
   }
   const codexHome = canonicalConfiguredPath(environment.CODEX_HOME);
   if (codexHome) {

--- a/packages/paperclip-runner/src/live/runnerd-codex-transport.test.ts
+++ b/packages/paperclip-runner/src/live/runnerd-codex-transport.test.ts
@@ -92,6 +92,9 @@ it("adds Codex-style turn updates only when collaboration instructions are enabl
   expect(enabled).toContain(base);
   expect(enabled).toContain("Before the first tool call in a turn");
   expect(enabled).toContain("Do not call it merely to create a completion comment");
+  expect(enabled).toContain("Before semantic finalization");
+  expect(enabled).toContain("semantic completion tool as the last action");
+  expect(enabled).not.toContain("After semantic finalization");
   expect(withCodexCollaborationRuntimeInstructions(base, false)).toBe(base);
 });
 

--- a/packages/paperclip-runner/src/live/runnerd-codex-transport.test.ts
+++ b/packages/paperclip-runner/src/live/runnerd-codex-transport.test.ts
@@ -894,7 +894,12 @@ it("binds an immediately failed durable turn before exposing its terminal", asyn
     });
   } finally {
     await session.close();
-    await rm(stateDirectory, { recursive: true, force: true });
+    await rm(stateDirectory, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 50,
+    });
   }
 }, 30_000);
 

--- a/packages/paperclip-runner/src/live/runnerd-codex-transport.test.ts
+++ b/packages/paperclip-runner/src/live/runnerd-codex-transport.test.ts
@@ -520,6 +520,29 @@ it("binds a canonical runnerd terminal to the active provider turn", () => {
   });
 });
 
+it("rehydrates a canonical runnerd terminal error into the Codex turn", () => {
+  expect(
+    rehydrateRunnerdTurnNotification(
+      {
+        providerTurnId: "provider-turn-1",
+        status: "failed",
+        error: { code: "provider_failed", message: "provider rejected the turn" },
+      },
+      "opened-thread-1",
+      "provider-turn-1",
+      "turn/completed",
+    ),
+  ).toMatchObject({
+    threadId: "opened-thread-1",
+    turnId: "provider-turn-1",
+    turn: {
+      id: "provider-turn-1",
+      status: "failed",
+      error: { code: "provider_failed", message: "provider rejected the turn" },
+    },
+  });
+});
+
 it("preserves the provider identity on a late canonical terminal", () => {
   expect(
     rehydrateRunnerdTurnNotification(
@@ -1318,7 +1341,10 @@ it("cold-restores a suspended provider session under its durable run binding", a
   }));
   try {
     const read = await restored.transport.request("thread/read", {});
-    expect(read.thread).toMatchObject({ id: "codex-thread-1" });
+    expect(read.thread).toMatchObject({
+      id: "codex-thread-1",
+      cwd: tmpdir(),
+    });
     expect((await stat(join(stateDirectory, "codex-home", "skills", "assigned"))).mode & 0o222).toBe(0);
     expect((await stat(join(stateDirectory, "codex-home", "skills", "assigned", "SKILL.md"))).mode & 0o222).toBe(0);
     const providerState = JSON.parse(

--- a/packages/paperclip-runner/src/live/runnerd-codex-transport.test.ts
+++ b/packages/paperclip-runner/src/live/runnerd-codex-transport.test.ts
@@ -92,9 +92,9 @@ it("adds Codex-style turn updates only when collaboration instructions are enabl
   expect(enabled).toContain(base);
   expect(enabled).toContain("Before the first tool call in a turn");
   expect(enabled).toContain("Do not call it merely to create a completion comment");
-  expect(enabled).toContain("Before semantic finalization");
-  expect(enabled).toContain("semantic completion tool as the last action");
-  expect(enabled).not.toContain("After semantic finalization");
+  expect(enabled).toContain("semantic completion tool exactly once before");
+  expect(enabled).toContain("After it succeeds");
+  expect(enabled).not.toContain("Before semantic finalization");
   expect(withCodexCollaborationRuntimeInstructions(base, false)).toBe(base);
 });
 

--- a/packages/paperclip-runner/src/live/runnerd-codex-transport.test.ts
+++ b/packages/paperclip-runner/src/live/runnerd-codex-transport.test.ts
@@ -13,6 +13,8 @@ import {
   nativeRuntimePromptDigest,
   type NativeRuntimeContextSnapshot,
 } from "../contracts/runtime-context.js";
+import { createCodexTaskEnvelope } from "../contracts/codex.js";
+import { CodexAppServerDriver } from "../drivers/codex/codex-app-server-driver.js";
 import { releaseMaterializedNativeRuntimeSkills } from "../drivers/runtime-context-materializer.js";
 
 import {
@@ -831,6 +833,66 @@ it("runs the lab provider boundary through authenticated durable PRP", async () 
     runnerExited: true,
     runnerExitCode: 0,
   });
+}, 30_000);
+
+it("binds an immediately failed durable turn before exposing its terminal", async () => {
+  const stateDirectory = await mkdtemp(join(tmpdir(), "runnerd-fast-terminal-"));
+  const bundle = createCapabilityRunnerdCodexTransport({
+    runnerBinary: defaultCapabilityRunnerdBinary(),
+    codexCommand: fakeCodex,
+    codexArgs: fakeCodexArgs(stateDirectory, "--fail-turn-immediately"),
+    stateDirectory,
+  });
+  const driver = new CodexAppServerDriver({
+    taskEnvelope: createCodexTaskEnvelope({
+      objective: "Exercise an immediate provider failure.",
+    }),
+    environment: {
+      PATH: process.env.PATH,
+      HOME: join(tmpdir(), "runnerd-fast-terminal-host-home"),
+      PAPERCLIP_WORKSPACE_CWD: stateDirectory,
+    },
+    approvalPolicy: "never",
+    transportFactory: () => bundle.transport,
+  });
+  const session = await driver.openSession({
+    runId: "run-fast-terminal",
+    normalizedSessionId: "session-fast-terminal",
+    workingDirectory: stateDirectory,
+  });
+  try {
+    const accepted = await session.startTurn({
+      message: { role: "user", text: "Fail this test turn." },
+    });
+    expect(accepted.turnId).toBe("provider-turn-1");
+    const events = [];
+    for await (const event of session.events()) {
+      events.push(event);
+      if (event.eventType === "turn.failed") break;
+    }
+    const eventTypes = events.map((event) => event.eventType);
+    expect(eventTypes).toEqual(
+      expect.arrayContaining(["turn.started", "turn.accepted", "turn.failed"]),
+    );
+    expect(eventTypes.indexOf("turn.started")).toBeLessThan(
+      eventTypes.indexOf("turn.accepted"),
+    );
+    expect(eventTypes.indexOf("turn.accepted")).toBeLessThan(
+      eventTypes.indexOf("turn.failed"),
+    );
+    expect(
+      events.find((event) => event.eventType === "session.failed"),
+    ).toBeUndefined();
+    expect(await session.snapshot()).toMatchObject({
+      activeTurnId: null,
+      terminalTurns: [
+        { turnId: "provider-turn-1", fingerprint: expect.any(String) },
+      ],
+    });
+  } finally {
+    await session.close();
+    await rm(stateDirectory, { recursive: true, force: true });
+  }
 }, 30_000);
 
 it("bridges a runnerd-native question into the server request handler and resolves it canonically", async () => {

--- a/packages/paperclip-runner/src/live/runnerd-codex-transport.ts
+++ b/packages/paperclip-runner/src/live/runnerd-codex-transport.ts
@@ -1165,6 +1165,7 @@ class DurablePrpCodexTransport implements CodexAppServerTransport {
   #sessionId: string | null = null;
   #providerIdentity: Record<string, unknown> | null = null;
   #turnId = "";
+  #turnStartResponsePending = false;
   #durableTurnId = "";
   #authorizedTools: Record<string, unknown> | null = null;
   #closed = false;
@@ -2171,22 +2172,27 @@ class DurablePrpCodexTransport implements CodexAppServerTransport {
       .join("\n");
     const pendingTurnId = `turn_lab_${randomUUID().replaceAll("-", "")}`;
     this.#turnId = pendingTurnId;
-    await this.#command("turn.start", { text: message });
-    // Command completion only means runnerd accepted the command. Codex assigns
-    // the authoritative turn identity in the subsequent turn/started event, so
-    // do not expose the temporary transport identity to the strict driver.
-    const deadline = Date.now() + 30_000;
-    while (this.#turnId === pendingTurnId && Date.now() < deadline) {
-      this.#throwIfFailed();
-      this.#pumpEvents();
-      if (this.#turnId !== pendingTurnId) break;
-      if (this.#handle?.child.exitCode !== null)
-        throw new Error("runnerd exited before provider turn startup");
-      await new Promise((resolveWait) => setTimeout(resolveWait, 10));
+    this.#turnStartResponsePending = true;
+    try {
+      await this.#command("turn.start", { text: message });
+      // Command completion only means runnerd accepted the command. Codex assigns
+      // the authoritative turn identity in the subsequent turn/started event, so
+      // do not expose the temporary transport identity to the strict driver.
+      const deadline = Date.now() + 30_000;
+      while (this.#turnId === pendingTurnId && Date.now() < deadline) {
+        this.#throwIfFailed();
+        this.#pumpEvents();
+        if (this.#turnId !== pendingTurnId) break;
+        if (this.#handle?.child.exitCode !== null)
+          throw new Error("runnerd exited before provider turn startup");
+        await new Promise((resolveWait) => setTimeout(resolveWait, 10));
+      }
+      if (this.#turnId === pendingTurnId)
+        throw new Error("runnerd did not report the provider turn identity");
+      return { turn: { id: this.#turnId, status: "inProgress" } };
+    } finally {
+      this.#turnStartResponsePending = false;
     }
-    if (this.#turnId === pendingTurnId)
-      throw new Error("runnerd did not report the provider turn identity");
-    return { turn: { id: this.#turnId, status: "inProgress" } };
   }
 
   async #command(
@@ -2529,6 +2535,17 @@ class DurablePrpCodexTransport implements CodexAppServerTransport {
         } else if (traceResult === "retry") {
           this.#traceRehydrationSpoolOverflow = true;
         }
+      }
+      // The strict Codex driver must bind the provider turn from the response
+      // before it observes terminal notifications. A fast provider can commit
+      // start and terminal events in one durable batch, so stop after exposing
+      // turn/started while the request is pending. The regular pump drains the
+      // remaining events after the promise resolves.
+      if (
+        this.#turnStartResponsePending &&
+        notifications.some((notification) => notification.method === "turn/started")
+      ) {
+        return;
       }
     }
   }

--- a/packages/paperclip-runner/src/live/runnerd-codex-transport.ts
+++ b/packages/paperclip-runner/src/live/runnerd-codex-transport.ts
@@ -1166,6 +1166,7 @@ class DurablePrpCodexTransport implements CodexAppServerTransport {
   #providerIdentity: Record<string, unknown> | null = null;
   #turnId = "";
   #turnStartResponsePending = false;
+  #turnStartNotificationQueued = false;
   #durableTurnId = "";
   #authorizedTools: Record<string, unknown> | null = null;
   #closed = false;
@@ -2172,6 +2173,7 @@ class DurablePrpCodexTransport implements CodexAppServerTransport {
       .join("\n");
     const pendingTurnId = `turn_lab_${randomUUID().replaceAll("-", "")}`;
     this.#turnId = pendingTurnId;
+    this.#turnStartNotificationQueued = false;
     this.#turnStartResponsePending = true;
     try {
       await this.#command("turn.start", { text: message });
@@ -2192,6 +2194,7 @@ class DurablePrpCodexTransport implements CodexAppServerTransport {
       return { turn: { id: this.#turnId, status: "inProgress" } };
     } finally {
       this.#turnStartResponsePending = false;
+      this.#turnStartNotificationQueued = false;
     }
   }
 
@@ -2289,6 +2292,12 @@ class DurablePrpCodexTransport implements CodexAppServerTransport {
 
   #pumpEvents(): void {
     this.#flushPendingTraceRehydrations();
+    // An interval pump can run again while turn/start is still awaiting its
+    // command response. Once turn/started is queued, hold the durable suffix
+    // until the strict driver has bound the returned provider turn.
+    if (this.#turnStartResponsePending && this.#turnStartNotificationQueued) {
+      return;
+    }
     const events = this.#core?.store.state.committedEvents ?? [];
     while (this.#eventIndex < events.length) {
       const event = events[this.#eventIndex++];
@@ -2545,6 +2554,7 @@ class DurablePrpCodexTransport implements CodexAppServerTransport {
         this.#turnStartResponsePending &&
         notifications.some((notification) => notification.method === "turn/started")
       ) {
+        this.#turnStartNotificationQueued = true;
         return;
       }
     }

--- a/packages/paperclip-runner/src/live/runnerd-codex-transport.ts
+++ b/packages/paperclip-runner/src/live/runnerd-codex-transport.ts
@@ -68,7 +68,7 @@ const CODEX_COLLABORATION_RUNTIME_INSTRUCTIONS = `## Codex-style collaboration
 - Before the first tool call in a turn, send a brief commentary update describing the immediate work you are starting.
 - During tool-driven work, send concise commentary updates at meaningful transitions so the user can follow progress without opening raw logs.
 - Reserve \`report_progress\` for meaningful durable milestones on longer work. Do not call it merely to create a completion comment on a short run; Paperclip materializes the final assistant response as the durable completion comment.
-- After semantic finalization, send one self-contained final assistant response with the outcome and verification.`;
+- Before semantic finalization, send one self-contained final assistant response with the outcome and verification. Treat the semantic completion tool as the last action and do not send a trailing acknowledgement.`;
 
 export function withCodexCollaborationRuntimeInstructions(
   instructions: string,

--- a/packages/paperclip-runner/src/live/runnerd-codex-transport.ts
+++ b/packages/paperclip-runner/src/live/runnerd-codex-transport.ts
@@ -733,6 +733,9 @@ export function rehydrateRunnerdTurnNotification(
       ...(rawTurn.status === undefined && rawParams.status !== undefined
         ? { status: rawParams.status }
         : {}),
+      ...(rawTurn.error === undefined && rawParams.error !== undefined
+        ? { error: rawParams.error }
+        : {}),
     },
   };
 }
@@ -1370,7 +1373,12 @@ class DurablePrpCodexTransport implements CodexAppServerTransport {
           ...(this.#providerIdentity === null
             ? {}
             : { providerIdentity: structuredClone(this.#providerIdentity) }),
-          cwd: this.options.runnerFilesystemRoot ?? tmpdir(),
+          cwd:
+            typeof snapshot.cwd === "string" && snapshot.cwd.length > 0
+              ? snapshot.cwd
+              : this.options.environment?.PAPERCLIP_WORKSPACE_CWD ??
+                this.options.runnerFilesystemRoot ??
+                tmpdir(),
           turns: recoveredTurns,
         },
       };

--- a/packages/paperclip-runner/src/live/runnerd-codex-transport.ts
+++ b/packages/paperclip-runner/src/live/runnerd-codex-transport.ts
@@ -68,7 +68,7 @@ const CODEX_COLLABORATION_RUNTIME_INSTRUCTIONS = `## Codex-style collaboration
 - Before the first tool call in a turn, send a brief commentary update describing the immediate work you are starting.
 - During tool-driven work, send concise commentary updates at meaningful transitions so the user can follow progress without opening raw logs.
 - Reserve \`report_progress\` for meaningful durable milestones on longer work. Do not call it merely to create a completion comment on a short run; Paperclip materializes the final assistant response as the durable completion comment.
-- Before semantic finalization, send one self-contained final assistant response with the outcome and verification. Treat the semantic completion tool as the last action and do not send a trailing acknowledgement.`;
+- Invoke the semantic completion tool exactly once before the final assistant response. After it succeeds, send one self-contained final response with the outcome and verification, then do not call another tool.`;
 
 export function withCodexCollaborationRuntimeInstructions(
   instructions: string,

--- a/packages/paperclip-runner/src/native-session-runtime.test.ts
+++ b/packages/paperclip-runner/src/native-session-runtime.test.ts
@@ -2877,6 +2877,117 @@ describe("executeNativeSession recovery", () => {
     ]);
   });
 
+  it("finalizes a durable semantic result without waiting for a provider terminal", async () => {
+    const lifecycle: string[] = [];
+    const cancel = vi.fn(() => {
+      lifecycle.push("cancelled");
+      return { cleanup: Promise.resolve() };
+    });
+    const providerResult = vi.fn(async () => null);
+    const close = vi.fn(async () => {
+      lifecycle.push("closed");
+    });
+    const events: PrpEvent[] = [];
+    const session: NativeSession = {
+      identity: () => identity,
+      async capabilities() {
+        return {
+          resume: true,
+          typedEvents: true,
+          steering: false,
+          interruption: true,
+          structuredResult: true,
+        };
+      },
+      async *events() {
+        yield runnerEvent(1, "run.result.proposed", result);
+        await new Promise<never>(() => undefined);
+      },
+      async startTurn() {
+        return { turnId: "turn-recovery" };
+      },
+      cancel,
+      result: providerResult,
+      async snapshot() {
+        return {
+          backendKind: "mock",
+          sessionId: identity.sessionId,
+          identity,
+          providerSessionId: "provider-recovery",
+          cursor: "1",
+          activeTurnId: "turn-recovery",
+          pendingRuntimeRequests: [],
+          lineage: [],
+        };
+      },
+      close,
+    };
+    const backend: NativeSessionBackend = {
+      async descriptor() {
+        return {
+          kind: "mock",
+          name: "semantic-result-terminal-stall-backend",
+          version: "1",
+          capabilities: await session.capabilities(),
+        };
+      },
+      async openSession() {
+        return session;
+      },
+    };
+    const port: ControlPlanePort = {
+      async openRun() {},
+      async checkpointSession() {},
+      async appendEvent(event) {
+        events.push(structuredClone(event as PrpEvent));
+        const sourceEvents = events.filter(
+          (candidate) => candidate.sourceInstanceId === event.sourceInstanceId,
+        );
+        return {
+          cursor: events.length,
+          highestContiguousSourceSeq: highestContiguous(sourceEvents),
+          disposition: "committed",
+        };
+      },
+      async replayEvents(replay) {
+        const sourceEvents = events.filter(
+          (event) => event.sourceInstanceId === replay.sourceInstanceId,
+        );
+        return {
+          events: structuredClone(
+            sourceEvents.filter(
+              (event) => event.sourceSeq > replay.afterSourceSeq,
+            ),
+          ),
+          highestContiguousSourceSeq: highestContiguous(sourceEvents),
+        };
+      },
+      async completeRun() {},
+    };
+
+    await expect(
+      executeNativeSession({
+        input,
+        backend,
+        controlPlane: port,
+        runnerInstanceId: "runner-recovery",
+        controlPlaneInstanceId: "control-recovery",
+      }),
+    ).resolves.toMatchObject({ result, terminal });
+
+    expect(cancel).toHaveBeenCalledWith({
+      reason: "Paperclip accepted the durable semantic result.",
+      signal: expect.any(AbortSignal),
+    });
+    expect(providerResult).not.toHaveBeenCalled();
+    expect(events.map((event) => event.eventType)).toEqual([
+      "run.result.proposed",
+      "run.result.accepted",
+      "run.terminal",
+    ]);
+    expect(lifecycle).toEqual(["cancelled", "closed"]);
+  });
+
   it("rejects a mismatched checkpoint before it mutates control-plane state", async () => {
     const openRun = vi.fn(async () => undefined);
     const checkpointSession = vi.fn(async () => undefined);
@@ -4233,12 +4344,87 @@ describe("executeNativeSession recovery", () => {
     });
   });
 
+  it("does not replace a failed provider session when recovery policy forbids it", async () => {
+    const checkpoint: PersistedNativeSession = {
+      backendKind: "mock",
+      sessionId: "driver-failed-constrained",
+      identity,
+      providerSessionId: "provider-failed-constrained",
+      providerRecoveryPolicy: "same_session_only",
+      cursor: null,
+      activeTurnId: null,
+      semanticResult: null,
+      terminal: {
+        schema: "paperclip.prp.terminal.v1",
+        turnTerminalState: "failed",
+        runTerminalState: "failed",
+        reportedWorkDisposition: "yielded",
+      },
+      terminalTurns: [{ turnId: "turn-failed", fingerprint: "failed" }],
+      pendingRuntimeRequests: [],
+      lineage: [],
+    };
+    const openRun = vi.fn(async () => undefined);
+    const openSession = vi.fn(async () => {
+      throw new Error("replacement is forbidden");
+    });
+    const recoverSession = vi.fn();
+    const backend: NativeSessionBackend = {
+      async descriptor() {
+        return {
+          kind: "mock",
+          name: "constrained-recovery-backend",
+          version: "1",
+          capabilities: {
+            resume: true,
+            typedEvents: true,
+            steering: false,
+            interruption: true,
+            structuredResult: true,
+          },
+        };
+      },
+      openSession,
+      recoverSession,
+    };
+    const port: ControlPlanePort = {
+      openRun,
+      async loadSessionCheckpoint() {
+        return structuredClone(checkpoint);
+      },
+      async appendEvent() {
+        throw new Error("unexpected event");
+      },
+      async replayEvents() {
+        return { events: [], highestContiguousSourceSeq: 0 };
+      },
+      async completeRun() {},
+    };
+
+    await expect(
+      executeNativeSession({
+        input,
+        backend,
+        controlPlane: port,
+        runnerInstanceId: "runner-constrained-recovery",
+        controlPlaneInstanceId: "control-constrained-recovery",
+      }),
+    ).rejects.toThrow(
+      "native_session_recovery_failed: provider session ended with a failed terminal",
+    );
+
+    expect(recoverSession).not.toHaveBeenCalled();
+    expect(openSession).not.toHaveBeenCalled();
+    expect(openRun).not.toHaveBeenCalled();
+  });
+
   it("replaces a provider session that already ended with a failed terminal", async () => {
     const checkpoint: PersistedNativeSession = {
       backendKind: "mock",
       sessionId: "driver-failed",
       identity,
       providerSessionId: "provider-failed",
+      providerRecoveryPolicy: "allow_replacement_after_resume_failure",
       cursor: null,
       activeTurnId: null,
       semanticResult: null,

--- a/packages/paperclip-runner/src/native-session-runtime.test.ts
+++ b/packages/paperclip-runner/src/native-session-runtime.test.ts
@@ -4233,6 +4233,130 @@ describe("executeNativeSession recovery", () => {
     });
   });
 
+  it("replaces a provider session that already ended with a failed terminal", async () => {
+    const checkpoint: PersistedNativeSession = {
+      backendKind: "mock",
+      sessionId: "driver-failed",
+      identity,
+      providerSessionId: "provider-failed",
+      cursor: null,
+      activeTurnId: null,
+      semanticResult: null,
+      terminal: {
+        schema: "paperclip.prp.terminal.v1",
+        turnTerminalState: "failed",
+        runTerminalState: "failed",
+        reportedWorkDisposition: "yielded",
+      },
+      terminalTurns: [{ turnId: "turn-failed", fingerprint: "failed" }],
+      pendingRuntimeRequests: [],
+      lineage: [],
+    };
+    const replacementSnapshot: PersistedNativeSession = {
+      ...checkpoint,
+      sessionId: "driver-replacement",
+      providerSessionId: "provider-replacement",
+      terminal: null,
+      terminalTurns: [],
+    };
+    const startTurn = vi.fn(async () => ({ turnId: "turn-replacement" }));
+    const replacementSession: NativeSession = {
+      identity: () => identity,
+      async capabilities() {
+        return {
+          resume: true,
+          typedEvents: true,
+          steering: false,
+          interruption: true,
+          structuredResult: true,
+        };
+      },
+      async *events() {
+        yield runnerEvent(1, "turn.completed");
+      },
+      startTurn,
+      async result() {
+        return { result, terminal, turnId: "turn-replacement" };
+      },
+      async snapshot() {
+        return structuredClone(replacementSnapshot);
+      },
+      async close() {},
+    };
+    const recoverSession = vi.fn(async () => ({
+      recovered: true as const,
+      session: replacementSession,
+    }));
+    const openReplacementSession = vi.fn(async () => replacementSession);
+    const onContinuityBreak = vi.fn(async () => undefined);
+    const backend: NativeSessionBackend = {
+      async descriptor() {
+        return {
+          kind: "mock",
+          name: "replacement-backend",
+          version: "1",
+          capabilities: {
+            resume: true,
+            typedEvents: true,
+            steering: false,
+            interruption: true,
+            structuredResult: true,
+          },
+        };
+      },
+      async openSession() {
+        throw new Error("replacement seam must be used");
+      },
+      recoverSession,
+      openReplacementSession,
+    };
+    const events: PrpEvent[] = [];
+    const port: ControlPlanePort = {
+      async openRun() {},
+      async loadSessionCheckpoint() {
+        return structuredClone(checkpoint);
+      },
+      async checkpointSession() {},
+      async appendEvent(event) {
+        events.push(structuredClone(event));
+        return {
+          cursor: events.length,
+          highestContiguousSourceSeq: highestContiguous(events),
+          disposition: "committed",
+        };
+      },
+      async replayEvents() {
+        return { events: [], highestContiguousSourceSeq: 0 };
+      },
+      async completeRun() {},
+    };
+
+    await expect(
+      executeNativeSession({
+        input,
+        backend,
+        controlPlane: port,
+        runnerInstanceId: "runner-replacement",
+        controlPlaneInstanceId: "control-replacement",
+        onContinuityBreak,
+      }),
+    ).resolves.toMatchObject({ providerSessionId: "provider-replacement" });
+
+    expect(recoverSession).not.toHaveBeenCalled();
+    expect(openReplacementSession).toHaveBeenCalledOnce();
+    const replacementEnvelope = JSON.parse(
+      startTurn.mock.calls[0]![0].message.text,
+    ) as { task: { prompt: string } };
+    expect(replacementEnvelope.task.prompt).toBe(input.task.prompt);
+    expect(onContinuityBreak).toHaveBeenCalledWith({
+      reason: "provider session ended with a failed terminal",
+      previousDriverSessionId: "driver-failed",
+      previousProviderSessionId: "provider-failed",
+      replacementDriverSessionId: "driver-replacement",
+      replacementProviderSessionId: "provider-replacement",
+    });
+  });
+
   it("retries disposition recovery when the driver releases an absent bound provider turn", async () => {
     const checkpoint: PersistedNativeSession = {
       backendKind: "mock",

--- a/packages/paperclip-runner/src/native-session-runtime.test.ts
+++ b/packages/paperclip-runner/src/native-session-runtime.test.ts
@@ -2972,6 +2972,7 @@ describe("executeNativeSession recovery", () => {
         controlPlane: port,
         runnerInstanceId: "runner-recovery",
         controlPlaneInstanceId: "control-recovery",
+        semanticResultTerminalGraceMs: 0,
       }),
     ).resolves.toMatchObject({ result, terminal });
 
@@ -2986,6 +2987,114 @@ describe("executeNativeSession recovery", () => {
       "run.terminal",
     ]);
     expect(lifecycle).toEqual(["cancelled", "closed"]);
+  });
+
+  it("retains provider output emitted after a durable semantic result", async () => {
+    const cancel = vi.fn(() => ({ cleanup: Promise.resolve() }));
+    const close = vi.fn(async () => undefined);
+    const events: PrpEvent[] = [];
+    const session: NativeSession = {
+      identity: () => identity,
+      async capabilities() {
+        return {
+          resume: true,
+          typedEvents: true,
+          steering: false,
+          interruption: true,
+          structuredResult: true,
+        };
+      },
+      async *events() {
+        yield runnerEvent(1, "run.result.proposed", result);
+        yield runnerEvent(2, "item.completed", {
+          item: { type: "assistant_message", text: "Final response." },
+        });
+        yield runnerEvent(3, "turn.completed");
+      },
+      async startTurn() {
+        return { turnId: "turn-recovery" };
+      },
+      cancel,
+      async result() {
+        return null;
+      },
+      async snapshot() {
+        return {
+          backendKind: "mock",
+          sessionId: identity.sessionId,
+          identity,
+          providerSessionId: "provider-recovery",
+          cursor: "3",
+          activeTurnId: null,
+          pendingRuntimeRequests: [],
+          lineage: [],
+        };
+      },
+      close,
+    };
+    const backend: NativeSessionBackend = {
+      async descriptor() {
+        return {
+          kind: "mock",
+          name: "semantic-result-final-response-backend",
+          version: "1",
+          capabilities: await session.capabilities(),
+        };
+      },
+      async openSession() {
+        return session;
+      },
+    };
+    const port: ControlPlanePort = {
+      async openRun() {},
+      async checkpointSession() {},
+      async appendEvent(event) {
+        events.push(structuredClone(event as PrpEvent));
+        const sourceEvents = events.filter(
+          (candidate) => candidate.sourceInstanceId === event.sourceInstanceId,
+        );
+        return {
+          cursor: events.length,
+          highestContiguousSourceSeq: highestContiguous(sourceEvents),
+          disposition: "committed",
+        };
+      },
+      async replayEvents(replay) {
+        const sourceEvents = events.filter(
+          (event) => event.sourceInstanceId === replay.sourceInstanceId,
+        );
+        return {
+          events: structuredClone(
+            sourceEvents.filter(
+              (event) => event.sourceSeq > replay.afterSourceSeq,
+            ),
+          ),
+          highestContiguousSourceSeq: highestContiguous(sourceEvents),
+        };
+      },
+      async completeRun() {},
+    };
+
+    await expect(
+      executeNativeSession({
+        input,
+        backend,
+        controlPlane: port,
+        runnerInstanceId: "runner-recovery",
+        controlPlaneInstanceId: "control-recovery",
+        semanticResultTerminalGraceMs: 50,
+      }),
+    ).resolves.toMatchObject({ result, terminal });
+
+    expect(cancel).not.toHaveBeenCalled();
+    expect(close).toHaveBeenCalledOnce();
+    expect(events.map((event) => event.eventType)).toEqual([
+      "run.result.proposed",
+      "item.completed",
+      "turn.completed",
+      "run.result.accepted",
+      "run.terminal",
+    ]);
   });
 
   it("rejects a mismatched checkpoint before it mutates control-plane state", async () => {

--- a/packages/paperclip-runner/src/native-session-runtime.ts
+++ b/packages/paperclip-runner/src/native-session-runtime.ts
@@ -17,10 +17,11 @@ import type {
   NativeSessionBackend,
 } from "./contracts/native-session-backend.js";
 import type { PersistedNativeSession } from "./contracts/native-session-backend.js";
-import type {
-  PrpEvent,
-  PrpStructuredRunResult,
-  PrpTerminalState,
+import {
+  validatePrpStructuredRunResult,
+  type PrpEvent,
+  type PrpStructuredRunResult,
+  type PrpTerminalState,
 } from "./protocol/replay-contract.js";
 import { parsePaperclipQuestionSet } from "./contracts/question-set.js";
 
@@ -723,6 +724,7 @@ async function consumeTurn(
     let eventCount = 0;
     let highestContiguousSourceSeq = 0;
     let governedResult: PrpStructuredRunResult | null = null;
+    let resultSource: "semantic_result" | "governed_wait" | null = null;
     while (true) {
       const next = await eventIterator.next();
       if (stopConsumer) throw new Error("native event consumer stopped");
@@ -820,6 +822,14 @@ async function consumeTurn(
           // Invalid structured inputs remain rejected by the driver and never become durable questions.
         }
       }
+      if (governedResult === null && event.eventType === "run.result.proposed") {
+        const validation = validatePrpStructuredRunResult(event.payload);
+        if (!validation.ok) {
+          throw new Error("native_semantic_result_invalid");
+        }
+        governedResult = validation.result;
+        resultSource = "semantic_result";
+      }
       if (governedResult === null && resolveGovernedWait) {
         if (appendAbort.signal.aborted) {
           throw (
@@ -831,33 +841,41 @@ async function consumeTurn(
           turnId: event.turnId ?? null,
           event,
         });
-        if (governedResult !== null && !isTurnTerminal(event)) {
-          if (session.cancel === undefined) {
+        if (governedResult !== null) resultSource = "governed_wait";
+      }
+      if (governedResult !== null && !isTurnTerminal(event)) {
+        if (session.cancel === undefined) {
+          if (resultSource === "governed_wait") {
             throw new Error("native_governed_wait_cancellation_unavailable");
           }
-          // A governed result is already durable. Commit cancellation
-          // synchronously, then stop consuming provider output now rather
-          // than waiting for an abort-insensitive cleanup or terminal event.
-          // The returned promise owns cleanup only and remains observed in
-          // finally, where its wait is bounded and the session quarantined.
-          const cancellation = session.cancel({
-            reason:
-              "Paperclip parked this turn on a durable governed interaction.",
-            signal: appendAbort.signal,
-          });
-          governedCancellationCommitted = true;
-          const cleanup = cancellation.cleanup;
-          governedCleanupOperations.add(cleanup);
-          void cleanup
-            .catch(() => quarantineSession())
-            .finally(() => governedCleanupOperations.delete(cleanup));
-          return {
-            event,
-            eventCount,
-            highestContiguousSourceSeq,
-            governedResult,
-          };
+          // Backends without interruption support still need their provider
+          // terminal. Retain the validated result and continue consuming.
+          continue;
         }
+        // A semantic proposal or governed result is already durable. Commit
+        // cancellation synchronously, then stop consuming provider output now
+        // rather than waiting indefinitely for a provider terminal. The
+        // returned promise owns cleanup only and remains observed in finally,
+        // where its wait is bounded and the session quarantined.
+        const cancellation = session.cancel({
+          reason:
+            resultSource === "semantic_result"
+              ? "Paperclip accepted the durable semantic result."
+              : "Paperclip parked this turn on a durable governed interaction.",
+          signal: appendAbort.signal,
+        });
+        governedCancellationCommitted = true;
+        const cleanup = cancellation.cleanup;
+        governedCleanupOperations.add(cleanup);
+        void cleanup
+          .catch(() => quarantineSession())
+          .finally(() => governedCleanupOperations.delete(cleanup));
+        return {
+          event,
+          eventCount,
+          highestContiguousSourceSeq,
+          governedResult,
+        };
       }
       if (isTurnTerminal(event)) {
         return {
@@ -1317,7 +1335,7 @@ export async function executeNativeSession(
             reason: "driver does not support recovery",
           };
     if (!recovery.recovered || !recovery.session) {
-      if (!replacementAllowed && !failedProviderSession) {
+      if (!replacementAllowed) {
         throw new Error(
           `native_session_recovery_failed: ${recovery.reason ?? "unknown"}`,
         );

--- a/packages/paperclip-runner/src/native-session-runtime.ts
+++ b/packages/paperclip-runner/src/native-session-runtime.ts
@@ -1286,30 +1286,38 @@ export async function executeNativeSession(
     const replacementAllowed =
       providerRecoveryCheckpoint.providerRecoveryPolicy ===
       "allow_replacement_after_resume_failure";
-    const recovery = options.backend.recoverSession
-      ? await runAbortableOperationWithin({
-          timeoutMs: recoveryTimeoutMs,
-          timeoutMessage: `native session provider recovery timed out after ${recoveryTimeoutMs}ms`,
-          operation: (signal) =>
-            options.backend.recoverSession!(providerRecoveryCheckpoint, {
-              signal,
-            }),
-          onLateResolution: async (lateRecovery) => {
-            if (lateRecovery.session) {
-              await disposeUnadmittedSession(
-                lateRecovery.session,
-                "native session provider recovery timed out",
-                cleanupDomain,
-              );
-            }
-          },
-        })
-      : {
+    const failedProviderSession =
+      providerRecoveryCheckpoint.terminal?.runTerminalState === "failed" &&
+      providerRecoveryCheckpoint.semanticResult === null;
+    const recovery = failedProviderSession
+      ? {
           recovered: false as const,
-          reason: "driver does not support recovery",
-        };
+          reason: "provider session ended with a failed terminal",
+        }
+      : options.backend.recoverSession
+        ? await runAbortableOperationWithin({
+            timeoutMs: recoveryTimeoutMs,
+            timeoutMessage: `native session provider recovery timed out after ${recoveryTimeoutMs}ms`,
+            operation: (signal) =>
+              options.backend.recoverSession!(providerRecoveryCheckpoint, {
+                signal,
+              }),
+            onLateResolution: async (lateRecovery) => {
+              if (lateRecovery.session) {
+                await disposeUnadmittedSession(
+                  lateRecovery.session,
+                  "native session provider recovery timed out",
+                  cleanupDomain,
+                );
+              }
+            },
+          })
+        : {
+            recovered: false as const,
+            reason: "driver does not support recovery",
+          };
     if (!recovery.recovered || !recovery.session) {
-      if (!replacementAllowed) {
+      if (!replacementAllowed && !failedProviderSession) {
         throw new Error(
           `native_session_recovery_failed: ${recovery.reason ?? "unknown"}`,
         );

--- a/packages/paperclip-runner/src/native-session-runtime.ts
+++ b/packages/paperclip-runner/src/native-session-runtime.ts
@@ -26,6 +26,7 @@ import {
 import { parsePaperclipQuestionSet } from "./contracts/question-set.js";
 
 export const DEFAULT_NATIVE_RUNTIME_INPUT_LIVE_WINDOW_MS = 120_000;
+export const DEFAULT_NATIVE_SEMANTIC_RESULT_TERMINAL_GRACE_MS = 5_000;
 const OPTIONAL_SESSION_CANCELLATION_GRACE_MS = 100;
 const FAILED_OPERATION_SETTLEMENT_GRACE_MS = 100;
 const DEFAULT_NATIVE_CHECKPOINT_TIMEOUT_MS = 30_000;
@@ -79,6 +80,8 @@ export interface ExecuteNativeSessionOptions {
   checkpointTimeoutMs?: number;
   /** Internal test seam; production uses the fixed 120-second platform policy. */
   runtimeInputLiveWindowMs?: number;
+  /** Internal test seam; production gives the provider five seconds to end after a result. */
+  semanticResultTerminalGraceMs?: number;
   onSession?: (session: NativeSession | null) => void;
   existingSession?: NativeSession;
   persistedSession?: PersistedNativeSession | null;
@@ -676,12 +679,15 @@ async function consumeTurn(
   controlPlane: ControlPlanePort,
   timeoutMs: number,
   runtimeInputLiveWindowMs: number,
+  semanticResultTerminalGraceMs: number,
   closeFailedSession: () => Promise<void>,
   quarantineSession: () => void,
   resolveGovernedWait?: ExecuteNativeSessionOptions["resolveGovernedWait"],
   externalSignal?: AbortSignal,
 ) {
   let timer: ReturnType<typeof setTimeout> | undefined;
+  let semanticResultTimer: ReturnType<typeof setTimeout> | undefined;
+  const semanticResultGraceExpired = Symbol("semantic_result_grace_expired");
   const appendAbort = new AbortController();
   const governedCleanupOperations = new Set<Promise<unknown>>();
   let governedCancellationCommitted = false;
@@ -725,13 +731,71 @@ async function consumeTurn(
     let highestContiguousSourceSeq = 0;
     let governedResult: PrpStructuredRunResult | null = null;
     let resultSource: "semantic_result" | "governed_wait" | null = null;
+    let semanticResultEvent: PrpEvent | null = null;
+    let semanticResultDeadline: Promise<
+      typeof semanticResultGraceExpired
+    > | null = null;
+    let pendingNext: ReturnType<typeof eventIterator.next> | null = null;
+    const settleDurableResult = (
+      event: PrpEvent,
+      result: PrpStructuredRunResult,
+      reason: string,
+    ) => {
+      if (session.cancel === undefined) {
+        throw new Error("native_governed_wait_cancellation_unavailable");
+      }
+      const cancellation = session.cancel({
+        reason,
+        signal: appendAbort.signal,
+      });
+      governedCancellationCommitted = true;
+      const cleanup = cancellation.cleanup;
+      governedCleanupOperations.add(cleanup);
+      void cleanup
+        .catch(() => quarantineSession())
+        .finally(() => governedCleanupOperations.delete(cleanup));
+      return {
+        event,
+        eventCount,
+        highestContiguousSourceSeq,
+        governedResult: result,
+      };
+    };
     while (true) {
-      const next = await eventIterator.next();
+      pendingNext ??= eventIterator.next();
+      const next = semanticResultDeadline === null
+        ? await pendingNext
+        : await Promise.race([pendingNext, semanticResultDeadline]);
+      if (next === semanticResultGraceExpired) {
+        void pendingNext.catch(() => undefined);
+        if (semanticResultEvent === null || governedResult === null) {
+          throw new Error("native_semantic_result_grace_lost_result");
+        }
+        return settleDurableResult(
+          semanticResultEvent,
+          governedResult,
+          "Paperclip accepted the durable semantic result.",
+        );
+      }
+      pendingNext = null;
       if (stopConsumer) throw new Error("native event consumer stopped");
-      if (next.done)
+      if (next.done) {
+        if (
+          resultSource === "semantic_result" &&
+          semanticResultEvent !== null &&
+          governedResult !== null
+        ) {
+          return {
+            event: semanticResultEvent,
+            eventCount,
+            highestContiguousSourceSeq,
+            governedResult,
+          };
+        }
         throw new Error(
           "native event stream closed before a turn terminal fact",
         );
+      }
       const event = next.value;
       const payload = event.payload as Record<string, unknown>;
       const settlingRequestId =
@@ -829,6 +893,16 @@ async function consumeTurn(
         }
         governedResult = validation.result;
         resultSource = "semantic_result";
+        semanticResultEvent = event;
+        if (session.cancel !== undefined) {
+          semanticResultDeadline = new Promise((resolve) => {
+            semanticResultTimer = setTimeout(
+              () => resolve(semanticResultGraceExpired),
+              semanticResultTerminalGraceMs,
+            );
+            semanticResultTimer.unref?.();
+          });
+        }
       }
       if (governedResult === null && resolveGovernedWait) {
         if (appendAbort.signal.aborted) {
@@ -844,38 +918,17 @@ async function consumeTurn(
         if (governedResult !== null) resultSource = "governed_wait";
       }
       if (governedResult !== null && !isTurnTerminal(event)) {
-        if (session.cancel === undefined) {
-          if (resultSource === "governed_wait") {
-            throw new Error("native_governed_wait_cancellation_unavailable");
-          }
-          // Backends without interruption support still need their provider
-          // terminal. Retain the validated result and continue consuming.
+        if (resultSource === "semantic_result") {
+          // Give the provider a short grace to publish its final assistant
+          // message and terminal after the semantic tool returns. If no
+          // terminal arrives, the deadline above finalizes the durable result.
           continue;
         }
-        // A semantic proposal or governed result is already durable. Commit
-        // cancellation synchronously, then stop consuming provider output now
-        // rather than waiting indefinitely for a provider terminal. The
-        // returned promise owns cleanup only and remains observed in finally,
-        // where its wait is bounded and the session quarantined.
-        const cancellation = session.cancel({
-          reason:
-            resultSource === "semantic_result"
-              ? "Paperclip accepted the durable semantic result."
-              : "Paperclip parked this turn on a durable governed interaction.",
-          signal: appendAbort.signal,
-        });
-        governedCancellationCommitted = true;
-        const cleanup = cancellation.cleanup;
-        governedCleanupOperations.add(cleanup);
-        void cleanup
-          .catch(() => quarantineSession())
-          .finally(() => governedCleanupOperations.delete(cleanup));
-        return {
+        return settleDurableResult(
           event,
-          eventCount,
-          highestContiguousSourceSeq,
           governedResult,
-        };
+          "Paperclip parked this turn on a durable governed interaction.",
+        );
       }
       if (isTurnTerminal(event)) {
         return {
@@ -1006,6 +1059,7 @@ async function consumeTurn(
       if (!teardownSettled) quarantineSession();
     }
     if (timer !== undefined) clearTimeout(timer);
+    if (semanticResultTimer !== undefined) clearTimeout(semanticResultTimer);
     removeExternalAbort();
   }
 }
@@ -1640,6 +1694,8 @@ export async function executeNativeSession(
               options.timeoutMs ?? 900_000,
               options.runtimeInputLiveWindowMs ??
                 DEFAULT_NATIVE_RUNTIME_INPUT_LIVE_WINDOW_MS,
+              options.semanticResultTerminalGraceMs ??
+                DEFAULT_NATIVE_SEMANTIC_RESULT_TERMINAL_GRACE_MS,
               closeSession,
               quarantineSession,
               options.resolveGovernedWait,

--- a/server/src/__tests__/agent-adapter-validation-routes.test.ts
+++ b/server/src/__tests__/agent-adapter-validation-routes.test.ts
@@ -643,7 +643,7 @@ describe("agent routes adapter validation", () => {
         adapterConfig: expect.objectContaining({
           provider: "codex",
           model: "gpt-5.6-sol",
-          codexPermissionMode: "never",
+          codexPermissionMode: "untrusted",
           lifecycleMode: "per_turn",
           paperclipSkillSync: { desiredSkills: ["company-1/reviewer"] },
         }),
@@ -686,7 +686,7 @@ describe("agent routes adapter validation", () => {
         adapterConfig: expect.objectContaining({
           provider: "codex",
           model: "gpt-5.5",
-          codexPermissionMode: "never",
+          codexPermissionMode: "untrusted",
           lifecycleMode: "per_turn",
           paperclipSkillSync: { desiredSkills: ["company-1/reviewer"] },
         }),

--- a/server/src/__tests__/agent-adapter-validation-routes.test.ts
+++ b/server/src/__tests__/agent-adapter-validation-routes.test.ts
@@ -627,16 +627,68 @@ describe("agent routes adapter validation", () => {
         .send({
           name: "Native Codex",
           adapterType: "paperclip_runner",
-          adapterConfig: { provider: "codex" },
+          adapterConfig: {
+            provider: "codex",
+            paperclipSkillSync: {
+              desiredSkills: ["paperclipai/paperclip/paperclip", "company-1/reviewer"],
+            },
+          },
         }),
     );
 
     expect(res.status, JSON.stringify(res.body)).toBe(201);
-    expect(mockAgentService.create).toHaveBeenCalledOnce();
+    expect(mockAgentService.create).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({
+        adapterConfig: expect.objectContaining({
+          provider: "codex",
+          codexPermissionMode: "never",
+          lifecycleMode: "per_turn",
+          paperclipSkillSync: { desiredSkills: ["company-1/reviewer"] },
+        }),
+      }),
+      expect.any(Object),
+    );
     expect(mockAgentInstructionsService.materializeManagedBundle).toHaveBeenCalledWith(
       expect.objectContaining({ adapterType: "paperclip_runner" }),
       expect.any(Object),
       expect.objectContaining({ entryFile: "AGENTS.md", replaceExisting: false }),
+    );
+  });
+
+  it("normalizes legacy skills and permissions when switching to paperclip_runner", async () => {
+    mockInstanceSettingsService.getExperimental.mockResolvedValue({ enableNativeRunner: true });
+    const existing = await mockAgentService.getById();
+    mockAgentService.getById.mockResolvedValue({
+      ...existing,
+      adapterType: "codex_local",
+      adapterConfig: {
+        paperclipSkillSync: {
+          desiredSkills: ["paperclipai/paperclip/paperclip", "company-1/reviewer"],
+        },
+      },
+    });
+    const app = await createApp();
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl)
+        .patch("/api/agents/11111111-1111-4111-8111-111111111111")
+        .send({ adapterType: "paperclip_runner", replaceAdapterConfig: true, adapterConfig: {} }),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        adapterType: "paperclip_runner",
+        adapterConfig: expect.objectContaining({
+          provider: "codex",
+          codexPermissionMode: "never",
+          lifecycleMode: "per_turn",
+          paperclipSkillSync: { desiredSkills: ["company-1/reviewer"] },
+        }),
+      }),
+      expect.any(Object),
     );
   });
 

--- a/server/src/__tests__/agent-adapter-validation-routes.test.ts
+++ b/server/src/__tests__/agent-adapter-validation-routes.test.ts
@@ -642,6 +642,7 @@ describe("agent routes adapter validation", () => {
       expect.objectContaining({
         adapterConfig: expect.objectContaining({
           provider: "codex",
+          model: "gpt-5.6-sol",
           codexPermissionMode: "never",
           lifecycleMode: "per_turn",
           paperclipSkillSync: { desiredSkills: ["company-1/reviewer"] },
@@ -663,6 +664,7 @@ describe("agent routes adapter validation", () => {
       ...existing,
       adapterType: "codex_local",
       adapterConfig: {
+        model: "gpt-5.5",
         paperclipSkillSync: {
           desiredSkills: ["paperclipai/paperclip/paperclip", "company-1/reviewer"],
         },
@@ -683,6 +685,7 @@ describe("agent routes adapter validation", () => {
         adapterType: "paperclip_runner",
         adapterConfig: expect.objectContaining({
           provider: "codex",
+          model: "gpt-5.5",
           codexPermissionMode: "never",
           lifecycleMode: "per_turn",
           paperclipSkillSync: { desiredSkills: ["company-1/reviewer"] },
@@ -690,6 +693,57 @@ describe("agent routes adapter validation", () => {
       }),
       expect.any(Object),
     );
+  });
+
+  it("uses the Codex default when a codex_local conversion has no model", async () => {
+    mockInstanceSettingsService.getExperimental.mockResolvedValue({ enableNativeRunner: true });
+    const app = await createApp();
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl)
+        .patch("/api/agents/11111111-1111-4111-8111-111111111111")
+        .send({
+          adapterType: "paperclip_runner",
+          replaceAdapterConfig: true,
+          adapterConfig: { model: "" },
+        }),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      expect.objectContaining({
+        adapterConfig: expect.objectContaining({ model: "gpt-5.6-sol" }),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("rejects conversion from an unsupported provider family", async () => {
+    mockInstanceSettingsService.getExperimental.mockResolvedValue({ enableNativeRunner: true });
+    const existing = await mockAgentService.getById();
+    mockAgentService.getById.mockResolvedValue({
+      ...existing,
+      adapterType: "claude_local",
+      adapterConfig: { model: "claude-sonnet-4-6" },
+    });
+    const app = await createApp();
+
+    const res = await requestApp(app, (baseUrl) =>
+      request(baseUrl)
+        .patch("/api/agents/11111111-1111-4111-8111-111111111111")
+        .send({
+          adapterType: "paperclip_runner",
+          replaceAdapterConfig: true,
+          adapterConfig: {},
+        }),
+    );
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.details).toMatchObject({
+      code: "paperclip_runner_adapter_conversion_unsupported",
+    });
+    expect(mockAgentService.update).not.toHaveBeenCalled();
   });
 
   it("accepts qualified local and managed providers on fresh runner agents and hires", async () => {

--- a/server/src/__tests__/agent-skills-routes.test.ts
+++ b/server/src/__tests__/agent-skills-routes.test.ts
@@ -838,17 +838,27 @@ describe.sequential("agent skill routes", () => {
     expect(mockAdapter.syncSkills).toHaveBeenCalled();
   });
 
-  it("rejects the reserved legacy Paperclip skill for paperclip_runner", async () => {
+  it("ignores the reserved legacy Paperclip skill for paperclip_runner", async () => {
     mockAgentService.getById.mockResolvedValue(makeAgent("paperclip_runner"));
 
     const res = await requestApp(await createApp(), (baseUrl) => request(baseUrl)
       .post("/api/agents/11111111-1111-4111-8111-111111111111/skills/sync?companyId=company-1")
       .send({ desiredSkills: ["paperclipai/paperclip/paperclip"], mode: "replace" }));
 
-    expect(res.status, JSON.stringify(res.body)).toBe(422);
-    expect(res.body.error).toContain("legacy Paperclip operational skill");
-    expect(mockAgentService.update).not.toHaveBeenCalled();
-    expect(mockAdapter.syncSkills).not.toHaveBeenCalled();
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockAgentService.update).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        adapterConfig: expect.objectContaining({
+          paperclipSkillSync: { desiredSkills: [] },
+        }),
+      }),
+      expect.any(Object),
+    );
+    expect(mockAdapter.syncSkills).toHaveBeenCalledWith(
+      expect.any(Object),
+      [],
+    );
   });
 
   it("allows paperclip_runner to remove a pre-existing legacy Paperclip skill", async () => {

--- a/server/src/__tests__/agents-paperclip-runner-skills.test.ts
+++ b/server/src/__tests__/agents-paperclip-runner-skills.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { PAPERCLIP_OPERATIONAL_SKILL_KEY } from "@paperclipai/adapter-utils/server-utils";
-import { assertPaperclipRunnerOperationalSkillInvariant } from "../services/agents.js";
+import {
+  normalizePaperclipOperationalSkillPreference,
+  normalizePaperclipRunnerAdapterConfig,
+  PAPERCLIP_OPERATIONAL_SKILL_KEY,
+  resolveLegacyPaperclipDesiredSkillNames,
+} from "@paperclipai/adapter-utils/server-utils";
 
 const legacyConfig = {
   paperclipSkillSync: {
@@ -8,48 +12,36 @@ const legacyConfig = {
   },
 };
 
-describe("paperclip_runner operational skill invariant", () => {
-  it("rejects the legacy operational skill on new runners", () => {
-    expect(() => assertPaperclipRunnerOperationalSkillInvariant({
-      adapterType: "paperclip_runner",
-      nextConfig: legacyConfig,
-    })).toThrow("does not support the legacy Paperclip operational skill");
+describe("paperclip_runner operational skill normalization", () => {
+  it("applies full-auto native runner defaults at persistence boundaries", () => {
+    expect(normalizePaperclipRunnerAdapterConfig("paperclip_runner", {})).toEqual({
+      provider: "codex",
+      codexPermissionMode: "never",
+      lifecycleMode: "per_turn",
+    });
   });
 
-  it("rejects adding the legacy skill or carrying it onto a runner adapter", () => {
-    expect(() => assertPaperclipRunnerOperationalSkillInvariant({
-      adapterType: "paperclip_runner",
-      nextConfig: legacyConfig,
-      priorAdapterType: "paperclip_runner",
-      priorConfig: {},
-    })).toThrow("does not support the legacy Paperclip operational skill");
-    expect(() => assertPaperclipRunnerOperationalSkillInvariant({
-      adapterType: "paperclip_runner",
-      nextConfig: legacyConfig,
-      priorAdapterType: "codex_local",
-      priorConfig: legacyConfig,
-    })).toThrow("does not support the legacy Paperclip operational skill");
+  it("removes the legacy operational skill while preserving optional skills", () => {
+    const normalized = normalizePaperclipOperationalSkillPreference("paperclip_runner", {
+      paperclipSkillSync: {
+        desiredSkills: [PAPERCLIP_OPERATIONAL_SKILL_KEY, "company-1/reviewer"],
+      },
+    });
+
+    expect(normalized).toEqual({
+      paperclipSkillSync: { desiredSkills: ["company-1/reviewer"] },
+    });
   });
 
-  it("allows stale runner assignments to remain inert while they are edited or removed", () => {
-    expect(() => assertPaperclipRunnerOperationalSkillInvariant({
-      adapterType: "paperclip_runner",
-      nextConfig: legacyConfig,
-      priorAdapterType: "paperclip_runner",
-      priorConfig: legacyConfig,
-    })).not.toThrow();
-    expect(() => assertPaperclipRunnerOperationalSkillInvariant({
-      adapterType: "paperclip_runner",
-      nextConfig: {},
-      priorAdapterType: "paperclip_runner",
-      priorConfig: legacyConfig,
-    })).not.toThrow();
+  it("restores the required operational skill through the legacy resolver after switching back", () => {
+    const normalized = normalizePaperclipOperationalSkillPreference("paperclip_runner", legacyConfig);
+    expect(resolveLegacyPaperclipDesiredSkillNames(normalized, [{
+      key: PAPERCLIP_OPERATIONAL_SKILL_KEY,
+      runtimeName: "paperclip",
+    }])).toEqual([PAPERCLIP_OPERATIONAL_SKILL_KEY]);
   });
 
-  it("does not apply the native-runner invariant to direct adapters", () => {
-    expect(() => assertPaperclipRunnerOperationalSkillInvariant({
-      adapterType: "codex_local",
-      nextConfig: legacyConfig,
-    })).not.toThrow();
+  it("does not change direct adapter preferences", () => {
+    expect(normalizePaperclipOperationalSkillPreference("codex_local", legacyConfig)).toBe(legacyConfig);
   });
 });

--- a/server/src/__tests__/agents-paperclip-runner-skills.test.ts
+++ b/server/src/__tests__/agents-paperclip-runner-skills.test.ts
@@ -17,7 +17,7 @@ describe("paperclip_runner operational skill normalization", () => {
     expect(normalizePaperclipRunnerAdapterConfig("paperclip_runner", {})).toEqual({
       provider: "codex",
       model: "gpt-5.6-sol",
-      codexPermissionMode: "never",
+      codexPermissionMode: "untrusted",
       lifecycleMode: "per_turn",
     });
   });

--- a/server/src/__tests__/agents-paperclip-runner-skills.test.ts
+++ b/server/src/__tests__/agents-paperclip-runner-skills.test.ts
@@ -16,9 +16,17 @@ describe("paperclip_runner operational skill normalization", () => {
   it("applies full-auto native runner defaults at persistence boundaries", () => {
     expect(normalizePaperclipRunnerAdapterConfig("paperclip_runner", {})).toEqual({
       provider: "codex",
+      model: "gpt-5.6-sol",
       codexPermissionMode: "never",
       lifecycleMode: "per_turn",
     });
+  });
+
+  it("repairs an existing blank model without replacing an explicit model", () => {
+    expect(normalizePaperclipRunnerAdapterConfig("paperclip_runner", { model: "" }))
+      .toMatchObject({ model: "gpt-5.6-sol" });
+    expect(normalizePaperclipRunnerAdapterConfig("paperclip_runner", { model: "gpt-5.5" }))
+      .toMatchObject({ model: "gpt-5.5" });
   });
 
   it("removes the legacy operational skill while preserving optional skills", () => {

--- a/server/src/__tests__/agents-paperclip-runner-skills.test.ts
+++ b/server/src/__tests__/agents-paperclip-runner-skills.test.ts
@@ -29,6 +29,16 @@ describe("paperclip_runner operational skill normalization", () => {
       .toMatchObject({ model: "gpt-5.5" });
   });
 
+  it("does not replace a non-Codex provider model with the Codex default", () => {
+    expect(normalizePaperclipRunnerAdapterConfig("paperclip_runner", {
+      provider: "claude_managed",
+      model: "claude-sonnet-5",
+    })).toMatchObject({
+      provider: "claude_managed",
+      model: "claude-sonnet-5",
+    });
+  });
+
   it("removes the legacy operational skill while preserving optional skills", () => {
     const normalized = normalizePaperclipOperationalSkillPreference("paperclip_runner", {
       paperclipSkillSync: {

--- a/server/src/__tests__/heartbeat-workspace-session.test.ts
+++ b/server/src/__tests__/heartbeat-workspace-session.test.ts
@@ -1169,6 +1169,31 @@ describe("resolveWorkspaceAfterLowTrustPreflight", () => {
 });
 
 describe("resolveRuntimeSessionParamsForWorkspace", () => {
+  it("keeps a legacy projectless Codex session in the default agent workspace", () => {
+    const agentId = "agent-projectless-legacy";
+    const fallbackCwd = resolveDefaultAgentWorkspaceDir(agentId);
+    const previousSessionParams = {
+      sessionId: "legacy-session-1",
+      cwd: fallbackCwd,
+    };
+
+    const result = resolveRuntimeSessionParamsForWorkspace({
+      agentId,
+      previousSessionParams,
+      resolvedWorkspace: buildResolvedWorkspace({
+        cwd: fallbackCwd,
+        source: "agent_home",
+        projectId: null,
+        workspaceId: null,
+      }),
+    });
+
+    expect(result).toEqual({
+      sessionParams: previousSessionParams,
+      warning: null,
+    });
+  });
+
   it("migrates fallback workspace sessions to project workspace when project cwd becomes available", () => {
     const agentId = "agent-123";
     const fallbackCwd = resolveDefaultAgentWorkspaceDir(agentId);

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -113,6 +113,12 @@ describe("redaction", () => {
       schema: "paperclip.run-performance-span.v1",
       span: "api.openai.com",
     })?.span).toBe(REDACTED_EVENT_VALUE);
+    expect(
+      redactEventPayload({
+        schema: "paperclip.run-performance-span.v1",
+        span: "runner.example.com",
+      })?.span,
+    ).toBe(REDACTED_EVENT_VALUE);
   });
 
   it("redacts payload objects while preserving null", () => {

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -75,6 +75,46 @@ describe("redaction", () => {
     });
   });
 
+  it("preserves native run span identities without weakening hostname redaction", () => {
+    const spanNames = [
+      "environment.workspace.realize",
+      "native.coordinator.claim",
+      "runner.transport.selected",
+      "runner.prp.route.register",
+      "runner.transport.connect",
+      "runner.session.bootstrap",
+      "runner.turn.submit",
+      "runner.session.startup",
+      "provider.turn.queue",
+      "native.session.execute",
+      "native.result.finalize",
+      "task.run.measured",
+    ];
+
+    for (const span of spanNames) {
+      const input = {
+        schema: "paperclip.run-performance-span.v1",
+        span,
+        parentSpan: "native.session.execute",
+        providerHostname: "api.openai.com",
+      };
+      const sanitized = redactEventPayload(input);
+
+      expect(sanitized).toMatchObject({
+        schema: input.schema,
+        span,
+        parentSpan: "native.session.execute",
+        providerHostname: REDACTED_EVENT_VALUE,
+      });
+      expect(redactEventPayload(sanitized)).toEqual(sanitized);
+    }
+
+    expect(redactEventPayload({
+      schema: "paperclip.run-performance-span.v1",
+      span: "api.openai.com",
+    })?.span).toBe(REDACTED_EVENT_VALUE);
+  });
+
   it("redacts payload objects while preserving null", () => {
     expect(redactEventPayload(null)).toBeNull();
     expect(redactEventPayload({ password: "hunter2", safe: "value" })).toEqual({

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -37,6 +37,10 @@ const JWT_VALUE_RE = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?:\.[A-Za-
 // public discriminators, not credentials. Exempt only the closed Paperclip
 // schema namespace while retaining the existing fail-closed JWT value guard.
 const PAPERCLIP_SCHEMA_ID_RE = /^paperclip\.[a-z0-9_-]+(?:\.[a-z0-9_-]+)*\.v\d+$/;
+const NATIVE_RUN_SPAN_SCHEMA = "paperclip.run-performance-span.v1";
+const NATIVE_RUN_SPAN_FIELDS = ["span", "parentSpan"] as const;
+const NATIVE_RUN_SPAN_NAME_RE =
+  /^(?:agent|environment|harness|native|provider|runner|sandbox|session|stage|task|workspace)\.[a-z][a-z0-9_-]*(?:\.[a-z][a-z0-9_-]*)*$/;
 const CLI_SECRET_FLAG_RE = new RegExp(String.raw`^-{1,2}${SECRET_FIELD_NAME_PATTERN}$`, "i");
 const JSON_SECRET_FIELD_TEXT_RE = new RegExp(
   String.raw`((?:"|')?${SECRET_FIELD_NAME_PATTERN}(?:"|')?\s*:\s*(?:"|'))[^"'` + "`" + String.raw`\r\n]+((?:"|'))`,
@@ -168,7 +172,21 @@ export function sanitizeRecord(record: Record<string, unknown>): Record<string, 
 export function redactEventPayload(payload: Record<string, unknown> | null): Record<string, unknown> | null {
   if (!payload) return null;
   if (!isPlainObject(payload)) return payload;
-  return sanitizeRecord(payload);
+  const sanitized = sanitizeRecord(payload);
+  if (payload.schema !== NATIVE_RUN_SPAN_SCHEMA) return sanitized;
+
+  // Native run span identities are controlled diagnostics emitted by
+  // createNativeRunTrace, not provider data. Their dotted names overlap the
+  // broad JWT-value heuristic, so restore only these two fields on the exact
+  // run-performance schema. Hostnames and JWT-shaped values on every other
+  // field and schema still fail closed through sanitizeRecord above.
+  for (const field of NATIVE_RUN_SPAN_FIELDS) {
+    const value = payload[field];
+    if (typeof value === "string" && value.length <= 160 && NATIVE_RUN_SPAN_NAME_RE.test(value)) {
+      sanitized[field] = value;
+    }
+  }
+  return sanitized;
 }
 
 export function redactSensitiveText(input: string): string {

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -39,8 +39,33 @@ const JWT_VALUE_RE = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+(?:\.[A-Za-
 const PAPERCLIP_SCHEMA_ID_RE = /^paperclip\.[a-z0-9_-]+(?:\.[a-z0-9_-]+)*\.v\d+$/;
 const NATIVE_RUN_SPAN_SCHEMA = "paperclip.run-performance-span.v1";
 const NATIVE_RUN_SPAN_FIELDS = ["span", "parentSpan"] as const;
-const NATIVE_RUN_SPAN_NAME_RE =
-  /^(?:agent|environment|harness|native|provider|runner|sandbox|session|stage|task|workspace)\.[a-z][a-z0-9_-]*(?:\.[a-z][a-z0-9_-]*)*$/;
+const NATIVE_RUN_SPAN_NAMES = new Set([
+  "agent.turn",
+  "environment.acquire",
+  "environment.startup",
+  "environment.workspace.realize",
+  "native.coordinator.claim",
+  "native.result.finalize",
+  "native.session.execute",
+  "provider.session.continuity_break",
+  "provider.session.resume",
+  "provider.time_to_first_agent_event",
+  "provider.turn.queue",
+  "runner.artifact.discover",
+  "runner.artifact.prepare",
+  "runner.prp.route.register",
+  "runner.runtime.stage",
+  "runner.session.bootstrap",
+  "runner.session.resume",
+  "runner.session.startup",
+  "runner.transport.connect",
+  "runner.transport.selected",
+  "runner.turn.submit",
+  "task.prepare",
+  "task.run",
+  "task.run.measured",
+  "task.settle",
+]);
 const CLI_SECRET_FLAG_RE = new RegExp(String.raw`^-{1,2}${SECRET_FIELD_NAME_PATTERN}$`, "i");
 const JSON_SECRET_FIELD_TEXT_RE = new RegExp(
   String.raw`((?:"|')?${SECRET_FIELD_NAME_PATTERN}(?:"|')?\s*:\s*(?:"|'))[^"'` + "`" + String.raw`\r\n]+((?:"|'))`,
@@ -182,7 +207,7 @@ export function redactEventPayload(payload: Record<string, unknown> | null): Rec
   // field and schema still fail closed through sanitizeRecord above.
   for (const field of NATIVE_RUN_SPAN_FIELDS) {
     const value = payload[field];
-    if (typeof value === "string" && value.length <= 160 && NATIVE_RUN_SPAN_NAME_RE.test(value)) {
+    if (typeof value === "string" && NATIVE_RUN_SPAN_NAMES.has(value)) {
       sanitized[field] = value;
     }
   }

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -36,6 +36,7 @@ import {
 } from "@paperclipai/shared";
 import {
   isForbiddenConfigEnvKey,
+  normalizePaperclipRunnerAdapterConfig,
   PAPERCLIP_OPERATIONAL_SKILL_KEY,
   parseObject,
   resolvePaperclipInstanceRootForAdapter,
@@ -1927,7 +1928,10 @@ export function agentRoutes(
         ? { ...input.constraintAdapterConfig, ...normalizedAdapterConfig }
         : normalizedAdapterConfig,
     );
-    return normalizedAdapterConfig;
+    return normalizePaperclipRunnerAdapterConfig(
+      input.adapterType ?? "",
+      normalizedAdapterConfig,
+    );
   }
 
   function generateEd25519PrivateKeyPem(): string {
@@ -1989,6 +1993,9 @@ export function agentRoutes(
     adapterConfig: Record<string, unknown>,
   ): Record<string, unknown> {
     const next = { ...adapterConfig };
+    if (adapterType === "paperclip_runner") {
+      return normalizePaperclipRunnerAdapterConfig(adapterType, next);
+    }
     if (adapterType === "codex_local") {
       const hasBypassFlag =
         typeof next.dangerouslyBypassApprovalsAndSandbox === "boolean" ||
@@ -2401,16 +2408,14 @@ export function agentRoutes(
       (entry, index, entries) => entries.findIndex((candidate) => candidate.key === entry.key) === index,
     );
 
-    const desiredSkillEntries = mergeDesiredSkillEntries(currentSkillEntries, requestedSkillEntries, mode);
-    if (
-      adapterType === "paperclip_runner"
-      && mode !== "remove"
-      && requestedSkillEntries.some((entry) => entry.key === PAPERCLIP_OPERATIONAL_SKILL_KEY)
-    ) {
-      throw unprocessable(
-        `paperclip_runner does not support the legacy Paperclip operational skill (${PAPERCLIP_OPERATIONAL_SKILL_KEY}); remove it from this agent`,
-      );
-    }
+    const desiredSkillEntries = mergeDesiredSkillEntries(
+      currentSkillEntries,
+      requestedSkillEntries,
+      mode,
+    ).filter(
+      (entry) => adapterType !== "paperclip_runner"
+        || entry.key.trim().toLowerCase() !== PAPERCLIP_OPERATIONAL_SKILL_KEY,
+    );
     const desiredSkills = desiredSkillEntries.map((entry) => entry.key);
     const resolvedKeys = new Set([
       ...resolvedCurrentSkillEntries.map((entry) => entry.key),

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -167,7 +167,10 @@ import type {
   SetupTokenTransportAdvisory,
 } from "@paperclipai/shared";
 import { SETUP_TOKEN_TRANSPORT_ADVISORY_CODE } from "@paperclipai/shared";
-import { DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX } from "@paperclipai/adapter-codex-local";
+import {
+  DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
+  DEFAULT_CODEX_LOCAL_MODEL,
+} from "@paperclipai/adapter-codex-local";
 import {
   checkStagedCredentialReadiness,
   promoteDeviceLoginCredential,
@@ -1715,6 +1718,33 @@ export function agentRoutes(
         "aws_bedrock_agentcore_harness",
       );
     }
+  }
+
+  function resolvePaperclipRunnerAdapterTransition(input: {
+    previousAdapterType: string;
+    nextAdapterType: string;
+    previousAdapterConfig: Record<string, unknown>;
+    nextAdapterConfig: Record<string, unknown>;
+  }): Record<string, unknown> {
+    if (
+      input.nextAdapterType !== "paperclip_runner"
+      || input.previousAdapterType === input.nextAdapterType
+    ) {
+      return input.nextAdapterConfig;
+    }
+    if (input.previousAdapterType !== "codex_local") {
+      throw unprocessable(
+        `Cannot convert ${input.previousAdapterType} to Paperclip Runner while only the Codex provider is available.`,
+        { code: "paperclip_runner_adapter_conversion_unsupported" },
+      );
+    }
+    return {
+      ...input.nextAdapterConfig,
+      model:
+        asNonEmptyString(input.nextAdapterConfig.model)
+        ?? asNonEmptyString(input.previousAdapterConfig.model)
+        ?? DEFAULT_CODEX_LOCAL_MODEL,
+    };
   }
 
   function assertProviderTraceSettingTransition(
@@ -4268,6 +4298,12 @@ export function agentRoutes(
           existingAdapterConfig,
           rawEffectiveAdapterConfig,
         );
+        rawEffectiveAdapterConfig = resolvePaperclipRunnerAdapterTransition({
+          previousAdapterType: existing.adapterType,
+          nextAdapterType: requestedAdapterType,
+          previousAdapterConfig: existingAdapterConfig,
+          nextAdapterConfig: rawEffectiveAdapterConfig,
+        });
       }
       const existingRunnerProvider =
         existing.adapterType === "paperclip_runner"

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -27,8 +27,7 @@ import {
   type AgentApiKeyScope,
 } from "@paperclipai/shared";
 import {
-  PAPERCLIP_OPERATIONAL_SKILL_KEY,
-  readPaperclipSkillSyncPreference,
+  normalizePaperclipRunnerAdapterConfig,
 } from "@paperclipai/adapter-utils/server-utils";
 import { conflict, notFound, unprocessable } from "../errors.js";
 import {
@@ -130,32 +129,6 @@ interface AgentShortnameCollisionOptions {
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function hasPaperclipOperationalSkill(config: unknown): boolean {
-  if (!isPlainRecord(config)) return false;
-  return readPaperclipSkillSyncPreference(config).desiredSkillEntries.some(
-    (entry) => entry.key.trim().toLowerCase() === PAPERCLIP_OPERATIONAL_SKILL_KEY,
-  );
-}
-
-export function assertPaperclipRunnerOperationalSkillInvariant(input: {
-  adapterType: string;
-  nextConfig: unknown;
-  priorAdapterType?: string | null;
-  priorConfig?: unknown;
-}): void {
-  if (input.adapterType !== "paperclip_runner" || !hasPaperclipOperationalSkill(input.nextConfig)) {
-    return;
-  }
-  const preservesStaleAssignment =
-    input.priorAdapterType === "paperclip_runner"
-    && hasPaperclipOperationalSkill(input.priorConfig);
-  if (preservesStaleAssignment) return;
-  throw unprocessable(
-    `paperclip_runner does not support the legacy Paperclip operational skill (${PAPERCLIP_OPERATIONAL_SKILL_KEY}); remove it from this agent`,
-    { code: "paperclip_runner_legacy_operational_skill" },
-  );
 }
 
 function jsonEqual(left: unknown, right: unknown): boolean {
@@ -710,22 +683,24 @@ export function agentService(db: Db) {
       Object.prototype.hasOwnProperty.call(normalizedPatch, "adapterConfig") &&
       isPlainRecord(normalizedPatch.adapterConfig)
     ) {
-      normalizedPatch.adapterConfig = await secretsSvc.normalizeAdapterConfigForPersistence(
+      const normalizedAdapterConfig = await secretsSvc.normalizeAdapterConfigForPersistence(
         existing.companyId,
         normalizedPatch.adapterConfig,
         { adapterType: (normalizedPatch.adapterType ?? existing.adapterType) as string },
       );
+      normalizedPatch.adapterConfig = normalizePaperclipRunnerAdapterConfig(
+        (normalizedPatch.adapterType ?? existing.adapterType) as string,
+        normalizedAdapterConfig,
+      );
+    } else if (
+      Object.prototype.hasOwnProperty.call(normalizedPatch, "adapterType")
+      && isPlainRecord(existing.adapterConfig)
+    ) {
+      normalizedPatch.adapterConfig = normalizePaperclipRunnerAdapterConfig(
+        normalizedPatch.adapterType as string,
+        existing.adapterConfig,
+      );
     }
-    const nextAdapterType = (normalizedPatch.adapterType ?? existing.adapterType) as string;
-    const nextAdapterConfig = Object.prototype.hasOwnProperty.call(normalizedPatch, "adapterConfig")
-      ? normalizedPatch.adapterConfig
-      : existing.adapterConfig;
-    assertPaperclipRunnerOperationalSkillInvariant({
-      adapterType: nextAdapterType,
-      nextConfig: nextAdapterConfig,
-      priorAdapterType: existing.adapterType,
-      priorConfig: existing.adapterConfig,
-    });
     // Run the server-enforced binding invariant when the patch touches the
     // adapter config. The update, approval, and rollback paths keep an existing
     // fixed binding but reject a newly introduced binding, because they carry no
@@ -834,13 +809,10 @@ export function agentService(db: Db) {
       const normalizedPermissions = normalizeAgentPermissions(data.permissions, role);
       const runtimeConfig = normalizeRuntimeConfigForNewAgent(data.runtimeConfig);
       const adapterType = data.adapterType ?? "process";
-      const adapterConfig = isPlainRecord(data.adapterConfig)
+      const rawAdapterConfig = isPlainRecord(data.adapterConfig)
         ? await secretsSvc.normalizeAdapterConfigForPersistence(companyId, data.adapterConfig, { adapterType })
         : {};
-      assertPaperclipRunnerOperationalSkillInvariant({
-        adapterType,
-        nextConfig: adapterConfig,
-      });
+      const adapterConfig = normalizePaperclipRunnerAdapterConfig(adapterType, rawAdapterConfig);
       // Run the server-enforced binding invariant after generic normalization
       // and before any database write. A create has no prior config.
       const bindingDecision = assertClaudeOAuthBindingInvariant({
@@ -1041,10 +1013,14 @@ export function agentService(db: Db) {
           Object.prototype.hasOwnProperty.call(patch, "adapterConfig") &&
           isPlainRecord(patch.adapterConfig)
         ) {
-          patch.adapterConfig = await secretService(txDb).normalizeAdapterConfigForPersistence(
+          const normalizedAdapterConfig = await secretService(txDb).normalizeAdapterConfigForPersistence(
             existing.companyId,
             patch.adapterConfig,
             { adapterType: (patch.adapterType ?? existing.adapterType) as string },
+          );
+          patch.adapterConfig = normalizePaperclipRunnerAdapterConfig(
+            (patch.adapterType ?? existing.adapterType) as string,
+            normalizedAdapterConfig,
           );
           // The approval activation keeps an existing fixed binding but rejects a
           // newly introduced binding, because it carries no stored-session claim.
@@ -1053,15 +1029,15 @@ export function agentService(db: Db) {
             nextConfig: patch.adapterConfig,
             priorConfig: existing.adapterConfig,
           });
+        } else if (
+          Object.prototype.hasOwnProperty.call(patch, "adapterType")
+          && isPlainRecord(existing.adapterConfig)
+        ) {
+          patch.adapterConfig = normalizePaperclipRunnerAdapterConfig(
+            patch.adapterType as string,
+            existing.adapterConfig,
+          );
         }
-        assertPaperclipRunnerOperationalSkillInvariant({
-          adapterType: (patch.adapterType ?? existing.adapterType) as string,
-          nextConfig: Object.prototype.hasOwnProperty.call(patch, "adapterConfig")
-            ? patch.adapterConfig
-            : existing.adapterConfig,
-          priorAdapterType: existing.adapterType,
-          priorConfig: existing.adapterConfig,
-        });
         if (patch.permissions !== undefined) {
           patch.permissions = normalizeAgentPermissions(
             patch.permissions,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -20431,10 +20431,15 @@ export function heartbeatService(
                     onLog,
                     onEvent: onAdapterEvent,
                     preparationSpans: nativeRunnerPreparationSpans,
-                    // Bootstrap the provider with executable/home discovery while
-                    // keeping the agent's configured provider values authoritative.
+                    // Bootstrap with executable/home discovery while keeping
+                    // configured provider values and the server-selected
+                    // workspace boundary authoritative.
                     runnerEnvironment: {
-                      ...buildNativeProviderEnvironment(adapterEnv),
+                      ...buildNativeProviderEnvironment(
+                        adapterEnv,
+                        process.env,
+                        executionWorkspace.cwd,
+                      ),
                       ...(nativeMcpServer
                         ? {
                             PAPERCLIP_NATIVE_MCP_NAME: nativeMcpServer.name,

--- a/server/src/services/native-runtime/native-session-executor.test.ts
+++ b/server/src/services/native-runtime/native-session-executor.test.ts
@@ -1192,6 +1192,22 @@ describe("native provider bootstrap environment", () => {
       OPENAI_API_KEY: "configured-provider-key",
     });
   });
+
+  it("pins the server-assigned workspace over configured environment input", () => {
+    expect(
+      buildNativeProviderEnvironment(
+        {
+          PAPERCLIP_WORKSPACE_CWD: "/untrusted/configured-workspace",
+        },
+        { HOME: "/Users/runner" },
+        "/Users/runner/.paperclip/instances/default/workspaces/agent-1",
+      ),
+    ).toEqual({
+      HOME: "/Users/runner",
+      PAPERCLIP_WORKSPACE_CWD:
+        "/Users/runner/.paperclip/instances/default/workspaces/agent-1",
+    });
+  });
 });
 
 const execution = {
@@ -2777,6 +2793,30 @@ describe("native process ownership", () => {
 });
 
 describe("runnerd provider runtime wiring", () => {
+  it("uses the native execution workspace as the local provider containment root", async () => {
+    state.createBackend.mockClear();
+    await createRunnerdBackend({
+      db: leaseDb(execution),
+      execution,
+      runnerInstanceId: "runner-local-workspace",
+      runnerEnvironment: {
+        HOME: "/home/runner",
+        PAPERCLIP_WORKSPACE_CWD: "/untrusted/configured-workspace",
+      },
+    });
+
+    const backendOptions = state.createBackend.mock.calls[0]![1];
+    state.createTransport.mockClear();
+    backendOptions.codexTransportFactory!();
+    expect(state.createTransport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        environment: expect.objectContaining({
+          PAPERCLIP_WORKSPACE_CWD: execution.workspace.cwd,
+        }),
+      }),
+    );
+  });
+
   it("reuses legacy unscoped state only for its exact durable run identity", async () => {
     const stateBase = await mkdtemp(
       join(tmpdir(), "paperclip-legacy-runner-state-"),
@@ -3008,6 +3048,16 @@ describe("runnerd provider runtime wiring", () => {
       expect.objectContaining({
         input: expect.objectContaining({
           workspace: expect.objectContaining({ cwd: remoteCwd }),
+        }),
+      }),
+    );
+    const backendOptions = state.createBackend.mock.calls[0]![1];
+    state.createTransport.mockClear();
+    backendOptions.codexTransportFactory!();
+    expect(state.createTransport).toHaveBeenCalledWith(
+      expect.objectContaining({
+        environment: expect.objectContaining({
+          PAPERCLIP_WORKSPACE_CWD: remoteCwd,
         }),
       }),
     );

--- a/server/src/services/native-runtime/native-session-executor.ts
+++ b/server/src/services/native-runtime/native-session-executor.ts
@@ -6012,6 +6012,7 @@ export async function createRunnerdBackend(input: {
   };
   const backend = createNativeSessionBackend(runnerExecution, {
     runnerInstanceId: input.runnerInstanceId,
+    environment: effectiveRunnerEnvironment,
     onSpawn: input.onSpawn,
     dynamicTools,
     dynamicToolHandler: (call) => authorityRouter.execute(call),

--- a/server/src/services/native-runtime/native-session-executor.ts
+++ b/server/src/services/native-runtime/native-session-executor.ts
@@ -247,11 +247,13 @@ async function measureNativeRunnerSpan<T>(
  * Provider bootstrap needs a small amount of host process context even when
  * the agent has no configured env. In particular, an empty environment makes
  * a bare `codex` command unresolvable. Agent-configured values remain
- * authoritative and may intentionally override the host defaults.
+ * authoritative and may intentionally override the host defaults, while the
+ * server-selected workspace remains an immutable containment boundary.
  */
 export function buildNativeProviderEnvironment(
   configured: NodeJS.ProcessEnv,
   host: NodeJS.ProcessEnv = process.env,
+  assignedWorkspaceCwd?: string,
 ): NodeJS.ProcessEnv {
   const inherited = Object.fromEntries(
     NATIVE_PROVIDER_HOST_ENV_KEYS.flatMap((key) => {
@@ -261,7 +263,11 @@ export function buildNativeProviderEnvironment(
         : [];
     }),
   );
-  return { ...inherited, ...configured };
+  const environment = { ...inherited, ...configured };
+  if (assignedWorkspaceCwd?.trim()) {
+    environment.PAPERCLIP_WORKSPACE_CWD = assignedWorkspaceCwd;
+  }
+  return environment;
 }
 
 type PlanSynchronization = {
@@ -5965,8 +5971,12 @@ export async function createRunnerdBackend(input: {
         ...(input.runnerEnvironment ?? process.env),
         HOME: remoteTarget!.remoteCwd,
         CODEX_HOME: posix.join(remoteTarget!.remoteCwd, ".codex"),
+        PAPERCLIP_WORKSPACE_CWD: remoteTarget!.remoteCwd,
       }
-    : (input.runnerEnvironment ?? process.env);
+    : {
+        ...(input.runnerEnvironment ?? process.env),
+        PAPERCLIP_WORKSPACE_CWD: input.execution.workspace.cwd,
+      };
   const archiveContinuityState = async () => {
     const archiveToken = `${Date.now()}-${randomUUID()}`;
     const archiveRoot = resolve(root, "continuity-breaks", archiveToken);

--- a/ui/src/components/AgentConfigForm.test.ts
+++ b/ui/src/components/AgentConfigForm.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { Environment } from "@paperclipai/shared";
-import { supportsAdapterModelRefresh } from "./AgentConfigForm";
+import {
+  resolvePaperclipRunnerTransitionModel,
+  supportsAdapterModelRefresh,
+} from "./AgentConfigForm";
 import { resolveForcedKubernetesEnvironment } from "../lib/forced-kubernetes-environment";
 
 describe("supportsAdapterModelRefresh", () => {
@@ -13,6 +16,18 @@ describe("supportsAdapterModelRefresh", () => {
   it("keeps the refresh action hidden for adapters without a live refresh hook", () => {
     expect(supportsAdapterModelRefresh("opencode_local")).toBe(false);
     expect(supportsAdapterModelRefresh("process")).toBe(false);
+  });
+});
+
+describe("resolvePaperclipRunnerTransitionModel", () => {
+  it("preserves an explicit model from codex_local", () => {
+    expect(resolvePaperclipRunnerTransitionModel("codex_local", "gpt-5.5"))
+      .toBe("gpt-5.5");
+  });
+
+  it("uses the current Codex default when the source model is blank", () => {
+    expect(resolvePaperclipRunnerTransitionModel("codex_local", ""))
+      .toBe("gpt-5.6-sol");
   });
 });
 

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -18,7 +18,10 @@ import { environmentsApi } from "../api/environments";
 import { instanceSettingsApi } from "../api/instanceSettings";
 import { secretsApi } from "../api/secrets";
 import { assetsApi } from "../api/assets";
-import { DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX } from "@paperclipai/adapter-codex-local";
+import {
+  DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
+  DEFAULT_CODEX_LOCAL_MODEL,
+} from "@paperclipai/adapter-codex-local";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import { DEFAULT_KIMI_LOCAL_MODEL } from "@paperclipai/adapter-kimi-local";
@@ -146,6 +149,17 @@ const EMPTY_ENV: Record<string, EnvBinding> = {};
 
 export function supportsAdapterModelRefresh(adapterType: string): boolean {
   return adapterType === "claude_local" || adapterType === "codex_local";
+}
+
+export function resolvePaperclipRunnerTransitionModel(
+  previousAdapterType: string,
+  previousModel: unknown,
+): string {
+  return previousAdapterType === "codex_local"
+    && typeof previousModel === "string"
+    && previousModel.trim().length > 0
+    ? previousModel.trim()
+    : DEFAULT_CODEX_LOCAL_MODEL;
 }
 
 function isOverlayDirty(o: AgentConfigOverlay): boolean {
@@ -1379,6 +1393,8 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                       nextValues.model = DEFAULT_CURSOR_LOCAL_MODEL;
                     } else if (t === "opencode_local") {
                       nextValues.model = DEFAULT_OPENCODE_LOCAL_MODEL;
+                    } else if (t === "paperclip_runner") {
+                      nextValues.model = DEFAULT_CODEX_LOCAL_MODEL;
                     }
                     set!(nextValues);
                   } else {
@@ -1397,6 +1413,8 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                               ? DEFAULT_OPENCODE_LOCAL_MODEL
                             : t === "cursor"
                               ? DEFAULT_CURSOR_LOCAL_MODEL
+                            : t === "paperclip_runner"
+                              ? resolvePaperclipRunnerTransitionModel(adapterType, config.model)
                               : "",
                         effort: "",
                         modelReasoningEffort: "",

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -79,7 +79,10 @@ import { resolveForcedKubernetesEnvironment } from "../lib/forced-kubernetes-env
 // Canonical type lives in @paperclipai/adapter-utils; re-exported here
 // so existing imports from this file keep working.
 export type { CreateConfigValues } from "@paperclipai/adapter-utils";
-import type { CreateConfigValues } from "@paperclipai/adapter-utils";
+import {
+  PAPERCLIP_RUNNER_PERMISSION_CAPABILITIES,
+  type CreateConfigValues,
+} from "@paperclipai/adapter-utils";
 import { Badge } from "@/components/ui/badge";
 
 /* ---- Props ---- */
@@ -1404,6 +1407,13 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                               dangerouslyBypassApprovalsAndSandbox:
                                 DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX,
                             }
+                          : t === "paperclip_runner"
+                            ? {
+                                provider: "codex",
+                                codexPermissionMode:
+                                  PAPERCLIP_RUNNER_PERMISSION_CAPABILITIES.codex.defaultMode,
+                                lifecycleMode: "per_turn",
+                              }
                           : {}),
                       },
                     }));

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -492,6 +492,9 @@ interface IssueChatThreadProps {
   /** Requeues a blocked task after its no-live-execution-path recovery notice. */
   onTryAgainNoLiveExecutionPath?: () => Promise<void> | void;
   tryAgainNoLiveExecutionPathPending?: boolean;
+  /** Starts a fresh on-demand run for the selected failed run. */
+  onRetryFailedRun?: (runId: string) => Promise<void> | void;
+  retryFailedRunId?: string | null;
   companyId?: string | null;
   projectId?: string | null;
   issueStatus?: string;
@@ -4595,6 +4598,8 @@ export function IssueChatThread({
   resumeAssigneePending = false,
   onTryAgainNoLiveExecutionPath: _onTryAgainNoLiveExecutionPath,
   tryAgainNoLiveExecutionPathPending: _tryAgainNoLiveExecutionPathPending,
+  onRetryFailedRun: _onRetryFailedRun,
+  retryFailedRunId: _retryFailedRunId,
   externalReferences,
   linkCaseReferences = false,
 }: IssueChatThreadProps) {

--- a/ui/src/components/TaskChatThread.tsx
+++ b/ui/src/components/TaskChatThread.tsx
@@ -435,6 +435,8 @@ export function TaskChatThread(props: TaskChatThreadProps) {
     interruptingQueuedRunId,
     onTryAgainNoLiveExecutionPath,
     tryAgainNoLiveExecutionPathPending = false,
+    onRetryFailedRun,
+    retryFailedRunId = null,
     queuedCommentQueue,
     onEditQueuedComment,
     onReorderQueuedComments,
@@ -1311,6 +1313,7 @@ export function TaskChatThread(props: TaskChatThreadProps) {
               label: "Run failed",
               detail,
               collapsible: true,
+              runId: source.id,
               createdAtIso: finishedAt
                 ? new Date(finishedAt).toISOString()
                 : undefined,
@@ -2225,6 +2228,8 @@ export function TaskChatThread(props: TaskChatThreadProps) {
             tryAgainNoLiveExecutionPathPending={
               tryAgainNoLiveExecutionPathPending
             }
+            onRetryFailedRun={onRetryFailedRun}
+            retryFailedRunId={retryFailedRunId}
             tail={
               tailRunId || optimisticRunnerStartup || bottomBlockerLinks ? (
                 <>

--- a/ui/src/components/TaskChatThread.tsx
+++ b/ui/src/components/TaskChatThread.tsx
@@ -1290,16 +1290,18 @@ export function TaskChatThread(props: TaskChatThreadProps) {
         ) {
           settledRunIds.add(source.id);
           const code = meta?.errorCode ?? "native_runner_process_exited";
-          const retryDetail = meta?.scheduledRetryAt
-            ? "Retry scheduled automatically."
-            : "You can retry this message now.";
           const detail =
             code === "provider_frame_too_large"
-              ? `Provider output exceeded the safe limit. ${retryDetail}`
-              : `The runner stopped before returning an answer (${code}). ${retryDetail}`;
+              ? "Provider output exceeded the safe limit."
+              : `The runner stopped before returning an answer (${code}).`;
           const id = `${source.id}:failure`;
+          const runAgent = meta?.agentId
+            ? agentMap?.get(meta.agentId)
+            : undefined;
+          const finishedAt =
+            meta?.finishedAt ?? meta?.startedAt ?? meta?.createdAt;
           entriesWithFailures.push({
-            ms: toMs(meta?.finishedAt ?? meta?.startedAt ?? meta?.createdAt),
+            ms: toMs(finishedAt),
             order: 3,
             id,
             item: {
@@ -1308,6 +1310,13 @@ export function TaskChatThread(props: TaskChatThreadProps) {
               variant: "interrupted",
               label: "Run failed",
               detail,
+              collapsible: true,
+              createdAtIso: finishedAt
+                ? new Date(finishedAt).toISOString()
+                : undefined,
+              runHref: runAgent
+                ? `/agents/${encodeURIComponent(runAgent.urlKey)}/runs/${encodeURIComponent(source.id)}`
+                : undefined,
             },
           });
         } else if (!lastCommentIdByRun.has(source.id)) {

--- a/ui/src/components/task-chat/TaskChatCompactInteractionCard.tsx
+++ b/ui/src/components/task-chat/TaskChatCompactInteractionCard.tsx
@@ -968,7 +968,7 @@ function ConfirmationCard({
               }}
               ariaLabelledBy={`${interaction.id}-reject-reason-label`}
               testId="plan-revision-composer"
-              attachAriaLabel="Attach image to revision"
+              showImageAttachControls={false}
             />
           ) : (
             <Textarea

--- a/ui/src/components/task-chat/TaskChatComposer.test.tsx
+++ b/ui/src/components/task-chat/TaskChatComposer.test.tsx
@@ -406,6 +406,50 @@ describe("TaskChatComposer", () => {
     expect(onAdd).toHaveBeenCalledWith("do the plan", undefined, undefined);
   });
 
+  it("cycles Auto, Plan, and Ask modes with Cmd+Period while focused", () => {
+    const onWorkModeChange = vi.fn().mockResolvedValue(undefined);
+    render(
+      <TaskChatComposer
+        onAdd={vi.fn()}
+        workMode="standard"
+        onWorkModeChange={onWorkModeChange}
+      />,
+    );
+
+    const chip = container.querySelector<HTMLButtonElement>(
+      '[data-testid="task-chat-composer-mode"]',
+    )!;
+    editable().focus();
+
+    expect(chip.getAttribute("aria-keyshortcuts")).toContain("Meta+Period");
+    expect(chip.getAttribute("data-pending-work-mode")).toBe("standard");
+
+    const cycleMode = () => {
+      const event = new KeyboardEvent("keydown", {
+        key: ".",
+        code: "Period",
+        metaKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+      flushSync(() => editable().dispatchEvent(event));
+      expect(event.defaultPrevented).toBe(true);
+    };
+
+    cycleMode();
+    expect(chip.getAttribute("data-pending-work-mode")).toBe("planning");
+    expect(chip.textContent).toContain("Plan");
+
+    cycleMode();
+    expect(chip.getAttribute("data-pending-work-mode")).toBe("ask");
+    expect(chip.textContent).toContain("Ask");
+
+    cycleMode();
+    expect(chip.getAttribute("data-pending-work-mode")).toBe("standard");
+    expect(chip.textContent).toContain("Auto");
+    expect(onWorkModeChange).not.toHaveBeenCalled();
+  });
+
   it("passes reopen=true when the issue resumes-to-todo and the assignee is an agent", async () => {
     const onAdd = vi.fn().mockResolvedValue(undefined);
     render(

--- a/ui/src/components/task-chat/TaskChatComposer.tsx
+++ b/ui/src/components/task-chat/TaskChatComposer.tsx
@@ -270,9 +270,9 @@ function escapeMarkdownLabel(name: string): string {
  * (rich lists, @-mentions, /-commands, inline pasted images) over a 32px
  * comp-bar of [attach] [mode chip] … [assignee] [send]. The mode chip is a
  * status-chip rectangle carrying the pending mode's hue; the composer chrome
- * itself stays neutral. Shift+Tab cycles modes (captured before Lexical);
- * Cmd/Ctrl+Enter posts via the editor's native onSubmit; plain Enter stays a
- * newline / next list item. Pasted or dropped images upload through
+ * itself stays neutral. Cmd/Ctrl+. and Shift+Tab cycle modes (captured before
+ * Lexical); Cmd/Ctrl+Enter posts via the editor's native onSubmit; plain Enter
+ * stays a newline / next list item. Pasted or dropped images upload through
  * `onAttachImage` (or the `onImageUpload` fallback) and land inline at the
  * caret via the editor's image plugin; non-image files render as shadcn
  * base/attachment chips (kind icon · name · size, remove ×, uploading/error
@@ -680,10 +680,16 @@ export function TaskChatComposer({
         "paperclip-task-chat-composer rounded-xl bg-card p-(--sz-18px)",
       )}
       onKeyDownCapture={(e) => {
-        // Shift+Tab cycles the pending mode; captured on the wrapper so it
-        // wins over Lexical's list-outdent binding inside the editor.
+        // Capture mode shortcuts on the wrapper so they work while the rich
+        // editor is focused and win over Lexical/browser bindings. Match the
+        // period by key and code because hardware keyboards on iOS can omit
+        // `code` for Cmd+Period.
         if (disabled || queuedEdit || takeoverVisible) return;
-        if (e.key === "Tab" && e.shiftKey) {
+        const isPeriod = e.key === "." || e.code === "Period";
+        const isModeShortcut =
+          (isPeriod && (e.metaKey || e.ctrlKey)) ||
+          (e.key === "Tab" && e.shiftKey);
+        if (isModeShortcut) {
           e.preventDefault();
           e.stopPropagation();
           setPendingMode((mode) => nextWorkMode(mode));
@@ -911,6 +917,7 @@ export function TaskChatComposer({
                   <button
                     type="button"
                     disabled={disabled || !onWorkModeChange}
+                    aria-keyshortcuts="Meta+Period Control+Period Shift+Tab"
                     className="status-chip flex h-8 shrink-0 items-center gap-1.5 rounded-md px-2.5 text-xs font-medium transition hover:brightness-110 focus-visible:brightness-110 focus-visible:outline-none disabled:opacity-50"
                     style={{ "--sc": modeHue(pendingMode) } as CSSProperties}
                     data-testid="task-chat-composer-mode"

--- a/ui/src/components/task-chat/TaskChatInteractionCard.test.tsx
+++ b/ui/src/components/task-chat/TaskChatInteractionCard.test.tsx
@@ -387,7 +387,7 @@ describe("TaskChatInteractionCard", () => {
     const requestChanges = Array.from(
       container.querySelectorAll<HTMLButtonElement>("button"),
     ).find((button) => button.textContent?.trim() === "Request changes");
-    await act(async () => requestChanges?.click());
+    flushSync(() => requestChanges?.click());
 
     expect(container.textContent).not.toContain("Do you accept this plan?");
     expect(container.textContent).toContain("What should change?");
@@ -400,8 +400,8 @@ describe("TaskChatInteractionCard", () => {
         .querySelector('[data-testid="mock-markdown-editor"]')
         ?.getAttribute("data-image-upload"),
     ).toBe("true");
-    expect(container.textContent).toContain("Attach image");
-    expect(container.textContent).toContain("drop/paste an image");
+    expect(container.textContent).not.toContain("Attach image");
+    expect(container.textContent).not.toContain("drop/paste an image");
     const reasonGroup = container.querySelector(
       '[data-testid="plan-revision-composer"]',
     )?.parentElement;

--- a/ui/src/components/task-chat/TaskChatMarker.test.tsx
+++ b/ui/src/components/task-chat/TaskChatMarker.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ThemeProvider } from "@/context/ThemeContext";
+import { TaskChatMarker } from "./TaskChatMarker";
+
+vi.mock("@/lib/router", () => ({
+  Link: ({ to, children }: { to: string; children: React.ReactNode }) => (
+    <a href={to}>{children}</a>
+  ),
+}));
+
+describe("TaskChatMarker", () => {
+  let container: HTMLDivElement;
+  let root: Root | null = null;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-01T12:05:00.000Z"));
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    flushSync(() => root?.unmount());
+    root = null;
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it("renders a failed run as a timestamped disclosure without divider rules", () => {
+    flushSync(() =>
+      root!.render(
+        <ThemeProvider>
+          <TaskChatMarker
+            item={{
+              id: "run-1:failure",
+              kind: "marker",
+              variant: "interrupted",
+              label: "Run failed",
+              detail: "The runner stopped before returning an answer (runner_exited).",
+              collapsible: true,
+              createdAtIso: "2026-09-01T12:00:00.000Z",
+              runHref: "/agents/codex/runs/run-1",
+            }}
+          />
+        </ThemeProvider>,
+      ),
+    );
+
+    const toggle = container.querySelector<HTMLButtonElement>(
+      '[data-testid="task-chat-collapsible-marker"] button[aria-expanded]',
+    )!;
+    expect(toggle.textContent).toContain("Run failed");
+    expect(toggle.textContent).toContain("5m ago");
+    expect(container.querySelector(".border-dashed")).toBeNull();
+    expect(container.textContent).not.toContain("runner_exited");
+
+    flushSync(() => toggle.click());
+
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(container.textContent).toContain("runner_exited");
+    expect(
+      container.querySelector('a[href="/agents/codex/runs/run-1"]')?.textContent,
+    ).toBe("View run");
+  });
+
+  it("keeps Try again available without retry instructions in the detail", async () => {
+    const onTryAgain = vi.fn();
+    flushSync(() =>
+      root!.render(
+        <ThemeProvider>
+          <TaskChatMarker
+            item={{
+              id: "run-1:failure",
+              kind: "marker",
+              variant: "interrupted",
+              label: "Run failed",
+              detail: "The runner stopped before returning an answer.",
+              collapsible: true,
+            }}
+            onTryAgain={onTryAgain}
+          />
+        </ThemeProvider>,
+      ),
+    );
+
+    const retry = container.querySelector<HTMLButtonElement>(
+      '[data-testid="task-chat-run-failed-try-again"]',
+    )!;
+    expect(container.textContent).not.toContain("You can retry this message now");
+    flushSync(() => retry.click());
+    await Promise.resolve();
+    expect(onTryAgain).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/components/task-chat/TaskChatMarker.test.tsx
+++ b/ui/src/components/task-chat/TaskChatMarker.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ThemeProvider } from "@/context/ThemeContext";
 import { TaskChatMarker } from "./TaskChatMarker";
+import { TaskChatThreadView } from "./TaskChatThreadView";
 
 vi.mock("@/lib/router", () => ({
   Link: ({ to, children }: { to: string; children: React.ReactNode }) => (
@@ -95,5 +96,38 @@ describe("TaskChatMarker", () => {
     flushSync(() => retry.click());
     await Promise.resolve();
     expect(onTryAgain).toHaveBeenCalledTimes(1);
+  });
+
+  it("routes Try again to the failed run retry callback", async () => {
+    const onRetryFailedRun = vi.fn();
+    flushSync(() =>
+      root!.render(
+        <ThemeProvider>
+          <TaskChatThreadView
+            scroll={false}
+            items={[
+              {
+                id: "run-1:failure",
+                kind: "marker",
+                variant: "interrupted",
+                label: "Run failed",
+                detail: "The runner stopped before returning an answer.",
+                collapsible: true,
+                runId: "run-1",
+              },
+            ]}
+            onRetryFailedRun={onRetryFailedRun}
+          />
+        </ThemeProvider>,
+      ),
+    );
+
+    const retry = container.querySelector<HTMLButtonElement>(
+      '[data-testid="task-chat-run-failed-try-again"]',
+    )!;
+    expect(retry).not.toBeNull();
+    flushSync(() => retry.click());
+    await Promise.resolve();
+    expect(onRetryFailedRun).toHaveBeenCalledWith("run-1");
   });
 });

--- a/ui/src/components/task-chat/TaskChatMarker.test.tsx
+++ b/ui/src/components/task-chat/TaskChatMarker.test.tsx
@@ -57,6 +57,11 @@ describe("TaskChatMarker", () => {
     )!;
     expect(toggle.textContent).toContain("Run failed");
     expect(toggle.textContent).toContain("5m ago");
+    expect(
+      container
+        .querySelector('[data-testid="task-chat-collapsible-marker"]')
+        ?.classList.contains("items-start"),
+    ).toBe(true);
     expect(container.querySelector(".border-dashed")).toBeNull();
     expect(container.textContent).not.toContain("runner_exited");
 

--- a/ui/src/components/task-chat/TaskChatMarker.tsx
+++ b/ui/src/components/task-chat/TaskChatMarker.tsx
@@ -1,7 +1,10 @@
+import { useId, useState } from "react";
 import { cn } from "@/lib/utils";
-import { CircleDot, OctagonX, Flag } from "lucide-react";
+import { ChevronDown, CircleDot, OctagonX, Flag } from "lucide-react";
 import type { TaskChatMarkerItem } from "./task-chat-model";
 import { Button } from "@/components/ui/button";
+import { Link } from "@/lib/router";
+import { timeAgo } from "@/lib/timeAgo";
 
 const VARIANT_ICON = {
   session_start: CircleDot,
@@ -23,14 +26,96 @@ export function TaskChatMarker({
   onTryAgain?: () => Promise<void> | void;
   tryAgainPending?: boolean;
 }) {
+  const [open, setOpen] = useState(false);
+  const detailsId = useId();
   const Icon = VARIANT_ICON[item.variant];
   const interrupted = item.variant === "interrupted";
+  const relative = item.createdAtIso ? timeAgo(item.createdAtIso) : undefined;
   const handleTryAgain = () => {
     void Promise.resolve()
       .then(() => onTryAgain?.())
       // The parent mutation owns visible error feedback.
       .catch(() => undefined);
   };
+
+  if (item.collapsible) {
+    return (
+      <div
+        className="tc-enter-marker flex flex-col items-center py-1 text-xs text-muted-foreground"
+        data-testid="task-chat-collapsible-marker"
+      >
+        <div className="flex max-w-(--pct-85) items-center gap-1.5">
+          <button
+            type="button"
+            onClick={() => setOpen((value) => !value)}
+            aria-expanded={open}
+            aria-controls={detailsId}
+            className={cn(
+              "flex min-w-0 items-center gap-1.5 rounded-md px-2 py-0.5 text-destructive",
+              "hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+            )}
+          >
+            <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden />
+            <span className="truncate font-medium">{item.label}</span>
+            {relative ? (
+              <span className="shrink-0 text-muted-foreground/70">· {relative}</span>
+            ) : null}
+            <ChevronDown
+              className={cn(
+                "tc-notice-chevron h-3.5 w-3.5 shrink-0 transition-transform",
+                open && "rotate-180",
+              )}
+              aria-hidden
+            />
+          </button>
+          {onTryAgain && !open ? (
+            <Button
+              type="button"
+              variant="outline"
+              size="xs"
+              onClick={handleTryAgain}
+              disabled={tryAgainPending}
+              data-testid="task-chat-run-failed-try-again"
+            >
+              {tryAgainPending ? "Trying again..." : "Try again"}
+            </Button>
+          ) : null}
+        </div>
+        {open ? (
+          <div
+            id={detailsId}
+            data-testid="task-chat-collapsible-marker-details"
+            className="mt-1 w-full max-w-(--pct-85) overflow-hidden rounded-lg border border-border bg-muted/25 text-left text-sm dark:bg-muted/15"
+          >
+            {item.detail ? (
+              <div className="px-3 py-2.5 text-foreground/90">{item.detail}</div>
+            ) : null}
+            {item.runHref || onTryAgain ? (
+              <div className="flex items-center justify-end gap-2 border-t border-border/70 bg-background/50 px-3 py-2 dark:bg-background/30">
+                {item.runHref ? (
+                  <Button asChild variant="ghost" size="xs">
+                    <Link to={item.runHref}>View run</Link>
+                  </Button>
+                ) : null}
+                {onTryAgain ? (
+                  <Button
+                    type="button"
+                    size="xs"
+                    onClick={handleTryAgain}
+                    disabled={tryAgainPending}
+                    data-testid="task-chat-run-failed-try-again"
+                  >
+                    {tryAgainPending ? "Trying again..." : "Try again"}
+                  </Button>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    );
+  }
+
   return (
     <div className="tc-enter-marker flex items-center gap-2 py-1 text-xs text-muted-foreground">
       <span className={cn("h-px flex-1", interrupted ? "border-t border-dashed border-destructive/50" : "bg-border")} />

--- a/ui/src/components/task-chat/TaskChatMarker.tsx
+++ b/ui/src/components/task-chat/TaskChatMarker.tsx
@@ -41,7 +41,7 @@ export function TaskChatMarker({
   if (item.collapsible) {
     return (
       <div
-        className="tc-enter-marker flex flex-col items-center py-1 text-xs text-muted-foreground"
+        className="tc-enter-marker flex flex-col items-start py-1 text-xs text-muted-foreground"
         data-testid="task-chat-collapsible-marker"
       >
         <div className="flex max-w-(--pct-85) items-center gap-1.5">

--- a/ui/src/components/task-chat/TaskChatRichInput.tsx
+++ b/ui/src/components/task-chat/TaskChatRichInput.tsx
@@ -20,6 +20,7 @@ interface TaskChatRichInputProps {
   ariaLabelledBy?: string;
   testId?: string;
   attachAriaLabel?: string;
+  showImageAttachControls?: boolean;
 }
 
 /** Composer-grade rich text field for takeover answers and revision notes. */
@@ -36,6 +37,7 @@ export function TaskChatRichInput({
   ariaLabelledBy,
   testId = "task-chat-rich-input",
   attachAriaLabel = "Attach image",
+  showImageAttachControls = true,
 }: TaskChatRichInputProps) {
   const editorRef = useRef<MarkdownEditorRef>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -104,7 +106,7 @@ export function TaskChatRichInput({
         bordered={false}
         contentClassName="max-h-(--sz-28dvh) min-h-(--sz-72px) overflow-y-auto px-0 py-0 text-sm scrollbar-auto-hide"
       />
-      {imageUploadHandler ? (
+      {imageUploadHandler && showImageAttachControls ? (
         <div className="mt-1 flex flex-wrap items-center gap-1 text-xs text-muted-foreground">
           <input
             ref={fileInputRef}

--- a/ui/src/components/task-chat/TaskChatSystemNotice.test.tsx
+++ b/ui/src/components/task-chat/TaskChatSystemNotice.test.tsx
@@ -151,6 +151,11 @@ describe("TaskChatSystemNotice (PAP-443)", () => {
 
     expect(onTryAgain).toHaveBeenCalledTimes(1);
     expect(toggleButton().getAttribute("aria-expanded")).toBe("false");
+    expect(
+      container
+        .querySelector('[data-testid="task-chat-system-notice"]')
+        ?.classList.contains("items-start"),
+    ).toBe(true);
   });
 
   it("moves Try again into the expanded notice footer", () => {

--- a/ui/src/components/task-chat/TaskChatSystemNotice.tsx
+++ b/ui/src/components/task-chat/TaskChatSystemNotice.tsx
@@ -37,7 +37,7 @@ const TONE_ICON_CLASS: Record<SystemNoticeTone, string> = {
 
 /**
  * System comment row in the chat shell (PAP-443 / PAP-442 Phase 1): collapsed,
- * it reads as a quiet centered one-liner in TaskChatMarker's register — tone
+ * it reads as a quiet left-aligned one-liner in TaskChatMarker's register — tone
  * icon + humanized plain-English title + relative time + chevron — instead of
  * a large gray paragraph of raw text. Expanding reveals the full
  * markdown-rendered body plus any structured metadata sections; nothing is
@@ -75,7 +75,7 @@ export function TaskChatSystemNotice({
   };
 
   return (
-    <div className="tc-enter-bubble flex flex-col items-center py-1" data-testid="task-chat-system-notice">
+    <div className="tc-enter-bubble flex flex-col items-start py-1" data-testid="task-chat-system-notice">
       <div className="flex max-w-(--pct-85) items-center gap-1.5">
         <button
           type="button"

--- a/ui/src/components/task-chat/TaskChatThreadView.tsx
+++ b/ui/src/components/task-chat/TaskChatThreadView.tsx
@@ -56,6 +56,8 @@ interface TaskChatThreadViewProps {
   /** Requeues a blocked task from its no-live-execution-path failure surfaces. */
   onTryAgainNoLiveExecutionPath?: () => Promise<void> | void;
   tryAgainNoLiveExecutionPathPending?: boolean;
+  onRetryFailedRun?: (runId: string) => Promise<void> | void;
+  retryFailedRunId?: string | null;
   /** Content appended inside the transcript scroller after the settled thread. */
   tail?: ReactNode;
   /** Optional streaming-aware key when `tail` changes without changing `items`. */
@@ -80,6 +82,8 @@ function renderItem(
   onTryAgainNoLiveExecutionPath?: () => Promise<void> | void,
   tryAgainNoLiveExecutionPathPending = false,
   retryableMarkerId?: string,
+  onRetryFailedRun?: (runId: string) => Promise<void> | void,
+  retryFailedRunId?: string | null,
 ) {
   switch (item.kind) {
     case "message": {
@@ -149,10 +153,16 @@ function renderItem(
           item={item}
           onTryAgain={
             item.id === retryableMarkerId
-              ? onTryAgainNoLiveExecutionPath
+              ? item.runId && onRetryFailedRun
+                ? () => onRetryFailedRun(item.runId!)
+                : onTryAgainNoLiveExecutionPath
               : undefined
           }
-          tryAgainPending={tryAgainNoLiveExecutionPathPending}
+          tryAgainPending={
+            item.runId
+              ? retryFailedRunId === item.runId
+              : tryAgainNoLiveExecutionPathPending
+          }
         />
       );
     case "thinking":
@@ -252,12 +262,14 @@ export function TaskChatThreadView({
   renderQueuedAction,
   onTryAgainNoLiveExecutionPath,
   tryAgainNoLiveExecutionPathPending = false,
+  onRetryFailedRun,
+  retryFailedRunId = null,
   tail,
   contentKey,
   className,
   scroll = true,
 }: TaskChatThreadViewProps) {
-  const retryableMarkerId = onTryAgainNoLiveExecutionPath
+  const retryableMarkerId = onRetryFailedRun || onTryAgainNoLiveExecutionPath
     ? [...items]
         .reverse()
         .find(
@@ -304,6 +316,8 @@ export function TaskChatThreadView({
             onTryAgainNoLiveExecutionPath,
             tryAgainNoLiveExecutionPathPending,
             retryableMarkerId,
+            onRetryFailedRun,
+            retryFailedRunId,
           )}
         </div>
       ))}

--- a/ui/src/components/task-chat/task-chat-model.ts
+++ b/ui/src/components/task-chat/task-chat-model.ts
@@ -239,6 +239,10 @@ export interface TaskChatMarkerItem {
   variant: "session_start" | "interrupted" | "turn_boundary";
   label: string;
   detail?: string;
+  /** Renders the marker as a quiet disclosure row with detail beneath it. */
+  collapsible?: boolean;
+  createdAtIso?: string;
+  runHref?: string;
 }
 
 /** A second-tier live token/cost readout (ACP UsageUpdate). */

--- a/ui/src/components/task-chat/task-chat-model.ts
+++ b/ui/src/components/task-chat/task-chat-model.ts
@@ -241,6 +241,7 @@ export interface TaskChatMarkerItem {
   detail?: string;
   /** Renders the marker as a quiet disclosure row with detail beneath it. */
   collapsible?: boolean;
+  runId?: string;
   createdAtIso?: string;
   runHref?: string;
 }

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -1499,6 +1499,44 @@ const IssueDetailChatTab = memo(function IssueDetailChatTab({
   });
   const resolvedActivity = activity ?? [];
   const resolvedLinkedRuns = linkedRuns ?? [];
+  const retryFailedRun = useMutation({
+    mutationFn: async (runId: string) => {
+      const failedRun = resolvedLinkedRuns.find((run) => run.runId === runId);
+      if (!failedRun) throw new Error("Failed run is no longer available.");
+      const result = await agentsApi.wakeup(
+        failedRun.agentId,
+        {
+          source: "on_demand",
+          triggerDetail: "manual",
+          reason: "retry_failed_run",
+          payload: { issueId },
+        },
+        companyId,
+      );
+      if (!("id" in result)) {
+        throw new Error(result.message ?? "Retry was skipped.");
+      }
+      return result;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.issues.runs(issueId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.issues.liveRuns(issueId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKeys.issues.activeRun(issueId),
+      });
+    },
+    onError: (error) => {
+      pushToast({
+        title: "Run retry failed",
+        body: error instanceof Error ? error.message : "Unable to retry run",
+        tone: "error",
+      });
+    },
+  });
 
   const interruptibleIssueRun = useMemo(
     () => resolveInterruptibleIssueRun(resolvedActiveRun, resolvedLiveRuns),
@@ -2122,6 +2160,12 @@ const IssueDetailChatTab = memo(function IssueDetailChatTab({
           feedbackDataSharingPreference={feedbackDataSharingPreference}
           feedbackTermsUrl={feedbackTermsUrl}
           linkedRuns={timelineRuns}
+          onRetryFailedRun={(runId) =>
+            retryFailedRun.mutateAsync(runId).then(() => undefined)
+          }
+          retryFailedRunId={
+            retryFailedRun.isPending ? retryFailedRun.variables : null
+          }
           timelineEvents={timelineEvents}
           workModeChanges={workModeChanges}
           liveRuns={resolvedLiveRuns}


### PR DESCRIPTION
## Thinking Path

> - Paperclip uses the native runner to execute agent work.
> - The runner must preserve work state and useful failure details.
> - Fast provider failures can arrive before the driver binds a turn.
> - Diagnostics must preserve useful context without exposing credentials.
> - Task chat must show failures and let an operator retry eligible runs.
> - This change improves recovery, diagnostics, adapter state, and task interaction behavior.

## Linked Issues or Issue Description

Refs #12616, #12591, and #12693.

**What existing behavior does this improve?**

This change improves native runner recovery, failure details, and task interaction behavior.

**Subsystem affected**

This change affects the runner, server, adapters, and task interaction UI.

**Current behavior**

Fast provider failures can race with turn binding. Some diagnostic formats can keep part of a credential. Adapter conversion can lose model or authentication state. Task chat can hide useful failure and retry details.

**Proposed behavior**

Bind the provider turn before terminal delivery. Redact complete credential values. Preserve adapter state. Show clear failure and retry controls in task chat.

**Reason and benefit**

Operators get stable recovery, useful safe diagnostics, and clear retry actions. Agent configuration stays stable across native sessions.

**Breaking changes**

None.

## What Changed

- Improved native runner failure reporting, retry state, and session recovery.
- Preserved adapter models, Codex authentication state, and constrained permission defaults.
- Added value-level redaction for JSON, compound, prefixed, camel-case, Digest, escaped-quote, and quoted authorization credentials.
- Held fast terminal events until the strict driver binds the provider turn.
- Improved task chat failure notices, retry actions, and compact interaction layout.
- Rebased the branch on current master and removed its obsolete workspace-picker copy.

## Verification

- Ran the focused adapter, server, heartbeat, task chat, and runner tests.
- Ran the full runner transport file. All 40 tests passed.
- Ran the durable runner Rust filter. All 41 tests passed.
- Ran the quoted authorization regression test. It passed.
- Ran `pnpm -r typecheck`. It passed.
- Ran `pnpm build`. It passed.
- Ran `pnpm check:token-gates`. It passed.
- Confirmed every latest-head GitHub check is green. Storybook is intentionally skipped.
- Confirmed Greptile is 5/5 with no unresolved review threads.

## Risks

- Runner recovery changes cross process and provider boundaries. The full CI matrix covers these paths.
- Diagnostic redaction can remove too much context. Focused tests cover context retention and credential removal.
- Task interaction changes can affect failure presentation. Component tests and the end-to-end CI shards cover this behavior.

> For core feature work, check [ROADMAP.md](ROADMAP.md) first and discuss it in #dev before opening the PR. Feature PRs that overlap with planned core work may need to be redirected. See CONTRIBUTING.md.

## Model Used

- OpenAI Codex with GPT-5. The runtime does not expose the exact model ID or context window. Tool use, code execution, and repository access were enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with Fixes: # / Closes # / Refs # OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub issue and pull request links)
- [x] My branch name describes the change and follows the assigned branch contract
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
