### PR TITLE
Log issue write denial code, issueId, actorAgentId, runId

### DIFF
--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -92,6 +92,23 @@ const mockObserveCrossIssueInfluence = vi.hoisted(() => vi.fn());
 const mockCrossIssueInfluenceLimitError = vi.hoisted(() => vi.fn());
 const mockCrossIssueInfluenceRunContextError = vi.hoisted(() => vi.fn());
 
+// Captures every logger call, so the write-denial test can assert the denial
+// code and actor context reach the logs (denyIssueWrite responds directly
+// rather than throwing, so this is the only place that context is observable).
+const mockLogger = vi.hoisted(() => {
+  const logger: Record<string, unknown> = {};
+  for (const level of ["info", "warn", "error", "debug", "trace", "fatal"]) {
+    logger[level] = vi.fn();
+  }
+  logger.child = vi.fn(() => logger);
+  return logger;
+});
+
+vi.mock("../middleware/logger.js", () => ({
+  logger: mockLogger,
+  httpLogger: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 vi.mock("@paperclipai/shared/telemetry", () => ({
   trackAgentTaskCompleted: vi.fn(),
   trackErrorHandlerCrash: vi.fn(),
@@ -701,6 +718,40 @@ describe.sequential("issue comment reopen routes", () => {
       expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
     },
   );
+
+  it("logs the denial code and actor context when an issue write is denied", async () => {
+    // Without this log line, a write denial reaches the caller in the response
+    // body but leaves no trace server-side — this class of 403 is undiagnosable
+    // from operations. Assert the logger, not the response, so the test fails
+    // if the log line is ever removed even though the HTTP behavior is unchanged.
+    const mentionedAgentId = "33333333-3333-4333-8333-333333333333";
+    mockIssueService.getById.mockResolvedValue(makeIssue("done"));
+    mockAccessService.decide.mockImplementation(async (input: { action?: string }) => {
+      const allowed = input.action === "issue:comment";
+      return {
+        allowed,
+        action: input.action,
+        reason: allowed ? "allow_issue_mention_grant" : "deny_missing_grant",
+        explanation: allowed ? "Allowed by a mention-scoped issue comment grant." : "Missing permission.",
+      };
+    });
+
+    const res = await request(await installActor(createApp(), agentActor(mentionedAgentId)))
+      .post("/api/issues/11111111-1111-4111-8111-111111111111/comments")
+      .send({ body: "Please continue this closed issue.", reopen: true });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.details.code).toBe("issue_write_not_visible");
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: "issue_write_not_visible",
+        issueId: "11111111-1111-4111-8111-111111111111",
+        actorAgentId: mentionedAgentId,
+        runId: "run-1",
+      }),
+      "issue write denied",
+    );
+  });
 
   // POST self-comment from the assignee agent on a done issue with explicit
   // reopen=true is the same log-class signal — the guard must suppress reopen.

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4001,12 +4001,21 @@ export function issueRoutes(
   async function denyIssueWrite(
     req: Request,
     res: Response,
-    issue: { identifier?: string | null; assigneeAgentId: string | null },
+    issue: { id: string; identifier?: string | null; assigneeAgentId: string | null },
     code: IssueWriteDenialCode,
     extraDetails: Record<string, unknown> = {},
   ) {
     const labels = await issueWriteDenialLabels(req, issue);
     const { status, body } = issueWriteDenialResponse(code, labels);
+    logger.warn(
+      {
+        code,
+        issueId: issue.id,
+        actorAgentId: req.actor.type === "agent" ? req.actor.agentId ?? null : null,
+        runId: req.actor.type === "agent" ? req.actor.runId ?? null : null,
+      },
+      "issue write denied",
+    );
     res.status(status).json({
       error: body.error,
       details: { ...body.details, ...extraDetails },


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - This concerns the issues HTTP route layer, specifically the write-authorization path for agent-initiated issue mutations
> - When an agent's `PATCH /api/issues/:id` is refused, `denyIssueWrite` returns a denial code in the response body, but that code is never written to the server log
> - It needs to be addressed because the code is the only signal that says WHICH authorization rule refused the write. Without it in the logs, an operator holding only server-side evidence cannot tell a checkout-lock refusal from a policy refusal, and a recurring 403 cannot be diagnosed at all after the fact
> - This pull request logs the denial code at warn level, together with the issue, actor agent, and run it applies to
> - The benefit is that this class of refusal becomes diagnosable from logs alone, without reproducing the request

## Linked Issues or Issue Description

Refs #12687

**What happened:** Agent-owned issues were repeatedly left in a non-terminal state after a run
ended. Each run's closing `PATCH /api/issues/:id` returned 403. About ten issues stranded this
way over three days.

**What was expected:** Either the write succeeds, or the server log states which rule refused it.

**Why it could not be diagnosed:** `denyIssueWrite` answers with `res.json()` and does not set
`res.__errorContext`, which is what the pino-http logger reads to record 4xx body detail. Only
`error-handler.ts` and one call site in `plugins.ts` set it. Searching the running server's logs
for any denial code therefore returns nothing, and the failing rule can only be guessed at by
reading the source.

**Impact:** Any 403 from this path is undiagnosable from operations. The related close-out defect
is tracked separately in #12686; this PR does not attempt to fix that defect, only to make it and
its whole class observable.

## What Changed

- Added a `logger.warn` call in `denyIssueWrite` (`server/src/routes/issues.ts`) that records the
  denial code with the issue id, the actor agent id, and the run id.
- Added a test that asserts the log fires with those fields on a denied write.

## Verification

- `pnpm --filter @paperclipai/server run typecheck` — clean.
- Targeted server route suite — passes, and the new log line is visible in the test output with
  the expected fields.
- The added test fails if the log call is removed, so it does not pass vacuously.
- No production behavior changes: the response status, the response body, and the control flow
  are all unchanged. Only an additional log record is emitted.

## Risks

Low risk. The change is additive and observability-only. The one thing to weigh is log volume on
a server with many denied writes, and the field set is deliberately small — code plus three ids,
no request body and no user content, so nothing sensitive is written to the log.

## Model Used

Claude Opus 4.5 (`claude-opus-4-5`), extended thinking, with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
