### PR TITLE
fix: let blocker owners remove obsolete dependencies

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -843,8 +843,30 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockIssueService.update).toHaveBeenCalledWith(
       issueId,
       expect.objectContaining({ blockedByIssueIds: [otherOwnedBlockerId] }),
+      expect.anything(),
     );
     expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+  });
+
+  it("denies the removal when blocker ownership changes after the initial authorization check", async () => {
+    mockIssueService.getRelationSummaries
+      .mockResolvedValueOnce({
+        blockedBy: [{ id: actorOwnedBlockerId, assigneeAgentId: peerAgentId }],
+        blocks: [],
+      })
+      .mockResolvedValueOnce({
+        blockedBy: [{ id: actorOwnedBlockerId, assigneeAgentId: ownerAgentId }],
+        blocks: [],
+      });
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ blockedByIssueIds: [] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body.details.code).toBe("issue_write_assignee_run_lock");
+    expect(mockIssueService.getByIdForUpdate).toHaveBeenCalledWith(issueId, expect.anything());
+    expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
   it("denies a blocker assignee removing another owner's blocker", async () => {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -10,6 +10,8 @@ const ownerAgentId = "33333333-3333-4333-8333-333333333333";
 const peerAgentId = "44444444-4444-4444-8444-444444444444";
 const ownerRunId = "55555555-5555-4555-8555-555555555555";
 const recoveryActionId = "77777777-7777-4777-8777-777777777777";
+const actorOwnedBlockerId = "88888888-8888-4888-8888-888888888888";
+const otherOwnedBlockerId = "99999999-9999-4999-8999-999999999999";
 
 const mockIssueService = vi.hoisted(() => ({
   addComment: vi.fn(),
@@ -822,6 +824,75 @@ describe("agent issue mutation checkout ownership", () => {
     expect(mockWorkProductService.update).not.toHaveBeenCalled();
     expect(mockStorageService.putFile).not.toHaveBeenCalled();
     expect(mockStorageService.deleteObject).not.toHaveBeenCalled();
+  });
+
+  it("allows a blocker assignee to remove only their blocker from another agent's active issue", async () => {
+    mockIssueService.getRelationSummaries.mockResolvedValue({
+      blockedBy: [
+        { id: actorOwnedBlockerId, assigneeAgentId: peerAgentId },
+        { id: otherOwnedBlockerId, assigneeAgentId: ownerAgentId },
+      ],
+      blocks: [],
+    });
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ blockedByIssueIds: [otherOwnedBlockerId] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ blockedByIssueIds: [otherOwnedBlockerId] }),
+    );
+    expect(mockIssueService.assertCheckoutOwner).not.toHaveBeenCalled();
+  });
+
+  it("denies a blocker assignee removing another owner's blocker", async () => {
+    mockIssueService.getRelationSummaries.mockResolvedValue({
+      blockedBy: [
+        { id: actorOwnedBlockerId, assigneeAgentId: peerAgentId },
+        { id: otherOwnedBlockerId, assigneeAgentId: ownerAgentId },
+      ],
+      blocks: [],
+    });
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ blockedByIssueIds: [] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body.details.code).toBe("issue_write_assignee_run_lock");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("denies unrelated field mutations bundled with an actor-owned blocker removal", async () => {
+    mockIssueService.getRelationSummaries.mockResolvedValue({
+      blockedBy: [{ id: actorOwnedBlockerId, assigneeAgentId: peerAgentId }],
+      blocks: [],
+    });
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ blockedByIssueIds: [], title: "Unauthorized title change" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body.details.code).toBe("issue_write_assignee_run_lock");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("denies adding blockers through the actor-owned blocker removal grant", async () => {
+    mockIssueService.getRelationSummaries.mockResolvedValue({
+      blockedBy: [{ id: actorOwnedBlockerId, assigneeAgentId: peerAgentId }],
+      blocks: [],
+    });
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ blockedByIssueIds: [otherOwnedBlockerId] });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body.details.code).toBe("issue_write_assignee_run_lock");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
   it("allows mentioned peer agents to post comments without ownership of an active checkout", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4247,6 +4247,24 @@ export function issueRoutes(
     return true;
   }
 
+  async function isActorOwnedBlockerRemoval(
+    req: Request,
+    issue: { id: string },
+  ) {
+    if (req.actor.type !== "agent" || !req.actor.agentId) return false;
+    if (!Array.isArray(req.body.blockedByIssueIds)) return false;
+    if (Object.keys(req.body).some((key) => key !== "blockedByIssueIds")) return false;
+
+    const relations = await svc.getRelationSummaries(issue.id);
+    const currentBlockerIds = new Set(relations.blockedBy.map((blocker) => blocker.id));
+    const requestedBlockerIds = new Set(req.body.blockedByIssueIds as string[]);
+    const removedBlockers = relations.blockedBy.filter((blocker) => !requestedBlockerIds.has(blocker.id));
+
+    if (removedBlockers.length === 0) return false;
+    if ([...requestedBlockerIds].some((blockerId) => !currentBlockerIds.has(blockerId))) return false;
+    return removedBlockers.every((blocker) => blocker.assigneeAgentId === req.actor.agentId);
+  }
+
   async function assertFreshTaskWatchdogSourceMutation(
     res: Response,
     scope: Awaited<ReturnType<typeof resolveTaskWatchdogMutationScope>>,
@@ -9895,16 +9913,19 @@ export function issueRoutes(
       await denyIssueWrite(req, res, existing, "issue_write_attribution_spoof_rejected");
       return;
     }
-    const issueMutationAccess = await assertAgentIssueMutationAllowed(
+    const actorOwnedBlockerRemoval = await isActorOwnedBlockerRemoval(req, existing);
+    const issueMutationAccess = actorOwnedBlockerRemoval || await assertAgentIssueMutationAllowed(
       req,
       res,
       existing,
       { allowVisibleIssueWrite: true },
     );
     if (!issueMutationAccess) return;
-    const issueMutationAuthorizationReason = req.actor.type === "agent"
-      ? issueWriteAuthorizationReason(req, await decideIssueAccess(req, existing, "issue:mutate"))
-      : issueWriteAuthorizationReason(req, true);
+    const issueMutationAuthorizationReason = actorOwnedBlockerRemoval
+      ? "allow_actor_owned_blocker_removal"
+      : req.actor.type === "agent"
+        ? issueWriteAuthorizationReason(req, await decideIssueAccess(req, existing, "issue:mutate"))
+        : issueWriteAuthorizationReason(req, true);
 
     const actor = getActorInfo(req);
     const isClosed = isClosedIssueStatus(existing.status);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4250,12 +4250,13 @@ export function issueRoutes(
   async function isActorOwnedBlockerRemoval(
     req: Request,
     issue: { id: string },
+    dbOrTx: Db = db,
   ) {
     if (req.actor.type !== "agent" || !req.actor.agentId) return false;
     if (!Array.isArray(req.body.blockedByIssueIds)) return false;
     if (Object.keys(req.body).some((key) => key !== "blockedByIssueIds")) return false;
 
-    const relations = await svc.getRelationSummaries(issue.id);
+    const relations = await svc.getRelationSummaries(issue.id, dbOrTx);
     const currentBlockerIds = new Set(relations.blockedBy.map((blocker) => blocker.id));
     const requestedBlockerIds = new Set(req.body.blockedByIssueIds as string[]);
     const removedBlockers = relations.blockedBy.filter((blocker) => !requestedBlockerIds.has(blocker.id));
@@ -10423,6 +10424,13 @@ export function issueRoutes(
       }
       return true;
     };
+    const assertLockedActorOwnedBlockerRemoval = async (
+      tx: Parameters<typeof svc.update>[2],
+    ) => {
+      const lockedExisting = await svc.getByIdForUpdate(id, tx);
+      if (!lockedExisting) return false;
+      return isActorOwnedBlockerRemoval(req, lockedExisting, tx as unknown as Db);
+    };
     const persistReviewTransitionActivity = async (
       tx: Parameters<typeof svc.update>[2],
       updated: NonNullable<Awaited<ReturnType<typeof svc.update>>>,
@@ -10495,13 +10503,26 @@ export function issueRoutes(
     });
     const decision = transition.decision && decisionId ? transition.decision : null;
     const shouldUseTransactionalIssueUpdate =
-      Boolean(decision)
+      actorOwnedBlockerRemoval
+      || Boolean(decision)
       || shouldRelayStop
       || persistReviewActivityTransactionally
       || reviewPolicySensitiveMutationRequested;
     try {
       if (shouldUseTransactionalIssueUpdate) {
         issue = await db.transaction(async (tx) => {
+          if (
+            actorOwnedBlockerRemoval
+            && !(await assertLockedActorOwnedBlockerRemoval(tx))
+          ) {
+            throw conflict("Issue blocker ownership changed before the dependency update", {
+              code: "issue_write_assignee_run_lock",
+              issueId: existing.id,
+              assigneeAgentId: existing.assigneeAgentId,
+              actorAgentId: req.actor.type === "agent" ? req.actor.agentId : null,
+              securityPrinciples: ["Least Privilege", "Complete Mediation", "Fail Securely"],
+            });
+          }
           if (
             reviewPolicySensitiveMutationRequested
             && !(await assertLockedReviewPolicyAllowsMutation(tx))

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -6139,14 +6139,14 @@ export function issueService(db: Db) {
       return getCurrentScheduledRetryForIssue(issue.id, issue.companyId);
     },
 
-    getRelationSummaries: async (issueId: string) => {
-      const issue = await db
+    getRelationSummaries: async (issueId: string, dbOrTx: any = db) => {
+      const issue = await dbOrTx
         .select({ id: issues.id, companyId: issues.companyId })
         .from(issues)
         .where(eq(issues.id, issueId))
-        .then((rows) => rows[0] ?? null);
+        .then((rows: Array<{ id: string; companyId: string }>) => rows[0] ?? null);
       if (!issue) throw notFound("Issue not found");
-      const relations = await getIssueRelationSummaryMap(issue.companyId, [issueId], db);
+      const relations = await getIssueRelationSummaryMap(issue.companyId, [issueId], dbOrTx);
       return relations.get(issueId) ?? { blockedBy: [], blocks: [] };
     },
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Issue dependencies record which work blocks other work.
> - A blocker assignee can learn that their blocker is obsolete.
> - The active dependent issue checkout currently prevents that assignee from removing the obsolete edge.
> - A broad write grant would let the blocker assignee change unrelated issue data.
> - This pull request adds a narrow grant for removal of blocker edges owned by the actor.
> - The benefit is safe dependency cleanup without wider mutation authority.

## Linked Issues or Issue Description

**What happened?**

An agent assigned to a blocking issue cannot remove that blocker from a dependent issue when another agent owns the dependent issue checkout.

**Expected behavior**

The blocker assignee can remove only their own blocker edge. The assignee cannot add blockers, remove another owner's blocker, or change another field through this grant.

**Steps to reproduce**

Create an active dependent issue owned by one agent. Add a blocker assigned to a second agent. Use the second agent to PATCH the dependent issue with the blocker removed.

**Paperclip version or commit**

Current master before this change.

**Deployment mode**

All deployment modes.

Related searches found #12306 and #9458. Neither implements this scoped permission.

## What Changed

- Add a narrow authorization check for actor-owned blocker removal.
- Reject blocker additions and removal of blockers assigned to other agents.
- Reject any request that bundles unrelated fields with the dependency removal.
- Add focused positive and negative route tests.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts --no-file-parallelism --maxWorkers=1`
- Result: 88 tests passed.
- `pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && pnpm exec tsc -p server/tsconfig.json --noEmit`
- Result: passed.

## Risks

- Low risk. The grant applies only to a dependency-only PATCH that removes at least one blocker assigned to the actor.
- Existing authorization handles every other update.

## Model Used

- OpenAI Codex, GPT-5, with reasoning, tool use, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
