### PR TITLE
fix: avoid false finalize gate on reused workspaces

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -3208,6 +3208,41 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
     });
   });
 
+  it("ignores unattributed operations when a done blocker reuses another issue's workspace", async () => {
+    const {
+      companyId,
+      executionWorkspaceId,
+      blockerId,
+      dependentId,
+      foreignIssueId,
+    } = await seedSharedWorkspaceDependency();
+
+    await db
+      .update(executionWorkspaces)
+      .set({ sourceIssueId: foreignIssueId })
+      .where(eq(executionWorkspaces.id, executionWorkspaceId));
+    await db.insert(workspaceOperations).values({
+      companyId,
+      executionWorkspaceId,
+      issueId: null,
+      phase: "worktree_prepare",
+      status: "succeeded",
+      startedAt: new Date("2026-05-23T22:00:00.000Z"),
+    });
+
+    await expect(svc.listWakeableBlockedDependents(blockerId)).resolves.toEqual([
+      expect.objectContaining({
+        id: dependentId,
+        blockerIssueIds: [blockerId],
+      }),
+    ]);
+    await expect(svc.getDependencyReadiness(dependentId)).resolves.toMatchObject({
+      isDependencyReady: true,
+      pendingFinalizeBlockerIssueIds: [],
+      unresolvedBlockerIssueIds: [],
+    });
+  });
+
   it("keeps dependents blocked on unattributed workspace operations for the blocker workspace", async () => {
     const {
       companyId,

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -692,7 +692,11 @@ export async function listUnfinalizedExecutionWorkspaceIds(
 async function listPendingFinalizeBlockerIssueIds(
   dbOrTx: Pick<Db, "select">,
   companyId: string,
-  blockerWorkspacePairs: Array<{ blockerIssueId: string; executionWorkspaceId: string }>,
+  blockerWorkspacePairs: Array<{
+    blockerIssueId: string;
+    executionWorkspaceId: string;
+    workspaceSourceIssueId: string | null;
+  }>,
 ): Promise<Set<string>> {
   const pending = new Set<string>();
   const blockerIssueIds = [...new Set(blockerWorkspacePairs.map((pair) => pair.blockerIssueId))];
@@ -748,8 +752,20 @@ async function listPendingFinalizeBlockerIssueIds(
   }
 
   for (const pair of blockerWorkspacePairs) {
-    const latest = latestAttributedByBlockerWorkspace.get(`${pair.blockerIssueId}:${pair.executionWorkspaceId}`)
-      ?? latestUnattributedByWorkspace.get(pair.executionWorkspaceId);
+    const attributed = latestAttributedByBlockerWorkspace.get(
+      `${pair.blockerIssueId}:${pair.executionWorkspaceId}`,
+    );
+    // Legacy operations had no issue attribution. They are safe to inherit only
+    // when this blocker owns the workspace (or the legacy workspace has no owner).
+    // A child that merely reuses its parent's workspace must not inherit the
+    // parent's unattributed operation and become a false pending-finalize blocker.
+    const mayUseUnattributedFallback =
+      pair.workspaceSourceIssueId === null || pair.workspaceSourceIssueId === pair.blockerIssueId;
+    const latest = attributed ?? (
+      mayUseUnattributedFallback
+        ? latestUnattributedByWorkspace.get(pair.executionWorkspaceId)
+        : undefined
+    );
     if (!latest) continue; // no ops recorded -> nothing to finalize for this blocker
     if (latest.phase === "workspace_finalize" && latest.status === "succeeded") continue;
     pending.add(pair.blockerIssueId);
@@ -813,9 +829,11 @@ async function listIssueDependencyReadinessMap(
       blockerIssueId: issueRelations.issueId,
       blockerStatus: issues.status,
       blockerExecutionWorkspaceId: issues.executionWorkspaceId,
+      blockerWorkspaceSourceIssueId: executionWorkspaces.sourceIssueId,
     })
     .from(issueRelations)
     .innerJoin(issues, eq(issueRelations.issueId, issues.id))
+    .leftJoin(executionWorkspaces, eq(issues.executionWorkspaceId, executionWorkspaces.id))
     .where(
       and(
         eq(issueRelations.companyId, companyId),
@@ -827,12 +845,17 @@ async function listIssueDependencyReadinessMap(
   // Collect issue/workspace pairs of "done" blockers — these are the only ones
   // subject to the workspace-finalize barrier. Blockers that aren't done already
   // mark the dependent as not-ready and don't need a finalize check.
-  const doneBlockerWorkspacePairs: Array<{ blockerIssueId: string; executionWorkspaceId: string }> = [];
+  const doneBlockerWorkspacePairs: Array<{
+    blockerIssueId: string;
+    executionWorkspaceId: string;
+    workspaceSourceIssueId: string | null;
+  }> = [];
   for (const row of blockerRows) {
     if (row.blockerStatus === "done" && row.blockerExecutionWorkspaceId) {
       doneBlockerWorkspacePairs.push({
         blockerIssueId: row.blockerIssueId,
         executionWorkspaceId: row.blockerExecutionWorkspaceId,
+        workspaceSourceIssueId: row.blockerWorkspaceSourceIssueId,
       });
     }
   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates agents and issue dependencies through explicit lifecycle gates.
> - Dependency readiness must keep a done blocker closed until that blocker's own workspace changes are finalized.
> - Older workspace operations can be unattributed, so the service has a legacy fallback for the workspace owner.
> - A child may reuse its parent's execution workspace without running any workspace operation itself.
> - The current fallback incorrectly assigns the parent's unattributed operation to that child, leaving a terminal blocker unresolved.
> - This pull request scopes the fallback to the workspace source issue while preserving fail-closed behavior for owned or explicitly attributed operations.

## Linked Issues or Issue Description

### What happened?

A done blocker that reused another issue's execution workspace remained in `pendingFinalizeBlockerIssueIds` when that shared workspace contained an older unattributed operation. The dependent issue could not resume even though the blocker had performed no workspace operation and was terminal.

### Expected behavior

A done blocker should inherit unattributed workspace operations only when it is the workspace's source issue, or when a legacy workspace has no source issue. Explicit operations attributed to the blocker must continue to require a successful `workspace_finalize`.

### Steps to reproduce

1. Create an execution workspace whose `sourceIssueId` is issue A.
2. Create a done blocker issue B that reuses A's execution workspace but has no attributed workspace operations.
3. Add an older workspace operation with `issueId = null` to the shared workspace.
4. Make issue C depend on B.
5. Observe that dependency readiness incorrectly reports B as pending finalize.

### Environment

- Reproduced on commit `4c6c0c6ad048838dda4a67e1aca43aa37a6fcf0d`
- Deployment: local dev, built from source
- Database: external Postgres
- Access context: agent API
- Adapter: not adapter-specific; core dependency-readiness bug
- Sensitive values and local identifiers omitted

## What Changed

- Include the execution workspace's `sourceIssueId` when evaluating done blockers.
- Use unattributed-operation fallback only for the workspace source issue or legacy ownerless workspaces.
- Add an integration regression test for a done child reusing another issue's workspace.

## Verification

- New regression test was run before implementation and failed with the dependent remaining non-wakeable.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issues-service.test.ts`: 91/91 passed after the fix.
- Four focused shared-workspace/finalize contracts passed.
- `pnpm --filter @paperclipai/server typecheck` passed.

## Risks

Low and bounded to dependency-readiness classification. Explicit blocker-attributed operations retain the finalize barrier. Legacy ownerless workspaces retain the existing unattributed fallback. The behavior change applies only when a blocker reuses a workspace owned by a different source issue and has no operation of its own.

## Model Used

OpenAI GPT-5.6-sol with high-reasoning mode, repository tools, executable tests, and live API reproduction.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this bug fix does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and found none
- [x] I have described the issue in-PR following the bug-report template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run tests locally and they pass
- [x] I have added a regression test
- [x] Documentation changes are not required for this internal correctness fix
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
