### PR TITLE
test(tool-access): cover archived pasted-link app recovery on re-connect

### DIFF
--- a/server/src/__tests__/tool-access-service.test.ts
+++ b/server/src/__tests__/tool-access-service.test.ts
@@ -8696,6 +8696,46 @@ describeEmbeddedPostgres("tool access service", () => {
     await expect(db.select().from(toolConnections)).resolves.toHaveLength(1);
   });
 
+  it("reuses and revives a removed pasted-link app without requiring its applicationId", async () => {
+    const company = await createCompany(db);
+    const service = createTestToolAccessService(db);
+    const actor = { actorType: "user" as const, actorId: "board" };
+    mockToolsList([
+      {
+        name: "read_items",
+        description: "Read items.",
+        inputSchema: { type: "object", properties: {} },
+        annotations: { readOnlyHint: true },
+      },
+    ]);
+
+    const first = await service.connectGalleryApp(company.id, {
+      link: "https://relink.example.test/mcp",
+      name: "Relinked app",
+    }, actor);
+    await service.archiveConnection(first.connectionId, company.id, actor);
+
+    const [archivedApplication] = await db.select().from(toolApplications)
+      .where(eq(toolApplications.id, first.application.id));
+    expect(archivedApplication.status).toBe("archived");
+
+    // Re-adding the same pasted link is a fresh connect with no applicationId,
+    // and no surface lists archived apps for the caller to reference. The
+    // archived row still holds the company-unique name, so this must adopt it
+    // rather than insert a duplicate the unique index rejects.
+    const second = await service.connectGalleryApp(company.id, {
+      link: "https://relink.example.test/mcp",
+      name: "Relinked app",
+    }, actor);
+
+    expect(second.application.id).toBe(first.application.id);
+    expect(second.connectionId).toBe(first.connectionId);
+    expect(second.application.status).toBe("draft");
+    expect(second.connection.status).toBe("draft");
+    await expect(db.select().from(toolApplications)).resolves.toHaveLength(1);
+    await expect(db.select().from(toolConnections)).resolves.toHaveLength(1);
+  });
+
   it("allows multiple same-named connections on one application", async () => {
     const company = await createCompany(db);
     const service = createTestToolAccessService(db);

--- a/server/src/__tests__/tool-access-service.test.ts
+++ b/server/src/__tests__/tool-access-service.test.ts
@@ -8732,6 +8732,13 @@ describeEmbeddedPostgres("tool access service", () => {
     expect(second.connectionId).toBe(first.connectionId);
     expect(second.application.status).toBe("draft");
     expect(second.connection.status).toBe("draft");
+    // Recovery restores the identity, not the access. The revived connection
+    // must stay disabled until it is configured and enabled again, so a
+    // removed app cannot silently regain a live tool-access path.
+    expect(second.connection.enabled).toBe(false);
+    const [revivedConnection] = await db.select().from(toolConnections)
+      .where(eq(toolConnections.id, first.connectionId));
+    expect(revivedConnection.enabled).toBe(false);
     await expect(db.select().from(toolApplications)).resolves.toHaveLength(1);
     await expect(db.select().from(toolConnections)).resolves.toHaveLength(1);
   });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents reach outside tools through Connected Apps, which store a `tool_applications` row and a `tool_connections` row for each app
> - Removing an app archives those rows. It does not delete them. The unique index `tool_applications_company_name_uq` spans archived rows, so the name stays reserved
> - A fresh connect sends no `applicationId`, no surface lists archived apps, and `reconnectGalleryApp` refuses archived connections. The user could not add the app again
> - #12346 fixed this with a recovery branch in `connectGalleryApp`, and it added a test for the gallery path only
> - The pasted-link path uses different branches of the same guard, and no test covers it
> - This pull request adds the regression test for the pasted-link path
> - The benefit is that the link path cannot silently regress back to the unrecoverable state

## Linked Issues or Issue Description

No public issue exists. The fix landed inside a feature pull request, so no bug report was filed. The description below follows `.github/ISSUE_TEMPLATE/bug_report.yml`.

Refs #12346

**What happened?**

A user removed a pasted-link MCP server from a company. The user then tried to add the same server again with the same name. The server refused the request and reported that the app already exists. The database raised:

```
duplicate key value violates unique constraint "tool_applications_company_name_uq"
```

No screen showed the archived app, so the user could not recover the name from the product. The only remedy was to delete the archived `tool_applications` and `tool_connections` rows directly in the database.

**Expected behavior**

Adding the app again must reuse the archived application and connection. The name must not stay reserved after removal.

**Steps to reproduce**

1. Open a company and add a Connected App from a pasted MCP link. Give it a name.
2. Remove the app.
3. Add the same link again with the same name.
4. The request fails on the unique index.

**Paperclip version or commit**

Reproduced on `v2026.831.1`. The fix from #12346 is on `master` and canary. It is not in `v2026.831.1`, `v2026.831.0`, or `v2026.824.1`, so released instances still reach this state.

## What Changed

- Adds one test to `server/src/__tests__/tool-access-service.test.ts`: `reuses and revives a removed pasted-link app without requiring its applicationId`.
- The test connects a pasted link, removes it with `archiveConnection`, asserts the application is archived, then connects the same link and name again with no `applicationId`.
- The test asserts the recovered application id and connection id match the originals, that both return to `draft`, and that only one application row and one connection row exist.
- The test also asserts the revived connection stays `enabled: false`, on the returned object and on the database row.

No source file changes. This pull request is test-only.

## Verification

- `npx vitest run src/__tests__/tool-access-service.test.ts` from `server/`. All 210 tests pass.
- The test pins behavior. It does not only exercise it. Revert the `recoverableSource === requestedSource` adoption in `connectGalleryApp`, and the test fails with the same `tool_applications_company_name_uq` duplicate-key error shown above.
- The gallery path already has `reuses and revives a removed gallery app without requiring its applicationId`. The link path reaches the guard differently, so it needs its own test:
  - `recoverableApplicationStatuses` is `["archived"]` for links. It is `["draft", "archived"]` for gallery entries.
  - `requestedSource` is the literal `"link"`, matched against `metadata.source`. For gallery entries it is the gallery slug, matched against `sourceTemplateKey` or `galleryKey`.

## Risks

Low risk. The change adds one test and modifies no source file. The test uses the existing `mockToolsList` helper and the same shape as the neighbouring gallery test, so it adds no new fixture or network dependency.

## Model Used

Claude Opus 5, model ID `claude-opus-5[1m]`, 1M context window, extended thinking enabled, run through Claude Code with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes — not applicable, this is a test-only change
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011v3dKsW9nGVGGe3qaF4kog
