### PR TITLE
fix(openapi): mark stalled-review-decision as board-only

### DIFF
--- a/server/src/__tests__/openapi-routes.test.ts
+++ b/server/src/__tests__/openapi-routes.test.ts
@@ -329,6 +329,20 @@ describe("openapi routes", () => {
     expect(spec.paths["/api/routines/{id}/run"].post.responses["422"]).toBeDefined();
   });
 
+  it("advertises the stalled-review-decision route as board-only", () => {
+    const { spec } = loadSpecRoutes();
+    const operation = spec.paths["/api/issues/{id}/stalled-review-decision"].post;
+
+    // The handler calls assertBoard and the service writes the decision under a
+    // user actor, so advertising AgentBearerAuth sent agents to a route that can
+    // only ever answer them "Board access required".
+    expect(operation.security).toEqual([
+      { BoardSessionAuth: [] },
+      { BoardApiKeyAuth: [] },
+    ]);
+    expect(operation["x-paperclip-authorization"]).toEqual({ actor: "board" });
+  });
+
   it("publishes the Claude browser-code grammar and strict setup-token response shapes", () => {
     const { spec } = loadSpecRoutes();
     const base = "/api/companies/{companyId}/setup-token-login-sessions";

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -922,6 +922,9 @@ const BOARD_ONLY_OPERATIONS = new Set([
   "POST /api/issues/{id}/interactions/{interactionId}/respond",
   "POST /api/issues/{id}/interactions/{interactionId}/skip",
   "POST /api/issues/{id}/interactions/{interactionId}/withdraw",
+  // Board-only: the handler calls assertBoard and the service records the
+  // decision under a user actor, so an agent bearer token can never satisfy it.
+  "POST /api/issues/{id}/stalled-review-decision",
   "GET /api/companies/{companyId}/tools/gallery",
   "GET /api/companies/{companyId}/tools/apps/{galleryKey}/preflight",
   "POST /api/companies/{companyId}/tools/apps/connect",


### PR DESCRIPTION
## What

`POST /api/issues/{id}/stalled-review-decision` is advertised in the served OpenAPI document as:

```json
"x-paperclip-authorization": {"actor": "board_or_agent"},
"security": [{"BoardSessionAuth": []}, {"BoardApiKeyAuth": []}, {"AgentBearerAuth": []}]
```

It is board-only in reality. `resolveOperationAuthLevel` has no entry for it, so it falls through to the `authenticated` default and picks up `AgentBearerAuth`.

## Why it matters

The implementation cannot serve an agent actor at all:

- `server/src/routes/issues.ts` — the handler calls `assertBoard(req)`, then requires an active non-viewer company membership.
- `server/src/services/stalled-review-decisions.ts` — `StalledReviewDecisionActor` carries a `userId`, and the decision is written with `actorType: "user"` / `authorUserId`.

So an agent key gets `Board access required`, every time.

This is a costly mismatch for this route specifically, because its summary is *Resolve a stalled issue review*. An agent that finds a review stage wedged does exactly what the spec tells it to: it calls the documented recovery route, gets refused, and has no documented alternative actor to escalate to. Advertising the real audience turns that dead end into an immediate "hand this to a board actor".

Found while diagnosing two review stages that sat `pending` with the participant already woken; the recovery route was the first thing tried, on the strength of the spec.

## Change

- Add `POST /api/issues/{id}/stalled-review-decision` to `BOARD_ONLY_OPERATIONS`, so it resolves to `board` and drops `AgentBearerAuth`.
- Add a regression test pinning both `security` and `x-paperclip-authorization`.

No runtime behaviour changes — the route already refused agents. Only the advertised contract moves, to match the code.

## Verification

```
$ npx vitest run src/__tests__/openapi-routes.test.ts
Test Files  1 passed (1)
     Tests  6 passed (6)
```

Confirmed the new test is not vacuous — with the `openapi.ts` change stashed it fails:

```
× advertises the stalled-review-decision route as board-only
AssertionError: expected [ { BoardSessionAuth: [] }, …(2) ] to deeply equal [ { BoardSessionAuth: [] }, …(1) ]
Tests  1 failed | 5 passed (6)
```

The `covers the mounted server routes exactly` test in the same file still passes, so the route stays documented — only its audience changes.