### PR TITLE
fix(interactions): raise custom target key limit and tolerate unparseable stored payloads in scans

### DIFF
--- a/packages/shared/src/validators/issue.ts
+++ b/packages/shared/src/validators/issue.ts
@@ -1057,7 +1057,12 @@ export const requestConfirmationIssueDocumentTargetSchema = requestConfirmationT
 
 export const requestConfirmationCustomTargetSchema = requestConfirmationTargetBaseSchema.extend({
   type: z.literal("custom"),
-  key: z.string().trim().min(1).max(120),
+  // 500, not 120: the server's own connection-delegation prompts
+  // (tool-access.ts / tool-gateway.ts) build keys like
+  // `connection:<connection.uid>:delegation:<userId>:<agentId>` (~150 chars),
+  // which max(120) rejected — and hydrateInteraction's hard parse then failed
+  // the whole issue's interaction scans.
+  key: z.string().trim().min(1).max(500),
   revisionId: z.string().trim().min(1).max(255).nullable().optional(),
   revisionNumber: z.number().int().positive().nullable().optional(),
 });

--- a/server/src/__tests__/issue-thread-interactions-service.test.ts
+++ b/server/src/__tests__/issue-thread-interactions-service.test.ts
@@ -2977,6 +2977,32 @@ describeEmbeddedPostgres("issueThreadInteractionService", () => {
     expect(listed[0]?.status).toBe("cancelled");
   });
 
