### PR TITLE
fix(adapter-pi-local): surface model-level stopReason=error as adapter failure

### DIFF
--- a/packages/adapters/pi-local/src/server/parse.test.ts
+++ b/packages/adapters/pi-local/src/server/parse.test.ts
@@ -260,6 +260,97 @@ describe("parsePiJsonl", () => {
     const parsed = parsePiJsonl(stdout);
     expect(parsed.errors).toEqual([]);
   });
+
+  it("surfaces model-level stopReason=error (402) as an error", () => {
+    const err402 =
+      '402: {"message":"Insufficient Balance","type":"unknown_error","param":null,"code":"invalid_request_error"}';
+    const stdout = [
+      JSON.stringify({ type: "agent_start" }),
+      JSON.stringify({
+        type: "turn_end",
+        message: {
+          role: "assistant",
+          content: [],
+          stopReason: "error",
+          errorMessage: err402,
+        },
+        toolResults: [],
+      }),
+      JSON.stringify({ type: "agent_end", messages: [] }),
+    ].join("\n");
+
+    const parsed = parsePiJsonl(stdout);
+    expect(parsed.errors).toContain(err402);
+  });
+
+  it("dedupes stopReason=error across turn_end and agent_end", () => {
+    const err402 =
+      '402: {"message":"Insufficient Balance","type":"unknown_error","param":null,"code":"invalid_request_error"}';
+    const stdout = [
+      JSON.stringify({ type: "agent_start" }),
+      JSON.stringify({
+        type: "turn_end",
+        message: {
+          role: "assistant",
+          content: [],
+          stopReason: "error",
+          errorMessage: err402,
+        },
+        toolResults: [],
+      }),
+      JSON.stringify({
+        type: "agent_end",
+        messages: [
+          {
+            role: "assistant",
+            content: [],
+            stopReason: "error",
+            errorMessage: err402,
+          },
+        ],
+      }),
+    ].join("\n");
+
+    const parsed = parsePiJsonl(stdout);
+    expect(parsed.errors).toEqual([err402]);
+  });
+
+  it("does not surface error for a normal end_turn", () => {
+    const stdout = [
+      JSON.stringify({
+        type: "turn_end",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "All good" }],
+          stopReason: "end_turn",
+        },
+        toolResults: [],
+      }),
+    ].join("\n");
+
+    const parsed = parsePiJsonl(stdout);
+    expect(parsed.errors).toEqual([]);
+    expect(parsed.finalMessage).toBe("All good");
+  });
+
+  it("uses a generic fallback when stopReason=error has an empty errorMessage", () => {
+    const stdout = [
+      JSON.stringify({
+        type: "turn_end",
+        message: {
+          role: "assistant",
+          content: [],
+          stopReason: "error",
+          errorMessage: "",
+        },
+        toolResults: [],
+      }),
+    ].join("\n");
+
+    const parsed = parsePiJsonl(stdout);
+    expect(parsed.errors).toHaveLength(1);
+    expect(parsed.errors[0]).toContain("stopReason=error");
+  });
 });
 
 describe("isPiUnknownSessionError", () => {

--- a/packages/adapters/pi-local/src/server/parse.ts
+++ b/packages/adapters/pi-local/src/server/parse.ts
@@ -28,6 +28,17 @@ function extractTextContent(content: string | Array<{ type: string; text?: strin
     .join("");
 }
 
+// Surface model-level failures (stopReason=error, e.g. 402/5xx provider errors) so the
+// harness reports adapter_failed instead of a silent empty success (missing_disposition).
+function recordModelError(result: ParsedPiOutput, message: Record<string, unknown>): void {
+  const stopReason = asString(message.stopReason, "");
+  if (stopReason !== "error") return;
+  const errorMessage = asString(message.errorMessage, "").trim() || "Pi model call failed (stopReason=error).";
+  if (!result.errors.includes(errorMessage)) {
+    result.errors.push(errorMessage);
+  }
+}
+
 export function parsePiJsonl(stdout: string): ParsedPiOutput {
   const result: ParsedPiOutput = {
     sessionId: null,
@@ -71,6 +82,7 @@ export function parsePiJsonl(stdout: string): ParsedPiOutput {
         if (lastMessage?.role === "assistant") {
           const content = lastMessage.content as string | Array<{ type: string; text?: string }>;
           result.finalMessage = extractTextContent(content);
+          recordModelError(result, lastMessage);
         }
       }
       continue;
@@ -93,6 +105,7 @@ export function parsePiJsonl(stdout: string): ParsedPiOutput {
     if (eventType === "turn_end") {
       const message = asRecord(event.message);
       if (message) {
+        recordModelError(result, message);
         const content = message.content as string | Array<{ type: string; text?: string }>;
         const text = extractTextContent(content);
         if (text) {


### PR DESCRIPTION
## Problem

The `pi_local` adapter wraps the Pi CLI, which reports a turn/agent that ends with `stopReason: "error"` (e.g. a `402 Insufficient Balance`, `5xx`, or other provider failure) inside the **nested `message` object** of `turn_end` / `agent_end` events.

`parsePiJsonl` only inspected top-level `type: "error"` events and `auto_retry_end`, so a failing model call was silently ignored — `errors: []` → exit code `0` → the harness reported the run as `succeeded` with empty output and filed `missing_disposition` (`successful_run_missing_state`) instead of surfacing `adapter_failed`.

## Fix

Add `recordModelError(result, message)` and call it from both the `turn_end` and `agent_end` handlers. When `stopReason === "error"`, it records `message.errorMessage` (or a generic fallback) into `result.errors`. Existing `toResult` already maps `errors` → failure, so no other change is required.

## Tests

Added 4 regression cases to `parse.test.ts`:

- surfaces model-level `stopReason=error` (402) as an error
- dedupes across `turn_end` + `agent_end`
- does not surface an error for a normal `end_turn`
- uses a generic fallback when `errorMessage` is empty

`pnpm exec vitest run src/server/parse.test.ts` → **17/17 pass** (13 existing + 4 new). `tsc` build clean.

## Repro

`parsePiJsonl(<turn_end with message.stopReason="error", errorMessage="402: Insufficient Balance">)` previously returned `errors: []`; now returns the 402 message in `errors`.