### PR TITLE
fix(opencode-local): inject Paperclip-managed MCP servers into OpenCode runs

### DIFF
--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -324,10 +324,21 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (authToken) {
     env.PAPERCLIP_API_KEY = authToken;
   }
-  const preparedRuntimeConfig = await prepareOpenCodeRuntimeConfig({ env, config });
+  const runtimeMcpServers = ctx.runtimeMcp?.getServers() ?? [];
+  const preparedRuntimeConfig = await prepareOpenCodeRuntimeConfig({
+    env,
+    config,
+    mcpServers: runtimeMcpServers,
+  });
   const localRuntimeConfigHome =
     preparedRuntimeConfig.notes.length > 0 ? preparedRuntimeConfig.env.XDG_CONFIG_HOME : "";
   try {
+    if (runtimeMcpServers.length > 0) {
+      await onLog(
+        "stdout",
+        `[paperclip] OpenCode will use ${runtimeMcpServers.length} Paperclip-managed MCP server(s): ${runtimeMcpServers.map((server) => server.name).join(", ")}.\n`,
+      );
+    }
     const runtimeEnv = Object.fromEntries(
       Object.entries(ensurePathInEnv({ ...process.env, ...preparedRuntimeConfig.env })).filter(
         (entry): entry is [string, string] => typeof entry[1] === "string",

--- a/packages/adapters/opencode-local/src/server/runtime-config.test.ts
+++ b/packages/adapters/opencode-local/src/server/runtime-config.test.ts
@@ -321,4 +321,118 @@ describe("prepareOpenCodeRuntimeConfig", () => {
     expect(prepared.notes).toEqual([]);
     await prepared.cleanup();
   });
+
+  it("injects Paperclip-managed remote MCP servers into the runtime OpenCode config", async () => {
+    const configHome = await makeConfigHome({
+      permission: { read: "allow" },
+    });
+
+    const prepared = await prepareOpenCodeRuntimeConfig({
+      env: { XDG_CONFIG_HOME: configHome },
+      config: { dangerouslySkipPermissions: false },
+      mcpServers: [
+        {
+          name: "paperclip-assigned",
+          url: "http://localhost:3100/api/mcp/gateways/gw_test",
+          token: "run-scoped-token",
+          connectionId: "assignment:digest",
+        },
+      ],
+    });
+    cleanupPaths.add(prepared.env.XDG_CONFIG_HOME);
+
+    const runtimeConfig = JSON.parse(
+      await fs.readFile(
+        path.join(prepared.env.XDG_CONFIG_HOME, "opencode", "opencode.json"),
+        "utf8",
+      ),
+    ) as {
+      mcp?: Record<string, unknown>;
+      permission?: Record<string, unknown>;
+    };
+    expect(runtimeConfig.mcp).toEqual({
+      "paperclip-assigned": {
+        type: "remote",
+        url: "http://localhost:3100/api/mcp/gateways/gw_test",
+        enabled: true,
+        oauth: false,
+        headers: { Authorization: "Bearer run-scoped-token" },
+        timeout: 30_000,
+      },
+    });
+    expect(runtimeConfig.permission?.["mcp__paperclip-assigned__*"]).toBe("allow");
+    expect(runtimeConfig.permission?.external_directory).toBeUndefined();
+    expect(prepared.notes.join("\n")).toContain("Paperclip-managed MCP server(s)");
+    await prepared.cleanup();
+  });
+
+  it("renames a managed MCP server instead of overwriting an existing user-defined entry of the same name", async () => {
+    const userDiscordConfig = { type: "local", command: ["my-discord-mcp"] };
+    const configHome = await makeConfigHome({
+      permission: { read: "allow" },
+      mcp: { discord: userDiscordConfig },
+    });
+
+    const prepared = await prepareOpenCodeRuntimeConfig({
+      env: { XDG_CONFIG_HOME: configHome },
+      config: {},
+      mcpServers: [
+        {
+          name: "discord",
+          url: "https://gateway.example/mcp/discord",
+          token: "tok-discord",
+          connectionId: "conn-aaaaaaaa",
+        },
+      ],
+    });
+    cleanupPaths.add(prepared.env.XDG_CONFIG_HOME);
+
+    const runtimeConfig = JSON.parse(
+      await fs.readFile(
+        path.join(prepared.env.XDG_CONFIG_HOME, "opencode", "opencode.json"),
+        "utf8",
+      ),
+    ) as { mcp?: Record<string, unknown> };
+    expect(runtimeConfig.mcp?.discord).toEqual(userDiscordConfig);
+    expect(runtimeConfig.mcp?.["discord-conn-aaa"]).toMatchObject({
+      type: "remote",
+      url: "https://gateway.example/mcp/discord",
+    });
+    await prepared.cleanup();
+  });
+
+  it("dedupes managed MCP server names against each other when no existing config entry collides", async () => {
+    const configHome = await makeConfigHome({ permission: { read: "allow" } });
+    const prepared = await prepareOpenCodeRuntimeConfig({
+      env: { XDG_CONFIG_HOME: configHome },
+      config: {},
+      mcpServers: [
+        {
+          name: "discord",
+          url: "https://gateway.example/mcp/a",
+          token: "tok-a",
+          connectionId: "conn-aaaaaaaa",
+        },
+        {
+          name: "discord",
+          url: "https://gateway.example/mcp/b",
+          token: "tok-b",
+          connectionId: "conn-bbbbbbbb",
+        },
+      ],
+    });
+    cleanupPaths.add(prepared.env.XDG_CONFIG_HOME);
+
+    const runtimeConfig = JSON.parse(
+      await fs.readFile(
+        path.join(prepared.env.XDG_CONFIG_HOME, "opencode", "opencode.json"),
+        "utf8",
+      ),
+    ) as { mcp?: Record<string, unknown> };
+    expect(runtimeConfig.mcp?.discord).toMatchObject({ url: "https://gateway.example/mcp/a" });
+    expect(runtimeConfig.mcp?.["discord-conn-bbb"]).toMatchObject({
+      url: "https://gateway.example/mcp/b",
+    });
+    await prepared.cleanup();
+  });
 });

--- a/packages/adapters/opencode-local/src/server/runtime-config.ts
+++ b/packages/adapters/opencode-local/src/server/runtime-config.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import type { AdapterRuntimeMcpServer } from "@paperclipai/adapter-utils";
 import { asBoolean } from "@paperclipai/adapter-utils/server-utils";
 
 type PreparedOpenCodeRuntimeConfig = {
@@ -8,6 +9,44 @@ type PreparedOpenCodeRuntimeConfig = {
   notes: string[];
   cleanup: () => Promise<void>;
 };
+
+function sanitizeOpenCodeMcpName(raw: string): string {
+  const cleaned = raw
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return cleaned.length > 0 ? cleaned.slice(0, 64) : "paperclip-mcp";
+}
+
+function buildOpenCodeMcpServers(
+  servers: AdapterRuntimeMcpServer[],
+  reservedNames: Iterable<string> = [],
+): Record<string, Record<string, unknown>> {
+  const mcp: Record<string, Record<string, unknown>> = {};
+  const used = new Set<string>(reservedNames);
+  for (const server of servers) {
+    let name = sanitizeOpenCodeMcpName(server.name);
+    if (used.has(name)) name = sanitizeOpenCodeMcpName(`${server.name}-${server.connectionId.slice(0, 8)}`);
+    let suffix = 2;
+    while (used.has(name)) {
+      name = sanitizeOpenCodeMcpName(`${server.name}-${server.connectionId.slice(0, 8)}-${suffix}`);
+      suffix += 1;
+    }
+    used.add(name);
+    mcp[name] = {
+      type: "remote",
+      url: server.url,
+      enabled: true,
+      oauth: false,
+      headers: {
+        Authorization: `Bearer ${server.token}`,
+      },
+      timeout: 30_000,
+    };
+  }
+  return mcp;
+}
 
 function resolveXdgConfigHome(env: Record<string, string>): string {
   return (
@@ -106,9 +145,12 @@ export async function prepareOpenCodeRuntimeConfig(input: {
   env: Record<string, string>;
   config: Record<string, unknown>;
   targetIsRemote?: boolean;
+  mcpServers?: AdapterRuntimeMcpServer[];
 }): Promise<PreparedOpenCodeRuntimeConfig> {
   const skipPermissions = asBoolean(input.config.dangerouslySkipPermissions, true);
-  if (!skipPermissions) {
+  const mcpServers = input.mcpServers ?? [];
+  const needsRuntimeConfig = skipPermissions || mcpServers.length > 0;
+  if (!needsRuntimeConfig) {
     return {
       env: input.env,
       notes: [],
@@ -152,9 +194,12 @@ export async function prepareOpenCodeRuntimeConfig(input: {
   const existingPermission = isPlainObject(existingConfig.permission)
     ? existingConfig.permission
     : {};
-  const notes = [
-    "Injected runtime OpenCode config with permission.external_directory=allow to avoid headless approval prompts.",
-  ];
+  const notes: string[] = [];
+  if (skipPermissions) {
+    notes.push(
+      "Injected runtime OpenCode config with permission.external_directory=allow to avoid headless approval prompts.",
+    );
+  }
 
   // Merge gateway/custom provider definitions supplied via PAPERCLIP_OPENCODE_PROVIDERS
   // (a JSON object in OpenCode's `provider` shape). OpenCode resolves a `--model
@@ -209,11 +254,33 @@ export async function prepareOpenCodeRuntimeConfig(input: {
     ...existingConfig,
     permission: {
       ...existingPermission,
-      external_directory: "allow",
+      ...(skipPermissions ? { external_directory: "allow" } : {}),
     },
   };
   if (Object.keys(nextProvider).length > 0) {
     nextConfig.provider = nextProvider;
+  }
+
+  if (mcpServers.length > 0) {
+    const existingMcp = isPlainObject(existingConfig.mcp) ? existingConfig.mcp : {};
+    const injectedMcp = buildOpenCodeMcpServers(mcpServers, Object.keys(existingMcp));
+    nextConfig.mcp = {
+      ...existingMcp,
+      ...injectedMcp,
+    };
+    // Headless runs must be able to call Paperclip-managed MCP tools without
+    // interactive approval prompts for every gateway tool.
+    const permission = isPlainObject(nextConfig.permission)
+      ? { ...(nextConfig.permission as Record<string, unknown>) }
+      : {};
+    for (const name of Object.keys(injectedMcp)) {
+      permission[`mcp__${name}__*`] = "allow";
+      permission[`${name}_*`] = "allow";
+    }
+    nextConfig.permission = permission;
+    notes.push(
+      `Injected ${Object.keys(injectedMcp).length} Paperclip-managed MCP server(s) into the runtime OpenCode config: ${Object.keys(injectedMcp).join(", ")}.`,
+    );
   }
 
   // Pin OpenCode's auxiliary "small" model (used for session-title generation and


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents reach company Apps (Linear, GitHub, Notion, and other connections) through Paperclip-managed MCP grants on `ctx.runtimeMcp`
> - `claude_local` and `codex_local` write those grants into the CLI MCP config before launch
> - `opencode_local` never read `ctx.runtimeMcp`, so OpenCode runs never received those tools
> - Operators then see a connected App in the board, while the OpenCode agent reports that Linear or GitHub is missing
> - This pull request writes Paperclip-managed remote MCP servers into the ephemeral runtime `opencode.json`
> - The benefit is that OpenCode agents get the same governed Apps tools as Claude and Codex agents

## Linked Issues or Issue Description

Refs #10293 (open, same gap, last updated 2026-07-27 and behind current `master`).

No public issue for this checkout. Bug description:

**What happened?**
An `opencode_local` agent with an installed Apps connection (for example Linear) cannot call those tools. The board shows the connection as healthy. The OpenCode process has no MCP server for that grant.

**Expected behavior**
OpenCode runs receive Paperclip-managed MCP servers from `ctx.runtimeMcp.getServers()`, the same way `claude_local` and `codex_local` do.

**Steps to reproduce**
1. Configure an agent with `adapterType: "opencode_local"`.
2. Install an Apps connection and grant it to that agent.
3. Wake the agent and ask it to use that App.
4. The agent has no MCP tool for the App, or it looks for a CLI / env API key instead.

**Paperclip version or commit**
Reproduced on `master` at `8c8934044` (local dirty tree before this branch).

**Deployment mode**
Local dev (`pnpm dev`)

**Agent adapter(s) involved**
OpenCode local (`opencode_local`). Claude Code and Codex already inject runtime MCP.

**Access context**
Agent (run-scoped bearer via the Paperclip MCP gateway)

**Additional context**
This branch rebases the #10293 idea onto current `master`. It also sets `oauth: false` for bearer-token remote servers, allows headless MCP tool calls, logs injected server names, and keeps user-defined `mcp` names from being overwritten.

## What Changed

- `prepareOpenCodeRuntimeConfig()` accepts `mcpServers` and writes OpenCode remote MCP entries (`type: "remote"`, bearer header, `oauth: false`) into the ephemeral runtime config.
- Runtime config injection now also runs when MCP servers are present, even if `dangerouslySkipPermissions` is false, so per-run tokens never land in the shared `opencode.json`.
- `execute.ts` passes `ctx.runtimeMcp.getServers()` into that helper and logs the injected server names.
- Managed MCP names that collide with an existing user `mcp` key, or with another managed server, get a connection-id suffix instead of overwriting the original entry.
- Tests cover injection, permission opt-out, user-name collision, and managed-name dedupe.

## Verification

- `pnpm --filter @paperclipai/adapter-opencode-local exec vitest run src/server/runtime-config.test.ts` — 17 tests passed.
- Live local `opencode_local` heartbeat log included: `OpenCode will use 1 Paperclip-managed MCP server(s): paperclip-assigned.`
- The same run called Linear MCP tools (`get-me`, `get-team`, `list-teams`) through the Paperclip gateway.

## Risks

Low. Additive when `mcpServers` is empty. One behavior change: MCP grants with `dangerouslySkipPermissions: false` now get an ephemeral runtime config dir so the bearer tokens stay run-scoped. That path does not set `permission.external_directory`. A colliding managed server name is now suffixed instead of replacing a user-defined MCP entry.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

Cursor Auto / Composer (Cursor agent, tool use, local code execution). Context window is the Cursor agent session. This change was implemented and verified in that agent session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge