### PR TITLE
fix(agents): clear stale error reason on status recovery

### DIFF
--- a/server/src/__tests__/agents-service-generic-status-update-error-reason.test.ts
+++ b/server/src/__tests__/agents-service-generic-status-update-error-reason.test.ts
@@ -1,0 +1,164 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { agents, companies, createDb } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { agentService } from "../services/agents.ts";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres agent service tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("agent service generic status update — errorReason invariant", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-agent-generic-status-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedCompany() {
+    const companyId = randomUUID();
+    const issuePrefix = `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`;
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix,
+      requireBoardApprovalForNewAgents: false,
+    });
+    return companyId;
+  }
+
+  async function seedAgent(
+    companyId: string,
+    overrides: Partial<typeof agents.$inferInsert> = {},
+  ) {
+    const agentId = randomUUID();
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: `Agent-${agentId.slice(0, 8)}`,
+      role: "engineer",
+      status: "idle",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+      ...overrides,
+    });
+    return agentId;
+  }
+
+  it("clears a stale errorReason when a generic update moves status out of error", async () => {
+    const companyId = await seedCompany();
+    const agentId = await seedAgent(companyId, {
+      status: "error",
+      errorReason: "Adapter exited with code 1",
+    });
+
+    const updated = await agentService(db).update(agentId, { status: "idle" });
+
+    expect(updated).toMatchObject({ id: agentId, status: "idle", errorReason: null });
+  });
+
+  it("cleans an already-idle record when a caller explicitly PATCHes status=idle again", async () => {
+    const companyId = await seedCompany();
+    // Simulates a record left over from before this invariant was enforced:
+    // status is already idle, but a diagnostic errorReason is still persisted.
+    const agentId = await seedAgent(companyId, {
+      status: "idle",
+      errorReason: "stale diagnostic from a prior incident",
+    });
+
+    const updated = await agentService(db).update(agentId, { status: "idle" });
+
+    expect(updated).toMatchObject({ id: agentId, status: "idle", errorReason: null });
+  });
+
+  it("does not touch errorReason when the patch leaves status untouched", async () => {
+    const companyId = await seedCompany();
+    const agentId = await seedAgent(companyId, {
+      status: "error",
+      errorReason: "Adapter exited with code 1",
+    });
+
+    const updated = await agentService(db).update(agentId, { title: "Renamed" });
+
+    expect(updated).toMatchObject({
+      id: agentId,
+      status: "error",
+      errorReason: "Adapter exited with code 1",
+      title: "Renamed",
+    });
+  });
+
+  it("preserves an explicit errorReason when status is set to error", async () => {
+    const companyId = await seedCompany();
+    const agentId = await seedAgent(companyId, { status: "idle" });
+
+    const updated = await agentService(db).update(agentId, {
+      status: "error",
+      errorReason: "Secret is not bound to agent at env.ANTHROPIC_API_KEY",
+    });
+
+    expect(updated).toMatchObject({
+      id: agentId,
+      status: "error",
+      errorReason: "Secret is not bound to agent at env.ANTHROPIC_API_KEY",
+    });
+  });
+
+  it("overrides a caller-supplied errorReason when the same patch moves status away from error", async () => {
+    const companyId = await seedCompany();
+    const agentId = await seedAgent(companyId, {
+      status: "error",
+      errorReason: "Adapter exited with code 1",
+    });
+
+    // A caller that sets status away from error while also (incorrectly) supplying
+    // an errorReason must not be able to leave a stale reason on a non-error agent.
+    const updated = await agentService(db).update(agentId, {
+      status: "paused",
+      errorReason: "should not persist",
+    });
+
+    expect(updated).toMatchObject({ id: agentId, status: "paused", errorReason: null });
+  });
+
+  it("still rejects status changes on terminated agents", async () => {
+    const companyId = await seedCompany();
+    const agentId = await seedAgent(companyId, { status: "terminated" });
+
+    await expect(agentService(db).update(agentId, { status: "idle" })).rejects.toMatchObject({
+      status: 409,
+      message: "Terminated agents cannot be resumed",
+    });
+  });
+
+  it("still rejects direct activation of pending_approval agents", async () => {
+    const companyId = await seedCompany();
+    const agentId = await seedAgent(companyId, { status: "pending_approval" });
+
+    await expect(agentService(db).update(agentId, { status: "idle" })).rejects.toMatchObject({
+      status: 409,
+      message: "Pending approval agents cannot be activated directly",
+    });
+  });
+});

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -738,6 +738,16 @@ export function agentService(db: Db) {
         })
       : null;
 
+    // errorReason is only meaningful while status=error (see heartbeat.ts finalization);
+    // any explicit move away from error — including a caller re-affirming a non-error
+    // status on an already-clean record — must clear a stale reason too.
+    if (
+      Object.prototype.hasOwnProperty.call(normalizedPatch, "status") &&
+      normalizedPatch.status !== "error"
+    ) {
+      normalizedPatch.errorReason = null;
+    }
+
     const shouldRecordRevision = Boolean(options?.recordRevision) && hasConfigPatchFields(normalizedPatch);
     const beforeConfig = shouldRecordRevision ? buildConfigSnapshot(existing) : null;
 


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Each agent has a `status` field, and an `errorReason` field that records the last failure
> - The heartbeat process already clears `errorReason` when it finalizes a status change away from `error`
> - But the generic agent update path — the code any `PATCH` to an agent goes through — did not enforce that same rule
> - So a caller could move an agent's status away from `error`, or simply re-affirm an already-clean status, and a stale `errorReason` from an old incident would stay on the row
> - This pull request adds the same invariant to the generic update path: any explicit status change away from `error` also clears `errorReason`
> - The benefit is a healthy agent never reports a leftover error message from a past incident, no matter which code path changed its status