+  it("lists interactions whose stored payload fails its schema by dropping that row, not the whole list", async () => {
+    const { companyId, issueId } = await seedConfirmationIssue("Unparseable stored payload");
+    const good = await interactionsSvc.create({ id: issueId, companyId }, {
+      kind: "request_confirmation",
+      payload: { version: 1, prompt: "Proceed?" },
+    }, { userId: "local-board" });
+
+    // A row whose payload never satisfied the schema (or drifted out of it):
+    // prompt is required non-empty. A hard parse here used to throw for the
+    // entire issue -- GET interactions 400, and comment posting inserted the
+    // comment but died before waking the assignee.
+    await db.insert(issueThreadInteractions).values({
+      id: randomUUID(),
+      companyId,
+      issueId,
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: { kind: "none" },
+      payload: { version: 1, prompt: "" },
+      createdByUserId: "local-board",
+    });
+
+    const listed = await interactionsSvc.listForIssue(issueId);
+    expect(listed.map((interaction) => interaction.id)).toEqual([good.id]);
+  });
+
   it("derives legacy pending interactions as expired on closed issues without mutating the GET", async () => {
     const { companyId, issueId } = await seedConfirmationIssue("Legacy pending interaction on closed issue");
     const created = await interactionsSvc.create({ id: issueId, companyId }, {

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -580,6 +580,34 @@ function hydrateInteraction(
   }
 }
 
+/**
+ * List/scan-context hydration. `hydrateInteraction` hard-parses `payload`,
+ * so one row whose stored payload no longer satisfies its schema (schema
+ * drift, or a server-written payload that never satisfied it — e.g. a
+ * connection-delegation `target.key` longer than the former 120-char cap)
+ * throws and fails the entire scan. On the web that 400s the issue's
+ * interactions list, and because comment posting runs
+ * `expireRequestConfirmationsSupersededByComment` after inserting the
+ * comment and before enqueuing wakeups, the comment lands but the assignee
+ * is never woken. In scan context, drop the row with a warning instead.
+ * Single-row paths (accept/reject/withdraw/cancel) keep the hard parse so a
+ * bad row still fails loudly where it is acted on.
+ */
+function hydrateInteractionOrNull(row: IssueThreadInteractionRow): IssueThreadInteraction | null {
+  try {
+    return hydrateInteraction(row);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      console.warn(
+        `[paperclip] Dropping ${row.kind} interaction ${row.id} from scan: stored payload does not satisfy its schema`,
+        err.issues,
+      );
+      return null;
+    }
+    throw err;
+  }
+}
+
 async function touchIssue(db: IssueTouchDb, issueId: string) {
   await db
     .update(issues)
@@ -2328,7 +2356,7 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
           .then((issueRows) => issueRows[0]?.status ?? null),
       ]);
 
-      return rows.map((row) => hydrateInteraction(
+      return rows.flatMap((row) => hydrateInteractionOrNull(
         issueStatus && isTerminalIssueStatus(issueStatus) && row.status === "pending"
           ? {
               ...row,
@@ -2337,7 +2365,7 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
               resolvedAt: row.updatedAt,
             }
           : row,
-      ));
+      ) ?? []);
     },
 
     getById: async (interactionId: string) => {
@@ -3249,7 +3277,8 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
 
       const superseded = rows.filter((row) => {
         if (!isUserCommentSupersedableKind(row.kind)) return false;
-        const interaction = hydrateInteraction(row) as UserCommentSupersedableInteraction;
+        const interaction = hydrateInteractionOrNull(row) as UserCommentSupersedableInteraction | null;
+        if (!interaction) return false;
         return (
           shouldSupersedeInteractionOnUserComment(interaction)
           && isCommentAtOrAfterInteraction({
@@ -3333,7 +3362,8 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
       >();
       for (const row of rows) {
         if (!isUserCommentSupersedableKind(row.kind)) continue;
-        const interaction = hydrateInteraction(row) as UserCommentSupersedableInteraction;
+        const interaction = hydrateInteractionOrNull(row) as UserCommentSupersedableInteraction | null;
+        if (!interaction) continue;
         if (!shouldSupersedeInteractionOnUserComment(interaction)) continue;
 
         const supersedingComment = comments.find((comment) => isCommentAtOrAfterInteraction({


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents and humans coordinate on issues through thread interactions (confirmations, questions, task suggestions) stored in `issue_thread_interactions`
> - The server reads these rows back with `hydrateInteraction`, which hard-parses the stored `payload` against the current zod schema
> - One row whose payload fails that parse makes the whole scan throw: the issue's interaction list returns 400, and posting a comment inserts the comment but throws before the assignee wakeup is enqueued
> - This happens in practice with rows the server writes itself: the connection-delegation prompt keys are ~150 characters and the custom target key schema allowed 120
> - This pull request raises the key limit so the server's own keys validate, and makes multi-row scans skip an unparseable row with a warning instead of failing the issue
> - The benefit is that one bad row can no longer disable comments and agent wakeups for an issue

## Linked Issues or Issue Description

No existing issue found. Related prior fix for the `result` field: #10119.

**What happened?**

On an issue with a pending "Connect your Google Drive" delegation prompt, every `GET /api/issues/:id/interactions` returned `400 {"error":"Validation error"}`. Posting a comment showed "Comment failed" in the UI. The comment appeared after a refresh, but the assigned agent did not run. Accepting the prompt also returned 400. Moving the issue backlog → in progress was the only way to wake the agent.

**Expected behavior**

Comments post and wake the assignee. The interaction list loads. One unreadable row does not affect the rest of the issue.

**Steps to reproduce**

1. Connect a Google app and let an agent run trigger a connection delegation prompt (`tool-access.ts` `connection:<connection.uid>:delegation:<userId>:<agentId>` target key, longer than 120 characters).
2. Open the issue. `GET /api/issues/:id/interactions` returns 400.
3. Post a comment. The request returns 400 after the comment is inserted. No wakeup is enqueued.

**Paperclip version or commit**

`master` at 141c5b134 (reproduced on a build from 2026-09-01).

**Deployment mode**

authenticated, private, Docker.

## What Changed

- `packages/shared/src/validators/issue.ts`: `requestConfirmationCustomTargetSchema.key` limit raised from 120 to 500 characters. The server composes this key from ids; 120 was shorter than the server's own values. 500 matches the other identifier-style limits in this file.
- `server/src/services/issue-thread-interactions.ts`: new `hydrateInteractionOrNull`. On a `ZodError` it logs a warning and returns `null`. Any other error is rethrown. It is used at the three multi-row scan sites: `listForIssue`, the comment-time supersede scan in `expireRequestConfirmationsSupersededByComment`, and the reconcile sweep. Single-row paths (accept, reject, withdraw, cancel) keep the hard parse, so a bad row still fails where it is acted on.
- `server/src/__tests__/issue-thread-interactions-service.test.ts`: one test. It inserts a valid interaction and a row with an invalid payload, then asserts `listForIssue` returns only the valid one.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-thread-interactions-service.test.ts -t "stored payload fails|LOOA-629"` — 2 passed against embedded Postgres.
- Manual: deployed to an instance that had three unreadable rows. The interaction list loads, comments post and wake the assignee, and the server logs one `Dropping … from scan` warning per bad row only when a row is actually unparseable.

## Risks

- Behavioral shift: a row with an unparseable payload is now omitted from list and scan results instead of failing the request. The row stays in the database and is logged. A pending prompt with a broken payload would not be shown until its payload is repaired. This is the same trade the `result` field already makes (#10119).
- The key limit change is additive. Existing rows with keys up to 500 characters now read back; nothing that validated before stops validating.
- No migration.

## Model Used

Claude (Anthropic), model id `claude-fable-5-1`, extended thinking, tool use (shell, file editing, Docker builds and test runs on the target host). Human reviewed and directed each step.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (none needed: code comments only)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YWRcaQqwKAUqQVbrrWUjiP
