### PR TITLE
fix(adapter-utils): clean up isolated Codex run homes safely

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -1244,3 +1244,28 @@ Networking behavior for this smoke script:
 - auto-detects and prints a Paperclip host URL reachable from inside OpenClaw Docker
 - default container-side host alias is `host.docker.internal` (override with `PAPERCLIP_HOST_FROM_CONTAINER` / `PAPERCLIP_HOST_PORT`)
 - if Paperclip rejects container hostnames in authenticated/private mode, allow `host.docker.internal` via `npx paperclipai allowed-hostname host.docker.internal` and restart Paperclip
+
+## Codex Run-Home Recovery
+
+Local Codex runs use a private home under
+`<company-dir>/acp-engine/agents/<agent-id>/codex-run-homes/<run-id>/home`.
+This preserves the restricted-run isolation boundary.
+Paperclip keeps sanitized session JSONL after the runtime closes. It then removes
+the raw run home. If retention or runtime close fails, Paperclip preserves the
+home and writes a sibling `<run-id>.quarantine` marker.
+
+The orphan sweeper is dry-run only unless `--delete` is present:
+
+```sh
+npx tsx packages/adapter-utils/src/acpx-engine/run-home-sweeper.ts \
+  --company-dir /path/to/companies/<company-id>
+```
+
+Set `PAPERCLIP_API_URL` and `PAPERCLIP_API_KEY` for both modes. The sweeper fails
+closed unless it can prove that the heartbeat run is terminal, the home has no
+open file handles, the home is older than the grace window, and a sanitized
+retention counterpart exists. A quarantine marker records an incident. It does
+not permit deletion of the only raw copy.
+
+Review the JSON manifest before you add `--delete`. Keep the default 24-hour
+grace period unless the operator has approved a different recovery window.

--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -1251,8 +1251,10 @@ Local Codex runs use a private home under
 `<company-dir>/acp-engine/agents/<agent-id>/codex-run-homes/<run-id>/home`.
 This preserves the restricted-run isolation boundary.
 Paperclip keeps sanitized session JSONL after the runtime closes. It then removes
-the raw run home. If retention or runtime close fails, Paperclip preserves the
-home and writes a sibling `<run-id>.quarantine` marker.
+the raw run home. Successful retention writes an atomic
+`retention-complete.json` manifest, including for valid zero-session runs. If
+retention or runtime close fails, Paperclip removes partial retained output,
+preserves the home, and writes a sibling `<run-id>.quarantine` marker.
 
 The orphan sweeper is dry-run only unless `--delete` is present:
 
@@ -1264,8 +1266,10 @@ npx tsx packages/adapter-utils/src/acpx-engine/run-home-sweeper.ts \
 Set `PAPERCLIP_API_URL` and `PAPERCLIP_API_KEY` for both modes. The sweeper fails
 closed unless it can prove that the heartbeat run is terminal, the home has no
 open file handles, the home is older than the grace window, and a sanitized
-retention counterpart exists. A quarantine marker records an incident. It does
-not permit deletion of the only raw copy.
+retention counterpart has proof of completion. New counterparts require a valid
+completion manifest. Legacy counterparts require a contained, non-empty JSONL
+artifact. Empty, unreadable, or symlinked counterparts fail closed. A quarantine
+marker records an incident. It does not permit deletion of the only raw copy.
 
 Review the JSON manifest before you add `--delete`. Keep the default 24-hour
 grace period unless the operator has approved a different recovery window.

--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -2241,6 +2241,47 @@ describe("shared ACPX engine runtime behavior", () => {
     expect(await pathExists(path.join(cwd, ".claude", "settings.local.json"))).toBe(false);
   });
 