## Linked Issues or Issue Description

Refs #11946 — related, but distinct. That issue is about the board-only `clear-error` endpoint: its OpenAPI contract wrongly advertises agent-level auth, and there is no way to `PATCH` `errorReason` directly at all. This PR does not change that permission surface or add a new PATCH-able field. It fixes a narrower gap that issue touches on in passing (its point 2): many status transitions already go through the generic agent update function without ever calling `clear-error`, and until now none of them cleared a stale `errorReason` as a side effect.

Dedup search also found #8905 (open) and its closed predecessor #8725, "Clear stale agent errorReason on recovered run start". That PR fixes a different code path: it clears `errorReason` specifically in the heartbeat recovered-run transition, and adds a read-time projection guard that hides (without persisting a clear for) `errorReason` on non-error agents in list/get responses. This PR instead changes the write path itself (the generic agent update function), so the fix applies to every caller that changes `status` through it, not only the recovered-run heartbeat transition and not only at read time. The two changes are complementary, not duplicates, but a reviewer may want to reconcile them before both merge.

No public issue describes this specific write-path gap yet, so here it is inline, following the bug report template:

**What happened?**
The generic agent update function in `server/src/services/agents.ts` persists `errorReason` independently of `status`. A caller can `PATCH` an agent to move its status away from `error` — or simply re-affirm its current non-error status — while an old `errorReason` from a prior incident stays on the row.

**Expected behavior**
Any generic update that explicitly sets `status` to a value other than `error` should also clear `errorReason` to `null`, matching the invariant `heartbeat.ts` already applies on finalization.

**Steps to reproduce**
1. Put an agent into `status: error` with an `errorReason` set (for example, after a failed run).
2. Call the generic agent update path with a patch that sets `status` to any non-`error` value, such as `idle`. This can be the agent's current status or a different one.
3. Read the agent record back. Before this fix, `errorReason` still shows the old message even though `status` is no longer `error`.

**Paperclip version or commit**
Reproduced against `master` at commit `5716fe907e596ce73501408fc6efdb19fb61edf2`, the base this PR is opened against.

**Deployment mode**
Not deployment-specific. The added test suite reproduces and verifies the fix against an embedded PGlite/Postgres instance.

## What Changed

- Added a lifecycle invariant to the generic agent update function in `server/src/services/agents.ts`: any patch that explicitly sets `status` to a value other than `error` now also sets `errorReason` to `null`.
- Scoped the invariant to patches that touch `status`. A patch that leaves `status` untouched never mutates `errorReason`, so this does not silently scrub diagnostics off unrelated field updates.
- Placed the check after existing `adapterConfig`/`permissions` normalization and before config-revision diffing, so it does not create a spurious revision-history entry.
- Added `server/src/__tests__/agents-service-generic-status-update-error-reason.test.ts` with 7 embedded-Postgres regression cases: clearing on recovery, clearing when a caller re-affirms an already-clean status, leaving `errorReason` untouched when `status` is absent from the patch, preserving an explicit `errorReason` when `status` is set to `error`, overriding a caller-supplied `errorReason` when the same patch moves status away from `error`, and confirming the existing `terminated`/`pending_approval` transition guards still run first and are unchanged.

## Verification

- `pnpm exec vitest run server/src/__tests__/agents-service-generic-status-update-error-reason.test.ts` — the 7 focused cases above, 7/7 passing, run against an embedded Postgres instance.
- The broader related agent-service test set (11 tests total, including pre-existing coverage) and `tsc --noEmit` on the `server` package were run before opening this PR; both passed.
- Re-verified the focused suite again at this PR's head commit, after rebasing the change onto two unrelated invariant checks that landed upstream in the meantime (an operational-skill invariant and an OAuth binding check, both unrelated to `status`/`errorReason`) — still 7/7.
- No full monorepo typecheck/build was run for this change; the change is scoped to one service function and its tests.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Risks

- Low risk. The change is narrowly scoped: it only fires when a patch explicitly includes `status`, and it only ever nulls `errorReason` — no other field is touched.
- `errorReason` remains an internal, non-`PATCH`-able field from the outside. This PR only changes what happens to it *internally* when a caller changes `status` through the generic update path. It does not add a new externally settable field, and does not touch the `clear-error` endpoint or its permission check.
- Behavior change in one corner case: if a caller sends both `status` and `errorReason` in the same patch, and `status` is not `error`, the supplied `errorReason` is now dropped rather than persisted. This is intentional — it enforces the same invariant `heartbeat.ts` already applies on finalization, applied consistently everywhere `status` changes.
- The existing guards that reject status changes on `terminated` and `pending_approval` agents run earlier in the update function and are unchanged by this PR. They still throw before this invariant is ever reached.
- No schema change and no migration needed.
- No relevant documentation, telemetry event, OpenTelemetry span, or run-log event needed updating: this is an internal write-path invariant with no new external contract.

## Model Used

Claude (Anthropic), model ID `claude-sonnet-5`, accessed through the Claude Code CLI in an agentic coding session with file-edit, test-execution, and git/gh tool use in the repository workspace. The same model implemented the fix, wrote the added tests, and opened this PR.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
