### PR TITLE
fix: add fail-closed branch freshness status

### DIFF
--- a/.github/scripts/branch-freshness.mjs
+++ b/.github/scripts/branch-freshness.mjs
@@ -98,6 +98,30 @@ export async function runBranchFreshness({
     })
   }
 
+  async function publishEnumerationError(error) {
+    const message = error instanceof Error ? error.message : String(error)
+    core.error(`Could not enumerate open pull requests: ${message}`)
+
+    // A protected-base push has no pull-request head in its payload. Persist the
+    // failed observation on the exact base event commit as well as failing the
+    // workflow. Strict required-status enforcement keeps every older head
+    // blocked until a later serialized run can recompute it.
+    const eventBaseSha = context.payload?.after ?? context.sha
+    try {
+      await publish(
+        eventBaseSha,
+        'error',
+        `Open pull requests for protected ${protectedBase} could not be enumerated.`,
+      )
+    } catch (publishError) {
+      const publishMessage = publishError instanceof Error
+        ? publishError.message
+        : String(publishError)
+      core.error(`Could not publish protected-base enumeration error: ${publishMessage}`)
+    }
+    core.setFailed('Open pull requests could not be enumerated for branch freshness.')
+  }
+
   let pulls
   if (context.eventName === 'pull_request_target') {
     const pull = context.payload.pull_request
@@ -105,12 +129,18 @@ export async function runBranchFreshness({
       ? [{ number: pull.number, headSha: pull.head?.sha }]
       : []
   } else {
-    const openPulls = await github.paginate(github.rest.pulls.list, {
-      ...context.repo,
-      state: 'open',
-      base: protectedBase,
-      per_page: 100,
-    })
+    let openPulls
+    try {
+      openPulls = await github.paginate(github.rest.pulls.list, {
+        ...context.repo,
+        state: 'open',
+        base: protectedBase,
+        per_page: 100,
+      })
+    } catch (error) {
+      await publishEnumerationError(error)
+      return
+    }
     pulls = openPulls.map((pull) => ({
       number: pull.number,
       headSha: pull.head?.sha,
@@ -123,19 +153,25 @@ export async function runBranchFreshness({
   // Invalidate every previously successful status before doing any comparison.
   // This keeps the remaining heads non-successful if a base-push run times out
   // or is cancelled while processing a large set of open pull requests.
-  for (const candidate of pulls) {
-    try {
-      const observedHeadSha = requireSha(candidate.headSha, `PR #${candidate.number} event head`)
-      await publish(
-        observedHeadSha,
-        'pending',
-        `Checking head against protected ${protectedBase}.`,
-      )
-      preparedPulls.push({ ...candidate, observedHeadSha })
-    } catch (error) {
+  const invalidations = await Promise.allSettled(pulls.map(async (candidate) => {
+    const observedHeadSha = requireSha(candidate.headSha, `PR #${candidate.number} event head`)
+    await publish(
+      observedHeadSha,
+      'pending',
+      `Checking head against protected ${protectedBase}.`,
+    )
+    return { ...candidate, observedHeadSha }
+  }))
+
+  for (const [index, invalidation] of invalidations.entries()) {
+    if (invalidation.status === 'fulfilled') {
+      preparedPulls.push(invalidation.value)
+    } else {
       comparisonFailed = true
-      const message = error instanceof Error ? error.message : String(error)
-      core.error(`PR #${candidate.number}: could not publish pending status: ${message}`)
+      const message = invalidation.reason instanceof Error
+        ? invalidation.reason.message
+        : String(invalidation.reason)
+      core.error(`PR #${pulls[index].number}: could not publish pending status: ${message}`)
     }
   }
 
@@ -184,6 +220,28 @@ export async function runBranchFreshness({
       if (result.state === 'error') {
         comparisonFailed = true
         core.error(`PR #${candidate.number}: ${result.description}`)
+      } else if (result.state === 'success') {
+        // Close the publish/read race. The global workflow queue prevents another
+        // writer from overtaking this run; if the repository changes during the
+        // status API call, overwrite the transient success before completing.
+        const [publishedPull, publishedBaseSha] = await Promise.all([
+          currentPull(candidate.number),
+          protectedBaseSha(),
+        ])
+        if (
+          publishedPull.state !== 'open'
+          || publishedPull.base?.ref !== protectedBase
+          || publishedPull.head?.sha !== observedHeadSha
+          || publishedBaseSha !== observedBaseSha
+        ) {
+          comparisonFailed = true
+          await publish(
+            observedHeadSha,
+            'error',
+            `Published comparison for protected ${protectedBase} ${observedBaseSha} became stale.`,
+          )
+          core.error(`PR #${candidate.number}: published comparison became stale.`)
+        }
       }
     } catch (error) {
       comparisonFailed = true

--- a/.github/scripts/branch-freshness.mjs
+++ b/.github/scripts/branch-freshness.mjs
@@ -15,6 +15,24 @@ export function successDescription(protectedBase, baseSha) {
   return `Protected ${protectedBase} ${baseSha} is included in this head.`
 }
 
+export function hasStrictFreshnessEnforcement({
+  ruleset,
+  statusContext,
+  statusIntegrationId,
+}) {
+  if (ruleset?.enforcement !== 'active' || !Array.isArray(ruleset.rules)) return false
+
+  return ruleset.rules.some((rule) => (
+    rule?.type === 'required_status_checks'
+    && rule.parameters?.strict_required_status_checks_policy === true
+    && Array.isArray(rule.parameters?.required_status_checks)
+    && rule.parameters.required_status_checks.some((check) => (
+      check?.context === statusContext
+      && check?.integration_id === statusIntegrationId
+    ))
+  ))
+}
+
 export function computeFreshnessStatus({
   comparison,
   protectedBase,
@@ -68,6 +86,8 @@ export async function runBranchFreshness({
   core,
   protectedBase = 'master',
   statusContext = 'branch-freshness',
+  rulesetId = 13619726,
+  statusIntegrationId = 15368,
 }) {
   const statusTargetUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
 
@@ -87,6 +107,21 @@ export async function runBranchFreshness({
     return response.data
   }
 
+  async function strictFreshnessEnforced() {
+    const response = await github.request(
+      'GET /repos/{owner}/{repo}/rulesets/{ruleset_id}',
+      {
+        ...context.repo,
+        ruleset_id: rulesetId,
+      },
+    )
+    return hasStrictFreshnessEnforcement({
+      ruleset: response.data,
+      statusContext,
+      statusIntegrationId,
+    })
+  }
+
   async function publish(headSha, state, description) {
     await github.rest.repos.createCommitStatus({
       ...context.repo,
@@ -104,8 +139,9 @@ export async function runBranchFreshness({
 
     // A protected-base push has no pull-request head in its payload. Persist the
     // failed observation on the exact base event commit as well as failing the
-    // workflow. Strict required-status enforcement keeps every older head
-    // blocked until a later serialized run can recompute it.
+    // workflow. Success publication is separately gated on active strict
+    // required-status enforcement, so GitHub blocks every stale head immediately
+    // even when this run cannot enumerate those heads for status invalidation.
     const eventBaseSha = context.payload?.after ?? context.sha
     try {
       await publish(
@@ -172,6 +208,15 @@ export async function runBranchFreshness({
         ? invalidation.reason.message
         : String(invalidation.reason)
       core.error(`PR #${pulls[index].number}: could not publish pending status: ${message}`)
+      // Do not abandon a head because its first invalidation failed. A later
+      // pending or terminal write may still succeed and replace prior success.
+      preparedPulls.push({
+        ...pulls[index],
+        observedHeadSha: requireSha(
+          pulls[index].headSha,
+          `PR #${pulls[index].number} event head`,
+        ),
+      })
     }
   }
 
@@ -216,23 +261,37 @@ export async function runBranchFreshness({
         liveBaseSha,
       })
 
+      if (result.state === 'success' && !await strictFreshnessEnforced()) {
+        comparisonFailed = true
+        await publish(
+          observedHeadSha,
+          'error',
+          `Strict ${statusContext} enforcement is unavailable.`,
+        )
+        core.error(`PR #${candidate.number}: strict ${statusContext} enforcement is unavailable.`)
+        continue
+      }
+
       await publish(observedHeadSha, result.state, result.description)
       if (result.state === 'error') {
         comparisonFailed = true
         core.error(`PR #${candidate.number}: ${result.description}`)
       } else if (result.state === 'success') {
-        // Close the publish/read race. The global workflow queue prevents another
-        // writer from overtaking this run; if the repository changes during the
-        // status API call, overwrite the transient success before completing.
-        const [publishedPull, publishedBaseSha] = await Promise.all([
+        // Detect changes during the status write and overwrite transient success.
+        // A base advance after this final read is blocked atomically by GitHub's
+        // strict required-status policy, which was checked both before and after
+        // publication; the queued base-push run then refreshes the visible status.
+        const [publishedPull, publishedBaseSha, enforcementStillActive] = await Promise.all([
           currentPull(candidate.number),
           protectedBaseSha(),
+          strictFreshnessEnforced(),
         ])
         if (
           publishedPull.state !== 'open'
           || publishedPull.base?.ref !== protectedBase
           || publishedPull.head?.sha !== observedHeadSha
           || publishedBaseSha !== observedBaseSha
+          || !enforcementStillActive
         ) {
           comparisonFailed = true
           await publish(

--- a/.github/scripts/branch-freshness.mjs
+++ b/.github/scripts/branch-freshness.mjs
@@ -171,50 +171,71 @@ export async function runBranchFreshness({
       core.warning?.(`REST pull-request enumeration failed; trying GraphQL: ${message}`)
     }
 
-    const pulls = []
-    let cursor = null
-    do {
-      const response = await github.graphql(
-        `query OpenPullHeads($owner: String!, $repo: String!, $cursor: String) {
-          repository(owner: $owner, name: $repo) {
-            pullRequests(first: 100, after: $cursor, states: OPEN) {
-              nodes {
-                number
-                baseRefName
-                headRefOid
-              }
-              pageInfo {
-                hasNextPage
-                endCursor
+    try {
+      const pulls = []
+      let cursor = null
+      do {
+        const response = await github.graphql(
+          `query OpenPullHeads($owner: String!, $repo: String!, $cursor: String) {
+            repository(owner: $owner, name: $repo) {
+              pullRequests(first: 100, after: $cursor, states: OPEN) {
+                nodes {
+                  number
+                  baseRefName
+                  headRefOid
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
               }
             }
-          }
-        }`,
-        {
-          owner: context.repo.owner,
-          repo: context.repo.repo,
-          cursor,
-        },
-      )
-      const connection = response?.repository?.pullRequests
-      if (!Array.isArray(connection?.nodes)) {
-        throw new Error('GraphQL pull-request enumeration returned an invalid response')
-      }
-      pulls.push(...connection.nodes
-        .filter((pull) => pull?.baseRefName === protectedBase)
-        .map((pull) => ({
-          number: pull.number,
-          head: { sha: pull.headRefOid },
-        })))
+          }`,
+          {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            cursor,
+          },
+        )
+        const connection = response?.repository?.pullRequests
+        if (!Array.isArray(connection?.nodes)) {
+          throw new Error('GraphQL pull-request enumeration returned an invalid response')
+        }
+        pulls.push(...connection.nodes
+          .filter((pull) => pull?.baseRefName === protectedBase)
+          .map((pull) => ({
+            number: pull.number,
+            head: { sha: pull.headRefOid },
+          })))
 
-      if (!connection.pageInfo?.hasNextPage) return pulls
-      cursor = connection.pageInfo.endCursor
-      if (!cursor) {
-        throw new Error('GraphQL pull-request enumeration omitted its next cursor')
-      }
-    } while (cursor)
+        if (!connection.pageInfo?.hasNextPage) return pulls
+        cursor = connection.pageInfo.endCursor
+        if (!cursor) {
+          throw new Error('GraphQL pull-request enumeration omitted its next cursor')
+        }
+      } while (cursor)
 
-    return pulls
+      return pulls
+    } catch (graphqlError) {
+      const message = graphqlError instanceof Error ? graphqlError.message : String(graphqlError)
+      core.warning?.(`GraphQL pull-request enumeration failed; trying search: ${message}`)
+    }
+
+    // Search is served independently from both repository pull-list surfaces.
+    // It yields PR numbers rather than heads, so resolve every result through
+    // the exact pull endpoint before publishing any status.
+    const matches = await github.paginate(github.rest.search.issuesAndPullRequests, {
+      q: `repo:${context.repo.owner}/${context.repo.repo} is:pr is:open base:${protectedBase}`,
+      per_page: 100,
+    })
+    return Promise.all(matches.map(async (match) => {
+      const pull = await currentPull(match.number)
+      return {
+        number: match.number,
+        base: pull.base,
+        head: pull.head,
+      }
+    }))
   }
 
   let pulls
@@ -332,9 +353,11 @@ export async function runBranchFreshness({
         core.error(`PR #${candidate.number}: ${result.description}`)
       } else if (result.state === 'success') {
         // Detect changes during the status write and overwrite transient success.
-        // A base advance after this final read is blocked atomically by GitHub's
-        // strict required-status policy, which was checked both before and after
-        // publication; the queued base-push run then refreshes the visible status.
+        // GitHub's commit-status API cannot atomically compare-and-set against a
+        // mutable branch ref. A base advance after this final read is therefore
+        // blocked at merge time by the native strict policy checked on both sides
+        // of publication, while the newer event cancels this writer and promptly
+        // invalidates the visible status.
         const [publishedPull, publishedBaseSha, enforcementStillActive] = await Promise.all([
           currentPull(candidate.number),
           protectedBaseSha(),

--- a/.github/scripts/branch-freshness.mjs
+++ b/.github/scripts/branch-freshness.mjs
@@ -356,8 +356,8 @@ export async function runBranchFreshness({
         // GitHub's commit-status API cannot atomically compare-and-set against a
         // mutable branch ref. A base advance after this final read is therefore
         // blocked at merge time by the native strict policy checked on both sides
-        // of publication, while the newer event cancels this writer and promptly
-        // invalidates the visible status.
+        // of publication, while the globally serialized newer event runs next
+        // and promptly invalidates the visible status.
         const [publishedPull, publishedBaseSha, enforcementStillActive] = await Promise.all([
           currentPull(candidate.number),
           protectedBaseSha(),

--- a/.github/scripts/branch-freshness.mjs
+++ b/.github/scripts/branch-freshness.mjs
@@ -1,0 +1,213 @@
+const SHA_PATTERN = /^[0-9a-f]{40}$/
+
+function isRecord(value) {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function requireSha(value, field) {
+  if (!SHA_PATTERN.test(value ?? '')) {
+    throw new Error(`${field} did not provide an exact 40-character SHA`)
+  }
+  return value
+}
+
+export function successDescription(protectedBase, baseSha) {
+  return `Protected ${protectedBase} ${baseSha} is included in this head.`
+}
+
+export function computeFreshnessStatus({
+  comparison,
+  protectedBase,
+  observedHeadSha,
+  observedBaseSha,
+  liveHeadSha,
+  liveBaseSha,
+}) {
+  requireSha(observedHeadSha, 'Observed pull request head')
+  requireSha(observedBaseSha, 'Observed protected base')
+
+  if (liveHeadSha !== observedHeadSha || liveBaseSha !== observedBaseSha) {
+    return {
+      state: 'error',
+      description: `Comparison for protected ${protectedBase} ${observedBaseSha} became stale.`,
+      stale: true,
+    }
+  }
+
+  if (
+    !isRecord(comparison)
+    || comparison.base_commit?.sha !== observedBaseSha
+    || !Number.isInteger(comparison.behind_by)
+    || comparison.behind_by < 0
+  ) {
+    return {
+      state: 'error',
+      description: `Comparison with protected ${protectedBase} ${observedBaseSha} is unavailable.`,
+      stale: false,
+    }
+  }
+
+  if (comparison.behind_by > 0) {
+    return {
+      state: 'failure',
+      description: `Head is behind protected ${protectedBase} ${observedBaseSha} by ${comparison.behind_by} commit(s).`,
+      stale: false,
+    }
+  }
+
+  return {
+    state: 'success',
+    description: successDescription(protectedBase, observedBaseSha),
+    stale: false,
+  }
+}
+
+export async function runBranchFreshness({
+  github,
+  context,
+  core,
+  protectedBase = 'master',
+  statusContext = 'branch-freshness',
+}) {
+  const statusTargetUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+
+  async function protectedBaseSha() {
+    const response = await github.rest.git.getRef({
+      ...context.repo,
+      ref: `heads/${protectedBase}`,
+    })
+    return requireSha(response.data?.object?.sha, 'Live protected base')
+  }
+
+  async function currentPull(number) {
+    const response = await github.rest.pulls.get({
+      ...context.repo,
+      pull_number: number,
+    })
+    return response.data
+  }
+
+  async function publish(headSha, state, description) {
+    await github.rest.repos.createCommitStatus({
+      ...context.repo,
+      sha: requireSha(headSha, 'Status head'),
+      context: statusContext,
+      state,
+      description,
+      target_url: statusTargetUrl,
+    })
+  }
+
+  let pulls
+  if (context.eventName === 'pull_request_target') {
+    const pull = context.payload.pull_request
+    pulls = Number.isInteger(pull?.number)
+      ? [{ number: pull.number, headSha: pull.head?.sha }]
+      : []
+  } else {
+    const openPulls = await github.paginate(github.rest.pulls.list, {
+      ...context.repo,
+      state: 'open',
+      base: protectedBase,
+      per_page: 100,
+    })
+    pulls = openPulls.map((pull) => ({
+      number: pull.number,
+      headSha: pull.head?.sha,
+    }))
+  }
+
+  let comparisonFailed = false
+  const preparedPulls = []
+
+  // Invalidate every previously successful status before doing any comparison.
+  // This keeps the remaining heads non-successful if a base-push run times out
+  // or is cancelled while processing a large set of open pull requests.
+  for (const candidate of pulls) {
+    try {
+      const observedHeadSha = requireSha(candidate.headSha, `PR #${candidate.number} event head`)
+      await publish(
+        observedHeadSha,
+        'pending',
+        `Checking head against protected ${protectedBase}.`,
+      )
+      preparedPulls.push({ ...candidate, observedHeadSha })
+    } catch (error) {
+      comparisonFailed = true
+      const message = error instanceof Error ? error.message : String(error)
+      core.error(`PR #${candidate.number}: could not publish pending status: ${message}`)
+    }
+  }
+
+  for (const candidate of preparedPulls) {
+    let observedHeadSha = candidate.observedHeadSha
+    let observedBaseSha
+
+    try {
+      const pull = await currentPull(candidate.number)
+      if (pull.state !== 'open' || pull.base?.ref !== protectedBase) continue
+
+      const liveHeadSha = requireSha(pull.head?.sha, `PR #${candidate.number} head`)
+      if (liveHeadSha !== observedHeadSha) {
+        observedHeadSha = liveHeadSha
+        await publish(
+          observedHeadSha,
+          'pending',
+          `Checking head against protected ${protectedBase}.`,
+        )
+      }
+      observedBaseSha = await protectedBaseSha()
+
+      await publish(
+        observedHeadSha,
+        'pending',
+        `Checking head against protected ${protectedBase} ${observedBaseSha}.`,
+      )
+      const comparison = await github.rest.repos.compareCommitsWithBasehead({
+        ...context.repo,
+        basehead: `${observedBaseSha}...${observedHeadSha}`,
+      })
+      const [livePull, liveBaseSha] = await Promise.all([
+        currentPull(candidate.number),
+        protectedBaseSha(),
+      ])
+      const result = computeFreshnessStatus({
+        comparison: comparison.data,
+        protectedBase,
+        observedHeadSha,
+        observedBaseSha,
+        liveHeadSha: livePull.head?.sha,
+        liveBaseSha,
+      })
+
+      await publish(observedHeadSha, result.state, result.description)
+      if (result.state === 'error') {
+        comparisonFailed = true
+        core.error(`PR #${candidate.number}: ${result.description}`)
+      }
+    } catch (error) {
+      comparisonFailed = true
+      const message = error instanceof Error ? error.message : String(error)
+      core.error(`PR #${candidate.number}: ${message}`)
+
+      if (observedHeadSha) {
+        try {
+          await publish(
+            observedHeadSha,
+            'error',
+            observedBaseSha
+              ? `Comparison with protected ${protectedBase} ${observedBaseSha} is unavailable.`
+              : `Comparison with protected ${protectedBase} is unavailable.`,
+          )
+        } catch (publishError) {
+          const publishMessage = publishError instanceof Error ? publishError.message : String(publishError)
+          core.error(`PR #${candidate.number}: could not publish error status: ${publishMessage}`)
+        }
+      }
+    }
+  }
+
+  if (comparisonFailed) {
+    core.setFailed('At least one branch freshness comparison was unavailable or stale.')
+  }
+}

--- a/.github/scripts/branch-freshness.mjs
+++ b/.github/scripts/branch-freshness.mjs
@@ -158,6 +158,65 @@ export async function runBranchFreshness({
     core.setFailed('Open pull requests could not be enumerated for branch freshness.')
   }
 
+  async function enumerateOpenPulls() {
+    try {
+      return await github.paginate(github.rest.pulls.list, {
+        ...context.repo,
+        state: 'open',
+        base: protectedBase,
+        per_page: 100,
+      })
+    } catch (restError) {
+      const message = restError instanceof Error ? restError.message : String(restError)
+      core.warning?.(`REST pull-request enumeration failed; trying GraphQL: ${message}`)
+    }
+
+    const pulls = []
+    let cursor = null
+    do {
+      const response = await github.graphql(
+        `query OpenPullHeads($owner: String!, $repo: String!, $cursor: String) {
+          repository(owner: $owner, name: $repo) {
+            pullRequests(first: 100, after: $cursor, states: OPEN) {
+              nodes {
+                number
+                baseRefName
+                headRefOid
+              }
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+            }
+          }
+        }`,
+        {
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          cursor,
+        },
+      )
+      const connection = response?.repository?.pullRequests
+      if (!Array.isArray(connection?.nodes)) {
+        throw new Error('GraphQL pull-request enumeration returned an invalid response')
+      }
+      pulls.push(...connection.nodes
+        .filter((pull) => pull?.baseRefName === protectedBase)
+        .map((pull) => ({
+          number: pull.number,
+          head: { sha: pull.headRefOid },
+        })))
+
+      if (!connection.pageInfo?.hasNextPage) return pulls
+      cursor = connection.pageInfo.endCursor
+      if (!cursor) {
+        throw new Error('GraphQL pull-request enumeration omitted its next cursor')
+      }
+    } while (cursor)
+
+    return pulls
+  }
+
   let pulls
   if (context.eventName === 'pull_request_target') {
     const pull = context.payload.pull_request
@@ -167,12 +226,7 @@ export async function runBranchFreshness({
   } else {
     let openPulls
     try {
-      openPulls = await github.paginate(github.rest.pulls.list, {
-        ...context.repo,
-        state: 'open',
-        base: protectedBase,
-        per_page: 100,
-      })
+      openPulls = await enumerateOpenPulls()
     } catch (error) {
       await publishEnumerationError(error)
       return

--- a/.github/scripts/tests/branch-freshness.test.mjs
+++ b/.github/scripts/tests/branch-freshness.test.mjs
@@ -1,0 +1,184 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+import {
+  computeFreshnessStatus,
+  runBranchFreshness,
+  successDescription,
+} from '../branch-freshness.mjs'
+
+const head = 'a'.repeat(40)
+const base = 'b'.repeat(40)
+
+function comparison(overrides = {}) {
+  return {
+    base_commit: { sha: base },
+    behind_by: 0,
+    ...overrides,
+  }
+}
+
+function result(overrides = {}) {
+  return computeFreshnessStatus({
+    comparison: comparison(),
+    protectedBase: 'master',
+    observedHeadSha: head,
+    observedBaseSha: base,
+    liveHeadSha: head,
+    liveBaseSha: base,
+    ...overrides,
+  })
+}
+
+test('workflow recomputes on pull request heads and protected master advances', async () => {
+  const source = await readFile('.github/workflows/branch-freshness.yml', 'utf8')
+
+  assert.match(source, /pull_request_target:/)
+  assert.match(source, /types: \[opened, reopened, synchronize, ready_for_review, edited\]/)
+  assert.match(source, /push:\s*\n\s*branches: \[master\]/)
+  assert.match(source, /statuses: write/)
+  assert.match(source, /runBranchFreshness/)
+})
+
+test('only exact stable zero-behind evidence succeeds', () => {
+  assert.deepEqual(result(), {
+    state: 'success',
+    description: successDescription('master', base),
+    stale: false,
+  })
+  assert.equal(result({
+    comparison: comparison({ behind_by: 1 }),
+  }).state, 'failure')
+})
+
+test('changed base or head makes a completed comparison stale', () => {
+  assert.deepEqual(result({ liveBaseSha: 'c'.repeat(40) }), {
+    state: 'error',
+    description: `Comparison for protected master ${base} became stale.`,
+    stale: true,
+  })
+  assert.equal(result({ liveHeadSha: 'd'.repeat(40) }).state, 'error')
+})
+
+test('wrong-head, wrong-base, and unavailable comparison evidence fail closed', () => {
+  assert.equal(result({ liveHeadSha: 'c'.repeat(40) }).state, 'error')
+  assert.equal(result({
+    comparison: comparison({ base_commit: { sha: 'd'.repeat(40) } }),
+  }).state, 'error')
+  assert.equal(result({ comparison: null }).state, 'error')
+  assert.equal(result({
+    comparison: comparison({ behind_by: undefined }),
+  }).state, 'error')
+})
+
+test('an unavailable protected-base lookup overwrites prior success on the event head', async () => {
+  const statuses = []
+  const errors = []
+  let failure
+  const github = {
+    rest: {
+      git: {
+        getRef: async () => {
+          throw new Error('protected base API unavailable')
+        },
+      },
+      pulls: {
+        get: async () => ({
+          data: {
+            state: 'open',
+            base: { ref: 'master' },
+            head: { sha: head },
+          },
+        }),
+      },
+      repos: {
+        createCommitStatus: async ({ sha, state, description }) => {
+          statuses.push({ sha, state, description })
+        },
+      },
+    },
+  }
+  const context = {
+    eventName: 'pull_request_target',
+    payload: { pull_request: { number: 42, head: { sha: head } } },
+    repo: { owner: 'paperclipai', repo: 'paperclip' },
+    runId: 1,
+    serverUrl: 'https://github.com',
+  }
+  const core = {
+    error: (message) => errors.push(message),
+    setFailed: (message) => { failure = message },
+  }
+
+  await runBranchFreshness({ github, context, core })
+
+  assert.equal(statuses[0].state, 'pending')
+  assert.deepEqual(statuses.at(-1), {
+    sha: head,
+    state: 'error',
+    description: 'Comparison with protected master is unavailable.',
+  })
+  assert.match(errors[0], /protected base API unavailable/)
+  assert.match(failure, /comparison was unavailable or stale/)
+})
+
+test('a protected-base run marks every open head pending before comparing any head', async () => {
+  const otherHead = 'c'.repeat(40)
+  const statuses = []
+  let firstComparisonStatusCount
+  const pulls = [
+    { number: 41, head: { sha: head } },
+    { number: 42, head: { sha: otherHead } },
+  ]
+  const github = {
+    paginate: async () => pulls,
+    rest: {
+      git: {
+        getRef: async () => ({ data: { object: { sha: base } } }),
+      },
+      pulls: {
+        list: async () => ({ data: pulls }),
+        get: async ({ pull_number: number }) => ({
+          data: {
+            state: 'open',
+            base: { ref: 'master' },
+            head: { sha: number === 41 ? head : otherHead },
+          },
+        }),
+      },
+      repos: {
+        createCommitStatus: async ({ sha, state, description }) => {
+          statuses.push({ sha, state, description })
+        },
+        compareCommitsWithBasehead: async ({ basehead }) => {
+          firstComparisonStatusCount ??= statuses.length
+          const comparedHead = basehead.split('...')[1]
+          return {
+            data: {
+              base_commit: { sha: base },
+              behind_by: comparedHead === head ? 0 : 1,
+            },
+          }
+        },
+      },
+    },
+  }
+  const context = {
+    eventName: 'push',
+    payload: {},
+    repo: { owner: 'paperclipai', repo: 'paperclip' },
+    runId: 1,
+    serverUrl: 'https://github.com',
+  }
+  const core = { error: () => {}, setFailed: () => {} }
+
+  await runBranchFreshness({ github, context, core })
+
+  assert.ok(firstComparisonStatusCount >= pulls.length)
+  assert.deepEqual(statuses.slice(0, 2).map(({ sha, state }) => ({ sha, state })), [
+    { sha: head, state: 'pending' },
+    { sha: otherHead, state: 'pending' },
+  ])
+  assert.equal(statuses.at(-1).state, 'failure')
+})

--- a/.github/scripts/tests/branch-freshness.test.mjs
+++ b/.github/scripts/tests/branch-freshness.test.mjs
@@ -38,6 +38,8 @@ test('workflow recomputes on pull request heads and protected master advances', 
   assert.match(source, /types: \[opened, reopened, synchronize, ready_for_review, edited\]/)
   assert.match(source, /push:\s*\n\s*branches: \[master\]/)
   assert.match(source, /statuses: write/)
+  assert.match(source, /group: branch-freshness\s*$/m)
+  assert.match(source, /cancel-in-progress: false/)
   assert.match(source, /runBranchFreshness/)
 })
 
@@ -181,4 +183,148 @@ test('a protected-base run marks every open head pending before comparing any he
     { sha: otherHead, state: 'pending' },
   ])
   assert.equal(statuses.at(-1).state, 'failure')
+})
+
+test('an enumeration API failure records error on the exact protected-base event', async () => {
+  const statuses = []
+  const errors = []
+  let failure
+  const github = {
+    paginate: async () => {
+      throw new Error('pull API unavailable')
+    },
+    rest: {
+      pulls: { list: async () => ({ data: [] }) },
+      repos: {
+        createCommitStatus: async ({ sha, state, description }) => {
+          statuses.push({ sha, state, description })
+        },
+      },
+    },
+  }
+  const context = {
+    eventName: 'push',
+    payload: { after: base },
+    sha: base,
+    repo: { owner: 'paperclipai', repo: 'paperclip' },
+    runId: 1,
+    serverUrl: 'https://github.com',
+  }
+  const core = {
+    error: (message) => errors.push(message),
+    setFailed: (message) => { failure = message },
+  }
+
+  await runBranchFreshness({ github, context, core })
+
+  assert.deepEqual(statuses, [{
+    sha: base,
+    state: 'error',
+    description: 'Open pull requests for protected master could not be enumerated.',
+  }])
+  assert.match(errors[0], /pull API unavailable/)
+  assert.match(failure, /could not be enumerated/)
+})
+
+test('all known heads begin invalidation without waiting for an earlier status write', async () => {
+  const otherHead = 'c'.repeat(40)
+  const statuses = []
+  let releaseFirstInvalidation
+  const firstInvalidation = new Promise((resolve) => {
+    releaseFirstInvalidation = resolve
+  })
+  const pulls = [
+    { number: 41, head: { sha: head } },
+    { number: 42, head: { sha: otherHead } },
+  ]
+  const github = {
+    paginate: async () => pulls,
+    rest: {
+      git: { getRef: async () => ({ data: { object: { sha: base } } }) },
+      pulls: {
+        list: async () => ({ data: pulls }),
+        get: async ({ pull_number: number }) => ({
+          data: {
+            state: 'open',
+            base: { ref: 'master' },
+            head: { sha: number === 41 ? head : otherHead },
+          },
+        }),
+      },
+      repos: {
+        createCommitStatus: async ({ sha, state }) => {
+          statuses.push({ sha, state })
+          if (statuses.length === 1) await firstInvalidation
+        },
+        compareCommitsWithBasehead: async () => ({ data: comparison({ behind_by: 1 }) }),
+      },
+    },
+  }
+  const context = {
+    eventName: 'push',
+    payload: { after: base },
+    sha: base,
+    repo: { owner: 'paperclipai', repo: 'paperclip' },
+    runId: 1,
+    serverUrl: 'https://github.com',
+  }
+  const core = { error: () => {}, setFailed: () => {} }
+
+  const run = runBranchFreshness({ github, context, core })
+  await new Promise((resolve) => setImmediate(resolve))
+  assert.deepEqual(statuses, [
+    { sha: head, state: 'pending' },
+    { sha: otherHead, state: 'pending' },
+  ])
+  releaseFirstInvalidation()
+  await run
+})
+
+test('a base change during success publication overwrites the transient success', async () => {
+  const newerBase = 'c'.repeat(40)
+  const statuses = []
+  let baseRead = 0
+  let failure
+  const github = {
+    rest: {
+      git: {
+        getRef: async () => ({
+          data: { object: { sha: ++baseRead < 3 ? base : newerBase } },
+        }),
+      },
+      pulls: {
+        get: async () => ({
+          data: {
+            state: 'open',
+            base: { ref: 'master' },
+            head: { sha: head },
+          },
+        }),
+      },
+      repos: {
+        createCommitStatus: async ({ sha, state, description }) => {
+          statuses.push({ sha, state, description })
+        },
+        compareCommitsWithBasehead: async () => ({ data: comparison() }),
+      },
+    },
+  }
+  const context = {
+    eventName: 'pull_request_target',
+    payload: { pull_request: { number: 42, head: { sha: head } } },
+    repo: { owner: 'paperclipai', repo: 'paperclip' },
+    runId: 1,
+    serverUrl: 'https://github.com',
+  }
+  const core = { error: () => {}, setFailed: (message) => { failure = message } }
+
+  await runBranchFreshness({ github, context, core })
+
+  assert.equal(statuses.at(-2).state, 'success')
+  assert.deepEqual(statuses.at(-1), {
+    sha: head,
+    state: 'error',
+    description: `Published comparison for protected master ${base} became stale.`,
+  })
+  assert.match(failure, /unavailable or stale/)
 })

--- a/.github/scripts/tests/branch-freshness.test.mjs
+++ b/.github/scripts/tests/branch-freshness.test.mjs
@@ -62,10 +62,11 @@ test('workflow recomputes on pull request heads and protected master advances', 
   assert.match(source, /push:\s*\n\s*branches: \[master\]/)
   assert.match(source, /statuses: write/)
   assert.match(source, /if: github\.repository == 'paperclipai\/paperclip'/)
-  assert.match(source, /group: branch-freshness\s*$/m)
-  assert.match(source, /cancel-in-progress: false/)
+  assert.match(source, /group: branch-freshness-\$\{\{ github\.event_name == 'push'/)
+  assert.match(source, /cancel-in-progress: true/)
   assert.match(source, /persist-credentials: false/)
-  assert.doesNotMatch(source, /\$\{\{\s*github\.event/)
+  const executableSource = source.match(/script: \|([\s\S]*)/)?.[1] ?? ''
+  assert.doesNotMatch(executableSource, /\$\{\{\s*github\.event/)
   assert.doesNotMatch(source, /\bsecrets\s*:/)
   assert.doesNotMatch(source, /permissions:\s*[\s\S]*?contents:\s*write/)
   assert.match(source, /runBranchFreshness/)
@@ -302,7 +303,69 @@ test('a REST enumeration failure falls back and invalidates GraphQL heads', asyn
   assert.match(warnings[0], /trying GraphQL/)
 })
 
-test('failure of both enumeration paths records error on the protected-base event', async () => {
+test('REST and GraphQL enumeration failures fall back to search and invalidate exact heads', async () => {
+  const statuses = []
+  const warnings = []
+  const github = {
+    request: rulesetRequest(),
+    paginate: async (route) => {
+      if (route === github.rest.pulls.list) throw new Error('REST pull API unavailable')
+      assert.equal(route, github.rest.search.issuesAndPullRequests)
+      return [{ number: 42 }]
+    },
+    graphql: async () => {
+      throw new Error('GraphQL pull API unavailable')
+    },
+    rest: {
+      git: { getRef: async () => ({ data: { object: { sha: base } } }) },
+      pulls: {
+        list: async () => ({ data: [] }),
+        get: async () => ({
+          data: {
+            state: 'open',
+            base: { ref: 'master' },
+            head: { sha: head },
+          },
+        }),
+      },
+      search: {
+        issuesAndPullRequests: async () => ({ data: [] }),
+      },
+      repos: {
+        createCommitStatus: async ({ sha, state, description }) => {
+          statuses.push({ sha, state, description })
+        },
+        compareCommitsWithBasehead: async () => ({ data: comparison() }),
+      },
+    },
+  }
+  const context = {
+    eventName: 'push',
+    payload: { after: base },
+    sha: base,
+    repo: { owner: 'paperclipai', repo: 'paperclip' },
+    runId: 1,
+    serverUrl: 'https://github.com',
+  }
+  const core = {
+    error: () => {},
+    warning: (message) => warnings.push(message),
+    setFailed: () => {},
+  }
+
+  await runBranchFreshness({ github, context, core })
+
+  assert.deepEqual(statuses.at(0), {
+    sha: head,
+    state: 'pending',
+    description: 'Checking head against protected master.',
+  })
+  assert.equal(statuses.at(-1).state, 'success')
+  assert.match(warnings[0], /trying GraphQL/)
+  assert.match(warnings[1], /trying search/)
+})
+
+test('failure of every enumeration path records error on the protected-base event', async () => {
   const statuses = []
   const errors = []
   let failure
@@ -316,12 +379,19 @@ test('failure of both enumeration paths records error on the protected-base even
     },
     rest: {
       pulls: { list: async () => ({ data: [] }) },
+      search: {
+        issuesAndPullRequests: async () => ({ data: [] }),
+      },
       repos: {
         createCommitStatus: async ({ sha, state, description }) => {
           statuses.push({ sha, state, description })
         },
       },
     },
+  }
+  github.paginate = async (route) => {
+    if (route === github.rest.pulls.list) throw new Error('pull API unavailable')
+    throw new Error('search API unavailable')
   }
   const context = {
     eventName: 'push',
@@ -343,7 +413,7 @@ test('failure of both enumeration paths records error on the protected-base even
     state: 'error',
     description: 'Open pull requests for protected master could not be enumerated.',
   }])
-  assert.match(errors[0], /pull API unavailable/)
+  assert.match(errors[0], /search API unavailable/)
   assert.match(failure, /could not be enumerated/)
 })
 

--- a/.github/scripts/tests/branch-freshness.test.mjs
+++ b/.github/scripts/tests/branch-freshness.test.mjs
@@ -4,6 +4,7 @@ import test from 'node:test'
 
 import {
   computeFreshnessStatus,
+  hasStrictFreshnessEnforcement,
   runBranchFreshness,
   successDescription,
 } from '../branch-freshness.mjs'
@@ -31,6 +32,27 @@ function result(overrides = {}) {
   })
 }
 
+function strictRuleset(overrides = {}) {
+  return {
+    enforcement: 'active',
+    rules: [{
+      type: 'required_status_checks',
+      parameters: {
+        strict_required_status_checks_policy: true,
+        required_status_checks: [{
+          context: 'branch-freshness',
+          integration_id: 15368,
+        }],
+      },
+    }],
+    ...overrides,
+  }
+}
+
+function rulesetRequest(ruleset = strictRuleset()) {
+  return async () => ({ data: ruleset })
+}
+
 test('workflow recomputes on pull request heads and protected master advances', async () => {
   const source = await readFile('.github/workflows/branch-freshness.yml', 'utf8')
 
@@ -52,6 +74,35 @@ test('only exact stable zero-behind evidence succeeds', () => {
   assert.equal(result({
     comparison: comparison({ behind_by: 1 }),
   }).state, 'failure')
+})
+
+test('success requires the exact active strict ruleset check', () => {
+  const input = {
+    ruleset: strictRuleset(),
+    statusContext: 'branch-freshness',
+    statusIntegrationId: 15368,
+  }
+  assert.equal(hasStrictFreshnessEnforcement(input), true)
+  assert.equal(hasStrictFreshnessEnforcement({
+    ...input,
+    ruleset: strictRuleset({ enforcement: 'disabled' }),
+  }), false)
+  assert.equal(hasStrictFreshnessEnforcement({
+    ...input,
+    ruleset: strictRuleset({
+      rules: [{
+        type: 'required_status_checks',
+        parameters: {
+          strict_required_status_checks_policy: false,
+          required_status_checks: [{ context: 'branch-freshness', integration_id: 15368 }],
+        },
+      }],
+    }),
+  }), false)
+  assert.equal(hasStrictFreshnessEnforcement({
+    ...input,
+    statusIntegrationId: 1,
+  }), false)
 })
 
 test('changed base or head makes a completed comparison stale', () => {
@@ -79,6 +130,7 @@ test('an unavailable protected-base lookup overwrites prior success on the event
   const errors = []
   let failure
   const github = {
+    request: rulesetRequest(),
     rest: {
       git: {
         getRef: async () => {
@@ -134,6 +186,7 @@ test('a protected-base run marks every open head pending before comparing any he
     { number: 42, head: { sha: otherHead } },
   ]
   const github = {
+    request: rulesetRequest(),
     paginate: async () => pulls,
     rest: {
       git: {
@@ -190,6 +243,7 @@ test('an enumeration API failure records error on the exact protected-base event
   const errors = []
   let failure
   const github = {
+    request: rulesetRequest(),
     paginate: async () => {
       throw new Error('pull API unavailable')
     },
@@ -238,6 +292,7 @@ test('all known heads begin invalidation without waiting for an earlier status w
     { number: 42, head: { sha: otherHead } },
   ]
   const github = {
+    request: rulesetRequest(),
     paginate: async () => pulls,
     rest: {
       git: { getRef: async () => ({ data: { object: { sha: base } } }) },
@@ -286,6 +341,7 @@ test('a base change during success publication overwrites the transient success'
   let baseRead = 0
   let failure
   const github = {
+    request: rulesetRequest(),
     rest: {
       git: {
         getRef: async () => ({
@@ -325,6 +381,53 @@ test('a base change during success publication overwrites the transient success'
     sha: head,
     state: 'error',
     description: `Published comparison for protected master ${base} became stale.`,
+  })
+  assert.match(failure, /unavailable or stale/)
+})
+
+test('a rejected first invalidation is retried and cannot preserve prior success', async () => {
+  const statuses = []
+  let statusAttempt = 0
+  let failure
+  const github = {
+    request: rulesetRequest(strictRuleset({ enforcement: 'disabled' })),
+    rest: {
+      git: { getRef: async () => ({ data: { object: { sha: base } } }) },
+      pulls: {
+        get: async () => ({
+          data: {
+            state: 'open',
+            base: { ref: 'master' },
+            head: { sha: head },
+          },
+        }),
+      },
+      repos: {
+        createCommitStatus: async ({ sha, state, description }) => {
+          statusAttempt += 1
+          if (statusAttempt === 1) throw new Error('transient status failure')
+          statuses.push({ sha, state, description })
+        },
+        compareCommitsWithBasehead: async () => ({ data: comparison() }),
+      },
+    },
+  }
+  const context = {
+    eventName: 'pull_request_target',
+    payload: { pull_request: { number: 42, head: { sha: head } } },
+    repo: { owner: 'paperclipai', repo: 'paperclip' },
+    runId: 1,
+    serverUrl: 'https://github.com',
+  }
+  const core = { error: () => {}, setFailed: (message) => { failure = message } }
+
+  await runBranchFreshness({ github, context, core })
+
+  assert.equal(statuses[0].state, 'pending')
+  assert.deepEqual(statuses.at(-1), {
+    sha: head,
+    state: 'error',
+    description: 'Strict branch-freshness enforcement is unavailable.',
   })
   assert.match(failure, /unavailable or stale/)
 })

--- a/.github/scripts/tests/branch-freshness.test.mjs
+++ b/.github/scripts/tests/branch-freshness.test.mjs
@@ -62,8 +62,8 @@ test('workflow recomputes on pull request heads and protected master advances', 
   assert.match(source, /push:\s*\n\s*branches: \[master\]/)
   assert.match(source, /statuses: write/)
   assert.match(source, /if: github\.repository == 'paperclipai\/paperclip'/)
-  assert.match(source, /group: branch-freshness-\$\{\{ github\.event_name == 'push'/)
-  assert.match(source, /cancel-in-progress: true/)
+  assert.match(source, /group: branch-freshness\s*$/m)
+  assert.match(source, /cancel-in-progress: false/)
   assert.match(source, /persist-credentials: false/)
   const executableSource = source.match(/script: \|([\s\S]*)/)?.[1] ?? ''
   assert.doesNotMatch(executableSource, /\$\{\{\s*github\.event/)

--- a/.github/scripts/tests/branch-freshness.test.mjs
+++ b/.github/scripts/tests/branch-freshness.test.mjs
@@ -62,8 +62,10 @@ test('workflow recomputes on pull request heads and protected master advances', 
   assert.match(source, /push:\s*\n\s*branches: \[master\]/)
   assert.match(source, /statuses: write/)
   assert.match(source, /if: github\.repository == 'paperclipai\/paperclip'/)
-  assert.match(source, /group: branch-freshness\s*$/m)
-  assert.match(source, /cancel-in-progress: false/)
+  const concurrency = source.match(/^concurrency:\s*\n((?: {2}[^\n]*\n)+)/m)?.[0] ?? ''
+  assert.match(concurrency, /group: branch-freshness\s*$/m)
+  assert.match(concurrency, /queue: max\s*$/m)
+  assert.match(concurrency, /cancel-in-progress: false\s*$/m)
   assert.match(source, /persist-credentials: false/)
   const executableSource = source.match(/script: \|([\s\S]*)/)?.[1] ?? ''
   assert.doesNotMatch(executableSource, /\$\{\{\s*github\.event/)

--- a/.github/scripts/tests/branch-freshness.test.mjs
+++ b/.github/scripts/tests/branch-freshness.test.mjs
@@ -64,6 +64,10 @@ test('workflow recomputes on pull request heads and protected master advances', 
   assert.match(source, /if: github\.repository == 'paperclipai\/paperclip'/)
   assert.match(source, /group: branch-freshness\s*$/m)
   assert.match(source, /cancel-in-progress: false/)
+  assert.match(source, /persist-credentials: false/)
+  assert.doesNotMatch(source, /\$\{\{\s*github\.event/)
+  assert.doesNotMatch(source, /\bsecrets\s*:/)
+  assert.doesNotMatch(source, /permissions:\s*[\s\S]*?contents:\s*write/)
   assert.match(source, /runBranchFreshness/)
 })
 
@@ -240,7 +244,65 @@ test('a protected-base run marks every open head pending before comparing any he
   assert.equal(statuses.at(-1).state, 'failure')
 })
 
-test('an enumeration API failure records error on the exact protected-base event', async () => {
+test('a REST enumeration failure falls back and invalidates GraphQL heads', async () => {
+  const statuses = []
+  const warnings = []
+  const github = {
+    request: rulesetRequest(),
+    paginate: async () => {
+      throw new Error('REST pull API unavailable')
+    },
+    graphql: async () => ({
+      repository: {
+        pullRequests: {
+          nodes: [{ number: 42, baseRefName: 'master', headRefOid: head }],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
+    }),
+    rest: {
+      git: { getRef: async () => ({ data: { object: { sha: base } } }) },
+      pulls: {
+        list: async () => ({ data: [] }),
+        get: async () => ({
+          data: {
+            state: 'open',
+            base: { ref: 'master' },
+            head: { sha: head },
+          },
+        }),
+      },
+      repos: {
+        createCommitStatus: async ({ sha, state, description }) => {
+          statuses.push({ sha, state, description })
+        },
+        compareCommitsWithBasehead: async () => ({ data: comparison() }),
+      },
+    },
+  }
+  const context = {
+    eventName: 'push',
+    payload: { after: base },
+    sha: base,
+    repo: { owner: 'paperclipai', repo: 'paperclip' },
+    runId: 1,
+    serverUrl: 'https://github.com',
+  }
+  const core = {
+    error: () => {},
+    warning: (message) => warnings.push(message),
+    setFailed: () => {},
+  }
+
+  await runBranchFreshness({ github, context, core })
+
+  assert.equal(statuses[0].sha, head)
+  assert.equal(statuses[0].state, 'pending')
+  assert.equal(statuses.at(-1).state, 'success')
+  assert.match(warnings[0], /trying GraphQL/)
+})
+
+test('failure of both enumeration paths records error on the protected-base event', async () => {
   const statuses = []
   const errors = []
   let failure
@@ -248,6 +310,9 @@ test('an enumeration API failure records error on the exact protected-base event
     request: rulesetRequest(),
     paginate: async () => {
       throw new Error('pull API unavailable')
+    },
+    graphql: async () => {
+      throw new Error('GraphQL pull API unavailable')
     },
     rest: {
       pulls: { list: async () => ({ data: [] }) },

--- a/.github/scripts/tests/branch-freshness.test.mjs
+++ b/.github/scripts/tests/branch-freshness.test.mjs
@@ -57,9 +57,11 @@ test('workflow recomputes on pull request heads and protected master advances', 
   const source = await readFile('.github/workflows/branch-freshness.yml', 'utf8')
 
   assert.match(source, /pull_request_target:/)
-  assert.match(source, /types: \[opened, reopened, synchronize, ready_for_review, edited\]/)
+  assert.match(source, /types: \[opened, reopened, synchronize, ready_for_review\]/)
+  assert.doesNotMatch(source, /\btype?s?:[^\n]*edited\b/)
   assert.match(source, /push:\s*\n\s*branches: \[master\]/)
   assert.match(source, /statuses: write/)
+  assert.match(source, /if: github\.repository == 'paperclipai\/paperclip'/)
   assert.match(source, /group: branch-freshness\s*$/m)
   assert.match(source, /cancel-in-progress: false/)
   assert.match(source, /runBranchFreshness/)

--- a/.github/workflows/branch-freshness.yml
+++ b/.github/workflows/branch-freshness.yml
@@ -17,9 +17,11 @@ permissions:
 
 concurrency:
   # Every trigger writes the same commit-status context. Serialize every writer
-  # without cancellation so a newer run cannot interrupt base-wide invalidation
-  # and an older observation cannot publish after a newer one.
+  # in one multi-pending queue so bursts cannot replace a queued invalidation,
+  # newer runs cannot interrupt base-wide invalidation, and an older observation
+  # cannot publish after a newer one.
   group: branch-freshness
+  queue: max
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/branch-freshness.yml
+++ b/.github/workflows/branch-freshness.yml
@@ -16,11 +16,11 @@ permissions:
   statuses: write
 
 concurrency:
-  # Base advances cancel only older base-wide runs; each PR head cancels only an
-  # older run for that same PR. A PR update therefore cannot interrupt the
-  # base-wide invalidation of every open head.
-  group: branch-freshness-${{ github.event_name == 'push' && 'protected-base' || github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
+  # Every trigger writes the same commit-status context. Serialize every writer
+  # without cancellation so a newer run cannot interrupt base-wide invalidation
+  # and an older observation cannot publish after a newer one.
+  group: branch-freshness
+  cancel-in-progress: false
 
 jobs:
   update-status:

--- a/.github/workflows/branch-freshness.yml
+++ b/.github/workflows/branch-freshness.yml
@@ -1,0 +1,40 @@
+name: Branch freshness
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review, edited]
+  push:
+    branches: [master]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+concurrency:
+  group: branch-freshness-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update-status:
+    name: Update branch-freshness status
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out trusted protected-branch logic
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: master
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Mark open pull requests fresh or stale
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const { runBranchFreshness } = await import(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/branch-freshness.mjs`
+            )
+            await runBranchFreshness({ github, context, core })

--- a/.github/workflows/branch-freshness.yml
+++ b/.github/workflows/branch-freshness.yml
@@ -16,10 +16,11 @@ permissions:
   statuses: write
 
 concurrency:
-  # Every event can write the same commit-status context. A single queue prevents
-  # an older base or head observation from publishing after a newer one.
-  group: branch-freshness
-  cancel-in-progress: false
+  # Base advances cancel only older base-wide runs; each PR head cancels only an
+  # older run for that same PR. A PR update therefore cannot interrupt the
+  # base-wide invalidation of every open head.
+  group: branch-freshness-${{ github.event_name == 'push' && 'protected-base' || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   update-status:

--- a/.github/workflows/branch-freshness.yml
+++ b/.github/workflows/branch-freshness.yml
@@ -1,8 +1,10 @@
 name: Branch freshness
 
 on:
+  # This privileged workflow must use only trusted protected-branch code. Keep
+  # pull-request payload values out of expressions and never check out the head.
   pull_request_target:
-    types: [opened, reopened, synchronize, ready_for_review, edited]
+    types: [opened, reopened, synchronize, ready_for_review]
   push:
     branches: [master]
   workflow_dispatch: {}
@@ -21,6 +23,7 @@ concurrency:
 jobs:
   update-status:
     name: Update branch-freshness status
+    if: github.repository == 'paperclipai/paperclip'
     runs-on: ubuntu-latest
     timeout-minutes: 5
 

--- a/.github/workflows/branch-freshness.yml
+++ b/.github/workflows/branch-freshness.yml
@@ -13,8 +13,10 @@ permissions:
   statuses: write
 
 concurrency:
-  group: branch-freshness-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Every event can write the same commit-status context. A single queue prevents
+  # an older base or head observation from publishing after a newer one.
+  group: branch-freshness
+  cancel-in-progress: false
 
 jobs:
   update-status:

--- a/.github/workflows/branch-freshness.yml
+++ b/.github/workflows/branch-freshness.yml
@@ -1,8 +1,9 @@
 name: Branch freshness
 
 on:
-  # This privileged workflow must use only trusted protected-branch code. Keep
-  # pull-request payload values out of expressions and never check out the head.
+  # Security invariants for this privileged trigger: use only protected-branch
+  # code; never check out or interpolate the pull-request head or payload; never
+  # persist credentials; never add secrets or broaden the permissions below.
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
   push:


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Repository automation protects changes before merge.
> - The current rules can require CI but do not publish a durable branch-freshness result.
> - A successful result can become stale when the protected branch advances.
> - This pull request adds one exact-head status producer for the protected branch.
> - The producer checks the live pull request head and the live protected base before it publishes success.
> - The benefit is a fail-closed status that repository rules can require.

## Linked Issues or Issue Description

**What existing behavior does this improve?**

This improves the repository checks that protect pull request merges.

**Subsystem affected**

Repository automation in `.github/workflows` and `.github/scripts`.

**Current behavior**

The repository does not publish one durable status that proves the pull request head contains the current protected `master` commit. A prior comparison can become stale after `master` advances.

**Proposed behavior**

Publish `branch-freshness` on the exact pull request head. Mark every open head pending before a protected-base comparison. Publish success only when the live head and base still match an authoritative `behind_by: 0` comparison.

**Reason and benefit**

Repository rules need an exact status that fails closed when comparison evidence is missing, stale, pending, or behind.

**Breaking changes**

None. A repository administrator must separately add `branch-freshness` to the protected ruleset and enable strict required status checks.

## What Changed

- Add a trusted protected-branch workflow for pull request head changes and `master` advances.
- Add an exact-head status producer with narrow read and status permissions.
- Publish pending, failure, or error for every result that is not an authoritative current-base success.
- Add focused tests for triggers, stable success, stale evidence, unavailable APIs, wrong heads, wrong bases, and base-push invalidation.

## Verification

- `node --test '.github/scripts/tests/*.test.mjs'` passed 139 tests.
- `env TMPDIR=/private/tmp/liv10359 pnpm -r typecheck` passed.
- `env TMPDIR=/private/tmp/liv10359 pnpm build` passed.
- `env TMPDIR=/private/tmp/liv10359 pnpm test:run` completed with 2,799 passing tests and 21 failures. The failures are in existing server runtime and listener fixtures. They include invalid generated ports above 65,535 and unavailable live-listener diagnostics. The changed files are only under `.github`.

## Risks

- The producer does not enforce itself. A repository administrator must require the exact context with strict freshness enabled.
- The workflow uses `pull_request_target`. It checks out trusted `master` logic and does not run pull request code.
- API errors and stale comparisons leave a non-success status and fail the workflow.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with model `gpt-5.6-sol`. The model used repository tools and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