+  it("rejects a traversal run ID before any run-home cleanup can escape its root", async () => {
+    const root = await makeTempRoot();
+    const stateDir = path.join(root, "state");
+    const sourceCodexHome = path.join(root, "source-codex-home");
+    const adjacentHome = path.join(stateDir, "home");
+    const sentinel = path.join(adjacentHome, "sentinel.txt");
+    let runtimeCreated = false;
+
+    await fs.mkdir(sourceCodexHome, { recursive: true });
+    await fs.writeFile(path.join(sourceCodexHome, "config.toml"), "model_provider = \"openai\"\n", "utf8");
+    await fs.mkdir(adjacentHome, { recursive: true });
+    await fs.writeFile(sentinel, "keep", "utf8");
+
+    const execute = createAcpxEngineExecutor({
+      adapterType: "codex_local",
+      createRuntime: () => {
+        runtimeCreated = true;
+        throw new Error("runtime must not start");
+      },
+    });
+
+    await expect(
+      execute({
+        runId: "..",
+        agent: { id: "agent-1", companyId: "company-1" },
+        runtime: {},
+        config: {
+          agent: "codex",
+          stateDir,
+          env: { CODEX_HOME: sourceCodexHome },
+        },
+        context: {},
+        onLog: async () => {},
+        onMeta: async () => {},
+      } as never),
+    ).rejects.toThrow("Run identifier is not a safe path segment");
+
+    expect(runtimeCreated).toBe(false);
+    await expect(fs.readFile(sentinel, "utf8")).resolves.toBe("keep");
+  });
+
   it("retains only sanitized run-local Codex session JSONL after the runtime closes", async () => {
     const root = await makeTempRoot();
     const stateDir = path.join(root, "state");

--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -2241,6 +2241,102 @@ describe("shared ACPX engine runtime behavior", () => {
     expect(await pathExists(path.join(cwd, ".claude", "settings.local.json"))).toBe(false);
   });
 
+  it("retains only sanitized run-local Codex session JSONL after the runtime closes", async () => {
+    const root = await makeTempRoot();
+    const stateDir = path.join(root, "state");
+    const sourceCodexHome = path.join(root, "source-codex-home");
+    const runId = "run-sentinel";
+    const fakeToken = `pcp_board_${"01234567".repeat(6)}`;
+    const runSessionFile = path.join(
+      stateDir,
+      "codex-run-homes",
+      runId,
+      "home",
+      "sessions",
+      "2026",
+      "08",
+      "session.jsonl",
+    );
+    const closeOrder: string[] = [];
+
+    await fs.mkdir(sourceCodexHome, { recursive: true });
+    await fs.writeFile(path.join(sourceCodexHome, "config.toml"), "model_provider = \"openai\"\n", "utf8");
+
+    const execute = createAcpxEngineExecutor({
+      adapterType: "codex_local",
+      createRuntime: () => ({
+        ensureSession: async () => ({
+          backendSessionId: "backend-session",
+          agentSessionId: "agent-session",
+          runtimeSessionName: "runtime-session",
+        }),
+        startTurn: () => ({
+          events: (async function* () {
+            await fs.mkdir(path.dirname(runSessionFile), { recursive: true });
+            await fs.writeFile(
+              runSessionFile,
+              `${JSON.stringify({ type: "message", text: `token=${fakeToken}` })}\n`,
+              "utf8",
+            );
+            yield { type: "done", stopReason: "end_turn" };
+          })(),
+          result: Promise.resolve({ status: "completed", stopReason: "end_turn" }),
+          cancel: async () => {},
+        }),
+        close: async () => {
+          closeOrder.push("close");
+          await fs.appendFile(
+            runSessionFile,
+            `${JSON.stringify({ type: "close", text: `Authorization: Bearer ${fakeToken}` })}\n`,
+            "utf8",
+          );
+        },
+      }) as never,
+    });
+
+    const logs: Array<{ stream: string; text: string }> = [];
+    const result = await execute({
+      runId,
+      agent: { id: "agent-1", companyId: "company-1" },
+      runtime: {},
+      config: {
+        agent: "codex",
+        stateDir,
+        warmHandleIdleMs: 60_000,
+        env: { CODEX_HOME: sourceCodexHome },
+      },
+      context: {},
+      onLog: async (stream: "stdout" | "stderr", text: string) => {
+        logs.push({ stream, text });
+      },
+      onMeta: async () => {},
+    } as never);
+
+    expect(result.exitCode).toBe(0);
+    expect(closeOrder).toEqual(["close"]);
+
+    const retainedFile = path.join(
+      stateDir,
+      "codex-session-retention",
+      runId,
+      "sessions",
+      "2026",
+      "08",
+      "session.jsonl",
+    );
+    const retained = await fs.readFile(retainedFile, "utf8");
+    expect(retained).not.toContain(fakeToken);
+    expect(retained).toContain("***REDACTED***");
+    expect(retained).toContain("\"type\":\"close\"");
+    expect((await fs.stat(retainedFile)).mode & 0o777).toBe(0o600);
+    expect((await fs.stat(path.dirname(retainedFile))).mode & 0o777).toBe(0o700);
+
+    const raw = await fs.readFile(runSessionFile, "utf8");
+    expect(raw).toContain(fakeToken);
+    expect((await fs.stat(path.join(stateDir, "codex-run-homes", runId, "home"))).mode & 0o777).toBe(0o700);
+    expect(logs.some((entry) => entry.text.includes("Retained 1 sanitized ACPX Codex session JSONL"))).toBe(true);
+  });
+
   it("changes the ACPX session fingerprint when the resolved secret manifest rotates", async () => {
     const root = await makeTempRoot();
     const baseConfig = {

--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -2407,6 +2407,72 @@ describe("shared ACPX engine runtime behavior", () => {
     expect(logs.every((entry) => !entry.text.includes("Deleted raw Codex run home"))).toBe(true);
   });
 
+  it("quarantines the raw run home when runtime close is not confirmed", async () => {
+    const root = await makeTempRoot();
+    const stateDir = path.join(root, "state");
+    const sourceCodexHome = path.join(root, "source-codex-home");
+    const runId = "run-close-fail";
+    const runSessionFile = path.join(
+      stateDir,
+      "codex-run-homes",
+      runId,
+      "home",
+      "sessions",
+      "session.jsonl",
+    );
+
+    await fs.mkdir(sourceCodexHome, { recursive: true });
+    await fs.writeFile(path.join(sourceCodexHome, "config.toml"), "model_provider = \"openai\"\n", "utf8");
+
+    const execute = createAcpxEngineExecutor({
+      adapterType: "codex_local",
+      createRuntime: () => ({
+        ensureSession: async () => ({
+          backendSessionId: "backend-session",
+          agentSessionId: "agent-session",
+          runtimeSessionName: "runtime-session",
+        }),
+        startTurn: () => ({
+          events: (async function* () {
+            await fs.mkdir(path.dirname(runSessionFile), { recursive: true });
+            await fs.writeFile(runSessionFile, `${JSON.stringify({ type: "message" })}\n`, "utf8");
+            yield { type: "done", stopReason: "end_turn" };
+          })(),
+          result: Promise.resolve({ status: "completed", stopReason: "end_turn" }),
+          cancel: async () => {},
+        }),
+        close: async () => {
+          throw new Error("close failed");
+        },
+      }) as never,
+    });
+
+    const logs: Array<{ stream: string; text: string }> = [];
+    const result = await execute({
+      runId,
+      agent: { id: "agent-1", companyId: "company-1" },
+      runtime: {},
+      config: {
+        agent: "codex",
+        stateDir,
+        warmHandleIdleMs: 60_000,
+        env: { CODEX_HOME: sourceCodexHome },
+      },
+      context: {},
+      onLog: async (stream: "stdout" | "stderr", text: string) => {
+        logs.push({ stream, text });
+      },
+      onMeta: async () => {},
+    } as never);
+
+    expect(result.exitCode).toBe(0);
+    await expect(fs.stat(path.dirname(path.dirname(runSessionFile)))).resolves.toBeDefined();
+    const quarantineMarker = path.join(stateDir, "codex-run-homes", `${runId}.quarantine`);
+    await expect(fs.readFile(quarantineMarker, "utf8")).resolves.toContain("runtime_close_unconfirmed");
+    expect(logs.some((entry) => entry.text.includes("runtime close was not confirmed"))).toBe(true);
+    expect(logs.every((entry) => !entry.text.includes("Deleted raw Codex run home"))).toBe(true);
+  });
+
   it("restricted-run isolation still holds after Fix A — restricted run gets its own unmanaged CODEX_HOME (KEWL-3852 AC3)", async () => {
     // A restricted run (runtimeToolPolicy.restricted=true) must still get an isolated
     // CODEX_HOME under codex-run-homes/<runId>/home.  Fix A must not weaken that boundary.

--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -2349,8 +2349,8 @@ describe("shared ACPX engine runtime behavior", () => {
     await fs.mkdir(sourceCodexHome, { recursive: true });
     await fs.writeFile(path.join(sourceCodexHome, "config.toml"), "model_provider = \"openai\"\n", "utf8");
 
-    // Pre-create the sessions dir as mode 000 so the runtime writes a session file
-    // but the retention JSONL read fails (unreadable) — simulating a retention failure.
+    // Replace the sessions directory with a file so retention enumeration fails
+    // deterministically, including when the test process runs with elevated access.
     const sessionsDir = path.join(stateDir, "codex-run-homes", runId, "home", "sessions");
     const runSessionFile = path.join(sessionsDir, "2026", "08", "session.jsonl");
 
@@ -2366,8 +2366,8 @@ describe("shared ACPX engine runtime behavior", () => {
           events: (async function* () {
             await fs.mkdir(path.dirname(runSessionFile), { recursive: true });
             await fs.writeFile(runSessionFile, `${JSON.stringify({ type: "message", text: `token=${fakeToken}` })}\n`, "utf8");
-            // Make sessions dir unreadable to force retention failure
-            await fs.chmod(sessionsDir, 0o000);
+            await fs.rm(sessionsDir, { recursive: true, force: true });
+            await fs.writeFile(sessionsDir, "not-a-directory", "utf8");
             yield { type: "done", stopReason: "end_turn" };
           })(),
           result: Promise.resolve({ status: "completed", stopReason: "end_turn" }),
@@ -2395,15 +2395,14 @@ describe("shared ACPX engine runtime behavior", () => {
       onMeta: async () => {},
     } as never);
 
-    // Restore permissions so cleanup can proceed
-    await fs.chmod(sessionsDir, 0o700).catch(() => {});
-
     expect(result.exitCode).toBe(0);
 
     // On retention failure: run home must remain (quarantined) and emit INCIDENT.
     const runHomeDir = path.join(stateDir, "codex-run-homes", runId, "home");
     const stat = await fs.stat(runHomeDir).catch(() => null);
     expect(stat).not.toBeNull();
+    const quarantineMarker = path.join(stateDir, "codex-run-homes", `${runId}.quarantine`);
+    await expect(fs.readFile(quarantineMarker, "utf8")).resolves.toContain("sanitized_session_retention_failed");
     expect(logs.some((entry) => entry.stream === "stderr" && entry.text.includes("INCIDENT"))).toBe(true);
     expect(logs.every((entry) => !entry.text.includes("Deleted raw Codex run home"))).toBe(true);
   });

--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -2380,6 +2380,58 @@ describe("shared ACPX engine runtime behavior", () => {
     expect(logs.some((entry) => entry.text.includes("Retained 1 sanitized ACPX Codex session JSONL"))).toBe(true);
   });
 
+  it("removes a closed raw run home when Codex created no sessions directory", async () => {
+    const root = await makeTempRoot();
+    const stateDir = path.join(root, "state");
+    const sourceCodexHome = path.join(root, "source-codex-home");
+    const runId = "run-without-sessions";
+
+    await fs.mkdir(sourceCodexHome, { recursive: true });
+    await fs.writeFile(path.join(sourceCodexHome, "config.toml"), "model_provider = \"openai\"\n", "utf8");
+
+    const execute = createAcpxEngineExecutor({
+      adapterType: "codex_local",
+      createRuntime: () => ({
+        ensureSession: async () => ({
+          backendSessionId: "backend-session",
+          agentSessionId: "agent-session",
+          runtimeSessionName: "runtime-session",
+        }),
+        startTurn: () => ({
+          events: (async function* () {
+            yield { type: "done", stopReason: "end_turn" };
+          })(),
+          result: Promise.resolve({ status: "completed", stopReason: "end_turn" }),
+          cancel: async () => {},
+        }),
+        close: async () => {},
+      }) as never,
+    });
+
+    const logs: Array<{ stream: string; text: string }> = [];
+    const result = await execute({
+      runId,
+      agent: { id: "agent-1", companyId: "company-1" },
+      runtime: {},
+      config: {
+        agent: "codex",
+        stateDir,
+        env: { CODEX_HOME: sourceCodexHome },
+      },
+      context: {},
+      onLog: async (stream: "stdout" | "stderr", text: string) => {
+        logs.push({ stream, text });
+      },
+      onMeta: async () => {},
+    } as never);
+
+    expect(result.exitCode).toBe(0);
+    await expect(fs.stat(path.join(stateDir, "codex-run-homes", runId, "home"))).rejects.toThrow();
+    await expect(fs.stat(path.join(stateDir, "codex-session-retention", runId, "sessions"))).resolves.toBeDefined();
+    expect(logs.some((entry) => entry.text.includes("Retained 0 sanitized ACPX Codex session JSONL"))).toBe(true);
+    expect(logs.every((entry) => !entry.text.includes("INCIDENT"))).toBe(true);
+  });
+
   it("quarantines the raw run home and emits INCIDENT log when session retention fails (KEWL-3852)", async () => {
     const root = await makeTempRoot();
     const stateDir = path.join(root, "state");

--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -2331,10 +2331,146 @@ describe("shared ACPX engine runtime behavior", () => {
     expect((await fs.stat(retainedFile)).mode & 0o777).toBe(0o600);
     expect((await fs.stat(path.dirname(retainedFile))).mode & 0o777).toBe(0o700);
 
-    const raw = await fs.readFile(runSessionFile, "utf8");
-    expect(raw).toContain(fakeToken);
-    expect((await fs.stat(path.join(stateDir, "codex-run-homes", runId, "home"))).mode & 0o777).toBe(0o700);
+    // Fix A (KEWL-3852): raw run home must be deleted after successful retention.
+    const runHomeDir = path.join(stateDir, "codex-run-homes", runId, "home");
+    await expect(fs.stat(runHomeDir)).rejects.toThrow();
+    expect(logs.some((entry) => entry.text.includes("Deleted raw Codex run home"))).toBe(true);
+    expect(logs.every((entry) => !entry.text.includes("INCIDENT"))).toBe(true);
     expect(logs.some((entry) => entry.text.includes("Retained 1 sanitized ACPX Codex session JSONL"))).toBe(true);
+  });
+
+  it("quarantines the raw run home and emits INCIDENT log when session retention fails (KEWL-3852)", async () => {
+    const root = await makeTempRoot();
+    const stateDir = path.join(root, "state");
+    const sourceCodexHome = path.join(root, "source-codex-home");
+    const runId = "run-retention-fail";
+    const fakeToken = `pcp_board_${"01234567".repeat(6)}`;
+
+    await fs.mkdir(sourceCodexHome, { recursive: true });
+    await fs.writeFile(path.join(sourceCodexHome, "config.toml"), "model_provider = \"openai\"\n", "utf8");
+
+    // Pre-create the sessions dir as mode 000 so the runtime writes a session file
+    // but the retention JSONL read fails (unreadable) — simulating a retention failure.
+    const sessionsDir = path.join(stateDir, "codex-run-homes", runId, "home", "sessions");
+    const runSessionFile = path.join(sessionsDir, "2026", "08", "session.jsonl");
+
+    const execute = createAcpxEngineExecutor({
+      adapterType: "codex_local",
+      createRuntime: () => ({
+        ensureSession: async () => ({
+          backendSessionId: "backend-session",
+          agentSessionId: "agent-session",
+          runtimeSessionName: "runtime-session",
+        }),
+        startTurn: () => ({
+          events: (async function* () {
+            await fs.mkdir(path.dirname(runSessionFile), { recursive: true });
+            await fs.writeFile(runSessionFile, `${JSON.stringify({ type: "message", text: `token=${fakeToken}` })}\n`, "utf8");
+            // Make sessions dir unreadable to force retention failure
+            await fs.chmod(sessionsDir, 0o000);
+            yield { type: "done", stopReason: "end_turn" };
+          })(),
+          result: Promise.resolve({ status: "completed", stopReason: "end_turn" }),
+          cancel: async () => {},
+        }),
+        close: async () => {},
+      }) as never,
+    });
+
+    const logs: Array<{ stream: string; text: string }> = [];
+    const result = await execute({
+      runId,
+      agent: { id: "agent-1", companyId: "company-1" },
+      runtime: {},
+      config: {
+        agent: "codex",
+        stateDir,
+        warmHandleIdleMs: 60_000,
+        env: { CODEX_HOME: sourceCodexHome },
+      },
+      context: {},
+      onLog: async (stream: "stdout" | "stderr", text: string) => {
+        logs.push({ stream, text });
+      },
+      onMeta: async () => {},
+    } as never);
+
+    // Restore permissions so cleanup can proceed
+    await fs.chmod(sessionsDir, 0o700).catch(() => {});
+
+    expect(result.exitCode).toBe(0);
+
+    // On retention failure: run home must remain (quarantined) and emit INCIDENT.
+    const runHomeDir = path.join(stateDir, "codex-run-homes", runId, "home");
+    const stat = await fs.stat(runHomeDir).catch(() => null);
+    expect(stat).not.toBeNull();
+    expect(logs.some((entry) => entry.stream === "stderr" && entry.text.includes("INCIDENT"))).toBe(true);
+    expect(logs.every((entry) => !entry.text.includes("Deleted raw Codex run home"))).toBe(true);
+  });
+
+  it("restricted-run isolation still holds after Fix A — restricted run gets its own unmanaged CODEX_HOME (KEWL-3852 AC3)", async () => {
+    // A restricted run (runtimeToolPolicy.restricted=true) must still get an isolated
+    // CODEX_HOME under codex-run-homes/<runId>/home.  Fix A must not weaken that boundary.
+    const root = await makeTempRoot();
+    const stateDir = path.join(root, "state");
+    const sourceCodexHome = path.join(root, "source-codex-home");
+    const runId = "run-restricted-isolation";
+
+    await fs.mkdir(sourceCodexHome, { recursive: true });
+    await fs.writeFile(path.join(sourceCodexHome, "config.toml"), "model_provider = \"openai\"\n", "utf8");
+
+    const capturedCodexHome: string[] = [];
+
+    const execute = createAcpxEngineExecutor({
+      adapterType: "codex_local",
+      createRuntime: () => ({
+        ensureSession: async (input: { sessionOptions?: { env?: Record<string, string> } }) => {
+          // Capture the CODEX_HOME the runtime was given via sessionOptions.env
+          const home = input.sessionOptions?.env?.CODEX_HOME;
+          if (home) capturedCodexHome.push(home);
+          return {
+            backendSessionId: "backend-session",
+            agentSessionId: "agent-session",
+            runtimeSessionName: "runtime-session",
+          };
+        },
+        startTurn: () => ({
+          events: (async function* () {
+            yield { type: "done", stopReason: "end_turn" };
+          })(),
+          result: Promise.resolve({ status: "completed", stopReason: "end_turn" }),
+          cancel: async () => {},
+        }),
+        close: async () => {},
+      }) as never,
+    });
+
+    const logs: Array<{ stream: string; text: string }> = [];
+    await execute({
+      runId,
+      agent: { id: "agent-1", companyId: "company-1" },
+      runtime: { runtimeToolPolicy: { restricted: true, enforcement: "required" } },
+      config: {
+        agent: "codex",
+        stateDir,
+        warmHandleIdleMs: 60_000,
+        env: { CODEX_HOME: sourceCodexHome },
+      },
+      context: {},
+      onLog: async (stream: "stdout" | "stderr", text: string) => {
+        logs.push({ stream, text });
+      },
+      onMeta: async () => {},
+    } as never);
+
+    // The CODEX_HOME must be an isolated run-specific directory, not the source home.
+    const expectedRunHome = path.join(stateDir, "codex-run-homes", runId, "home");
+    expect(capturedCodexHome.length).toBeGreaterThan(0);
+    expect(capturedCodexHome[0]).toBe(expectedRunHome);
+    // And it must not be the original source home
+    expect(capturedCodexHome[0]).not.toBe(sourceCodexHome);
+    // The isolation log line must appear
+    expect(logs.some((entry) => entry.text.includes("run-isolated") && entry.text.includes(runId))).toBe(true);
   });
 
   it("changes the ACPX session fingerprint when the resolved secret manifest rotates", async () => {

--- a/packages/adapter-utils/src/acpx-engine/execute.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.test.ts
@@ -2428,6 +2428,11 @@ describe("shared ACPX engine runtime behavior", () => {
     expect(result.exitCode).toBe(0);
     await expect(fs.stat(path.join(stateDir, "codex-run-homes", runId, "home"))).rejects.toThrow();
     await expect(fs.stat(path.join(stateDir, "codex-session-retention", runId, "sessions"))).resolves.toBeDefined();
+    const manifest = JSON.parse(await fs.readFile(
+      path.join(stateDir, "codex-session-retention", runId, "retention-complete.json"),
+      "utf8",
+    )) as { status: string; runId: string; sessionFileCount: number };
+    expect(manifest).toMatchObject({ status: "complete", runId, sessionFileCount: 0 });
     expect(logs.some((entry) => entry.text.includes("Retained 0 sanitized ACPX Codex session JSONL"))).toBe(true);
     expect(logs.every((entry) => !entry.text.includes("INCIDENT"))).toBe(true);
   });
@@ -2496,6 +2501,7 @@ describe("shared ACPX engine runtime behavior", () => {
     expect(stat).not.toBeNull();
     const quarantineMarker = path.join(stateDir, "codex-run-homes", `${runId}.quarantine`);
     await expect(fs.readFile(quarantineMarker, "utf8")).resolves.toContain("sanitized_session_retention_failed");
+    await expect(fs.stat(path.join(stateDir, "codex-session-retention", runId))).rejects.toThrow();
     expect(logs.some((entry) => entry.stream === "stderr" && entry.text.includes("INCIDENT"))).toBe(true);
     expect(logs.every((entry) => !entry.text.includes("Deleted raw Codex run home"))).toBe(true);
   });
@@ -2562,6 +2568,7 @@ describe("shared ACPX engine runtime behavior", () => {
     await expect(fs.stat(path.dirname(path.dirname(runSessionFile)))).resolves.toBeDefined();
     const quarantineMarker = path.join(stateDir, "codex-run-homes", `${runId}.quarantine`);
     await expect(fs.readFile(quarantineMarker, "utf8")).resolves.toContain("runtime_close_unconfirmed");
+    await expect(fs.stat(path.join(stateDir, "codex-session-retention", runId))).rejects.toThrow();
     expect(logs.some((entry) => entry.text.includes("runtime close was not confirmed"))).toBe(true);
     expect(logs.every((entry) => !entry.text.includes("Deleted raw Codex run home"))).toBe(true);
   });

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -1075,17 +1075,27 @@ async function retainSanitizedCodexSessionsAfterClose(input: {
   onLog: AdapterExecutionContext["onLog"];
 }): Promise<void> {
   if (!input.prepared.codexSessionRetention) return;
+  const { runHome, retainedSessionsDir } = input.prepared.codexSessionRetention;
   try {
     await retainSanitizedCodexSessionJsonl({
       retention: input.prepared.codexSessionRetention,
       onLog: input.onLog,
     });
-  } catch (err) {
-    await chmodPrivateTree(input.prepared.codexSessionRetention.runHome).catch(() => {});
-    await fs.rm(input.prepared.codexSessionRetention.retainedSessionsDir, { recursive: true, force: true }).catch(() => {});
+    // Fix A (KEWL-3852): delete the raw run home now that sanitized retention succeeded.
+    await fs.rm(runHome, { recursive: true, force: true });
     await input.onLog(
       "stderr",
-      `[paperclip] Failed to retain sanitized ACPX Codex session JSONL; raw run home is quarantined at "${input.prepared.codexSessionRetention.runHome}": ${err instanceof Error ? err.message : String(err)}\n`,
+      `[paperclip] Deleted raw Codex run home "${runHome}" after successful session retention.\n`,
+    );
+  } catch (err) {
+    // Retention failed — leave the run home in place as an explicit quarantine so it
+    // can be inspected or swept later.  The INCIDENT prefix is the signal KEWL-3853
+    // monitoring greps for unswept quarantines.
+    await chmodPrivateTree(runHome).catch(() => {});
+    await fs.rm(retainedSessionsDir, { recursive: true, force: true }).catch(() => {});
+    await input.onLog(
+      "stderr",
+      `[paperclip] INCIDENT: failed to retain sanitized ACPX Codex session JSONL; raw run home quarantined at "${runHome}": ${err instanceof Error ? err.message : String(err)}\n`,
     );
   }
 }

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -149,6 +149,7 @@ import {
   type StartupStepMeasureOptions,
   type StartupTraceContext,
 } from "./startup-timing.js";
+import { redactCommandText } from "../command-redaction.js";
 
 const defaultModuleDir = path.dirname(fileURLToPath(import.meta.url));
 const PAPERCLIP_MANAGED_CODEX_SKILLS_MANIFEST = ".paperclip-managed-skills.json";
@@ -449,6 +450,7 @@ interface AcpxPreparedRuntime {
   skillsIdentity: Record<string, unknown>;
   childStderrLogPath: string | null;
   paperclipClaudeSettings: PaperclipClaudeSettingsResult | null;
+  codexSessionRetention: CodexSessionRetentionContext | null;
   mcpServers: NonNullable<AcpRuntimeOptions["mcpServers"]>;
   mcpIdentity: Array<{ name: string; url: string; connectionId: string }>;
   // Per-step round-trip / provider-duration readers sourced from the sandbox
@@ -457,6 +459,11 @@ interface AcpxPreparedRuntime {
   // `acp.handshake` `measureStartupStep` call in the executor (the other six
   // boundaries live inside `buildRuntime` and read it directly).
   stepMetrics: StartupStepMeasureOptions;
+}
+
+interface CodexSessionRetentionContext {
+  runHome: string;
+  retainedSessionsDir: string;
 }
 
 const defaultWarmHandles = new Map<string, RuntimeCacheEntry>();
@@ -957,6 +964,160 @@ async function ensureCopiedFile(target: string, source: string): Promise<void> {
   await fs.copyFile(source, target);
 }
 
+function safePathSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+async function chmodPrivateTree(root: string): Promise<void> {
+  const stat = await fs.lstat(root).catch(() => null);
+  if (!stat) return;
+  if (stat.isDirectory()) {
+    await fs.chmod(root, 0o700).catch(() => {});
+    const entries = await fs.readdir(root, { withFileTypes: true }).catch(() => []);
+    await Promise.all(entries.map((entry) => chmodPrivateTree(path.join(root, entry.name))));
+    return;
+  }
+  if (stat.isFile()) {
+    await fs.chmod(root, 0o600).catch(() => {});
+  }
+}
+
+async function removeDirectoryContents(dir: string): Promise<void> {
+  const entries = await fs.readdir(dir).catch(() => []);
+  await Promise.all(entries.map((entry) => fs.rm(path.join(dir, entry), { recursive: true, force: true })));
+}
+
+async function prepareRunIsolatedCodexHome(input: {
+  sourceHome: string;
+  runHome: string;
+  onLog: AdapterExecutionContext["onLog"];
+}): Promise<void> {
+  await fs.rm(input.runHome, { recursive: true, force: true });
+  await fs.mkdir(input.runHome, { recursive: true, mode: 0o700 });
+
+  const authJson = path.join(input.sourceHome, "auth.json");
+  if (await pathExists(authJson)) await ensureSymlink(path.join(input.runHome, "auth.json"), authJson);
+
+  for (const name of ["config.json", "config.toml", "instructions.md"]) {
+    const source = path.join(input.sourceHome, name);
+    if (await pathExists(source)) await ensureCopiedFile(path.join(input.runHome, name), source);
+  }
+
+  await chmodPrivateTree(input.runHome);
+  await input.onLog(
+    "stdout",
+    `[paperclip] Using run-isolated ACPX Codex home "${input.runHome}" (seeded from "${input.sourceHome}").\n`,
+  );
+}
+
+async function listCodexSessionJsonlFiles(input: {
+  root: string;
+  dir: string;
+  relativeDir?: string;
+}): Promise<string[]> {
+  const entries = await fs.readdir(input.dir, { withFileTypes: true }).catch(() => []);
+  const files: string[] = [];
+  for (const entry of entries) {
+    const relativePath = input.relativeDir ? path.join(input.relativeDir, entry.name) : entry.name;
+    const absolutePath = path.join(input.dir, entry.name);
+    if (entry.isSymbolicLink()) continue;
+    if (entry.isDirectory()) {
+      files.push(...await listCodexSessionJsonlFiles({
+        root: input.root,
+        dir: absolutePath,
+        relativeDir: relativePath,
+      }));
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+    const resolved = path.resolve(absolutePath);
+    const root = path.resolve(input.root) + path.sep;
+    if (!resolved.startsWith(root)) continue;
+    files.push(relativePath);
+  }
+  return files;
+}
+
+async function retainSanitizedCodexSessionJsonl(input: {
+  retention: CodexSessionRetentionContext;
+  onLog: AdapterExecutionContext["onLog"];
+}): Promise<void> {
+  const sessionsDir = path.join(input.retention.runHome, "sessions");
+  await chmodPrivateTree(input.retention.runHome);
+  const sessionFiles = await listCodexSessionJsonlFiles({
+    root: sessionsDir,
+    dir: sessionsDir,
+  });
+
+  await fs.mkdir(input.retention.retainedSessionsDir, { recursive: true, mode: 0o700 });
+  await removeDirectoryContents(input.retention.retainedSessionsDir);
+
+  for (const relativePath of sessionFiles) {
+    const source = path.join(sessionsDir, relativePath);
+    const target = path.join(input.retention.retainedSessionsDir, relativePath);
+    const raw = await fs.readFile(source, "utf8");
+    await writeFileAtomically({
+      target,
+      contents: redactCommandText(raw),
+      mode: 0o600,
+    });
+  }
+
+  await chmodPrivateTree(input.retention.retainedSessionsDir);
+  await input.onLog(
+    "stdout",
+    `[paperclip] Retained ${sessionFiles.length} sanitized ACPX Codex session JSONL file(s) in "${input.retention.retainedSessionsDir}".\n`,
+  );
+}
+
+async function retainSanitizedCodexSessionsAfterClose(input: {
+  prepared: AcpxPreparedRuntime;
+  onLog: AdapterExecutionContext["onLog"];
+}): Promise<void> {
+  if (!input.prepared.codexSessionRetention) return;
+  try {
+    await retainSanitizedCodexSessionJsonl({
+      retention: input.prepared.codexSessionRetention,
+      onLog: input.onLog,
+    });
+  } catch (err) {
+    await chmodPrivateTree(input.prepared.codexSessionRetention.runHome).catch(() => {});
+    await fs.rm(input.prepared.codexSessionRetention.retainedSessionsDir, { recursive: true, force: true }).catch(() => {});
+    await input.onLog(
+      "stderr",
+      `[paperclip] Failed to retain sanitized ACPX Codex session JSONL; raw run home is quarantined at "${input.prepared.codexSessionRetention.runHome}": ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+}
+
+async function quarantineCodexRunHomeWithoutClose(input: {
+  prepared: AcpxPreparedRuntime;
+  onLog: AdapterExecutionContext["onLog"];
+  reason: string;
+}): Promise<void> {
+  const retention = input.prepared.codexSessionRetention;
+  if (!retention) return;
+  await chmodPrivateTree(retention.runHome).catch(() => {});
+  await fs.rm(retention.retainedSessionsDir, { recursive: true, force: true }).catch(() => {});
+  const runHomeParent = path.dirname(retention.runHome);
+  const quarantineMarker = path.join(
+    path.dirname(runHomeParent),
+    `${path.basename(runHomeParent)}.quarantine`,
+  );
+  await writeFileAtomically({
+    target: quarantineMarker,
+    contents: `${JSON.stringify({
+      createdAt: new Date().toISOString(),
+      reason: "runtime_close_unconfirmed",
+    })}\n`,
+    mode: 0o600,
+  }).catch(() => {});
+  await input.onLog(
+    "stderr",
+    `[paperclip] INCIDENT: raw ACPX Codex run home quarantined because runtime close was not confirmed at "${retention.runHome}": ${input.reason}\n`,
+  );
+}
+
 async function prepareManagedCodexHome(input: {
   companyId: string;
   sourceHome: string;
@@ -1188,7 +1349,10 @@ async function prepareCodexSkillRuntime(input: {
   companyId: string;
   config: Record<string, unknown>;
   env: Record<string, string>;
+  adapterType: string;
   moduleDir: string;
+  runId: string;
+  stateDir: string;
   onLog: AdapterExecutionContext["onLog"];
   // Step-timing seam: threaded from `buildRuntime` so the nested
   // `skills.reconcile` boundary (step 3) can emit its own `run.startup.step`
@@ -1202,7 +1366,7 @@ async function prepareCodexSkillRuntime(input: {
   // same host→sandbox counters as its siblings (0 here — skill prep is
   // host-only — which is itself the answer to "does this step exec?").
   stepMetrics?: StartupStepMeasureOptions;
-}): Promise<{ identity: Record<string, unknown>; commandNotes: string[] }> {
+}): Promise<{ identity: Record<string, unknown>; commandNotes: string[]; retention: CodexSessionRetentionContext | null }> {
   const now = input.now ?? (() => Date.now());
   const envConfig = parseObject(input.config.env);
   const configuredCodexHome =
@@ -1214,13 +1378,29 @@ async function prepareCodexSkillRuntime(input: {
       ? path.resolve(process.env.CODEX_HOME.trim())
       : path.join(os.homedir(), ".codex");
   const managedCodexHome = resolveManagedCodexHomeDir(input.companyId);
-  const effectiveCodexHome = configuredCodexHome ??
+  const seededCodexHome = configuredCodexHome ??
     await prepareManagedCodexHome({
       companyId: input.companyId,
       sourceHome: sourceCodexHome,
       targetHome: managedCodexHome,
       onLog: input.onLog,
     });
+  let effectiveCodexHome = seededCodexHome;
+  let retention: CodexSessionRetentionContext | null = null;
+  if (input.adapterType === "codex_local") {
+    const runKey = safePathSegment(input.runId);
+    const runHome = path.join(input.stateDir, "codex-run-homes", runKey, "home");
+    retention = {
+      runHome,
+      retainedSessionsDir: path.join(input.stateDir, "codex-session-retention", runKey, "sessions"),
+    };
+    await prepareRunIsolatedCodexHome({
+      sourceHome: seededCodexHome,
+      runHome,
+      onLog: input.onLog,
+    });
+    effectiveCodexHome = runHome;
+  }
   const { allSkills, selectedSkills, desiredSkillNames } = await resolveSelectedRuntimeSkills(input.config, input.moduleDir);
   const skillSetKey = await buildSkillSetKey({ skills: selectedSkills, label: "codex" });
   const skillsHome = path.join(effectiveCodexHome, "skills");
@@ -1276,6 +1456,7 @@ async function prepareCodexSkillRuntime(input: {
       skillsHome,
     },
     commandNotes: [`Prepared ACPX Codex skill home at ${skillsHome}.`],
+    retention,
   };
 }
 
@@ -1935,6 +2116,7 @@ async function buildRuntime(input: {
   let skillsIdentity: Record<string, unknown> = { mode: "unsupported" };
   const skillCommandNotes: string[] = [];
   let paperclipClaudeSettings: PaperclipClaudeSettingsResult | null = null;
+  let codexSessionRetention: CodexSessionRetentionContext | null = null;
   if (acpxAgent === "claude") {
     const preparedSkills = await prepareClaudeSkillRuntime({
       stateDir,
@@ -1965,7 +2147,10 @@ async function buildRuntime(input: {
         companyId: agent.companyId,
         config,
         env,
+        adapterType: input.engine.adapterType,
         moduleDir: input.engine.moduleDir,
+        runId,
+        stateDir,
         onLog: input.ctx.onLog,
         onEvent: input.ctx.onEvent,
         now: nowMs,
@@ -1975,6 +2160,7 @@ async function buildRuntime(input: {
     );
     skillsIdentity = preparedSkills.identity;
     skillCommandNotes.push(...preparedSkills.commandNotes);
+    codexSessionRetention = preparedSkills.retention;
   } else if (acpxAgent === "gemini") {
     const preparedSkills = await prepareGeminiSkillRuntime({
       config,
@@ -2427,6 +2613,7 @@ async function buildRuntime(input: {
     },
     childStderrLogPath,
     paperclipClaudeSettings,
+    codexSessionRetention,
     mcpServers,
     mcpIdentity,
     stepMetrics,
@@ -4880,7 +5067,11 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
           // Host lane: save a clean persistent warm-eligible turn, but carry the
           // live run-scoped credential so the gate blocks the transfer.
           if (!slots.has("acp_runtime")) return null;
-          const permits = clean && prepared.mode === "persistent" && warmIdleMs > 0;
+          const permits =
+            clean &&
+            prepared.mode === "persistent" &&
+            warmIdleMs > 0 &&
+            !prepared.codexSessionRetention;
           if (!permits) return null;
           return { kind: "host", causePermitsSave: true, liveRunScopedCredentials: [LIVE_RUN_SCOPED_API_KEY] };
         },
@@ -4892,8 +5083,18 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
           // below, including the empty-slot and save early returns: a late
           // handle that already arrived must never race this step.
           const lateHandle = handshakeFence.seal();
-          if (!slots.has("acp_runtime")) return;
-          if (decision.kind === "save" && decision.savedId === "acp_runtime") return;
+          if (!slots.has("acp_runtime")) {
+            await retainSanitizedCodexSessionsAfterClose({ prepared, onLog: ctx.onLog });
+            return;
+          }
+          if (decision.kind === "save" && decision.savedId === "acp_runtime") {
+            await quarantineCodexRunHomeWithoutClose({
+              prepared,
+              onLog: ctx.onLog,
+              reason: "the runtime was transferred to the warm-session store",
+            });
+            return;
+          }
           const baseSettlement: RuntimeSettlementPlan = runtimeSettlement ?? {
             mode: "direct",
             handle: syntheticCloseHandle(),
@@ -4934,6 +5135,11 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
               warmHandles.delete(prepared.sessionKey);
               flushChildStderr(existing.childStderrState);
             }
+            await quarantineCodexRunHomeWithoutClose({
+              prepared,
+              onLog: ctx.onLog,
+              reason: "the runtime close was skipped after duplex channel loss",
+            });
             return;
           }
           // The handshake guard abandoned this `ensureSession` call and no late
@@ -4943,7 +5149,14 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
           // hook (armed at the `ensureSession` call site) closes it once,
           // whenever it shows up. A guarded call only ever runs on a cold
           // start, so there is no matching warm entry here to drop.
-          if (handshakeAbandoned && !lateHandle) return;
+          if (handshakeAbandoned && !lateHandle) {
+            await quarantineCodexRunHomeWithoutClose({
+              prepared,
+              onLog: ctx.onLog,
+              reason: "the abandoned session handshake had not returned a closeable handle",
+            });
+            return;
+          }
           if (
             settlement.mode === "warm_or_close" &&
             warmHandleMatches(existing, runtime, settlement.handle) &&
@@ -4951,28 +5164,51 @@ export function createAcpxEngineExecutor(deps: AcpxEngineExecutorOptions = {}) {
           ) {
             // A matching warm entry closes through the warm store, which also
             // clears its idle timer and flushes its child stderr.
-            await closeWarmHandle({
-              handles: warmHandles,
-              key: prepared.sessionKey,
-              entry: existing,
-              reason: settlement.reason,
-              discardPersistentState: settlement.discardPersistentState,
-            });
+            try {
+              await closeWarmHandle({
+                handles: warmHandles,
+                key: prepared.sessionKey,
+                entry: existing,
+                reason: settlement.reason,
+                discardPersistentState: settlement.discardPersistentState,
+              });
+            } catch (closeErr) {
+              await quarantineCodexRunHomeWithoutClose({
+                prepared,
+                onLog: ctx.onLog,
+                reason: `warm runtime close failed: ${closeErr instanceof Error ? closeErr.message : String(closeErr)}`,
+              });
+              throw closeErr;
+            }
+            await retainSanitizedCodexSessionsAfterClose({ prepared, onLog: ctx.onLog });
             return;
           }
           const onCloseError = settlement.recordCloseError
             ? (closeErr: unknown) => recordTeardownError("runtime-close", closeErr)
             : () => {};
+          let runtimeCloseConfirmed = false;
           await runtime
             .close({
               handle: settlement.handle,
               reason: settlement.reason,
               discardPersistentState: settlement.discardPersistentState,
             })
+            .then(() => {
+              runtimeCloseConfirmed = true;
+            })
             .catch(onCloseError);
           if (settlement.dropWarmEntry && warmHandleMatches(existing, runtime, settlement.handle) && existing) {
             clearWarmHandleTimer(existing);
             warmHandles.delete(prepared.sessionKey);
+          }
+          if (runtimeCloseConfirmed) {
+            await retainSanitizedCodexSessionsAfterClose({ prepared, onLog: ctx.onLog });
+          } else {
+            await quarantineCodexRunHomeWithoutClose({
+              prepared,
+              onLog: ctx.onLog,
+              reason: "runtime.close did not complete successfully",
+            });
           }
         }),
         // Perform the reuse decision. A save transfers the staged files to the site

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -965,7 +965,20 @@ async function ensureCopiedFile(target: string, source: string): Promise<void> {
 }
 
 function safePathSegment(value: string): string {
-  return value.replace(/[^a-zA-Z0-9._-]/g, "_");
+  if (value.length === 0 || value.length > 128 || !/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(value)) {
+    throw new Error("Run identifier is not a safe path segment");
+  }
+  return value;
+}
+
+function resolveContainedRunPath(root: string, runKey: string, leaf: string): string {
+  const resolvedRoot = path.resolve(root);
+  const candidate = path.resolve(resolvedRoot, runKey, leaf);
+  const relative = path.relative(resolvedRoot, candidate);
+  if (relative.length === 0 || relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error("Run path escaped its configured root");
+  }
+  return candidate;
 }
 
 async function chmodPrivateTree(root: string): Promise<void> {
@@ -1420,10 +1433,18 @@ async function prepareCodexSkillRuntime(input: {
   let retention: CodexSessionRetentionContext | null = null;
   if (input.adapterType === "codex_local") {
     const runKey = safePathSegment(input.runId);
-    const runHome = path.join(input.stateDir, "codex-run-homes", runKey, "home");
+    const runHome = resolveContainedRunPath(
+      path.join(input.stateDir, "codex-run-homes"),
+      runKey,
+      "home",
+    );
     retention = {
       runHome,
-      retainedSessionsDir: path.join(input.stateDir, "codex-session-retention", runKey, "sessions"),
+      retainedSessionsDir: resolveContainedRunPath(
+        path.join(input.stateDir, "codex-session-retention"),
+        runKey,
+        "sessions",
+      ),
     };
     await prepareRunIsolatedCodexHome({
       sourceHome: seededCodexHome,

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -1015,7 +1015,9 @@ async function listCodexSessionJsonlFiles(input: {
   dir: string;
   relativeDir?: string;
 }): Promise<string[]> {
-  const entries = await fs.readdir(input.dir, { withFileTypes: true }).catch(() => []);
+  // Fail closed. A read failure must reach the retention caller so the raw home
+  // is quarantined instead of being mistaken for a successful zero-file copy.
+  const entries = await fs.readdir(input.dir, { withFileTypes: true });
   const files: string[] = [];
   for (const entry of entries) {
     const relativePath = input.relativeDir ? path.join(input.relativeDir, entry.name) : entry.name;
@@ -1093,9 +1095,25 @@ async function retainSanitizedCodexSessionsAfterClose(input: {
     // monitoring greps for unswept quarantines.
     await chmodPrivateTree(runHome).catch(() => {});
     await fs.rm(retainedSessionsDir, { recursive: true, force: true }).catch(() => {});
+    const runHomeParent = path.dirname(runHome);
+    const quarantineMarker = path.join(
+      path.dirname(runHomeParent),
+      `${path.basename(runHomeParent)}.quarantine`,
+    );
+    let quarantineMarkerError: unknown;
+    await writeFileAtomically({
+      target: quarantineMarker,
+      contents: `${JSON.stringify({
+        createdAt: new Date().toISOString(),
+        reason: "sanitized_session_retention_failed",
+      })}\n`,
+      mode: 0o600,
+    }).catch((markerErr) => {
+      quarantineMarkerError = markerErr;
+    });
     await input.onLog(
       "stderr",
-      `[paperclip] INCIDENT: failed to retain sanitized ACPX Codex session JSONL; raw run home quarantined at "${runHome}": ${err instanceof Error ? err.message : String(err)}\n`,
+      `[paperclip] INCIDENT: failed to retain sanitized ACPX Codex session JSONL; raw run home quarantined at "${runHome}"${quarantineMarkerError ? `, but marker creation at "${quarantineMarker}" also failed: ${quarantineMarkerError instanceof Error ? quarantineMarkerError.message : String(quarantineMarkerError)}` : ` with marker "${quarantineMarker}"`}: ${err instanceof Error ? err.message : String(err)}\n`,
     );
   }
 }

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -1132,6 +1132,7 @@ async function quarantineCodexRunHomeWithoutClose(input: {
     path.dirname(runHomeParent),
     `${path.basename(runHomeParent)}.quarantine`,
   );
+  let quarantineMarkerError: unknown;
   await writeFileAtomically({
     target: quarantineMarker,
     contents: `${JSON.stringify({
@@ -1139,10 +1140,12 @@ async function quarantineCodexRunHomeWithoutClose(input: {
       reason: "runtime_close_unconfirmed",
     })}\n`,
     mode: 0o600,
-  }).catch(() => {});
+  }).catch((markerErr) => {
+    quarantineMarkerError = markerErr;
+  });
   await input.onLog(
     "stderr",
-    `[paperclip] INCIDENT: raw ACPX Codex run home quarantined because runtime close was not confirmed at "${retention.runHome}": ${input.reason}\n`,
+    `[paperclip] INCIDENT: raw ACPX Codex run home quarantined because runtime close was not confirmed at "${retention.runHome}"${quarantineMarkerError ? `, but marker creation at "${quarantineMarker}" also failed: ${quarantineMarkerError instanceof Error ? quarantineMarkerError.message : String(quarantineMarkerError)}` : ` with marker "${quarantineMarker}"`}: ${input.reason}\n`,
   );
 }
 

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import fsSync from "node:fs";
+import type { Dirent } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { execFile } from "node:child_process";
@@ -1030,7 +1031,16 @@ async function listCodexSessionJsonlFiles(input: {
 }): Promise<string[]> {
   // Fail closed. A read failure must reach the retention caller so the raw home
   // is quarantined instead of being mistaken for a successful zero-file copy.
-  const entries = await fs.readdir(input.dir, { withFileTypes: true });
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir(input.dir, { withFileTypes: true });
+  } catch (err) {
+    // A provider can complete before it creates the top-level sessions directory.
+    // That is a successful empty retention. A missing nested directory or any
+    // other read failure remains an incident and must reach the quarantine path.
+    if (input.relativeDir === undefined && isErrnoException(err, "ENOENT")) return [];
+    throw err;
+  }
   const files: string[] = [];
   for (const entry of entries) {
     const relativePath = input.relativeDir ? path.join(input.relativeDir, entry.name) : entry.name;

--- a/packages/adapter-utils/src/acpx-engine/execute.ts
+++ b/packages/adapter-utils/src/acpx-engine/execute.ts
@@ -154,6 +154,7 @@ import { redactCommandText } from "../command-redaction.js";
 
 const defaultModuleDir = path.dirname(fileURLToPath(import.meta.url));
 const PAPERCLIP_MANAGED_CODEX_SKILLS_MANIFEST = ".paperclip-managed-skills.json";
+const CODEX_SESSION_RETENTION_MANIFEST = "retention-complete.json";
 const BENIGN_NES_CLOSE_STDERR = /method: ['"]nes\/close['"].*-32601/;
 
 function routeChildStderr(state: ChildStderrState, chunk: string) {
@@ -1068,14 +1069,16 @@ async function retainSanitizedCodexSessionJsonl(input: {
   onLog: AdapterExecutionContext["onLog"];
 }): Promise<void> {
   const sessionsDir = path.join(input.retention.runHome, "sessions");
+  const retainedRunDir = path.dirname(input.retention.retainedSessionsDir);
   await chmodPrivateTree(input.retention.runHome);
   const sessionFiles = await listCodexSessionJsonlFiles({
     root: sessionsDir,
     dir: sessionsDir,
   });
 
+  await fs.mkdir(retainedRunDir, { recursive: true, mode: 0o700 });
+  await removeDirectoryContents(retainedRunDir);
   await fs.mkdir(input.retention.retainedSessionsDir, { recursive: true, mode: 0o700 });
-  await removeDirectoryContents(input.retention.retainedSessionsDir);
 
   for (const relativePath of sessionFiles) {
     const source = path.join(sessionsDir, relativePath);
@@ -1089,6 +1092,19 @@ async function retainSanitizedCodexSessionJsonl(input: {
   }
 
   await chmodPrivateTree(input.retention.retainedSessionsDir);
+  await writeFileAtomically({
+    target: path.join(retainedRunDir, CODEX_SESSION_RETENTION_MANIFEST),
+    contents: `${JSON.stringify({
+      schemaVersion: 1,
+      status: "complete",
+      runId: path.basename(retainedRunDir),
+      completedAt: new Date().toISOString(),
+      sessionFileCount: sessionFiles.length,
+      sessionFiles,
+    })}\n`,
+    mode: 0o600,
+  });
+  await chmodPrivateTree(retainedRunDir);
   await input.onLog(
     "stdout",
     `[paperclip] Retained ${sessionFiles.length} sanitized ACPX Codex session JSONL file(s) in "${input.retention.retainedSessionsDir}".\n`,
@@ -1101,6 +1117,7 @@ async function retainSanitizedCodexSessionsAfterClose(input: {
 }): Promise<void> {
   if (!input.prepared.codexSessionRetention) return;
   const { runHome, retainedSessionsDir } = input.prepared.codexSessionRetention;
+  const retainedRunDir = path.dirname(retainedSessionsDir);
   try {
     await retainSanitizedCodexSessionJsonl({
       retention: input.prepared.codexSessionRetention,
@@ -1117,7 +1134,7 @@ async function retainSanitizedCodexSessionsAfterClose(input: {
     // can be inspected or swept later.  The INCIDENT prefix is the signal KEWL-3853
     // monitoring greps for unswept quarantines.
     await chmodPrivateTree(runHome).catch(() => {});
-    await fs.rm(retainedSessionsDir, { recursive: true, force: true }).catch(() => {});
+    await fs.rm(retainedRunDir, { recursive: true, force: true }).catch(() => {});
     const runHomeParent = path.dirname(runHome);
     const quarantineMarker = path.join(
       path.dirname(runHomeParent),
@@ -1149,7 +1166,7 @@ async function quarantineCodexRunHomeWithoutClose(input: {
   const retention = input.prepared.codexSessionRetention;
   if (!retention) return;
   await chmodPrivateTree(retention.runHome).catch(() => {});
-  await fs.rm(retention.retainedSessionsDir, { recursive: true, force: true }).catch(() => {});
+  await fs.rm(path.dirname(retention.retainedSessionsDir), { recursive: true, force: true }).catch(() => {});
   const runHomeParent = path.dirname(retention.runHome);
   const quarantineMarker = path.join(
     path.dirname(runHomeParent),

--- a/packages/adapter-utils/src/acpx-engine/run-home-sweeper.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/run-home-sweeper.test.ts
@@ -263,6 +263,30 @@ describe("run-home sweeper", () => {
       });
       await expect(fs.stat(runHomeDir)).rejects.toThrow();
     });
+
+    it("rejects a completion manifest whose listed artifact is missing", async () => {
+      const runId = "run-missing-manifest-artifact";
+      const { runHomeDir, retentionDir } = await buildRunHome({
+        companyDir,
+        agentId: "agent-1",
+        runId,
+        ageHours: 30,
+      });
+      await fs.mkdir(path.join(retentionDir, "sessions"), { recursive: true });
+      await fs.writeFile(path.join(retentionDir, "retention-complete.json"), JSON.stringify({
+        schemaVersion: 1,
+        status: "complete",
+        runId,
+        sessionFileCount: 1,
+        sessionFiles: ["missing.jsonl"],
+      }), "utf8");
+
+      const result = await sweep({ companyDir, dryRun: false, graceHours: 24 });
+
+      expect(result.entries[0]?.eligible).toBe(false);
+      expect(result.entries[0]?.ineligibleReason).toMatch(/could not be validated/i);
+      await expect(fs.stat(runHomeDir)).resolves.toBeDefined();
+    });
   });
 
   describe("active/ambiguous home exclusion (AC2c)", () => {

--- a/packages/adapter-utils/src/acpx-engine/run-home-sweeper.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/run-home-sweeper.test.ts
@@ -287,6 +287,34 @@ describe("run-home sweeper", () => {
       expect(result.entries[0]?.ineligibleReason).toMatch(/could not be validated/i);
       await expect(fs.stat(runHomeDir)).resolves.toBeDefined();
     });
+
+    it("rejects a completion manifest whose sessions directory is a symlink", async () => {
+      const runId = "run-symlinked-manifest-sessions";
+      const { runHomeDir, retentionDir } = await buildRunHome({
+        companyDir,
+        agentId: "agent-1",
+        runId,
+        ageHours: 30,
+      });
+      const externalSessions = path.join(companyDir, "external-manifest-sessions");
+      await fs.mkdir(externalSessions, { recursive: true });
+      await fs.writeFile(path.join(externalSessions, "session.jsonl"), '{"type":"session"}\n', "utf8");
+      await fs.mkdir(retentionDir, { recursive: true });
+      await fs.symlink(externalSessions, path.join(retentionDir, "sessions"), "dir");
+      await fs.writeFile(path.join(retentionDir, "retention-complete.json"), JSON.stringify({
+        schemaVersion: 1,
+        status: "complete",
+        runId,
+        sessionFileCount: 1,
+        sessionFiles: ["session.jsonl"],
+      }), "utf8");
+
+      const result = await sweep({ companyDir, dryRun: false, graceHours: 24 });
+
+      expect(result.entries[0]?.eligible).toBe(false);
+      expect(result.entries[0]?.ineligibleReason).toMatch(/sessions path is not a real directory/i);
+      await expect(fs.stat(runHomeDir)).resolves.toBeDefined();
+    });
   });
 
   describe("active/ambiguous home exclusion (AC2c)", () => {

--- a/packages/adapter-utils/src/acpx-engine/run-home-sweeper.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/run-home-sweeper.test.ts
@@ -341,6 +341,112 @@ describe("run-home sweeper", () => {
       const stat = await fs.stat(runHomeDir).catch(() => null);
       expect(stat).not.toBeNull();
     });
+
+    it("rejects a configured grace window shorter than the required 24 hours", async () => {
+      await expect(sweep({ companyDir, dryRun: true, graceHours: 23 })).rejects.toThrow(
+        "graceHours must be at least 24",
+      );
+    });
+  });
+
+  describe("filesystem containment", () => {
+    it("does not follow a symlinked agents root", async () => {
+      const externalCompanyDir = await makeTempRoot();
+      try {
+        const { runHomeDir } = await buildRunHome({
+          companyDir: externalCompanyDir,
+          agentId: "external-agent",
+          runId: "run-external-root",
+          ageHours: 30,
+          withRetained: true,
+        });
+        await fs.mkdir(path.join(companyDir, "acp-engine"), { recursive: true });
+        await fs.symlink(
+          path.join(externalCompanyDir, "acp-engine", "agents"),
+          path.join(companyDir, "acp-engine", "agents"),
+          "dir",
+        );
+
+        const result = await sweep({ companyDir, dryRun: false, graceHours: 24 });
+
+        expect(result.scanned).toBe(0);
+        await expect(fs.stat(runHomeDir)).resolves.toBeDefined();
+      } finally {
+        await fs.rm(externalCompanyDir, { recursive: true, force: true });
+      }
+    });
+
+    it("does not follow a symlinked agent directory", async () => {
+      const externalCompanyDir = await makeTempRoot();
+      try {
+        const { runHomeDir } = await buildRunHome({
+          companyDir: externalCompanyDir,
+          agentId: "external-agent",
+          runId: "run-external",
+          ageHours: 30,
+          withRetained: true,
+        });
+        const agentsDir = path.join(companyDir, "acp-engine", "agents");
+        await fs.mkdir(agentsDir, { recursive: true });
+        await fs.symlink(
+          path.join(externalCompanyDir, "acp-engine", "agents", "external-agent"),
+          path.join(agentsDir, "linked-agent"),
+          "dir",
+        );
+
+        const result = await sweep({ companyDir, dryRun: false, graceHours: 24 });
+
+        expect(result.scanned).toBe(0);
+        await expect(fs.stat(runHomeDir)).resolves.toBeDefined();
+      } finally {
+        await fs.rm(externalCompanyDir, { recursive: true, force: true });
+      }
+    });
+
+    it("marks a symlinked run home ineligible without touching its target", async () => {
+      const agentDir = path.join(companyDir, "acp-engine", "agents", "agent-1");
+      const runDir = path.join(agentDir, "codex-run-homes", "run-linked-home");
+      const externalHome = path.join(companyDir, "external-home");
+      await fs.mkdir(runDir, { recursive: true });
+      await fs.mkdir(externalHome, { recursive: true });
+      await fs.writeFile(path.join(externalHome, "sentinel"), "keep", "utf8");
+      await fs.symlink(externalHome, path.join(runDir, "home"), "dir");
+
+      const result = await sweep({ companyDir, dryRun: false, graceHours: 24 });
+
+      expect(result.entries[0]).toMatchObject({
+        eligible: false,
+        ineligibleReason: "run home is not a real directory",
+      });
+      await expect(fs.readFile(path.join(externalHome, "sentinel"), "utf8")).resolves.toBe("keep");
+    });
+
+    it("does not accept retention proof through a symlinked retention root", async () => {
+      const runId = "run-linked-retention-root";
+      const { runHomeDir } = await buildRunHome({
+        companyDir,
+        agentId: "agent-1",
+        runId,
+        ageHours: 30,
+      });
+      const agentDir = path.join(companyDir, "acp-engine", "agents", "agent-1");
+      const externalRetention = path.join(companyDir, "external-retention-root");
+      await fs.mkdir(path.join(externalRetention, runId), { recursive: true });
+      await fs.writeFile(
+        path.join(externalRetention, runId, "session.jsonl"),
+        '{"type":"session"}\n',
+        "utf8",
+      );
+      await fs.symlink(externalRetention, path.join(agentDir, "codex-session-retention"), "dir");
+
+      const result = await sweep({ companyDir, dryRun: false, graceHours: 24 });
+
+      expect(result.entries[0]).toMatchObject({
+        eligible: false,
+        ineligibleReason: "retention root is not a real directory",
+      });
+      await expect(fs.stat(runHomeDir)).resolves.toBeDefined();
+    });
   });
 
   describe("multi-agent scanning", () => {

--- a/packages/adapter-utils/src/acpx-engine/run-home-sweeper.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/run-home-sweeper.test.ts
@@ -174,13 +174,13 @@ describe("run-home sweeper", () => {
       expect(entry!.deleted).toBe(true);
     });
 
-    it("accepts a quarantine marker in lieu of a retained session (QUARANTINE path)", async () => {
+    it("does not treat quarantine as permission to delete the only raw copy", async () => {
       const { runHomeDir } = await buildRunHome({
         companyDir,
         agentId: "agent-1",
         runId: "run-quarantined",
         ageHours: 30,
-        withQuarantine: true, // no retained dir, but QUARANTINE marker present
+        withQuarantine: true,
       });
 
       const result = await sweep({
@@ -191,18 +191,18 @@ describe("run-home sweeper", () => {
 
       const entry = result.entries.find((e) => e.runId === "run-quarantined");
       expect(entry).toBeDefined();
-      expect(entry!.eligible).toBe(true);
-      expect(entry!.deleted).toBe(true);
+      expect(entry!.eligible).toBe(false);
+      expect(entry!.ineligibleReason).toMatch(/quarantined.*no retained session/i);
       const stat = await fs.stat(runHomeDir).catch(() => null);
-      expect(stat).toBeNull();
+      expect(stat).not.toBeNull();
       await expect(
         fs.stat(path.join(path.dirname(path.dirname(runHomeDir)), "run-quarantined.quarantine")),
-      ).rejects.toThrow();
+      ).resolves.toBeDefined();
     });
   });
 
   describe("active/ambiguous home exclusion (AC2c)", () => {
-    it("excludes a run home that has no retained session and no QUARANTINE marker", async () => {
+    it("excludes a run home that has no retained session and no quarantine marker", async () => {
       const { runHomeDir } = await buildRunHome({
         companyDir,
         agentId: "agent-1",
@@ -220,7 +220,7 @@ describe("run-home sweeper", () => {
       const entry = result.entries.find((e) => e.runId === "run-no-retention");
       expect(entry).toBeDefined();
       expect(entry!.eligible).toBe(false);
-      expect(entry!.ineligibleReason).toMatch(/retained|QUARANTINE/i);
+      expect(entry!.ineligibleReason).toMatch(/retained/i);
 
       // Must not be deleted
       const stat = await fs.stat(runHomeDir).catch(() => null);

--- a/packages/adapter-utils/src/acpx-engine/run-home-sweeper.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/run-home-sweeper.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Tests for the orphan run-home sweeper (KEWL-3852).
+ *
+ * Covers:
+ *   AC2a — dry-run produces an auditable manifest without deleting
+ *   AC2b — real-delete removes eligible homes
+ *   AC2c — active/ambiguous run homes are excluded (no retention, no quarantine)
+ *   AC2d — homes within the grace window are excluded
+ */
+
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { sweepRunHomes } from "./run-home-sweeper.js";
+
+async function makeTempRoot(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "paperclip-sweeper-test-"));
+}
+
+/**
+ * Build a minimal company-dir fixture:
+ *   <companyDir>/acp-engine/agents/<agentId>/codex-run-homes/<runId>/home/
+ *   <companyDir>/acp-engine/agents/<agentId>/codex-session-retention/<runId>/  (optional)
+ *
+ * The mtime of the run-home dir is backdated by `ageHours` hours.
+ */
+async function buildRunHome(opts: {
+  companyDir: string;
+  agentId: string;
+  runId: string;
+  ageHours: number;
+  withRetained?: boolean;
+  withQuarantine?: boolean;
+}): Promise<{ runHomeDir: string; retentionDir: string }> {
+  const agentDir = path.join(opts.companyDir, "acp-engine", "agents", opts.agentId);
+  const runHomeParent = path.join(agentDir, "codex-run-homes", opts.runId);
+  const runHomeDir = path.join(runHomeParent, "home");
+
+  await fs.mkdir(runHomeDir, { recursive: true });
+  await fs.writeFile(path.join(runHomeDir, "sessions"), "dummy", "utf8");
+
+  // Backdate mtime by ageHours
+  const now = Date.now();
+  const mtime = new Date(now - opts.ageHours * 60 * 60 * 1000);
+  await fs.utimes(runHomeDir, mtime, mtime);
+  await fs.utimes(runHomeParent, mtime, mtime);
+
+  const retentionDir = path.join(agentDir, "codex-session-retention", opts.runId);
+
+  if (opts.withRetained) {
+    await fs.mkdir(retentionDir, { recursive: true });
+    await fs.writeFile(path.join(retentionDir, "sessions.jsonl"), "", "utf8");
+  }
+
+  if (opts.withQuarantine) {
+    await fs.writeFile(path.join(runHomeParent, "QUARANTINE"), "", "utf8");
+  }
+
+  return { runHomeDir, retentionDir };
+}
+
+describe("run-home sweeper", () => {
+  let companyDir: string;
+
+  beforeEach(async () => {
+    companyDir = await makeTempRoot();
+  });
+
+  afterEach(async () => {
+    await fs.rm(companyDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  describe("dry-run mode (AC2a)", () => {
+    it("produces a JSON manifest listing eligible homes without deleting anything", async () => {
+      const { runHomeDir } = await buildRunHome({
+        companyDir,
+        agentId: "agent-1",
+        runId: "run-old-1",
+        ageHours: 26,
+        withRetained: true,
+      });
+
+      const result = await sweepRunHomes({
+        companyDir,
+        dryRun: true,
+        graceHours: 24,
+      });
+
+      expect(result.scanned).toBeGreaterThanOrEqual(1);
+      expect(result.eligible).toBeGreaterThanOrEqual(1);
+      // Dry run: nothing deleted
+      expect(result.deleted).toBe(0);
+      expect(result.errors).toBe(0);
+
+      // The run-home directory must still exist (dry-run must not delete)
+      const stat = await fs.stat(runHomeDir).catch(() => null);
+      expect(stat).not.toBeNull();
+
+      // Manifest has an entry for our run
+      const entry = result.entries.find((e) => e.runId === "run-old-1");
+      expect(entry).toBeDefined();
+      expect(entry!.eligible).toBe(true);
+      expect(entry!.deleted).toBeUndefined();
+    });
+
+    it("marks ineligible homes in the manifest with a reason", async () => {
+      // Home within grace window (only 1 hour old)
+      await buildRunHome({
+        companyDir,
+        agentId: "agent-1",
+        runId: "run-fresh",
+        ageHours: 1,
+        withRetained: true,
+      });
+
+      const result = await sweepRunHomes({
+        companyDir,
+        dryRun: true,
+        graceHours: 24,
+      });
+
+      const entry = result.entries.find((e) => e.runId === "run-fresh");
+      expect(entry).toBeDefined();
+      expect(entry!.eligible).toBe(false);
+      expect(entry!.ineligibleReason).toMatch(/grace/i);
+    });
+  });
+
+  describe("real-delete mode (AC2b)", () => {
+    it("deletes eligible run homes and reports bytes reclaimed", async () => {
+      const { runHomeDir } = await buildRunHome({
+        companyDir,
+        agentId: "agent-1",
+        runId: "run-old-2",
+        ageHours: 30,
+        withRetained: true,
+      });
+
+      const result = await sweepRunHomes({
+        companyDir,
+        dryRun: false,
+        graceHours: 24,
+      });
+
+      expect(result.eligible).toBeGreaterThanOrEqual(1);
+      expect(result.deleted).toBeGreaterThanOrEqual(1);
+      expect(result.errors).toBe(0);
+
+      // The run-home must be gone
+      const stat = await fs.stat(runHomeDir).catch(() => null);
+      expect(stat).toBeNull();
+
+      const entry = result.entries.find((e) => e.runId === "run-old-2");
+      expect(entry!.deleted).toBe(true);
+    });
+
+    it("accepts a quarantine marker in lieu of a retained session (QUARANTINE path)", async () => {
+      const { runHomeDir } = await buildRunHome({
+        companyDir,
+        agentId: "agent-1",
+        runId: "run-quarantined",
+        ageHours: 30,
+        withQuarantine: true, // no retained dir, but QUARANTINE marker present
+      });
+
+      const result = await sweepRunHomes({
+        companyDir,
+        dryRun: false,
+        graceHours: 24,
+      });
+
+      const entry = result.entries.find((e) => e.runId === "run-quarantined");
+      expect(entry).toBeDefined();
+      expect(entry!.eligible).toBe(true);
+      expect(entry!.deleted).toBe(true);
+      const stat = await fs.stat(runHomeDir).catch(() => null);
+      expect(stat).toBeNull();
+    });
+  });
+
+  describe("active/ambiguous home exclusion (AC2c)", () => {
+    it("excludes a run home that has no retained session and no QUARANTINE marker", async () => {
+      const { runHomeDir } = await buildRunHome({
+        companyDir,
+        agentId: "agent-1",
+        runId: "run-no-retention",
+        ageHours: 48,
+        // no withRetained, no withQuarantine
+      });
+
+      const result = await sweepRunHomes({
+        companyDir,
+        dryRun: false,
+        graceHours: 24,
+      });
+
+      const entry = result.entries.find((e) => e.runId === "run-no-retention");
+      expect(entry).toBeDefined();
+      expect(entry!.eligible).toBe(false);
+      expect(entry!.ineligibleReason).toMatch(/retained|QUARANTINE/i);
+
+      // Must not be deleted
+      const stat = await fs.stat(runHomeDir).catch(() => null);
+      expect(stat).not.toBeNull();
+    });
+  });
+
+  describe("grace window exclusion (AC2d)", () => {
+    it("excludes a home whose mtime is within the grace window", async () => {
+      const { runHomeDir } = await buildRunHome({
+        companyDir,
+        agentId: "agent-1",
+        runId: "run-recent",
+        ageHours: 2, // well within 24h grace
+        withRetained: true,
+      });
+
+      const result = await sweepRunHomes({
+        companyDir,
+        dryRun: false,
+        graceHours: 24,
+      });
+
+      const entry = result.entries.find((e) => e.runId === "run-recent");
+      expect(entry).toBeDefined();
+      expect(entry!.eligible).toBe(false);
+      expect(entry!.ineligibleReason).toMatch(/grace/i);
+
+      // Must not be deleted
+      const stat = await fs.stat(runHomeDir).catch(() => null);
+      expect(stat).not.toBeNull();
+    });
+  });
+
+  describe("multi-agent scanning", () => {
+    it("scans all agent subdirectories and returns combined results", async () => {
+      await buildRunHome({ companyDir, agentId: "agent-a", runId: "run-1", ageHours: 30, withRetained: true });
+      await buildRunHome({ companyDir, agentId: "agent-b", runId: "run-2", ageHours: 30, withRetained: true });
+      // One ineligible (fresh)
+      await buildRunHome({ companyDir, agentId: "agent-a", runId: "run-3", ageHours: 1, withRetained: true });
+
+      const result = await sweepRunHomes({ companyDir, dryRun: true, graceHours: 24 });
+
+      expect(result.scanned).toBe(3);
+      expect(result.eligible).toBe(2);
+      expect(result.deleted).toBe(0); // dry-run
+    });
+  });
+});

--- a/packages/adapter-utils/src/acpx-engine/run-home-sweeper.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/run-home-sweeper.test.ts
@@ -18,6 +18,25 @@ async function makeTempRoot(): Promise<string> {
   return fs.mkdtemp(path.join(os.tmpdir(), "paperclip-sweeper-test-"));
 }
 
+const terminalAndClosedDeps = {
+  checkOpenHandles: async () => ({ ok: true as const, hasOpenHandles: false }),
+  getRunStatus: async () => ({ ok: true as const, status: "succeeded" }),
+};
+
+async function sweep(
+  opts: { companyDir: string; dryRun: boolean; graceHours: number },
+  deps: NonNullable<Parameters<typeof sweepRunHomes>[1]> = terminalAndClosedDeps,
+) {
+  return sweepRunHomes(
+    {
+      ...opts,
+      paperclipApiBase: "http://paperclip.test",
+      paperclipApiKey: "test-key",
+    },
+    deps,
+  );
+}
+
 /**
  * Build a minimal company-dir fixture:
  *   <companyDir>/acp-engine/agents/<agentId>/codex-run-homes/<runId>/home/
@@ -54,7 +73,7 @@ async function buildRunHome(opts: {
   }
 
   if (opts.withQuarantine) {
-    await fs.writeFile(path.join(runHomeParent, "QUARANTINE"), "", "utf8");
+    await fs.writeFile(path.join(path.dirname(runHomeParent), `${opts.runId}.quarantine`), "", "utf8");
   }
 
   return { runHomeDir, retentionDir };
@@ -81,7 +100,7 @@ describe("run-home sweeper", () => {
         withRetained: true,
       });
 
-      const result = await sweepRunHomes({
+      const result = await sweep({
         companyDir,
         dryRun: true,
         graceHours: 24,
@@ -114,7 +133,7 @@ describe("run-home sweeper", () => {
         withRetained: true,
       });
 
-      const result = await sweepRunHomes({
+      const result = await sweep({
         companyDir,
         dryRun: true,
         graceHours: 24,
@@ -137,7 +156,7 @@ describe("run-home sweeper", () => {
         withRetained: true,
       });
 
-      const result = await sweepRunHomes({
+      const result = await sweep({
         companyDir,
         dryRun: false,
         graceHours: 24,
@@ -164,7 +183,7 @@ describe("run-home sweeper", () => {
         withQuarantine: true, // no retained dir, but QUARANTINE marker present
       });
 
-      const result = await sweepRunHomes({
+      const result = await sweep({
         companyDir,
         dryRun: false,
         graceHours: 24,
@@ -176,6 +195,9 @@ describe("run-home sweeper", () => {
       expect(entry!.deleted).toBe(true);
       const stat = await fs.stat(runHomeDir).catch(() => null);
       expect(stat).toBeNull();
+      await expect(
+        fs.stat(path.join(path.dirname(path.dirname(runHomeDir)), "run-quarantined.quarantine")),
+      ).rejects.toThrow();
     });
   });
 
@@ -189,7 +211,7 @@ describe("run-home sweeper", () => {
         // no withRetained, no withQuarantine
       });
 
-      const result = await sweepRunHomes({
+      const result = await sweep({
         companyDir,
         dryRun: false,
         graceHours: 24,
@@ -216,7 +238,7 @@ describe("run-home sweeper", () => {
         withRetained: true,
       });
 
-      const result = await sweepRunHomes({
+      const result = await sweep({
         companyDir,
         dryRun: false,
         graceHours: 24,
@@ -240,11 +262,95 @@ describe("run-home sweeper", () => {
       // One ineligible (fresh)
       await buildRunHome({ companyDir, agentId: "agent-a", runId: "run-3", ageHours: 1, withRetained: true });
 
-      const result = await sweepRunHomes({ companyDir, dryRun: true, graceHours: 24 });
+      const result = await sweep({ companyDir, dryRun: true, graceHours: 24 });
 
       expect(result.scanned).toBe(3);
       expect(result.eligible).toBe(2);
       expect(result.deleted).toBe(0); // dry-run
+    });
+  });
+
+  describe("fail-closed deletion proof", () => {
+    it("rejects deletion when Paperclip API configuration is absent", async () => {
+      const { runHomeDir } = await buildRunHome({
+        companyDir,
+        agentId: "agent-1",
+        runId: "run-no-api",
+        ageHours: 30,
+        withRetained: true,
+      });
+
+      const result = await sweepRunHomes({ companyDir, dryRun: false, graceHours: 24 });
+
+      expect(result.eligible).toBe(0);
+      expect(result.entries[0]?.ineligibleReason).toMatch(/API URL and key are required/i);
+      await expect(fs.stat(runHomeDir)).resolves.toBeDefined();
+    });
+
+    it("rejects deletion when terminal status cannot be verified", async () => {
+      const { runHomeDir } = await buildRunHome({
+        companyDir,
+        agentId: "agent-1",
+        runId: "run-status-error",
+        ageHours: 30,
+        withRetained: true,
+      });
+
+      const result = await sweep(
+        { companyDir, dryRun: false, graceHours: 24 },
+        {
+          ...terminalAndClosedDeps,
+          getRunStatus: async () => ({ ok: false as const, error: "HTTP 503" }),
+        },
+      );
+
+      expect(result.eligible).toBe(0);
+      expect(result.entries[0]?.ineligibleReason).toMatch(/could not be verified.*503/i);
+      await expect(fs.stat(runHomeDir)).resolves.toBeDefined();
+    });
+
+    it("rejects deletion when the run is not terminal", async () => {
+      const { runHomeDir } = await buildRunHome({
+        companyDir,
+        agentId: "agent-1",
+        runId: "run-active",
+        ageHours: 30,
+        withRetained: true,
+      });
+
+      const result = await sweep(
+        { companyDir, dryRun: false, graceHours: 24 },
+        {
+          ...terminalAndClosedDeps,
+          getRunStatus: async () => ({ ok: true as const, status: "running" }),
+        },
+      );
+
+      expect(result.eligible).toBe(0);
+      expect(result.entries[0]?.ineligibleReason).toMatch(/non-terminal/i);
+      await expect(fs.stat(runHomeDir)).resolves.toBeDefined();
+    });
+
+    it("rejects deletion when the open-handle check fails", async () => {
+      const { runHomeDir } = await buildRunHome({
+        companyDir,
+        agentId: "agent-1",
+        runId: "run-lsof-error",
+        ageHours: 30,
+        withRetained: true,
+      });
+
+      const result = await sweep(
+        { companyDir, dryRun: false, graceHours: 24 },
+        {
+          ...terminalAndClosedDeps,
+          checkOpenHandles: async () => ({ ok: false as const, error: "lsof unavailable" }),
+        },
+      );
+
+      expect(result.eligible).toBe(0);
+      expect(result.entries[0]?.ineligibleReason).toMatch(/open-handle check failed.*lsof unavailable/i);
+      await expect(fs.stat(runHomeDir)).resolves.toBeDefined();
     });
   });
 });

--- a/packages/adapter-utils/src/acpx-engine/run-home-sweeper.test.ts
+++ b/packages/adapter-utils/src/acpx-engine/run-home-sweeper.test.ts
@@ -69,7 +69,7 @@ async function buildRunHome(opts: {
 
   if (opts.withRetained) {
     await fs.mkdir(retentionDir, { recursive: true });
-    await fs.writeFile(path.join(retentionDir, "sessions.jsonl"), "", "utf8");
+    await fs.writeFile(path.join(retentionDir, "sessions.jsonl"), '{"type":"session"}\n', "utf8");
   }
 
   if (opts.withQuarantine) {
@@ -120,6 +120,7 @@ describe("run-home sweeper", () => {
       const entry = result.entries.find((e) => e.runId === "run-old-1");
       expect(entry).toBeDefined();
       expect(entry!.eligible).toBe(true);
+      expect(entry!.retentionProof).toBe("legacy_nonempty_jsonl");
       expect(entry!.deleted).toBeUndefined();
     });
 
@@ -198,6 +199,69 @@ describe("run-home sweeper", () => {
       await expect(
         fs.stat(path.join(path.dirname(path.dirname(runHomeDir)), "run-quarantined.quarantine")),
       ).resolves.toBeDefined();
+    });
+
+    it("rejects an empty retained-session directory", async () => {
+      const { runHomeDir, retentionDir } = await buildRunHome({
+        companyDir,
+        agentId: "agent-1",
+        runId: "run-empty-retention",
+        ageHours: 30,
+      });
+      await fs.mkdir(retentionDir, { recursive: true });
+
+      const result = await sweep({ companyDir, dryRun: false, graceHours: 24 });
+
+      expect(result.entries[0]?.eligible).toBe(false);
+      expect(result.entries[0]?.ineligibleReason).toMatch(/no completion manifest or non-empty JSONL/i);
+      await expect(fs.stat(runHomeDir)).resolves.toBeDefined();
+    });
+
+    it("rejects a symlinked retained-session counterpart", async () => {
+      const { runHomeDir, retentionDir } = await buildRunHome({
+        companyDir,
+        agentId: "agent-1",
+        runId: "run-symlink-retention",
+        ageHours: 30,
+      });
+      const externalDir = path.join(companyDir, "external-retention");
+      await fs.mkdir(externalDir, { recursive: true });
+      await fs.writeFile(path.join(externalDir, "session.jsonl"), '{"type":"session"}\n', "utf8");
+      await fs.mkdir(path.dirname(retentionDir), { recursive: true });
+      await fs.symlink(externalDir, retentionDir, "dir");
+
+      const result = await sweep({ companyDir, dryRun: false, graceHours: 24 });
+
+      expect(result.entries[0]?.eligible).toBe(false);
+      expect(result.entries[0]?.ineligibleReason).toMatch(/not a real directory/i);
+      await expect(fs.stat(runHomeDir)).resolves.toBeDefined();
+    });
+
+    it("accepts a valid zero-session completion manifest", async () => {
+      const runId = "run-zero-session-manifest";
+      const { runHomeDir, retentionDir } = await buildRunHome({
+        companyDir,
+        agentId: "agent-1",
+        runId,
+        ageHours: 30,
+      });
+      await fs.mkdir(path.join(retentionDir, "sessions"), { recursive: true });
+      await fs.writeFile(path.join(retentionDir, "retention-complete.json"), JSON.stringify({
+        schemaVersion: 1,
+        status: "complete",
+        runId,
+        sessionFileCount: 0,
+        sessionFiles: [],
+      }), "utf8");
+
+      const result = await sweep({ companyDir, dryRun: false, graceHours: 24 });
+
+      expect(result.entries[0]).toMatchObject({
+        eligible: true,
+        deleted: true,
+        retentionProof: "completion_manifest",
+      });
+      await expect(fs.stat(runHomeDir)).rejects.toThrow();
     });
   });
 

--- a/packages/adapter-utils/src/acpx-engine/run-home-sweeper.ts
+++ b/packages/adapter-utils/src/acpx-engine/run-home-sweeper.ts
@@ -1,0 +1,261 @@
+/**
+ * Orphan run-home sweeper (KEWL-3852).
+ *
+ * Codex run-homes under codex-run-homes/<runId>/home accumulate when Fix A has
+ * not yet deployed or when retention failure leaves a quarantine.  This sweeper
+ * identifies "orphan" homes that are safe to remove and deletes them after a
+ * conservative grace window.
+ *
+ * Safety invariants (all must hold for a home to be eligible):
+ *   1. The Paperclip run is terminal   (status: done|cancelled|failed|timed_out)
+ *   2. Zero open file handles on the directory tree   (lsof check)
+ *   3. mtime of the run-home dir is >=24h ago
+ *   4. A sanitized session counterpart exists under codex-session-retention/<runId>/
+ *      OR the run-home contains a file named QUARANTINE (explicit quarantine marker)
+ *
+ * Invariant 4 ensures we never silently discard a home whose session data was
+ * never retained — only homes where retention already succeeded (or was explicitly
+ * quarantined by the runtime) are swept.
+ *
+ * Dry-run mode (default) produces a JSON manifest without deleting anything.
+ * Pass --delete to actually remove eligible homes.
+ *
+ * Usage:
+ *   npx tsx packages/adapter-utils/src/acpx-engine/run-home-sweeper.ts \
+ *     --company-dir /path/to/companies/<companyId> \
+ *     [--delete] [--grace-hours 24]
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+interface SweeperOptions {
+  companyDir: string;
+  dryRun: boolean;
+  graceHours: number;
+  paperclipApiBase?: string;
+  paperclipApiKey?: string;
+}
+
+interface RunHomeEntry {
+  agentId: string;
+  runId: string;
+  runHomeDir: string;
+  ageSecs: number;
+  sizeBytes?: number;
+  eligible: boolean;
+  ineligibleReason?: string;
+  deleted?: boolean;
+  error?: string;
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  return fs.access(p).then(() => true, () => false);
+}
+
+async function hasOpenHandles(dir: string): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync("/usr/sbin/lsof", ["-n", "+D", dir], { timeout: 10_000 });
+    return stdout.trim().length > 0;
+  } catch {
+    // lsof exits non-zero when no files are found — that means no open handles
+    return false;
+  }
+}
+
+async function getRunStatus(
+  runId: string,
+  apiBase: string,
+  apiKey: string,
+): Promise<string | null> {
+  try {
+    const { default: fetch } = await import("node-fetch");
+    const url = `${apiBase}/api/runs/${runId}`;
+    const res = await (fetch as Function)(url, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(8_000),
+    });
+    if (!res.ok) return null;
+    const body = await (res as Response).json() as { status?: string };
+    return body?.status ?? null;
+  } catch {
+    return null;
+  }
+}
+
+const TERMINAL_STATUSES = new Set(["done", "cancelled", "failed", "timed_out", "error"]);
+
+async function dirSizeBytes(dir: string): Promise<number> {
+  try {
+    const { stdout } = await execFileAsync("du", ["-sk", dir], { timeout: 30_000 });
+    const kb = parseInt(stdout.split("\t")[0] ?? "0", 10);
+    return kb * 1024;
+  } catch {
+    return 0;
+  }
+}
+
+async function sweepAgentDir(
+  agentDir: string,
+  agentId: string,
+  opts: SweeperOptions,
+): Promise<RunHomeEntry[]> {
+  const runHomesParent = path.join(agentDir, "codex-run-homes");
+  if (!(await pathExists(runHomesParent))) return [];
+
+  const retentionParent = path.join(agentDir, "codex-session-retention");
+  const entries: RunHomeEntry[] = [];
+  const now = Date.now();
+  const graceMs = opts.graceHours * 60 * 60 * 1000;
+
+  let runIds: string[];
+  try {
+    runIds = await fs.readdir(runHomesParent);
+  } catch {
+    return [];
+  }
+
+  for (const runId of runIds) {
+    const runDir = path.join(runHomesParent, runId);
+    const runHomeDir = path.join(runDir, "home");
+
+    let stat: Awaited<ReturnType<typeof fs.stat>>;
+    try {
+      stat = await fs.stat(runHomeDir);
+    } catch {
+      // home subdir missing — stale or already cleaned; remove the wrapper dir
+      await fs.rm(runDir, { recursive: true, force: true }).catch(() => {});
+      continue;
+    }
+
+    const ageSecs = (now - stat.mtimeMs) / 1000;
+    const entry: RunHomeEntry = { agentId, runId, runHomeDir, ageSecs, eligible: false };
+
+    // Grace window
+    if (stat.mtimeMs > now - graceMs) {
+      entry.ineligibleReason = `mtime within ${opts.graceHours}h grace window`;
+      entries.push(entry);
+      continue;
+    }
+
+    // Open handles
+    if (await hasOpenHandles(runHomeDir)) {
+      entry.ineligibleReason = "open file handles detected";
+      entries.push(entry);
+      continue;
+    }
+
+    // Retained session counterpart or explicit quarantine marker
+    const retainedDir = path.join(retentionParent, runId);
+    const quarantineMarker = path.join(runDir, "QUARANTINE");
+    const hasRetained = await pathExists(retainedDir);
+    const hasQuarantine = await pathExists(quarantineMarker);
+
+    if (!hasRetained && !hasQuarantine) {
+      entry.ineligibleReason = "no retained session counterpart and no QUARANTINE marker";
+      entries.push(entry);
+      continue;
+    }
+
+    // Paperclip run status (if API available)
+    if (opts.paperclipApiBase && opts.paperclipApiKey) {
+      const status = await getRunStatus(runId, opts.paperclipApiBase, opts.paperclipApiKey);
+      if (status !== null && !TERMINAL_STATUSES.has(status)) {
+        entry.ineligibleReason = `run status is "${status}" (non-terminal)`;
+        entries.push(entry);
+        continue;
+      }
+    }
+
+    entry.eligible = true;
+    entry.sizeBytes = await dirSizeBytes(runDir);
+
+    if (!opts.dryRun) {
+      try {
+        await fs.rm(runDir, { recursive: true, force: true });
+        entry.deleted = true;
+      } catch (err) {
+        entry.deleted = false;
+        entry.error = err instanceof Error ? err.message : String(err);
+      }
+    }
+
+    entries.push(entry);
+  }
+
+  return entries;
+}
+
+export async function sweepRunHomes(opts: SweeperOptions): Promise<{
+  scanned: number;
+  eligible: number;
+  deleted: number;
+  errors: number;
+  totalBytesReclaimed: number;
+  entries: RunHomeEntry[];
+}> {
+  const agentsDir = path.join(opts.companyDir, "acp-engine", "agents");
+  if (!(await pathExists(agentsDir))) {
+    return { scanned: 0, eligible: 0, deleted: 0, errors: 0, totalBytesReclaimed: 0, entries: [] };
+  }
+
+  const agentIds = await fs.readdir(agentsDir).catch(() => [] as string[]);
+  const allEntries: RunHomeEntry[] = [];
+
+  for (const agentId of agentIds) {
+    const agentDir = path.join(agentsDir, agentId);
+    const agentEntries = await sweepAgentDir(agentDir, agentId, opts);
+    allEntries.push(...agentEntries);
+  }
+
+  const eligible = allEntries.filter((e) => e.eligible);
+  const deleted = eligible.filter((e) => e.deleted === true);
+  const errors = eligible.filter((e) => e.deleted === false);
+  const totalBytesReclaimed = deleted.reduce((sum, e) => sum + (e.sizeBytes ?? 0), 0);
+
+  return {
+    scanned: allEntries.length,
+    eligible: eligible.length,
+    deleted: deleted.length,
+    errors: errors.length,
+    totalBytesReclaimed,
+    entries: allEntries,
+  };
+}
+
+// CLI entrypoint
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const args = process.argv.slice(2);
+  const companyDir = args[args.indexOf("--company-dir") + 1];
+  const dryRun = !args.includes("--delete");
+  const graceIdx = args.indexOf("--grace-hours");
+  const graceHours = graceIdx >= 0 ? parseInt(args[graceIdx + 1] ?? "24", 10) : 24;
+
+  if (!companyDir) {
+    process.stderr.write("Usage: run-home-sweeper.ts --company-dir <path> [--delete] [--grace-hours N]\n");
+    process.exit(1);
+  }
+
+  sweepRunHomes({
+    companyDir,
+    dryRun,
+    graceHours,
+    paperclipApiBase: process.env["PAPERCLIP_API_BASE"],
+    paperclipApiKey: process.env["PAPERCLIP_API_KEY"],
+  })
+    .then((result) => {
+      process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+      const verb = dryRun ? "DRY-RUN" : "DELETED";
+      process.stderr.write(
+        `[sweeper] ${verb}: scanned=${result.scanned} eligible=${result.eligible} deleted=${result.deleted} errors=${result.errors} reclaimed=${(result.totalBytesReclaimed / 1024 / 1024).toFixed(1)}MB\n`,
+      );
+    })
+    .catch((err) => {
+      process.stderr.write(`[sweeper] fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+      process.exit(1);
+    });
+}

--- a/packages/adapter-utils/src/acpx-engine/run-home-sweeper.ts
+++ b/packages/adapter-utils/src/acpx-engine/run-home-sweeper.ts
@@ -10,7 +10,8 @@
  *   1. The Paperclip heartbeat run is terminal
  *   2. Zero open file handles on the directory tree   (lsof check)
  *   3. mtime of the run-home dir is >=24h ago
- *   4. A sanitized session counterpart exists under codex-session-retention/<runId>/
+ *   4. A sanitized session counterpart has a valid completion manifest, or a
+ *      legacy counterpart contains a non-empty JSONL artifact
  *
  * Invariant 4 ensures we never silently discard a home whose session data was
  * never retained. A sibling <runId>.quarantine marker records retention failure,
@@ -47,10 +48,18 @@ interface RunHomeEntry {
   ageSecs: number;
   sizeBytes?: number;
   eligible: boolean;
+  retentionProof?: "completion_manifest" | "legacy_nonempty_jsonl";
+  quarantined?: boolean;
   ineligibleReason?: string;
   deleted?: boolean;
   error?: string;
 }
+
+const RETENTION_MANIFEST_NAME = "retention-complete.json";
+
+type RetentionProofCheck =
+  | { ok: true; proof: "completion_manifest" | "legacy_nonempty_jsonl" }
+  | { ok: false; error: string };
 
 type OpenHandleCheck =
   | { ok: true; hasOpenHandles: boolean }
@@ -67,6 +76,120 @@ interface SweeperDependencies {
 
 async function pathExists(p: string): Promise<boolean> {
   return fs.access(p).then(() => true, () => false);
+}
+
+function isPathBelow(root: string, candidate: string): boolean {
+  const resolvedRoot = path.resolve(root);
+  const resolvedCandidate = path.resolve(candidate);
+  return resolvedCandidate.startsWith(`${resolvedRoot}${path.sep}`);
+}
+
+async function findLegacyRetainedJsonl(root: string, dir = root): Promise<boolean> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const candidate = path.join(dir, entry.name);
+    if (!isPathBelow(root, candidate) || entry.isSymbolicLink()) continue;
+    if (entry.isDirectory()) {
+      if (await findLegacyRetainedJsonl(root, candidate)) return true;
+      continue;
+    }
+    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) continue;
+    const stat = await fs.lstat(candidate);
+    if (stat.isFile() && !stat.isSymbolicLink() && stat.size > 0) return true;
+  }
+  return false;
+}
+
+async function validateRetentionProof(
+  retentionParent: string,
+  runId: string,
+): Promise<RetentionProofCheck> {
+  const retainedDir = path.resolve(retentionParent, runId);
+  if (!isPathBelow(retentionParent, retainedDir)) {
+    return { ok: false, error: "retained-session path escaped the retention root" };
+  }
+
+  let retainedStat: Awaited<ReturnType<typeof fs.lstat>>;
+  try {
+    retainedStat = await fs.lstat(retainedDir);
+  } catch (err) {
+    return {
+      ok: false,
+      error: isErrnoException(err, "ENOENT")
+        ? "no retained session counterpart"
+        : `retained-session counterpart could not be inspected: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  if (!retainedStat.isDirectory() || retainedStat.isSymbolicLink()) {
+    return { ok: false, error: "retained-session counterpart is not a real directory" };
+  }
+
+  const manifestPath = path.join(retainedDir, RETENTION_MANIFEST_NAME);
+  try {
+    const manifestStat = await fs.lstat(manifestPath);
+    if (!manifestStat.isFile() || manifestStat.isSymbolicLink()) {
+      return { ok: false, error: "retention completion manifest is not a real file" };
+    }
+    const manifest = JSON.parse(await fs.readFile(manifestPath, "utf8")) as {
+      schemaVersion?: unknown;
+      status?: unknown;
+      runId?: unknown;
+      sessionFileCount?: unknown;
+      sessionFiles?: unknown;
+    };
+    if (
+      manifest.schemaVersion !== 1 ||
+      manifest.status !== "complete" ||
+      manifest.runId !== runId ||
+      !Number.isInteger(manifest.sessionFileCount) ||
+      (manifest.sessionFileCount as number) < 0 ||
+      !Array.isArray(manifest.sessionFiles) ||
+      manifest.sessionFiles.length !== manifest.sessionFileCount
+    ) {
+      return { ok: false, error: "retention completion manifest is invalid" };
+    }
+    const sessionsDir = path.join(retainedDir, "sessions");
+    for (const relativePath of manifest.sessionFiles) {
+      if (typeof relativePath !== "string" || relativePath.length === 0 || path.isAbsolute(relativePath)) {
+        return { ok: false, error: "retention completion manifest contains an unsafe session path" };
+      }
+      const artifact = path.resolve(sessionsDir, relativePath);
+      if (!isPathBelow(sessionsDir, artifact)) {
+        return { ok: false, error: "retention completion manifest contains an unsafe session path" };
+      }
+      const artifactStat = await fs.lstat(artifact);
+      if (!artifactStat.isFile() || artifactStat.isSymbolicLink()) {
+        return { ok: false, error: "retention completion manifest references a missing session artifact" };
+      }
+    }
+    return { ok: true, proof: "completion_manifest" };
+  } catch (err) {
+    if (!isErrnoException(err, "ENOENT")) {
+      return {
+        ok: false,
+        error: `retention completion manifest could not be validated: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }
+
+  try {
+    if (await findLegacyRetainedJsonl(retainedDir)) {
+      return { ok: true, proof: "legacy_nonempty_jsonl" };
+    }
+    return {
+      ok: false,
+      error: "retained-session counterpart has no completion manifest or non-empty JSONL artifact",
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      error: `legacy retained-session artifacts could not be inspected: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+function isErrnoException(err: unknown, code: string): err is NodeJS.ErrnoException {
+  return err instanceof Error && "code" in err && err.code === code;
 }
 
 async function checkOpenHandles(dir: string): Promise<OpenHandleCheck> {
@@ -203,20 +326,21 @@ async function sweepAgentDir(
 
     // A retained session counterpart is mandatory. Quarantine is evidence that
     // retention failed, so it must never substitute for a sanitized copy.
-    const retainedDir = path.join(retentionParent, runId);
     const quarantineMarker = path.join(runHomesParent, `${runId}.quarantine`);
-    const hasRetained = await pathExists(retainedDir);
     const hasQuarantine = await pathExists(quarantineMarker);
+    entry.quarantined = hasQuarantine;
+    const retentionProof = await validateRetentionProof(retentionParent, runId);
 
-    if (!hasRetained) {
+    if (!retentionProof.ok) {
       entry.ineligibleReason = hasQuarantine
-        ? "run home is quarantined and has no retained session counterpart"
-        : "no retained session counterpart";
+        ? `run home is quarantined; ${retentionProof.error}`
+        : retentionProof.error;
       entries.push(entry);
       continue;
     }
 
     entry.eligible = true;
+    entry.retentionProof = retentionProof.proof;
     entry.sizeBytes = await dirSizeBytes(runDir);
 
     if (!opts.dryRun) {

--- a/packages/adapter-utils/src/acpx-engine/run-home-sweeper.ts
+++ b/packages/adapter-utils/src/acpx-engine/run-home-sweeper.ts
@@ -11,7 +11,7 @@
  *   2. Zero open file handles on the directory tree   (lsof check)
  *   3. mtime of the run-home dir is >=24h ago
  *   4. A sanitized session counterpart exists under codex-session-retention/<runId>/
- *      OR the run-home contains a file named QUARANTINE (explicit quarantine marker)
+ *      OR codex-run-homes contains a sibling <runId>.quarantine marker
  *
  * Invariant 4 ensures we never silently discard a home whose session data was
  * never retained — only homes where retention already succeeded (or was explicitly
@@ -53,17 +53,39 @@ interface RunHomeEntry {
   error?: string;
 }
 
+type OpenHandleCheck =
+  | { ok: true; hasOpenHandles: boolean }
+  | { ok: false; error: string };
+
+type RunStatusCheck =
+  | { ok: true; status: string }
+  | { ok: false; error: string };
+
+interface SweeperDependencies {
+  checkOpenHandles?: (dir: string) => Promise<OpenHandleCheck>;
+  getRunStatus?: (runId: string, apiBase: string, apiKey: string) => Promise<RunStatusCheck>;
+}
+
 async function pathExists(p: string): Promise<boolean> {
   return fs.access(p).then(() => true, () => false);
 }
 
-async function hasOpenHandles(dir: string): Promise<boolean> {
+async function checkOpenHandles(dir: string): Promise<OpenHandleCheck> {
   try {
     const { stdout } = await execFileAsync("/usr/sbin/lsof", ["-n", "+D", dir], { timeout: 10_000 });
-    return stdout.trim().length > 0;
-  } catch {
-    // lsof exits non-zero when no files are found — that means no open handles
-    return false;
+    return { ok: true, hasOpenHandles: stdout.trim().length > 0 };
+  } catch (err) {
+    const result = err as { code?: string | number; stdout?: string; stderr?: string };
+    // lsof uses exit code 1 with no output when it found no matching handles.
+    // Missing binaries, permission errors, timeouts, and diagnostic output are
+    // not proof of safety and must block deletion.
+    if (result.code === 1 && !(result.stdout ?? "").trim() && !(result.stderr ?? "").trim()) {
+      return { ok: true, hasOpenHandles: false };
+    }
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
   }
 }
 
@@ -71,23 +93,26 @@ async function getRunStatus(
   runId: string,
   apiBase: string,
   apiKey: string,
-): Promise<string | null> {
+): Promise<RunStatusCheck> {
   try {
-    const { default: fetch } = await import("node-fetch");
-    const url = `${apiBase}/api/runs/${runId}`;
-    const res = await (fetch as Function)(url, {
+    const normalizedBase = apiBase.replace(/\/+$/, "").replace(/\/api$/, "");
+    const url = `${normalizedBase}/api/heartbeat-runs/${encodeURIComponent(runId)}`;
+    const res = await fetch(url, {
       headers: { Authorization: `Bearer ${apiKey}` },
       signal: AbortSignal.timeout(8_000),
     });
-    if (!res.ok) return null;
-    const body = await (res as Response).json() as { status?: string };
-    return body?.status ?? null;
-  } catch {
-    return null;
+    if (!res.ok) return { ok: false, error: `run-status lookup returned HTTP ${res.status}` };
+    const body = await res.json() as { status?: string };
+    if (typeof body?.status !== "string" || body.status.length === 0) {
+      return { ok: false, error: "run-status lookup returned no status" };
+    }
+    return { ok: true, status: body.status };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
   }
 }
 
-const TERMINAL_STATUSES = new Set(["done", "cancelled", "failed", "timed_out", "error"]);
+const TERMINAL_STATUSES = new Set(["succeeded", "interrupted", "cancelled", "failed", "timed_out"]);
 
 async function dirSizeBytes(dir: string): Promise<number> {
   try {
@@ -103,6 +128,7 @@ async function sweepAgentDir(
   agentDir: string,
   agentId: string,
   opts: SweeperOptions,
+  deps: SweeperDependencies,
 ): Promise<RunHomeEntry[]> {
   const runHomesParent = path.join(agentDir, "codex-run-homes");
   if (!(await pathExists(runHomesParent))) return [];
@@ -142,8 +168,35 @@ async function sweepAgentDir(
       continue;
     }
 
-    // Open handles
-    if (await hasOpenHandles(runHomeDir)) {
+    if (!opts.paperclipApiBase || !opts.paperclipApiKey) {
+      entry.ineligibleReason = "Paperclip API URL and key are required to verify terminal run status";
+      entries.push(entry);
+      continue;
+    }
+
+    const statusCheck = await (deps.getRunStatus ?? getRunStatus)(
+      runId,
+      opts.paperclipApiBase,
+      opts.paperclipApiKey,
+    );
+    if (!statusCheck.ok) {
+      entry.ineligibleReason = `terminal run status could not be verified: ${statusCheck.error}`;
+      entries.push(entry);
+      continue;
+    }
+    if (!TERMINAL_STATUSES.has(statusCheck.status)) {
+      entry.ineligibleReason = `run status is "${statusCheck.status}" (non-terminal)`;
+      entries.push(entry);
+      continue;
+    }
+
+    const handleCheck = await (deps.checkOpenHandles ?? checkOpenHandles)(runHomeDir);
+    if (!handleCheck.ok) {
+      entry.ineligibleReason = `open-handle check failed: ${handleCheck.error}`;
+      entries.push(entry);
+      continue;
+    }
+    if (handleCheck.hasOpenHandles) {
       entry.ineligibleReason = "open file handles detected";
       entries.push(entry);
       continue;
@@ -151,24 +204,14 @@ async function sweepAgentDir(
 
     // Retained session counterpart or explicit quarantine marker
     const retainedDir = path.join(retentionParent, runId);
-    const quarantineMarker = path.join(runDir, "QUARANTINE");
+    const quarantineMarker = path.join(runHomesParent, `${runId}.quarantine`);
     const hasRetained = await pathExists(retainedDir);
     const hasQuarantine = await pathExists(quarantineMarker);
 
     if (!hasRetained && !hasQuarantine) {
-      entry.ineligibleReason = "no retained session counterpart and no QUARANTINE marker";
+      entry.ineligibleReason = "no retained session counterpart and no sibling quarantine marker";
       entries.push(entry);
       continue;
-    }
-
-    // Paperclip run status (if API available)
-    if (opts.paperclipApiBase && opts.paperclipApiKey) {
-      const status = await getRunStatus(runId, opts.paperclipApiBase, opts.paperclipApiKey);
-      if (status !== null && !TERMINAL_STATUSES.has(status)) {
-        entry.ineligibleReason = `run status is "${status}" (non-terminal)`;
-        entries.push(entry);
-        continue;
-      }
     }
 
     entry.eligible = true;
@@ -177,6 +220,7 @@ async function sweepAgentDir(
     if (!opts.dryRun) {
       try {
         await fs.rm(runDir, { recursive: true, force: true });
+        if (hasQuarantine) await fs.rm(quarantineMarker, { force: true });
         entry.deleted = true;
       } catch (err) {
         entry.deleted = false;
@@ -190,7 +234,7 @@ async function sweepAgentDir(
   return entries;
 }
 
-export async function sweepRunHomes(opts: SweeperOptions): Promise<{
+export async function sweepRunHomes(opts: SweeperOptions, deps: SweeperDependencies = {}): Promise<{
   scanned: number;
   eligible: number;
   deleted: number;
@@ -208,7 +252,7 @@ export async function sweepRunHomes(opts: SweeperOptions): Promise<{
 
   for (const agentId of agentIds) {
     const agentDir = path.join(agentsDir, agentId);
-    const agentEntries = await sweepAgentDir(agentDir, agentId, opts);
+    const agentEntries = await sweepAgentDir(agentDir, agentId, opts, deps);
     allEntries.push(...agentEntries);
   }
 
@@ -244,7 +288,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     companyDir,
     dryRun,
     graceHours,
-    paperclipApiBase: process.env["PAPERCLIP_API_BASE"],
+    paperclipApiBase: process.env["PAPERCLIP_API_URL"] ?? process.env["PAPERCLIP_API_BASE"],
     paperclipApiKey: process.env["PAPERCLIP_API_KEY"],
   })
     .then((result) => {

--- a/packages/adapter-utils/src/acpx-engine/run-home-sweeper.ts
+++ b/packages/adapter-utils/src/acpx-engine/run-home-sweeper.ts
@@ -166,6 +166,10 @@ async function validateRetentionProof(
       return { ok: false, error: "retention completion manifest is invalid" };
     }
     const sessionsDir = path.join(retainedDir, "sessions");
+    const sessionsDirStat = await fs.lstat(sessionsDir);
+    if (!sessionsDirStat.isDirectory() || sessionsDirStat.isSymbolicLink()) {
+      return { ok: false, error: "retained sessions path is not a real directory" };
+    }
     for (const relativePath of manifest.sessionFiles) {
       if (typeof relativePath !== "string" || relativePath.length === 0 || path.isAbsolute(relativePath)) {
         return { ok: false, error: "retention completion manifest contains an unsafe session path" };

--- a/packages/adapter-utils/src/acpx-engine/run-home-sweeper.ts
+++ b/packages/adapter-utils/src/acpx-engine/run-home-sweeper.ts
@@ -56,6 +56,7 @@ interface RunHomeEntry {
 }
 
 const RETENTION_MANIFEST_NAME = "retention-complete.json";
+const MINIMUM_GRACE_HOURS = 24;
 
 type RetentionProofCheck =
   | { ok: true; proof: "completion_manifest" | "legacy_nonempty_jsonl" }
@@ -104,6 +105,20 @@ async function validateRetentionProof(
   retentionParent: string,
   runId: string,
 ): Promise<RetentionProofCheck> {
+  let retentionParentStat: Awaited<ReturnType<typeof fs.lstat>>;
+  try {
+    retentionParentStat = await fs.lstat(retentionParent);
+  } catch (err) {
+    return {
+      ok: false,
+      error: isErrnoException(err, "ENOENT")
+        ? "no retained session counterpart"
+        : `retention root could not be inspected: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  if (!retentionParentStat.isDirectory() || retentionParentStat.isSymbolicLink()) {
+    return { ok: false, error: "retention root is not a real directory" };
+  }
   const retainedDir = path.resolve(retentionParent, runId);
   if (!isPathBelow(retentionParent, retainedDir)) {
     return { ok: false, error: "retained-session path escaped the retention root" };
@@ -251,11 +266,17 @@ async function dirSizeBytes(dir: string): Promise<number> {
 async function sweepAgentDir(
   agentDir: string,
   agentId: string,
+  agentsDir: string,
   opts: SweeperOptions,
   deps: SweeperDependencies,
 ): Promise<RunHomeEntry[]> {
+  if (!isPathBelow(agentsDir, agentDir)) return [];
+  const agentStat = await fs.lstat(agentDir).catch(() => null);
+  if (!agentStat?.isDirectory() || agentStat.isSymbolicLink()) return [];
+
   const runHomesParent = path.join(agentDir, "codex-run-homes");
-  if (!(await pathExists(runHomesParent))) return [];
+  const runHomesParentStat = await fs.lstat(runHomesParent).catch(() => null);
+  if (!runHomesParentStat?.isDirectory() || runHomesParentStat.isSymbolicLink()) return [];
 
   const retentionParent = path.join(agentDir, "codex-session-retention");
   const entries: RunHomeEntry[] = [];
@@ -273,12 +294,27 @@ async function sweepAgentDir(
     const runDir = path.join(runHomesParent, runId);
     const runHomeDir = path.join(runDir, "home");
 
-    let stat: Awaited<ReturnType<typeof fs.stat>>;
+    if (!isPathBelow(runHomesParent, runDir) || !isPathBelow(runDir, runHomeDir)) continue;
+    const runDirStat = await fs.lstat(runDir).catch(() => null);
+    if (!runDirStat?.isDirectory() || runDirStat.isSymbolicLink()) continue;
+
+    let stat: Awaited<ReturnType<typeof fs.lstat>>;
     try {
-      stat = await fs.stat(runHomeDir);
+      stat = await fs.lstat(runHomeDir);
     } catch {
       // The raw home is already gone. Remove the wrapper only when it is empty.
       await fs.rmdir(runDir).catch(() => {});
+      continue;
+    }
+    if (!stat.isDirectory() || stat.isSymbolicLink()) {
+      entries.push({
+        agentId,
+        runId,
+        runHomeDir,
+        ageSecs: (now - stat.mtimeMs) / 1000,
+        eligible: false,
+        ineligibleReason: "run home is not a real directory",
+      });
       continue;
     }
 
@@ -369,8 +405,12 @@ export async function sweepRunHomes(opts: SweeperOptions, deps: SweeperDependenc
   totalBytesReclaimed: number;
   entries: RunHomeEntry[];
 }> {
+  if (!Number.isFinite(opts.graceHours) || opts.graceHours < MINIMUM_GRACE_HOURS) {
+    throw new Error(`graceHours must be at least ${MINIMUM_GRACE_HOURS}`);
+  }
   const agentsDir = path.join(opts.companyDir, "acp-engine", "agents");
-  if (!(await pathExists(agentsDir))) {
+  const agentsDirStat = await fs.lstat(agentsDir).catch(() => null);
+  if (!agentsDirStat?.isDirectory() || agentsDirStat.isSymbolicLink()) {
     return { scanned: 0, eligible: 0, deleted: 0, errors: 0, totalBytesReclaimed: 0, entries: [] };
   }
 
@@ -379,7 +419,7 @@ export async function sweepRunHomes(opts: SweeperOptions, deps: SweeperDependenc
 
   for (const agentId of agentIds) {
     const agentDir = path.join(agentsDir, agentId);
-    const agentEntries = await sweepAgentDir(agentDir, agentId, opts, deps);
+    const agentEntries = await sweepAgentDir(agentDir, agentId, agentsDir, opts, deps);
     allEntries.push(...agentEntries);
   }
 

--- a/packages/adapter-utils/src/acpx-engine/run-home-sweeper.ts
+++ b/packages/adapter-utils/src/acpx-engine/run-home-sweeper.ts
@@ -125,8 +125,10 @@ async function validateRetentionProof(
   }
 
   const manifestPath = path.join(retainedDir, RETENTION_MANIFEST_NAME);
+  let manifestFound = false;
   try {
     const manifestStat = await fs.lstat(manifestPath);
+    manifestFound = true;
     if (!manifestStat.isFile() || manifestStat.isSymbolicLink()) {
       return { ok: false, error: "retention completion manifest is not a real file" };
     }
@@ -158,13 +160,13 @@ async function validateRetentionProof(
         return { ok: false, error: "retention completion manifest contains an unsafe session path" };
       }
       const artifactStat = await fs.lstat(artifact);
-      if (!artifactStat.isFile() || artifactStat.isSymbolicLink()) {
-        return { ok: false, error: "retention completion manifest references a missing session artifact" };
+      if (!artifactStat.isFile() || artifactStat.isSymbolicLink() || artifactStat.size === 0) {
+        return { ok: false, error: "retention completion manifest references an invalid session artifact" };
       }
     }
     return { ok: true, proof: "completion_manifest" };
   } catch (err) {
-    if (!isErrnoException(err, "ENOENT")) {
+    if (manifestFound || !isErrnoException(err, "ENOENT")) {
       return {
         ok: false,
         error: `retention completion manifest could not be validated: ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/adapter-utils/src/acpx-engine/run-home-sweeper.ts
+++ b/packages/adapter-utils/src/acpx-engine/run-home-sweeper.ts
@@ -7,15 +7,14 @@
  * conservative grace window.
  *
  * Safety invariants (all must hold for a home to be eligible):
- *   1. The Paperclip run is terminal   (status: done|cancelled|failed|timed_out)
+ *   1. The Paperclip heartbeat run is terminal
  *   2. Zero open file handles on the directory tree   (lsof check)
  *   3. mtime of the run-home dir is >=24h ago
  *   4. A sanitized session counterpart exists under codex-session-retention/<runId>/
- *      OR codex-run-homes contains a sibling <runId>.quarantine marker
  *
  * Invariant 4 ensures we never silently discard a home whose session data was
- * never retained — only homes where retention already succeeded (or was explicitly
- * quarantined by the runtime) are swept.
+ * never retained. A sibling <runId>.quarantine marker records retention failure,
+ * but does not authorize deletion of the only raw copy.
  *
  * Dry-run mode (default) produces a JSON manifest without deleting anything.
  * Pass --delete to actually remove eligible homes.
@@ -153,8 +152,8 @@ async function sweepAgentDir(
     try {
       stat = await fs.stat(runHomeDir);
     } catch {
-      // home subdir missing — stale or already cleaned; remove the wrapper dir
-      await fs.rm(runDir, { recursive: true, force: true }).catch(() => {});
+      // The raw home is already gone. Remove the wrapper only when it is empty.
+      await fs.rmdir(runDir).catch(() => {});
       continue;
     }
 
@@ -202,14 +201,17 @@ async function sweepAgentDir(
       continue;
     }
 
-    // Retained session counterpart or explicit quarantine marker
+    // A retained session counterpart is mandatory. Quarantine is evidence that
+    // retention failed, so it must never substitute for a sanitized copy.
     const retainedDir = path.join(retentionParent, runId);
     const quarantineMarker = path.join(runHomesParent, `${runId}.quarantine`);
     const hasRetained = await pathExists(retainedDir);
     const hasQuarantine = await pathExists(quarantineMarker);
 
-    if (!hasRetained && !hasQuarantine) {
-      entry.ineligibleReason = "no retained session counterpart and no sibling quarantine marker";
+    if (!hasRetained) {
+      entry.ineligibleReason = hasQuarantine
+        ? "run home is quarantined and has no retained session counterpart"
+        : "no retained session counterpart";
       entries.push(entry);
       continue;
     }
@@ -220,7 +222,6 @@ async function sweepAgentDir(
     if (!opts.dryRun) {
       try {
         await fs.rm(runDir, { recursive: true, force: true });
-        if (hasQuarantine) await fs.rm(quarantineMarker, { force: true });
         entry.deleted = true;
       } catch (err) {
         entry.deleted = false;

--- a/packages/adapter-utils/src/command-redaction.test.ts
+++ b/packages/adapter-utils/src/command-redaction.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   REDACTED_COMMAND_TEXT_VALUE,
+  redactCommandText,
   redactDiagnosticText,
 } from "./command-redaction.js";
 
@@ -91,5 +92,78 @@ second-line\" status=401`;
     const output = redactDiagnosticText(input);
     expect(output).not.toContain("MARKERBACKSLASH_B");
     expect(output).toContain(REDACTED_COMMAND_TEXT_VALUE);
+  });
+});
+
+const BOARD_TOKEN = `pcp_board_${"a1b2c3d4".repeat(6)}`;
+const CLI_AUTH_TOKEN = `pcp_cli_auth_${"f0e1d2c3".repeat(6)}`;
+
+describe("redactCommandText - Paperclip bearer credentials", () => {
+  it("redacts a bare board token with no surrounding secret-name hint", () => {
+    expect(redactCommandText(BOARD_TOKEN)).toBe(REDACTED_COMMAND_TEXT_VALUE);
+  });
+
+  it("redacts a board token inside a serialized header dump", () => {
+    expect(redactCommandText(`{"headers":{"x-api-key":"${BOARD_TOKEN}"}}`)).not.toContain(BOARD_TOKEN);
+  });
+
+  it("redacts a board token in a curl invocation", () => {
+    const output = redactCommandText(
+      `curl -sS -H 'x-api-key: ${BOARD_TOKEN}' http://localhost:3100/api/agents/me`,
+    );
+    expect(output).not.toContain(BOARD_TOKEN);
+  });
+
+  it("redacts CLI auth secrets", () => {
+    expect(redactCommandText(`stored credential ${CLI_AUTH_TOKEN} for localhost`)).not.toContain(CLI_AUTH_TOKEN);
+  });
+
+  it("covers future pcp credential prefixes generically", () => {
+    const future = `pcp_runner_${"0f1e2d3c".repeat(6)}`;
+    expect(redactCommandText(future)).not.toContain(future);
+  });
+
+  it("leaves non-credential pcp identifiers alone", () => {
+    const notASecret = "pcp_run_12";
+    expect(redactCommandText(notASecret)).toContain(notASecret);
+  });
+});
+
+describe("redactCommandText - Slack tokens", () => {
+  it("redacts bot tokens", () => {
+    const token = `xoxb-${"1234567890-9876543210-AbCdEfGhIjKlMnOpQrStUvWx"}`;
+    expect(redactCommandText(token)).not.toContain(token);
+  });
+
+  it("redacts app-level tokens", () => {
+    const token = `xapp-${"1-A012BCDEFGH-1234567890123-abcdef0123456789"}`;
+    expect(redactCommandText(token)).not.toContain(token);
+  });
+
+  it("redacts a bot token inside a postMessage command", () => {
+    const token = `xoxb-${"1111111111-2222222222-ZzYyXxWwVvUuTtSsRrQqPpOo"}`;
+    const output = redactCommandText(
+      `curl -X POST https://slack.com/api/chat.postMessage -H "Authorization: Bearer ${token}"`,
+    );
+    expect(output).not.toContain(token);
+  });
+});
+
+describe("redactCommandText - existing behavior is preserved", () => {
+  it("still redacts OpenAI-style and Anthropic keys", () => {
+    const openai = `sk-${"proj-abcdefghijklmnop123456"}`;
+    const anthropic = `sk-${"ant-api03-abcdefghijklmnopqrstuvwx"}`;
+    expect(redactCommandText(openai)).not.toContain(openai);
+    expect(redactCommandText(anthropic)).not.toContain(anthropic);
+  });
+
+  it("still redacts GitHub tokens", () => {
+    const token = `ghp_${"abcdefghijklmnopqrstuvwxyz0123456789"}`;
+    expect(redactCommandText(token)).not.toContain(token);
+  });
+
+  it("leaves ordinary command text untouched", () => {
+    const plain = "pnpm vitest run packages/adapter-utils";
+    expect(redactCommandText(plain)).toBe(plain);
   });
 });

--- a/packages/adapter-utils/src/command-redaction.ts
+++ b/packages/adapter-utils/src/command-redaction.ts
@@ -20,6 +20,15 @@ const COMMAND_AUTHORIZATION_BEARER_RE =
   /(\bAuthorization\s*:\s*Bearer\s+)[^\s"'`]+/gi;
 const COMMAND_OPENAI_KEY_RE = /\bsk-[A-Za-z0-9_-]{12,}\b/g;
 const COMMAND_GITHUB_TOKEN_RE = /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g;
+// Paperclip-issued bearer credentials. Minted in server/src/services/board-auth.ts as
+// `pcp_board_<48 hex>` and `pcp_cli_auth_<48 hex>`; the prefix segment is matched
+// generically so a future `pcp_<kind>_` credential is covered without another edit.
+// These are value-shaped: they leak as bare tokens in process stdout and in HTTP
+// header dumps, where no adjacent `key=` or `--flag` gives the name-based rules a handle.
+const COMMAND_PAPERCLIP_TOKEN_RE = /\bpcp_[a-z][a-z0-9_]*_[0-9a-f]{24,}\b/gi;
+// Slack tokens: bot (xoxb), user (xoxp), app (xoxa/xoxr), refresh (xoxs), and
+// app-level (xapp).
+const COMMAND_SLACK_TOKEN_RE = /\b(?:xox[abprs]|xapp)-[A-Za-z0-9-]{10,}\b/g;
 const COMMAND_JWT_RE =
   /\b[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}(?:\.[A-Za-z0-9_-]{8,})?\b/g;
 const COMMAND_SECRET_HINTS = [
@@ -41,6 +50,12 @@ const COMMAND_SECRET_HINTS = [
   "ghu_",
   "ghs_",
   "ghr_",
+  // Value-prefix hints. Without these, a chunk carrying a bare `pcp_board_...` or
+  // `xoxb-...` and nothing else can short-circuit out of redactCommandText before
+  // the patterns above ever run.
+  "pcp_",
+  "xox",
+  "xapp-",
 ] as const;
 
 function maybeContainsSecretText(command: string) {
@@ -76,6 +91,8 @@ export function redactCommandText(
     )
     .replace(COMMAND_OPENAI_KEY_RE, redactedValue)
     .replace(COMMAND_GITHUB_TOKEN_RE, redactedValue)
+    .replace(COMMAND_PAPERCLIP_TOKEN_RE, redactedValue)
+    .replace(COMMAND_SLACK_TOKEN_RE, redactedValue)
     .replace(COMMAND_JWT_RE, redactedValue);
 }
 

--- a/packages/adapters/codex-local/src/server/acp.test.ts
+++ b/packages/adapters/codex-local/src/server/acp.test.ts
@@ -148,6 +148,7 @@ class FakeRuntime {
     mode: "persistent" | "oneshot";
     cwd?: string;
     resumeSessionId?: string;
+    sessionOptions?: { env?: Record<string, string> };
   }> = [];
   startInputs: Array<{ handle: FakeRuntimeHandle; text: string; requestId: string; timeoutMs?: number }> = [];
   closeInputs: Array<{ handle: FakeRuntimeHandle; reason: string; discardPersistentState?: boolean }> = [];
@@ -168,6 +169,7 @@ class FakeRuntime {
     mode: "persistent" | "oneshot";
     cwd?: string;
     resumeSessionId?: string;
+    sessionOptions?: { env?: Record<string, string> };
   }): Promise<FakeRuntimeHandle> {
     this.ensureInputs.push(input);
     this.ensureCount += 1;
@@ -711,9 +713,21 @@ describe("codex_local ACP lane", () => {
     const skill = await createRuntimeSkill(root);
     const runtimes: FakeRuntime[] = [];
     const meta: AdapterInvocationMeta[] = [];
+    let stagedSkillContents = "";
     const execute = createCodexAcpExecutor({
       createRuntime: (options: FakeRuntimeOptions) => {
         const runtime = new FakeRuntime(options);
+        const ensureSession = runtime.ensureSession.bind(runtime);
+        runtime.ensureSession = async (input) => {
+          const codexHome = input.sessionOptions?.env?.CODEX_HOME;
+          if (codexHome) {
+            stagedSkillContents = await fs.readFile(
+              path.join(codexHome, "skills", "review", "SKILL.md"),
+              "utf8",
+            );
+          }
+          return ensureSession(input);
+        };
         runtimes.push(runtime);
         return runtime as never;
       },
@@ -752,7 +766,10 @@ describe("codex_local ACP lane", () => {
     });
     const skillsHome = (result.sessionParams?.skills as { skillsHome?: string }).skillsHome;
     expect(skillsHome).toBeTruthy();
-    await expect(fs.readFile(path.join(skillsHome!, "review", "SKILL.md"), "utf8")).resolves.toContain("review skill");
+    expect(stagedSkillContents).toContain("review skill");
+    await expect(fs.readFile(path.join(skillsHome!, "review", "SKILL.md"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
     expect(runtimes[0]?.ensureInputs[0]).toMatchObject({
       agent: "codex",
       mode: "persistent",
@@ -760,7 +777,9 @@ describe("codex_local ACP lane", () => {
     });
     expect(runtimes[0]?.setConfigInputs).toEqual([]);
     expect(meta[0]?.commandNotes?.join("\n")).toContain("Prepared ACPX Codex skill home");
-    expect(meta[0]?.env?.CODEX_HOME).toBe(path.join(root, "codex-home"));
+    expect(meta[0]?.env?.CODEX_HOME).toBe(
+      path.join(root, "state", "codex-run-homes", "run-1", "home"),
+    );
     expect(JSON.parse(String(meta[0]?.env?.CODEX_CONFIG))).toEqual({
       model: "gpt-5.5",
       model_reasoning_effort: "high",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Local Codex runs need private per-run homes to enforce runtime isolation
> - These homes retained raw session and tool data after runs reached terminal states
> - Repeated runs therefore caused unbounded disk growth
> - Cleanup must preserve sanitized session evidence and fail closed on every ambiguous condition
> - This pull request adds lifecycle cleanup and a conservative recovery sweeper
> - The benefit is bounded disk use without weakening the Codex isolation boundary

## Linked Issues or Issue Description

Refs #12008. This pull request supersedes that incomplete cleanup-only change and adds the required sweeper and fail-closed safeguards.

**What happened?**

Each local Codex run created a private raw home. Paperclip retained sanitized session JSONL after close, but it did not remove the raw home. Old raw homes accumulated and consumed disk space.

**Expected behavior**

Paperclip must remove a raw home only after the runtime closes and sanitized retention succeeds. It must preserve and mark the home when close or retention is not confirmed. Recovery deletion must require terminal state, zero open handles, a 24-hour grace window, and a retained counterpart.

**Steps to reproduce**

1. Start repeated local Codex runs.
2. Let the runs reach terminal states.
3. Inspect `codex-run-homes` under the agent state directory.
4. Observe that raw homes remain after sanitized retention completes.

## What Changed

- Keep each local Codex run in a private run-specific home.
- Retain redacted session JSONL after the ordered runtime-close settlement step.
- Delete the raw home only after close and retention succeed.
- Preserve the raw home and write a sibling quarantine marker when close or retention fails.
- Add a dry-run-first orphan sweeper with mandatory API status, open-handle, age, and retained-copy checks.
- Fail closed when API credentials, terminal status, or open-handle proof are unavailable.
- Add Paperclip and Slack credential patterns to command-output redaction.
- Add operator documentation for the cleanup and sweeper safeguards.

## Verification

- `pnpm exec vitest run packages/adapter-utils/src/acpx-engine/execute.test.ts -t 'traversal run ID|retains only sanitized|created no sessions|quarantines the raw run home|quarantines the raw run home when runtime close|restricted-run isolation'` — 6 passed.
- `pnpm exec vitest run packages/adapter-utils/src/acpx-engine/run-home-sweeper.test.ts packages/adapter-utils/src/command-redaction.test.ts` — 34 passed.
- `pnpm --filter @paperclipai/adapter-utils typecheck` — passed.
- `git diff --check` — passed.
- Full CI and a fresh Greptile review are required on the new head.
- Live terminal-run and dry-run manifest evidence remain required before deployment completion.

## Risks

- The cleanup path uses recursive deletion. It is limited to the current run-specific directory and runs only after close and retention succeed.
- A failed status or `lsof` check can leave disk data in place. This is intentional fail-closed behavior.
- A quarantined home can continue to use disk until an operator resolves retention. The sweeper does not delete the only raw copy.
- The branch was created before the current branch-name rule and contains an internal ticket key. The existing pull request cannot change its head branch in place.
- There is no database migration and no schema change.

> This change does not overlap with a planned item in `ROADMAP.md`. The duplicate search found #12008, which this pull request supersedes.

## Model Used

- Anthropic Claude Code produced the original branch. The exact model ID and context window were not recorded in the commit metadata.
- OpenAI GPT-5 Codex performed the current-master rebase, security remediation, tests, and documentation with tool use and code execution. The runtime did not expose a more specific API model ID or context-window value.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change and contains no internal Paperclip ticket id. The existing head branch predates this rule and cannot be renamed in place.
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
