### PR TITLE
docs(release): add v2026.831.1 stable notes to master

### DIFF
--- a/releases/v2026.831.1.md
+++ b/releases/v2026.831.1.md
@@ -1,0 +1,13 @@
+# Paperclip v2026.831.1
+
+> Released: 2026-09-02
+
+A patch on top of [2026.831.0](https://github.com/paperclipai/paperclip/releases/tag/v2026.831.0) that fixes first-run onboarding. It carries a single targeted change; everything else in 2026.831.0 is unchanged.
+
+## Fixes
+
+- **Onboarding no longer gets stuck on the organization step.** On the first onboarding screen ("What is the name of your organization?"), clicking **Continue** created the organization on the server but could leave the wizard sitting on the same step — so the page appeared to just refresh, and repeated clicks silently created duplicate organizations. The company-created list refresh can make the surrounding app adopt the just-created organization before the create request's continuation runs; the wizard now recognizes that as the same successful transition and advances to the first-agent step, while a genuine switch to a different organization still stops with a clear message. ([#12667](https://github.com/paperclipai/paperclip/pull/12667))
+
+## Upgrade Guide
+
+- No migrations, no configuration changes, no API changes. Upgrade in place.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The release pipeline keeps a canonical stable note at `releases/vX.md` on master for every published stable.
> - Stable `2026.831.1` was a hotfix cut from a branch off `v2026.831.0`, with its notes committed into the source tree.
> - In that path the workflow resolves notes in `source_tree` mode and skips `canonicalize_stable_notes`, which is the job that normally copies the note to master.
> - As a result `releases/v2026.831.1.md` exists on the tag but never landed on master, so the stable-notes history has a gap.
> - This pull request adds the canonical copy of that note to master.
> - The benefit is a complete, consistent stable-notes history for readers and for the release tooling.

## Linked Issues or Issue Description

No separate issue. Describing the gap in-PR with the docs template fields:

**Issue type**
Documentation gap in the release-notes history on master.

**Where is the issue?**
`releases/` on the master branch — the file `releases/v2026.831.1.md` is missing, although the stable `2026.831.1` release has already published.

**What's wrong?**
The `2026.831.1` patch was published from a hotfix branch whose notes lived in the source tree (`source_tree` notes mode). That mode skips `canonicalize_stable_notes`, the job that copies a stable's note onto master. So every other stable has a `releases/vX.md` on master, but `2026.831.1` does not.

**Suggested fix**
Add the canonical `releases/v2026.831.1.md` to master, identical to the copy published with the tag.

## What Changed

- Add `releases/v2026.831.1.md` to master, copied verbatim from the published `v2026.831.1` tag.

## Verification

- `diff` of the added file against `git show v2026.831.1:releases/v2026.831.1.md` is empty (identical to the shipped note).
- Docs-only change: no code, tests, or build outputs are affected.

## Risks

- Low risk. The change adds one Markdown file and touches no code, schema, or configuration.

## Model Used

- Claude (Anthropic), model id `claude-fable-5` (Claude Fable 5), used with tool use, shell commands, and file editing.
