### PR TITLE
fix(codex-local): sync Codex credential copy-back to the selected account home

### DIFF
--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -143,14 +143,11 @@ export type {
   PaperclipRunnerPermissionOption,
   PaperclipRunnerProvider,
 } from "./paperclip-runner-permissions.js";
-export {
-  assertManagedCredentialHome,
-  assertNoSymlinkInManagedCredentialPath,
-  resolveManagedCredentialHomeBoundary,
-  ManagedCredentialHomeRejectedError,
-} from "./managed-credential-home.js";
 // Keep the root adapter-utils entry browser-safe because the UI imports it.
 // The sandbox callback bridge stays available via its dedicated subpath export.
+// `managed-credential-home.js` uses `node:fs/promises`, so it stays off this
+// root entry too — a server-only caller reaches it through the dedicated
+// subpath export, `@paperclipai/adapter-utils/managed-credential-home`.
 export type {
   SandboxCallbackBridgeRequest,
   SandboxCallbackBridgeResponse,

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -143,6 +143,7 @@ export type {
   PaperclipRunnerPermissionOption,
   PaperclipRunnerProvider,
 } from "./paperclip-runner-permissions.js";
+export { assertManagedCredentialHome } from "./managed-credential-home.js";
 // Keep the root adapter-utils entry browser-safe because the UI imports it.
 // The sandbox callback bridge stays available via its dedicated subpath export.
 export type {

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -147,6 +147,7 @@ export {
   assertManagedCredentialHome,
   assertNoSymlinkInManagedCredentialPath,
   resolveManagedCredentialHomeBoundary,
+  ManagedCredentialHomeRejectedError,
 } from "./managed-credential-home.js";
 // Keep the root adapter-utils entry browser-safe because the UI imports it.
 // The sandbox callback bridge stays available via its dedicated subpath export.

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -143,7 +143,11 @@ export type {
   PaperclipRunnerPermissionOption,
   PaperclipRunnerProvider,
 } from "./paperclip-runner-permissions.js";
-export { assertManagedCredentialHome } from "./managed-credential-home.js";
+export {
+  assertManagedCredentialHome,
+  assertNoSymlinkInManagedCredentialPath,
+  resolveManagedCredentialHomeBoundary,
+} from "./managed-credential-home.js";
 // Keep the root adapter-utils entry browser-safe because the UI imports it.
 // The sandbox callback bridge stays available via its dedicated subpath export.
 export type {

--- a/packages/adapter-utils/src/managed-credential-home.test.ts
+++ b/packages/adapter-utils/src/managed-credential-home.test.ts
@@ -1,7 +1,8 @@
+import { promises as fsPromises } from "node:fs";
 import { mkdir, mkdtemp, readdir, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   assertManagedCredentialHome,
   assertNoSymlinkInManagedCredentialPath,
@@ -247,5 +248,105 @@ describe("assertManagedCredentialHome", () => {
       "outside the company-managed directory tree",
     );
     expect(await readdir(externalTarget)).toEqual([]);
+  });
+});
+
+// On a case-insensitive filesystem (the default on macOS and Windows),
+// `fs.realpath` can return the on-disk spelling of a directory whose
+// configured casing (from `PAPERCLIP_HOME`) differs only by letter case. This
+// suite forces `process.platform` to a non-Linux value and stubs `realpath`
+// to reproduce that exact scenario against a real temp directory tree — the
+// test filesystem itself is case-sensitive, so a genuine case-insensitive
+// `realpath` behavior has to be simulated — to prove a same-location casing
+// difference no longer rejects a valid managed home, while containment and
+// symlink rejection still hold.
+describe("assertManagedCredentialHome on a case-insensitive filesystem", () => {
+  const cleanupDirs: string[] = [];
+  const originalPlatform = process.platform;
+
+  afterEach(async () => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+    vi.restoreAllMocks();
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  it("accepts a managed home when PAPERCLIP_HOME's casing differs from fs.realpath's on-disk spelling", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+
+    const realHomeDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-managed-credential-home-casing-"));
+    cleanupDirs.push(realHomeDir);
+    const companyId = "company-a";
+    const companyRoot = path.join(realHomeDir, "instances", "default", "companies", companyId);
+    await mkdir(companyRoot, { recursive: true });
+    const candidateDir = path.join(companyRoot, "codex-home");
+    await mkdir(candidateDir, { recursive: true });
+
+    // `PAPERCLIP_HOME` is configured with different letter casing than the
+    // directory actually created above (same length, same characters, only
+    // upper-cased). Stub `fs.realpath` so every path under the
+    // differently-cased `configuredHomeDir` resolves to its real, on-disk
+    // -cased counterpart under `realHomeDir` — reproducing what a genuine
+    // case-insensitive filesystem's `fs.realpath` returns, without needing
+    // one for this test run.
+    const configuredHomeDir = realHomeDir.toUpperCase();
+    const realRealpath = fsPromises.realpath.bind(fsPromises);
+    vi.spyOn(fsPromises, "realpath").mockImplementation(async (input, ...rest) => {
+      if (typeof input === "string" && input.startsWith(configuredHomeDir)) {
+        return realRealpath(realHomeDir + input.slice(configuredHomeDir.length), ...(rest as []));
+      }
+      return realRealpath(input, ...(rest as []));
+    });
+
+    const env: NodeJS.ProcessEnv = { PAPERCLIP_HOME: configuredHomeDir, PAPERCLIP_INSTANCE_ID: "default" };
+    const configuredCandidateDir = path.join(
+      configuredHomeDir,
+      "instances",
+      "default",
+      "companies",
+      companyId,
+      "codex-home",
+    );
+
+    const resolved = await assertManagedCredentialHome({ env, companyId, candidateDir: configuredCandidateDir });
+
+    expect(resolved).toBe(candidateDir);
+  });
+
+  async function setUpNonLinuxInstance() {
+    const homeDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-managed-credential-home-nonlinux-"));
+    cleanupDirs.push(homeDir);
+    const env: NodeJS.ProcessEnv = { PAPERCLIP_HOME: homeDir, PAPERCLIP_INSTANCE_ID: "default" };
+    const companyId = "company-a";
+    const companyRoot = path.join(homeDir, "instances", "default", "companies", companyId);
+    await mkdir(companyRoot, { recursive: true });
+    return { env, companyId, companyRoot };
+  }
+
+  it("still rejects a genuine redirect to a different location, not just a casing difference", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    const { env, companyId } = await setUpNonLinuxInstance();
+    const outsideDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-outside-nonlinux-"));
+    cleanupDirs.push(outsideDir);
+
+    await expect(
+      assertManagedCredentialHome({ env, companyId, candidateDir: outsideDir }),
+    ).rejects.toThrow("outside the company-managed directory tree");
+  });
+
+  it("still rejects a symbolic link on a non-Linux platform", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    const { env, companyId, companyRoot } = await setUpNonLinuxInstance();
+    const outsideTarget = await mkdtemp(path.join(os.tmpdir(), "paperclip-symlink-target-nonlinux-"));
+    cleanupDirs.push(outsideTarget);
+    const linkPath = path.join(companyRoot, "codex-home");
+    await symlink(outsideTarget, linkPath, "dir");
+
+    await expect(
+      assertManagedCredentialHome({ env, companyId, candidateDir: linkPath }),
+    ).rejects.toThrow("outside the company-managed directory tree");
   });
 });

--- a/packages/adapter-utils/src/managed-credential-home.test.ts
+++ b/packages/adapter-utils/src/managed-credential-home.test.ts
@@ -254,12 +254,15 @@ describe("assertManagedCredentialHome", () => {
 // On a case-insensitive filesystem (the default on macOS and Windows),
 // `fs.realpath` can return the on-disk spelling of a directory whose
 // configured casing (from `PAPERCLIP_HOME`) differs only by letter case. This
-// suite forces `process.platform` to a non-Linux value and stubs `realpath`
-// to reproduce that exact scenario against a real temp directory tree — the
-// test filesystem itself is case-sensitive, so a genuine case-insensitive
-// `realpath` behavior has to be simulated — to prove a same-location casing
-// difference no longer rejects a valid managed home, while containment and
-// symlink rejection still hold.
+// suite stubs `realpath` to reproduce that exact scenario against a real temp
+// directory tree — the test filesystem itself is case-sensitive, so a
+// genuine case-insensitive `realpath` behavior has to be simulated — to prove
+// a same-location casing difference no longer rejects a valid managed home,
+// while containment and symlink rejection still hold. `process.platform` is
+// still forced to a non-Linux value in each test as a reminder that the
+// guard's behavior must not depend on the host platform; the guard checks
+// on-disk directory entries instead, so the forced value does not change the
+// outcome.
 describe("assertManagedCredentialHome on a case-insensitive filesystem", () => {
   const cleanupDirs: string[] = [];
   const originalPlatform = process.platform;
@@ -347,6 +350,49 @@ describe("assertManagedCredentialHome on a case-insensitive filesystem", () => {
 
     await expect(
       assertManagedCredentialHome({ env, companyId, candidateDir: linkPath }),
+    ).rejects.toThrow("outside the company-managed directory tree");
+  });
+
+  it("rejects a same-cased-looking symbolic link that actually redirects to a colliding, differently-cased directory", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    const homeDir = await mkdtemp(
+      path.join(os.tmpdir(), "paperclip-managed-credential-home-casecollision-"),
+    );
+    cleanupDirs.push(homeDir);
+    const companyId = "company-a";
+
+    // A directory named "INSTANCES" — a sibling of the literal "instances"
+    // name, differing only by letter case. On a case-sensitive filesystem,
+    // this is a distinct, attacker-controlled directory, not the same entry
+    // a case-insensitive filesystem would report for either spelling.
+    const attackerInstancesDir = path.join(homeDir, "INSTANCES");
+    const attackerCompanyDir = path.join(attackerInstancesDir, "default", "companies", companyId);
+    await mkdir(attackerCompanyDir, { recursive: true });
+
+    // The literal "instances" path is a symbolic link to that colliding
+    // sibling. `fs.realpath` on the literal instance root then returns a
+    // path that differs from it only by the letter case of this one
+    // segment — the exact shape a genuine case-insensitive filesystem also
+    // produces, but here it is a real redirect to a different directory.
+    await symlink(attackerInstancesDir, path.join(homeDir, "instances"), "dir");
+    const env: NodeJS.ProcessEnv = { PAPERCLIP_HOME: homeDir, PAPERCLIP_INSTANCE_ID: "default" };
+
+    // Build the candidate the same way an honest caller would: from the
+    // literal, lowercase "instances" spelling, not from the attacker's
+    // directory directly. This is what makes the redirect dangerous — the
+    // literal candidate reaches the attacker's tree only because the
+    // instance-root check above adopted it as the boundary.
+    const literalCandidateDir = path.join(
+      homeDir,
+      "instances",
+      "default",
+      "companies",
+      companyId,
+      "codex-home",
+    );
+
+    await expect(
+      assertManagedCredentialHome({ env, companyId, candidateDir: literalCandidateDir }),
     ).rejects.toThrow("outside the company-managed directory tree");
   });
 });

--- a/packages/adapter-utils/src/managed-credential-home.test.ts
+++ b/packages/adapter-utils/src/managed-credential-home.test.ts
@@ -1,8 +1,11 @@
-import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { assertManagedCredentialHome } from "./managed-credential-home.js";
+import {
+  assertManagedCredentialHome,
+  assertNoSymlinkInManagedCredentialPath,
+} from "./managed-credential-home.js";
 
 describe("assertManagedCredentialHome", () => {
   const cleanupDirs: string[] = [];
@@ -24,6 +27,17 @@ describe("assertManagedCredentialHome", () => {
     const companyRoot = path.join(instanceRoot, "companies", companyId);
     await mkdir(companyRoot, { recursive: true });
     return { env, companyId, companyRoot, instanceRoot };
+  }
+
+  /** Same as {@link setUpInstance}, but leaves the company directory itself unmade, so a test can put a symbolic link there instead. */
+  async function setUpInstanceWithoutCompanyDir() {
+    const homeDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-managed-credential-home-"));
+    cleanupDirs.push(homeDir);
+    const env: NodeJS.ProcessEnv = { PAPERCLIP_HOME: homeDir, PAPERCLIP_INSTANCE_ID: "default" };
+    const instanceRoot = path.join(homeDir, "instances", "default");
+    const companiesRoot = path.join(instanceRoot, "companies");
+    await mkdir(companiesRoot, { recursive: true });
+    return { env, instanceRoot, companiesRoot };
   }
 
   it("accepts the company default home", async () => {
@@ -104,5 +118,68 @@ describe("assertManagedCredentialHome", () => {
     await expect(
       assertManagedCredentialHome({ env, companyId, candidateDir: outsideDir }),
     ).rejects.toThrow(/^The credential home is outside the company-managed directory tree\.$/);
+  });
+
+  it("rejects a company-root symbolic link that points at another company's directory", async () => {
+    const { env, companiesRoot } = await setUpInstanceWithoutCompanyDir();
+    const companyId = "company-a";
+    const otherCompanyDir = path.join(companiesRoot, "company-b");
+    await mkdir(otherCompanyDir, { recursive: true });
+    const companyLinkPath = path.join(companiesRoot, companyId);
+    await symlink(otherCompanyDir, companyLinkPath, "dir");
+
+    await expect(
+      assertManagedCredentialHome({
+        env,
+        companyId,
+        candidateDir: path.join(companyLinkPath, "codex-home"),
+      }),
+    ).rejects.toThrow("outside the company-managed directory tree");
+  });
+
+  it("rejects a company-root symbolic link that points outside the instance tree", async () => {
+    const { env, companiesRoot } = await setUpInstanceWithoutCompanyDir();
+    const companyId = "company-a";
+    const outsideTarget = await mkdtemp(path.join(os.tmpdir(), "paperclip-outside-company-root-"));
+    cleanupDirs.push(outsideTarget);
+    const companyLinkPath = path.join(companiesRoot, companyId);
+    await symlink(outsideTarget, companyLinkPath, "dir");
+
+    await expect(
+      assertManagedCredentialHome({
+        env,
+        companyId,
+        candidateDir: path.join(companyLinkPath, "codex-home"),
+      }),
+    ).rejects.toThrow("outside the company-managed directory tree");
+  });
+
+  it("rejects a symbolic-link swap made after the check, so no token file lands at the swapped-to target", async () => {
+    const { env, companyId, companyRoot } = await setUpInstance();
+    const candidateDir = path.join(companyRoot, "codex-home");
+    await mkdir(candidateDir, { recursive: true });
+
+    const resolved = await assertManagedCredentialHome({ env, companyId, candidateDir });
+    expect(resolved).toBe(candidateDir);
+
+    // An attacker swaps the checked directory for a symbolic link to an
+    // external target between the check above and a caller's write below.
+    const externalTarget = await mkdtemp(path.join(os.tmpdir(), "paperclip-swap-target-"));
+    cleanupDirs.push(externalTarget);
+    await rm(candidateDir, { recursive: true, force: true });
+    await symlink(externalTarget, candidateDir, "dir");
+
+    // A caller must re-verify with a no-follow check immediately before it
+    // writes. This simulates that contract: the token write only runs when
+    // the re-check passes.
+    async function writeTokenIfStillContained(): Promise<void> {
+      await assertNoSymlinkInManagedCredentialPath(companyRoot, resolved);
+      await writeFile(path.join(resolved, "auth.json"), "token-bytes");
+    }
+
+    await expect(writeTokenIfStillContained()).rejects.toThrow(
+      "outside the company-managed directory tree",
+    );
+    expect(await readdir(externalTarget)).toEqual([]);
   });
 });

--- a/packages/adapter-utils/src/managed-credential-home.test.ts
+++ b/packages/adapter-utils/src/managed-credential-home.test.ts
@@ -1,0 +1,108 @@
+import { mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { assertManagedCredentialHome } from "./managed-credential-home.js";
+
+describe("assertManagedCredentialHome", () => {
+  const cleanupDirs: string[] = [];
+
+  afterEach(async () => {
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  async function setUpInstance() {
+    const homeDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-managed-credential-home-"));
+    cleanupDirs.push(homeDir);
+    const env: NodeJS.ProcessEnv = { PAPERCLIP_HOME: homeDir, PAPERCLIP_INSTANCE_ID: "default" };
+    const instanceRoot = path.join(homeDir, "instances", "default");
+    const companyId = "company-a";
+    const companyRoot = path.join(instanceRoot, "companies", companyId);
+    await mkdir(companyRoot, { recursive: true });
+    return { env, companyId, companyRoot, instanceRoot };
+  }
+
+  it("accepts the company default home", async () => {
+    const { env, companyId, companyRoot } = await setUpInstance();
+    const candidateDir = path.join(companyRoot, "codex-home");
+    await mkdir(candidateDir, { recursive: true });
+
+    const resolved = await assertManagedCredentialHome({ env, companyId, candidateDir });
+
+    expect(resolved).toBe(candidateDir);
+  });
+
+  it("accepts an account home under the company root", async () => {
+    const { env, companyId, companyRoot } = await setUpInstance();
+    const candidateDir = path.join(companyRoot, "codex-auth-cache", "some-handle");
+    await mkdir(candidateDir, { recursive: true });
+
+    const resolved = await assertManagedCredentialHome({ env, companyId, candidateDir });
+
+    expect(resolved).toBe(candidateDir);
+  });
+
+  it("rejects a path outside the instance root", async () => {
+    const { env, companyId } = await setUpInstance();
+    const outsideDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-outside-"));
+    cleanupDirs.push(outsideDir);
+
+    await expect(
+      assertManagedCredentialHome({ env, companyId, candidateDir: outsideDir }),
+    ).rejects.toThrow("outside the company-managed directory tree");
+  });
+
+  it("rejects a path under another company", async () => {
+    const { env, companyId, instanceRoot } = await setUpInstance();
+    const otherCompanyDir = path.join(instanceRoot, "companies", "company-b", "codex-home");
+    await mkdir(otherCompanyDir, { recursive: true });
+
+    await expect(
+      assertManagedCredentialHome({ env, companyId, candidateDir: otherCompanyDir }),
+    ).rejects.toThrow("outside the company-managed directory tree");
+  });
+
+  it("rejects a symbolic link inside the company root that points outside it", async () => {
+    const { env, companyId, companyRoot } = await setUpInstance();
+    const outsideTarget = await mkdtemp(path.join(os.tmpdir(), "paperclip-symlink-target-"));
+    cleanupDirs.push(outsideTarget);
+    const linkPath = path.join(companyRoot, "codex-home");
+    await symlink(outsideTarget, linkPath, "dir");
+
+    await expect(
+      assertManagedCredentialHome({ env, companyId, candidateDir: linkPath }),
+    ).rejects.toThrow("outside the company-managed directory tree");
+  });
+
+  it("rejects a relative path that escapes with \"..\"", async () => {
+    const { env, companyId, companyRoot } = await setUpInstance();
+    const escapingPath = path.join(companyRoot, "..", "..", "escaped");
+
+    await expect(
+      assertManagedCredentialHome({ env, companyId, candidateDir: escapingPath }),
+    ).rejects.toThrow("outside the company-managed directory tree");
+  });
+
+  it("accepts a candidate directory that does not exist yet", async () => {
+    const { env, companyId, companyRoot } = await setUpInstance();
+    const candidateDir = path.join(companyRoot, "codex-auth-cache", "not-created-yet");
+
+    const resolved = await assertManagedCredentialHome({ env, companyId, candidateDir });
+
+    expect(resolved).toBe(candidateDir);
+  });
+
+  it("names no path and no identifier in its rejection message", async () => {
+    const { env, companyId } = await setUpInstance();
+    const outsideDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-outside-"));
+    cleanupDirs.push(outsideDir);
+
+    await expect(
+      assertManagedCredentialHome({ env, companyId, candidateDir: outsideDir }),
+    ).rejects.toThrow(/^The credential home is outside the company-managed directory tree\.$/);
+  });
+});

--- a/packages/adapter-utils/src/managed-credential-home.test.ts
+++ b/packages/adapter-utils/src/managed-credential-home.test.ts
@@ -154,6 +154,45 @@ describe("assertManagedCredentialHome", () => {
     ).rejects.toThrow("outside the company-managed directory tree");
   });
 
+  it("rejects a companies directory that is itself a symbolic link to an external location", async () => {
+    const homeDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-managed-credential-home-"));
+    cleanupDirs.push(homeDir);
+    const env: NodeJS.ProcessEnv = { PAPERCLIP_HOME: homeDir, PAPERCLIP_INSTANCE_ID: "default" };
+    const instanceRoot = path.join(homeDir, "instances", "default");
+    await mkdir(instanceRoot, { recursive: true });
+    const externalCompaniesTarget = await mkdtemp(
+      path.join(os.tmpdir(), "paperclip-external-companies-"),
+    );
+    cleanupDirs.push(externalCompaniesTarget);
+    const companyId = "company-a";
+    await mkdir(path.join(externalCompaniesTarget, companyId), { recursive: true });
+    await symlink(externalCompaniesTarget, path.join(instanceRoot, "companies"), "dir");
+
+    await expect(
+      assertManagedCredentialHome({
+        env,
+        companyId,
+        candidateDir: path.join(externalCompaniesTarget, companyId, "codex-home"),
+      }),
+    ).rejects.toThrow("outside the company-managed directory tree");
+  });
+
+  it("rejects a candidate symlink to another account home inside the same company", async () => {
+    const { env, companyId, companyRoot } = await setUpInstance();
+    const realAccountHome = path.join(companyRoot, "codex-homes", "account-b");
+    await mkdir(realAccountHome, { recursive: true });
+    const candidateDir = path.join(companyRoot, "codex-homes", "account-a");
+    await mkdir(path.dirname(candidateDir), { recursive: true });
+    await symlink(realAccountHome, candidateDir, "dir");
+
+    // Even though the symlink target is still inside the company tree — so
+    // the old resolved-path containment check alone would have accepted it —
+    // the literal candidate itself is a symbolic link and must be rejected.
+    await expect(
+      assertManagedCredentialHome({ env, companyId, candidateDir }),
+    ).rejects.toThrow("outside the company-managed directory tree");
+  });
+
   it("rejects a symbolic-link swap made after the check, so no token file lands at the swapped-to target", async () => {
     const { env, companyId, companyRoot } = await setUpInstance();
     const candidateDir = path.join(companyRoot, "codex-home");

--- a/packages/adapter-utils/src/managed-credential-home.test.ts
+++ b/packages/adapter-utils/src/managed-credential-home.test.ts
@@ -177,6 +177,33 @@ describe("assertManagedCredentialHome", () => {
     ).rejects.toThrow("outside the company-managed directory tree");
   });
 
+  it("rejects an instance root reached through a symbolic-link ancestor", async () => {
+    const homeDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-managed-credential-home-"));
+    cleanupDirs.push(homeDir);
+    const externalInstancesTarget = await mkdtemp(
+      path.join(os.tmpdir(), "paperclip-external-instances-"),
+    );
+    cleanupDirs.push(externalInstancesTarget);
+    const companyId = "company-a";
+    const externalInstanceRoot = path.join(externalInstancesTarget, "default");
+    const externalCompanyDir = path.join(externalInstanceRoot, "companies", companyId);
+    await mkdir(externalCompanyDir, { recursive: true });
+    // `PAPERCLIP_HOME/instances` is a symbolic link to an external directory.
+    // Both the instance root and the `companies` directory resolve through
+    // this SAME redirect, so a check that only compares the two resolved
+    // paths against each other would still pass.
+    await symlink(externalInstancesTarget, path.join(homeDir, "instances"), "dir");
+    const env: NodeJS.ProcessEnv = { PAPERCLIP_HOME: homeDir, PAPERCLIP_INSTANCE_ID: "default" };
+
+    await expect(
+      assertManagedCredentialHome({
+        env,
+        companyId,
+        candidateDir: path.join(externalCompanyDir, "codex-home"),
+      }),
+    ).rejects.toThrow("outside the company-managed directory tree");
+  });
+
   it("rejects a candidate symlink to another account home inside the same company", async () => {
     const { env, companyId, companyRoot } = await setUpInstance();
     const realAccountHome = path.join(companyRoot, "codex-homes", "account-b");

--- a/packages/adapter-utils/src/managed-credential-home.ts
+++ b/packages/adapter-utils/src/managed-credential-home.ts
@@ -95,6 +95,13 @@ async function resolveRealPathAllowingMissingSegments(candidateDir: string): Pro
  *
  * Rejects with {@link REJECTED_CREDENTIAL_HOME_MESSAGE} when:
  * - the instance root does not exist.
+ * - `PAPERCLIP_HOME`, its `instances` directory, or the instance root itself
+ *   is a symbolic link, or sits anywhere other than its own literal,
+ *   unresolved path once resolved — this stops a redirected ancestor from
+ *   being silently adopted as the credential-write boundary. A redirected
+ *   ancestor moves BOTH the instance root and the `companies` directory
+ *   through the same target, so the `companies`-only check below cannot
+ *   catch it on its own; this check must run first.
  * - the `companies` directory does not exist.
  * - the `companies` directory is a symbolic link, or sits anywhere other
  *   than `<realInstanceRoot>/companies` once resolved — this stops a
@@ -121,6 +128,18 @@ export async function resolveManagedCredentialHomeBoundary(
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") rejectCredentialHome();
     throw error;
+  }
+
+  // A symbolic link anywhere up the ancestor chain — `PAPERCLIP_HOME`, its
+  // `instances` directory, or the instance root itself — redirects
+  // `realInstanceRoot` to an external location. The `companies`-root check
+  // below re-derives its expected value from `realInstanceRoot`, so it
+  // resolves through the SAME redirect on both sides and cannot detect this
+  // on its own. Require the resolved instance root to equal the literal,
+  // unresolved `instanceRoot`; a difference means some ancestor component is
+  // a symbolic link, so reject before it can be adopted as the boundary.
+  if (realInstanceRoot !== instanceRoot) {
+    rejectCredentialHome();
   }
 
   let realCompaniesRoot: string;

--- a/packages/adapter-utils/src/managed-credential-home.ts
+++ b/packages/adapter-utils/src/managed-credential-home.ts
@@ -34,6 +34,28 @@ function rejectCredentialHome(): never {
   throw new ManagedCredentialHomeRejectedError();
 }
 
+/**
+ * True when `realPath` (the output of `fs.realpath`) matches `literalPath`
+ * (the same path built from configuration, not yet resolved) closely enough
+ * to trust as the SAME location, not a redirect to a different one.
+ *
+ * An exact match always passes. On a case-insensitive filesystem — the
+ * default on macOS and Windows — `fs.realpath` can return the on-disk
+ * spelling of a directory whose configured casing differs only by letter
+ * case; two strings that differ only by letter case address the same file on
+ * that filesystem, so tolerate that difference there. Linux is excluded: its
+ * default filesystems are case-sensitive, so two differently-cased strings
+ * there name two different directories, and a symbolic link could redirect
+ * one to the other. Restricting the tolerance to non-Linux platforms keeps a
+ * genuine redirect on Linux caught, while a same-location casing difference
+ * on macOS or Windows no longer rejects a valid managed home.
+ */
+function realPathMatchesLiteral(realPath: string, literalPath: string): boolean {
+  if (realPath === literalPath) return true;
+  if (process.platform === "linux") return false;
+  return realPath.toLowerCase() === literalPath.toLowerCase();
+}
+
 /** True when `segment` is exactly one path component: not empty, not `.` or `..`, and free of a path separator. */
 function isSafePathSegment(segment: string): boolean {
   if (!segment) return false;
@@ -101,7 +123,10 @@ async function resolveRealPathAllowingMissingSegments(candidateDir: string): Pro
  *   being silently adopted as the credential-write boundary. A redirected
  *   ancestor moves BOTH the instance root and the `companies` directory
  *   through the same target, so the `companies`-only check below cannot
- *   catch it on its own; this check must run first.
+ *   catch it on its own; this check must run first. A same-location
+ *   difference of letter case only, the kind a case-insensitive filesystem's
+ *   `fs.realpath` can return on macOS or Windows, is not a redirect and does
+ *   not reject — see {@link realPathMatchesLiteral}.
  * - the `companies` directory does not exist.
  * - the `companies` directory is a symbolic link, or sits anywhere other
  *   than `<realInstanceRoot>/companies` once resolved — this stops a
@@ -135,10 +160,12 @@ export async function resolveManagedCredentialHomeBoundary(
   // `realInstanceRoot` to an external location. The `companies`-root check
   // below re-derives its expected value from `realInstanceRoot`, so it
   // resolves through the SAME redirect on both sides and cannot detect this
-  // on its own. Require the resolved instance root to equal the literal,
-  // unresolved `instanceRoot`; a difference means some ancestor component is
-  // a symbolic link, so reject before it can be adopted as the boundary.
-  if (realInstanceRoot !== instanceRoot) {
+  // on its own. Require the resolved instance root to match the literal,
+  // unresolved `instanceRoot` (tolerating a letter-case-only difference on a
+  // non-Linux platform — see {@link realPathMatchesLiteral}); anything else
+  // means some ancestor component is a symbolic link, so reject before it
+  // can be adopted as the boundary.
+  if (!realPathMatchesLiteral(realInstanceRoot, instanceRoot)) {
     rejectCredentialHome();
   }
 
@@ -152,11 +179,12 @@ export async function resolveManagedCredentialHomeBoundary(
 
   // A symbolic link at (or above) the `companies` segment can redirect
   // `realCompaniesRoot` to any external location `fs.realpath` is willing to
-  // follow. Require it to land exactly at `<realInstanceRoot>/companies` —
-  // the only location a managed `companies` directory may occupy — so a
-  // redirected companies root is rejected instead of silently adopted as the
-  // credential-write boundary.
-  if (realCompaniesRoot !== path.join(realInstanceRoot, "companies")) {
+  // follow. Require it to land at `<realInstanceRoot>/companies` — the only
+  // location a managed `companies` directory may occupy, tolerating a
+  // letter-case-only difference on a non-Linux platform the same way as the
+  // instance-root check above — so a redirected companies root is rejected
+  // instead of silently adopted as the credential-write boundary.
+  if (!realPathMatchesLiteral(realCompaniesRoot, path.join(realInstanceRoot, "companies"))) {
     rejectCredentialHome();
   }
 

--- a/packages/adapter-utils/src/managed-credential-home.ts
+++ b/packages/adapter-utils/src/managed-credential-home.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolvePaperclipInstanceRootForAdapter } from "./server-utils.js";
+
+// A credential copy-back writes real token bytes to its destination
+// directory. This guard is the containment check that a copy-back target must
+// pass before any write. It accepts only a directory under one company's own
+// tree (`<instanceRoot>/companies/<companyId>`) and rejects everything else —
+// an external path, a path under a different company, or a path that only
+// looks contained until a symbolic link is followed.
+//
+// The rejection message is fixed text with no path and no identifier, so a
+// log line built from it can never leak which company or which path a run
+// tried to reach.
+const REJECTED_CREDENTIAL_HOME_MESSAGE =
+  "The credential home is outside the company-managed directory tree.";
+
+export interface AssertManagedCredentialHomeInput {
+  env?: NodeJS.ProcessEnv;
+  companyId: string;
+  candidateDir: string;
+}
+
+/**
+ * Resolves the real (symbolic-link-free) path of `candidateDir`. When the
+ * directory does not exist yet, this walks up to the nearest existing
+ * ancestor, resolves that ancestor's real path, and joins the still-missing
+ * segments back on. This way a candidate a caller has not created yet still
+ * gets a real prefix to check, and a symbolic link anywhere on an EXISTING
+ * part of the path still resolves to its true target.
+ */
+async function resolveRealPathAllowingMissingSegments(candidateDir: string): Promise<string> {
+  const resolved = path.resolve(candidateDir);
+  const missingSegments: string[] = [];
+  let current = resolved;
+  for (;;) {
+    try {
+      const realAncestor = await fs.realpath(current);
+      return missingSegments.length > 0
+        ? path.join(realAncestor, ...missingSegments.reverse())
+        : realAncestor;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      const parent = path.dirname(current);
+      if (parent === current) throw error;
+      missingSegments.push(path.basename(current));
+      current = parent;
+    }
+  }
+}
+
+/**
+ * Guards a Codex/Grok credential copy-back target. Call this with the
+ * directory a copy-back is about to write into, before any file write.
+ *
+ * Resolves the real path of the company root and the real path of
+ * `candidateDir`, then accepts the candidate only when it equals the company
+ * root or sits under it. Rejects every other candidate — a path outside the
+ * instance root, a path under a different company, a symbolic link that
+ * points outside the company root, and a relative path that escapes with
+ * `..` — with the fixed {@link REJECTED_CREDENTIAL_HOME_MESSAGE}.
+ *
+ * Returns the resolved, real candidate directory on success, so the caller
+ * writes through the same path this check just verified.
+ */
+export async function assertManagedCredentialHome(
+  input: AssertManagedCredentialHomeInput,
+): Promise<string> {
+  const env = input.env ?? process.env;
+  const instanceRoot = resolvePaperclipInstanceRootForAdapter({ env });
+  const companyRoot = path.resolve(instanceRoot, "companies", input.companyId);
+  const realCompanyRoot = await resolveRealPathAllowingMissingSegments(companyRoot);
+  const realCandidateDir = await resolveRealPathAllowingMissingSegments(input.candidateDir);
+
+  const isContained =
+    realCandidateDir === realCompanyRoot ||
+    realCandidateDir.startsWith(realCompanyRoot + path.sep);
+  if (!isContained) {
+    throw new Error(REJECTED_CREDENTIAL_HOME_MESSAGE);
+  }
+  return realCandidateDir;
+}

--- a/packages/adapter-utils/src/managed-credential-home.ts
+++ b/packages/adapter-utils/src/managed-credential-home.ts
@@ -34,26 +34,82 @@ function rejectCredentialHome(): never {
   throw new ManagedCredentialHomeRejectedError();
 }
 
+/** Splits an absolute path into its root (`/`, or a drive letter such as `C:\`) followed by each directory segment, in order. */
+function splitPathIntoSegments(absolutePath: string): string[] {
+  const { root } = path.parse(absolutePath);
+  const rest = absolutePath.slice(root.length);
+  const segments = rest.split(path.sep).filter((segment) => segment.length > 0);
+  return [root, ...segments];
+}
+
+/**
+ * True when `dir` contains exactly one entry whose name matches `name` when
+ * both are compared in lower case.
+ *
+ * On a filesystem that folds case, two spellings that differ only by letter
+ * case cannot both exist as separate entries in the same directory — the
+ * filesystem stores one entry, addressable by any casing. On a filesystem
+ * that does not fold case, an attacker can create a second, distinct entry
+ * next to the expected one, differing only by letter case. Counting the
+ * matching entries tells these two situations apart directly, without any
+ * assumption about the host platform.
+ */
+async function directoryHasExactlyOneEntryIgnoringCase(dir: string, name: string): Promise<boolean> {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+  const target = name.toLowerCase();
+  return entries.filter((entry) => entry.toLowerCase() === target).length === 1;
+}
+
 /**
  * True when `realPath` (the output of `fs.realpath`) matches `literalPath`
  * (the same path built from configuration, not yet resolved) closely enough
  * to trust as the SAME location, not a redirect to a different one.
  *
- * An exact match always passes. On a case-insensitive filesystem — the
- * default on macOS and Windows — `fs.realpath` can return the on-disk
- * spelling of a directory whose configured casing differs only by letter
- * case; two strings that differ only by letter case address the same file on
- * that filesystem, so tolerate that difference there. Linux is excluded: its
- * default filesystems are case-sensitive, so two differently-cased strings
- * there name two different directories, and a symbolic link could redirect
- * one to the other. Restricting the tolerance to non-Linux platforms keeps a
- * genuine redirect on Linux caught, while a same-location casing difference
- * on macOS or Windows no longer rejects a valid managed home.
+ * An exact match always passes. Otherwise this walks both paths segment by
+ * segment. A segment pair must match exactly, or match only by letter case —
+ * anything else is a real redirect, rejected immediately. For a
+ * letter-case-only segment, this checks the real parent directory on disk
+ * with {@link directoryHasExactlyOneEntryIgnoringCase}: exactly one matching
+ * entry means the filesystem folds case there, so the difference is benign;
+ * two or more means a colliding, differently-cased entry exists, so the
+ * difference is treated as a redirect and rejected.
+ *
+ * This does not assume case-folding from the host platform. A non-Linux
+ * platform is not proof of a case-insensitive filesystem — macOS and other
+ * non-Linux hosts can mount or format a case-sensitive filesystem — so a
+ * platform check alone could accept a redirect through a colliding,
+ * differently-cased sibling entry. Checking the actual directory entries
+ * instead catches that redirect on every platform.
  */
-function realPathMatchesLiteral(realPath: string, literalPath: string): boolean {
+async function realPathMatchesLiteral(realPath: string, literalPath: string): Promise<boolean> {
   if (realPath === literalPath) return true;
-  if (process.platform === "linux") return false;
-  return realPath.toLowerCase() === literalPath.toLowerCase();
+
+  const realSegments = splitPathIntoSegments(realPath);
+  const literalSegments = splitPathIntoSegments(literalPath);
+  if (realSegments.length !== literalSegments.length) return false;
+
+  let realPrefix = "";
+  for (let i = 0; i < realSegments.length; i++) {
+    const realSegment = realSegments[i];
+    const literalSegment = literalSegments[i];
+    if (realSegment !== literalSegment) {
+      if (realSegment.toLowerCase() !== literalSegment.toLowerCase()) return false;
+      // The root segment (a drive letter or the POSIX "/") has no parent
+      // directory to hold a colliding sibling, so a case-only difference
+      // there is tolerated directly, with no directory check to run.
+      if (i > 0 && !(await directoryHasExactlyOneEntryIgnoringCase(realPrefix, realSegment))) {
+        return false;
+      }
+    }
+    realPrefix = i === 0 ? realSegment : path.join(realPrefix, realSegment);
+  }
+  return true;
 }
 
 /** True when `segment` is exactly one path component: not empty, not `.` or `..`, and free of a path separator. */
@@ -125,8 +181,8 @@ async function resolveRealPathAllowingMissingSegments(candidateDir: string): Pro
  *   through the same target, so the `companies`-only check below cannot
  *   catch it on its own; this check must run first. A same-location
  *   difference of letter case only, the kind a case-insensitive filesystem's
- *   `fs.realpath` can return on macOS or Windows, is not a redirect and does
- *   not reject — see {@link realPathMatchesLiteral}.
+ *   `fs.realpath` can return, is not a redirect and does not reject — see
+ *   {@link realPathMatchesLiteral}.
  * - the `companies` directory does not exist.
  * - the `companies` directory is a symbolic link, or sits anywhere other
  *   than `<realInstanceRoot>/companies` once resolved — this stops a
@@ -161,11 +217,12 @@ export async function resolveManagedCredentialHomeBoundary(
   // below re-derives its expected value from `realInstanceRoot`, so it
   // resolves through the SAME redirect on both sides and cannot detect this
   // on its own. Require the resolved instance root to match the literal,
-  // unresolved `instanceRoot` (tolerating a letter-case-only difference on a
-  // non-Linux platform — see {@link realPathMatchesLiteral}); anything else
-  // means some ancestor component is a symbolic link, so reject before it
-  // can be adopted as the boundary.
-  if (!realPathMatchesLiteral(realInstanceRoot, instanceRoot)) {
+  // unresolved `instanceRoot` (tolerating a letter-case-only difference the
+  // real filesystem itself confirms is benign — see
+  // {@link realPathMatchesLiteral}); anything else means some ancestor
+  // component is a symbolic link, so reject before it can be adopted as the
+  // boundary.
+  if (!(await realPathMatchesLiteral(realInstanceRoot, instanceRoot))) {
     rejectCredentialHome();
   }
 
@@ -181,10 +238,10 @@ export async function resolveManagedCredentialHomeBoundary(
   // `realCompaniesRoot` to any external location `fs.realpath` is willing to
   // follow. Require it to land at `<realInstanceRoot>/companies` — the only
   // location a managed `companies` directory may occupy, tolerating a
-  // letter-case-only difference on a non-Linux platform the same way as the
-  // instance-root check above — so a redirected companies root is rejected
-  // instead of silently adopted as the credential-write boundary.
-  if (!realPathMatchesLiteral(realCompaniesRoot, path.join(realInstanceRoot, "companies"))) {
+  // letter-case-only difference the same way as the instance-root check
+  // above — so a redirected companies root is rejected instead of silently
+  // adopted as the credential-write boundary.
+  if (!(await realPathMatchesLiteral(realCompaniesRoot, path.join(realInstanceRoot, "companies")))) {
     rejectCredentialHome();
   }
 

--- a/packages/adapter-utils/src/managed-credential-home.ts
+++ b/packages/adapter-utils/src/managed-credential-home.ts
@@ -15,10 +15,26 @@ import { resolvePaperclipInstanceRootForAdapter } from "./server-utils.js";
 const REJECTED_CREDENTIAL_HOME_MESSAGE =
   "The credential home is outside the company-managed directory tree.";
 
+function rejectCredentialHome(): never {
+  throw new Error(REJECTED_CREDENTIAL_HOME_MESSAGE);
+}
+
+/** True when `segment` is exactly one path component: not empty, not `.` or `..`, and free of a path separator. */
+function isSafePathSegment(segment: string): boolean {
+  if (!segment) return false;
+  if (segment === "." || segment === "..") return false;
+  return !segment.includes("/") && !segment.includes("\\");
+}
+
 export interface AssertManagedCredentialHomeInput {
   env?: NodeJS.ProcessEnv;
   companyId: string;
   candidateDir: string;
+}
+
+export interface ManagedCredentialHomeBoundaryInput {
+  env?: NodeJS.ProcessEnv;
+  companyId: string;
 }
 
 /**
@@ -50,33 +66,134 @@ async function resolveRealPathAllowingMissingSegments(candidateDir: string): Pro
 }
 
 /**
+ * Resolves and verifies the one real directory a company's credential writes
+ * may land under: `<realCompaniesRoot>/<companyId>`.
+ *
+ * Anchors on the real `companies` directory itself, not on the company
+ * directory. An earlier design resolved the company directory in isolation;
+ * when the logical company directory was itself a symbolic link, that
+ * resolution and a candidate's resolution both landed on the same link
+ * target, so containment passed when it should not have. Anchoring one
+ * level up removes that blind spot: `companyId` is validated as one path
+ * segment and then checked with a no-follow `lstat`, so a symbolic link AT
+ * the company-root segment is caught directly.
+ *
+ * Rejects with {@link REJECTED_CREDENTIAL_HOME_MESSAGE} when:
+ * - `companyId` is empty, is `.` or `..`, or contains a path separator.
+ * - the `companies` directory does not exist.
+ * - `<realCompaniesRoot>/<companyId>` is missing, is not a directory, or is
+ *   a symbolic link.
+ *
+ * Call this again immediately before a write that uses the result. Do not
+ * carry a boundary computed earlier across an `await` that the write does
+ * not need — a mutable ancestor can be rebound while that write waits.
+ */
+export async function resolveManagedCredentialHomeBoundary(
+  input: ManagedCredentialHomeBoundaryInput,
+): Promise<string> {
+  const env = input.env ?? process.env;
+  const instanceRoot = resolvePaperclipInstanceRootForAdapter({ env });
+  const companiesRoot = path.resolve(instanceRoot, "companies");
+
+  let realCompaniesRoot: string;
+  try {
+    realCompaniesRoot = await fs.realpath(companiesRoot);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") rejectCredentialHome();
+    throw error;
+  }
+
+  if (!isSafePathSegment(input.companyId)) rejectCredentialHome();
+
+  const companyDir = path.join(realCompaniesRoot, input.companyId);
+  let companyStat;
+  try {
+    companyStat = await fs.lstat(companyDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") rejectCredentialHome();
+    throw error;
+  }
+  if (companyStat.isSymbolicLink() || !companyStat.isDirectory()) {
+    rejectCredentialHome();
+  }
+
+  return companyDir;
+}
+
+/**
+ * Verifies every EXISTING directory segment between `boundary` (a path
+ * {@link resolveManagedCredentialHomeBoundary} already verified) and
+ * `target` with a no-follow `lstat`, so a symbolic link anywhere in the
+ * existing part of the chain is caught. Stops at the first segment that
+ * does not exist yet — a copy-back may still create it, and a missing
+ * segment carries no symbolic link to check.
+ *
+ * Node.js exposes no `openat`, `mkdirat`, or `renameat`, so this walk
+ * cannot pin a directory file descriptor across the segments the way a
+ * single kernel-level containment check would. Calling this immediately
+ * before the write it guards — with no other `await` in between — is the
+ * strongest containment the standard library supports; a segment could
+ * still be rebound in the gap between this call returning and the write
+ * that follows it.
+ */
+export async function assertNoSymlinkInManagedCredentialPath(
+  boundary: string,
+  target: string,
+): Promise<void> {
+  const relative = path.relative(boundary, target);
+  if (relative === "") return;
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    rejectCredentialHome();
+  }
+
+  let current = boundary;
+  for (const segment of relative.split(path.sep)) {
+    current = path.join(current, segment);
+    let stat;
+    try {
+      stat = await fs.lstat(current);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw error;
+    }
+    if (stat.isSymbolicLink() || !stat.isDirectory()) {
+      rejectCredentialHome();
+    }
+  }
+}
+
+/**
  * Guards a Codex/Grok credential copy-back target. Call this with the
  * directory a copy-back is about to write into, before any file write.
  *
- * Resolves the real path of the company root and the real path of
- * `candidateDir`, then accepts the candidate only when it equals the company
- * root or sits under it. Rejects every other candidate — a path outside the
- * instance root, a path under a different company, a symbolic link that
- * points outside the company root, and a relative path that escapes with
- * `..` — with the fixed {@link REJECTED_CREDENTIAL_HOME_MESSAGE}.
+ * Verifies the company boundary with {@link resolveManagedCredentialHomeBoundary},
+ * resolves the real path of `candidateDir` only after that boundary passes,
+ * requires the candidate to equal the boundary or sit under it, then
+ * re-checks every existing segment between them with a no-follow `lstat`
+ * through {@link assertNoSymlinkInManagedCredentialPath}. Rejects every
+ * other candidate — a path outside the instance root, a path under a
+ * different company, a symbolic link anywhere on the chain, and a relative
+ * path that escapes with `..` — with the fixed
+ * {@link REJECTED_CREDENTIAL_HOME_MESSAGE}.
  *
- * Returns the resolved, real candidate directory on success, so the caller
- * writes through the same path this check just verified.
+ * Returns the resolved, real candidate directory on success. A caller that
+ * uses the result for a write must not treat it as still valid after an
+ * unrelated `await` — re-verify with {@link assertNoSymlinkInManagedCredentialPath}
+ * right before that write.
  */
 export async function assertManagedCredentialHome(
   input: AssertManagedCredentialHomeInput,
 ): Promise<string> {
-  const env = input.env ?? process.env;
-  const instanceRoot = resolvePaperclipInstanceRootForAdapter({ env });
-  const companyRoot = path.resolve(instanceRoot, "companies", input.companyId);
-  const realCompanyRoot = await resolveRealPathAllowingMissingSegments(companyRoot);
+  const boundary = await resolveManagedCredentialHomeBoundary(input);
   const realCandidateDir = await resolveRealPathAllowingMissingSegments(input.candidateDir);
 
   const isContained =
-    realCandidateDir === realCompanyRoot ||
-    realCandidateDir.startsWith(realCompanyRoot + path.sep);
+    realCandidateDir === boundary || realCandidateDir.startsWith(boundary + path.sep);
   if (!isContained) {
-    throw new Error(REJECTED_CREDENTIAL_HOME_MESSAGE);
+    rejectCredentialHome();
   }
+
+  await assertNoSymlinkInManagedCredentialPath(boundary, realCandidateDir);
+
   return realCandidateDir;
 }

--- a/packages/adapter-utils/src/managed-credential-home.ts
+++ b/packages/adapter-utils/src/managed-credential-home.ts
@@ -15,8 +15,23 @@ import { resolvePaperclipInstanceRootForAdapter } from "./server-utils.js";
 const REJECTED_CREDENTIAL_HOME_MESSAGE =
   "The credential home is outside the company-managed directory tree.";
 
+/**
+ * Thrown only for a containment rejection: a candidate directory outside the
+ * company-managed tree, under the wrong company, or reached through a
+ * symbolic link. A caller can catch this class alone to treat "not
+ * contained" as benign, and let every other error (a permission fault, an
+ * unexpected read fault) stay fail-loud. The message is fixed text with no
+ * path and no identifier.
+ */
+export class ManagedCredentialHomeRejectedError extends Error {
+  constructor() {
+    super(REJECTED_CREDENTIAL_HOME_MESSAGE);
+    this.name = "ManagedCredentialHomeRejectedError";
+  }
+}
+
 function rejectCredentialHome(): never {
-  throw new Error(REJECTED_CREDENTIAL_HOME_MESSAGE);
+  throw new ManagedCredentialHomeRejectedError();
 }
 
 /** True when `segment` is exactly one path component: not empty, not `.` or `..`, and free of a path separator. */

--- a/packages/adapter-utils/src/managed-credential-home.ts
+++ b/packages/adapter-utils/src/managed-credential-home.ts
@@ -262,6 +262,13 @@ export async function resolveManagedCredentialHomeBoundary(
   return companyDir;
 }
 
+/** The device and inode `fs.lstat` reported for one existing ancestor directory segment, at the moment a containment walk checked it. */
+export interface ManagedCredentialAncestorIdentity {
+  path: string;
+  dev: number;
+  ino: number;
+}
+
 /**
  * Verifies every EXISTING directory segment between `boundary` (a path
  * {@link resolveManagedCredentialHomeBoundary} already verified) and
@@ -269,6 +276,21 @@ export async function resolveManagedCredentialHomeBoundary(
  * existing part of the chain is caught. Stops at the first segment that
  * does not exist yet — a copy-back may still create it, and a missing
  * segment carries no symbolic link to check.
+ *
+ * Returns the device and inode this walk recorded for every checked
+ * segment EXCEPT `target` itself — every existing ANCESTOR of `target`, in
+ * order. A caller that separately pins `target` behind a directory
+ * descriptor can re-`lstat` these same ancestor paths after that open call
+ * succeeds and compare identities, to catch a symbolic link substituted
+ * into an ancestor segment in the gap between this walk and that open call,
+ * then LEFT in place: `open`'s own `O_NOFOLLOW` flag only refuses a
+ * symbolic link at the FINAL path segment, so it cannot see that swap, and
+ * neither can a plain `lstat` of `target` alone — resolved through the same
+ * swapped ancestor, it reports the same identity as the (attacker-pointing)
+ * pinned descriptor. `target` itself is excluded because a caller re-checks
+ * it a different way: against the pinned descriptor's own identity,
+ * immediately before each write, not against a value this walk recorded
+ * before the open call ran.
  *
  * Node.js exposes no `openat`, `mkdirat`, or `renameat`, so this walk
  * cannot pin a directory file descriptor across the segments the way a
@@ -278,30 +300,49 @@ export async function resolveManagedCredentialHomeBoundary(
  * still be rebound in the gap between this call returning and the write
  * that follows it.
  */
-export async function assertNoSymlinkInManagedCredentialPath(
+export async function assertNoSymlinkInManagedCredentialPathAndCaptureAncestors(
   boundary: string,
   target: string,
-): Promise<void> {
+): Promise<ManagedCredentialAncestorIdentity[]> {
   const relative = path.relative(boundary, target);
-  if (relative === "") return;
+  if (relative === "") return [];
   if (relative.startsWith("..") || path.isAbsolute(relative)) {
     rejectCredentialHome();
   }
 
+  const segments = relative.split(path.sep);
+  const ancestorIdentities: ManagedCredentialAncestorIdentity[] = [];
   let current = boundary;
-  for (const segment of relative.split(path.sep)) {
-    current = path.join(current, segment);
+  for (let i = 0; i < segments.length; i++) {
+    current = path.join(current, segments[i]);
     let stat;
     try {
       stat = await fs.lstat(current);
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return ancestorIdentities;
       throw error;
     }
     if (stat.isSymbolicLink() || !stat.isDirectory()) {
       rejectCredentialHome();
     }
+    const isTargetItself = i === segments.length - 1;
+    if (!isTargetItself) {
+      ancestorIdentities.push({ path: current, dev: stat.dev, ino: stat.ino });
+    }
   }
+  return ancestorIdentities;
+}
+
+/**
+ * Verifies every EXISTING directory segment between `boundary` and `target`,
+ * the same way as {@link assertNoSymlinkInManagedCredentialPathAndCaptureAncestors},
+ * for a caller that only needs the pass/reject outcome.
+ */
+export async function assertNoSymlinkInManagedCredentialPath(
+  boundary: string,
+  target: string,
+): Promise<void> {
+  await assertNoSymlinkInManagedCredentialPathAndCaptureAncestors(boundary, target);
 }
 
 /**

--- a/packages/adapter-utils/src/managed-credential-home.ts
+++ b/packages/adapter-utils/src/managed-credential-home.ts
@@ -94,8 +94,13 @@ async function resolveRealPathAllowingMissingSegments(candidateDir: string): Pro
  * the company-root segment is caught directly.
  *
  * Rejects with {@link REJECTED_CREDENTIAL_HOME_MESSAGE} when:
- * - `companyId` is empty, is `.` or `..`, or contains a path separator.
+ * - the instance root does not exist.
  * - the `companies` directory does not exist.
+ * - the `companies` directory is a symbolic link, or sits anywhere other
+ *   than `<realInstanceRoot>/companies` once resolved — this stops a
+ *   redirected `companies` entry from being silently adopted as the
+ *   credential-write boundary.
+ * - `companyId` is empty, is `.` or `..`, or contains a path separator.
  * - `<realCompaniesRoot>/<companyId>` is missing, is not a directory, or is
  *   a symbolic link.
  *
@@ -110,12 +115,30 @@ export async function resolveManagedCredentialHomeBoundary(
   const instanceRoot = resolvePaperclipInstanceRootForAdapter({ env });
   const companiesRoot = path.resolve(instanceRoot, "companies");
 
+  let realInstanceRoot: string;
+  try {
+    realInstanceRoot = await fs.realpath(instanceRoot);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") rejectCredentialHome();
+    throw error;
+  }
+
   let realCompaniesRoot: string;
   try {
     realCompaniesRoot = await fs.realpath(companiesRoot);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") rejectCredentialHome();
     throw error;
+  }
+
+  // A symbolic link at (or above) the `companies` segment can redirect
+  // `realCompaniesRoot` to any external location `fs.realpath` is willing to
+  // follow. Require it to land exactly at `<realInstanceRoot>/companies` —
+  // the only location a managed `companies` directory may occupy — so a
+  // redirected companies root is rejected instead of silently adopted as the
+  // credential-write boundary.
+  if (realCompaniesRoot !== path.join(realInstanceRoot, "companies")) {
+    rejectCredentialHome();
   }
 
   if (!isSafePathSegment(input.companyId)) rejectCredentialHome();
@@ -182,13 +205,16 @@ export async function assertNoSymlinkInManagedCredentialPath(
  * directory a copy-back is about to write into, before any file write.
  *
  * Verifies the company boundary with {@link resolveManagedCredentialHomeBoundary},
- * resolves the real path of `candidateDir` only after that boundary passes,
- * requires the candidate to equal the boundary or sit under it, then
- * re-checks every existing segment between them with a no-follow `lstat`
- * through {@link assertNoSymlinkInManagedCredentialPath}. Rejects every
- * other candidate — a path outside the instance root, a path under a
- * different company, a symbolic link anywhere on the chain, and a relative
- * path that escapes with `..` — with the fixed
+ * then walks the ORIGINAL, unresolved `candidateDir` against the literal
+ * boundary text with a no-follow `lstat` through
+ * {@link assertNoSymlinkInManagedCredentialPath}, so a symbolic link
+ * anywhere in the candidate — even one whose target is still inside the
+ * company tree — is rejected before it can be followed. Only then resolves
+ * the real path of `candidateDir`, requires the candidate to equal the
+ * boundary or sit under it, and re-checks every existing segment between
+ * them a second time. Rejects every other candidate — a path outside the
+ * instance root, a path under a different company, a symbolic link anywhere
+ * on the chain, and a relative path that escapes with `..` — with the fixed
  * {@link REJECTED_CREDENTIAL_HOME_MESSAGE}.
  *
  * Returns the resolved, real candidate directory on success. A caller that
@@ -200,6 +226,23 @@ export async function assertManagedCredentialHome(
   input: AssertManagedCredentialHomeInput,
 ): Promise<string> {
   const boundary = await resolveManagedCredentialHomeBoundary(input);
+
+  // Reject a symbolic link anywhere in the ORIGINAL candidate path before any
+  // symlink-following resolution runs. Compare against the LITERAL boundary
+  // text (`<instanceRoot>/companies/<companyId>`, not yet real-pathed) — a
+  // caller always builds a managed candidate directory with that same
+  // literal text, so an honest candidate still passes. The resolution below
+  // calls `fs.realpath`, which follows a symbolic link and adopts its
+  // target — including an in-tree link that points at a different, equally
+  // in-tree location, for example another account's credential home. A
+  // no-follow walk over the ALREADY-RESOLVED path can never see a link the
+  // resolution already followed, so this walk must run first, on the
+  // unresolved path.
+  const env = input.env ?? process.env;
+  const instanceRoot = resolvePaperclipInstanceRootForAdapter({ env });
+  const literalBoundary = path.resolve(instanceRoot, "companies", input.companyId);
+  await assertNoSymlinkInManagedCredentialPath(literalBoundary, path.resolve(input.candidateDir));
+
   const realCandidateDir = await resolveRealPathAllowingMissingSegments(input.candidateDir);
 
   const isContained =

--- a/packages/adapters/codex-local/src/server/acp.test.ts
+++ b/packages/adapters/codex-local/src/server/acp.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AdapterExecutionContext, AdapterInvocationMeta } from "@paperclipai/adapter-utils";
 import { runChildProcess } from "@paperclipai/adapter-utils/server-utils";
+import { resolveCodexAuthCacheEntryPath } from "./codex-auth-cache.js";
 
 // Every test in this file needs a real teardown, so the mock below delegates
 // to the actual factory by default. Only the wiring test further down reads
@@ -877,31 +878,36 @@ describe("codex_local ACP lane", () => {
     expect(Object.keys(meta[0]?.env ?? {}).filter((key) => key.startsWith("XDG_"))).toEqual([]);
   });
 
-  it("copies a strictly-newer sandbox Codex auth back to the shared host on teardown", async () => {
+  it("copies a strictly-newer sandbox Codex auth back to the selected account home on teardown", async () => {
     const root = await makeTempRoot("paperclip-codex-acp-copyback-newer-");
     const localCwd = path.join(root, "worktree");
     const remoteCwd = path.join(root, "remote-workspace");
-    const sourceHome = path.join(root, "codex-home");
-    const sharedHostHome = path.join(root, "shared-codex-home");
+    // A managed account home under this company's tree: the copy-back target the
+    // run selected via its configured CODEX_HOME.
+    const sourceHome = path.join(root, "paperclip-home", "instances", "test", "companies", "company-1", "codex-home");
+    // An unrelated fixed host location: the pre-Phase-4 copy-back target. It
+    // must stay untouched now that the copy-back writes to the selected home.
+    const unrelatedHostHome = path.join(root, "unrelated-host-home");
     await fs.mkdir(localCwd, { recursive: true });
     await fs.mkdir(remoteCwd, { recursive: true });
     await fs.mkdir(sourceHome, { recursive: true });
-    await fs.mkdir(sharedHostHome, { recursive: true });
-    // The home staged into the sandbox carries a strictly-newer, same-identity
-    // credential (simulating an in-sandbox token rotation); the shared host copy
-    // is older.
+    await fs.mkdir(unrelatedHostHome, { recursive: true });
     await fs.writeFile(
       path.join(sourceHome, "auth.json"),
-      subscriptionAuthJson("acct-same", NEWER_REFRESH, "sandbox-newer"),
-      { mode: 0o600 },
-    );
-    await fs.writeFile(
-      path.join(sharedHostHome, "auth.json"),
       subscriptionAuthJson("acct-same", OLDER_REFRESH, "host-older"),
       { mode: 0o600 },
     );
-    process.env.CODEX_HOME = sharedHostHome;
+    await fs.writeFile(
+      path.join(unrelatedHostHome, "auth.json"),
+      subscriptionAuthJson("acct-same", OLDER_REFRESH, "unrelated-host"),
+      { mode: 0o600 },
+    );
+    process.env.CODEX_HOME = unrelatedHostHome;
 
+    // The local runner stages the sandbox home onto a real host path (the
+    // remapped CODEX_HOME): writing a strictly-newer credential there before the
+    // turn starts simulates an in-sandbox token rotation.
+    let remappedCodexHome = "";
     const execute = createCodexAcpExecutor({
       createRuntime: (options: FakeRuntimeOptions) => new FakeRuntime(options) as never,
     });
@@ -927,44 +933,51 @@ describe("codex_local ACP lane", () => {
           runner: createLocalSandboxRunner(),
         } as never,
         authToken: "real-run-jwt",
+        onMeta: async (payload: AdapterInvocationMeta) => {
+          remappedCodexHome = String(payload.env?.CODEX_HOME ?? "");
+          await fs.writeFile(
+            path.join(remappedCodexHome, "auth.json"),
+            subscriptionAuthJson("acct-same", NEWER_REFRESH, "sandbox-newer"),
+            { mode: 0o600 },
+          );
+        },
       }),
     );
 
     expect(result.exitCode).toBe(0);
+    expect(remappedCodexHome).not.toBe("");
     // C5 — copy-back fired on teardown and installed the strictly-newer sandbox
-    // credential onto the shared host under the merge-lock / monotonic guard.
-    const hostAuth = JSON.parse(await fs.readFile(path.join(sharedHostHome, "auth.json"), "utf8"));
+    // credential onto the selected account home under the merge-lock / monotonic
+    // guard.
+    const hostAuth = JSON.parse(await fs.readFile(path.join(sourceHome, "auth.json"), "utf8"));
     expect(hostAuth.last_refresh).toBe(NEWER_REFRESH);
     expect(hostAuth.tokens.refresh_token).toBe("ref-sandbox-newer");
     // Mode preserved at 0600 by the atomic same-directory rename.
-    const mode = (await fs.stat(path.join(sharedHostHome, "auth.json"))).mode & 0o777;
+    const mode = (await fs.stat(path.join(sourceHome, "auth.json"))).mode & 0o777;
     expect(mode).toBe(0o600);
+    // The unrelated fixed host location the pre-Phase-4 copy-back used to write
+    // is untouched.
+    expect(
+      JSON.parse(await fs.readFile(path.join(unrelatedHostHome, "auth.json"), "utf8")).tokens.refresh_token,
+    ).toBe("ref-unrelated-host");
   });
 
-  it("keeps the shared host Codex auth when the sandbox copy is not strictly newer", async () => {
+  it("keeps the selected account home's Codex auth when the sandbox copy is not strictly newer", async () => {
     const root = await makeTempRoot("paperclip-codex-acp-copyback-older-");
     const localCwd = path.join(root, "worktree");
     const remoteCwd = path.join(root, "remote-workspace");
-    const sourceHome = path.join(root, "codex-home");
-    const sharedHostHome = path.join(root, "shared-codex-home");
+    const sourceHome = path.join(root, "paperclip-home", "instances", "test", "companies", "company-1", "codex-home");
     await fs.mkdir(localCwd, { recursive: true });
     await fs.mkdir(remoteCwd, { recursive: true });
     await fs.mkdir(sourceHome, { recursive: true });
-    await fs.mkdir(sharedHostHome, { recursive: true });
-    // The staged/sandbox credential is OLDER than the shared host copy: the
-    // strictly-newer guard must keep the host credential (never overwrite a good
-    // token with a spent one).
+    // The selected home already carries the newer credential; the sandbox copy
+    // (set below, via `onMeta`) is older, so the strictly-newer guard must keep
+    // the home's own credential (never overwrite a good token with a spent one).
     await fs.writeFile(
       path.join(sourceHome, "auth.json"),
-      subscriptionAuthJson("acct-same", OLDER_REFRESH, "sandbox-older"),
-      { mode: 0o600 },
-    );
-    await fs.writeFile(
-      path.join(sharedHostHome, "auth.json"),
       subscriptionAuthJson("acct-same", NEWER_REFRESH, "host-newer"),
       { mode: 0o600 },
     );
-    process.env.CODEX_HOME = sharedHostHome;
 
     const execute = createCodexAcpExecutor({
       createRuntime: (options: FakeRuntimeOptions) => new FakeRuntime(options) as never,
@@ -991,11 +1004,19 @@ describe("codex_local ACP lane", () => {
           runner: createLocalSandboxRunner(),
         } as never,
         authToken: "real-run-jwt",
+        onMeta: async (payload: AdapterInvocationMeta) => {
+          const remappedCodexHome = String(payload.env?.CODEX_HOME ?? "");
+          await fs.writeFile(
+            path.join(remappedCodexHome, "auth.json"),
+            subscriptionAuthJson("acct-same", OLDER_REFRESH, "sandbox-older"),
+            { mode: 0o600 },
+          );
+        },
       }),
     );
 
     expect(result.exitCode).toBe(0);
-    const hostAuth = JSON.parse(await fs.readFile(path.join(sharedHostHome, "auth.json"), "utf8"));
+    const hostAuth = JSON.parse(await fs.readFile(path.join(sourceHome, "auth.json"), "utf8"));
     expect(hostAuth.last_refresh).toBe(NEWER_REFRESH);
     expect(hostAuth.tokens.refresh_token).toBe("ref-host-newer");
   });
@@ -1010,24 +1031,15 @@ describe("codex_local ACP lane", () => {
     const root = await makeTempRoot("paperclip-codex-acp-keep-staged-");
     const localCwd = path.join(root, "worktree");
     const remoteCwd = path.join(root, "remote-workspace");
-    const sourceHome = path.join(root, "codex-home");
-    const sharedHostHome = path.join(root, "shared-codex-home");
+    const sourceHome = path.join(root, "paperclip-home", "instances", "test", "companies", "company-1", "codex-home");
     await fs.mkdir(localCwd, { recursive: true });
     await fs.mkdir(remoteCwd, { recursive: true });
     await fs.mkdir(sourceHome, { recursive: true });
-    await fs.mkdir(sharedHostHome, { recursive: true });
-    // Strictly-newer sandbox credential so the per-run copy-back has real work.
     await fs.writeFile(
       path.join(sourceHome, "auth.json"),
-      subscriptionAuthJson("acct-same", NEWER_REFRESH, "sandbox-newer"),
-      { mode: 0o600 },
-    );
-    await fs.writeFile(
-      path.join(sharedHostHome, "auth.json"),
       subscriptionAuthJson("acct-same", OLDER_REFRESH, "host-older"),
       { mode: 0o600 },
     );
-    process.env.CODEX_HOME = sharedHostHome;
 
     // Isolated staged-runtime cache so this test observes only its own entry.
     const stagedRuntimes = new Map();
@@ -1059,6 +1071,16 @@ describe("codex_local ACP lane", () => {
           runner: createLocalSandboxRunner(),
         } as never,
         authToken: "real-run-jwt",
+        // Strictly-newer sandbox credential so the per-run copy-back has real
+        // work: written onto the remapped in-sandbox path before the turn starts.
+        onMeta: async (payload: AdapterInvocationMeta) => {
+          const remappedCodexHome = String(payload.env?.CODEX_HOME ?? "");
+          await fs.writeFile(
+            path.join(remappedCodexHome, "auth.json"),
+            subscriptionAuthJson("acct-same", NEWER_REFRESH, "sandbox-newer"),
+            { mode: 0o600 },
+          );
+        },
       }),
     );
 
@@ -1070,8 +1092,8 @@ describe("codex_local ACP lane", () => {
     await expect(fs.stat(stagedDirs[0]!)).resolves.toBeDefined();
     expect(stagedRuntimes.size).toBe(1);
     // The per-run copy-back still fired: the strictly-newer sandbox credential
-    // landed on the shared host under the monotonic guard.
-    const hostAuth = JSON.parse(await fs.readFile(path.join(sharedHostHome, "auth.json"), "utf8"));
+    // landed on the selected account home under the monotonic guard.
+    const hostAuth = JSON.parse(await fs.readFile(path.join(sourceHome, "auth.json"), "utf8"));
     expect(hostAuth.last_refresh).toBe(NEWER_REFRESH);
     expect(hostAuth.tokens.refresh_token).toBe("ref-sandbox-newer");
     // No `disposeStaged` fires while the entry stays warm, so remove the
@@ -1088,23 +1110,15 @@ describe("codex_local ACP lane", () => {
     const root = await makeTempRoot("paperclip-codex-acp-drop-staged-");
     const localCwd = path.join(root, "worktree");
     const remoteCwd = path.join(root, "remote-workspace");
-    const sourceHome = path.join(root, "codex-home");
-    const sharedHostHome = path.join(root, "shared-codex-home");
+    const sourceHome = path.join(root, "paperclip-home", "instances", "test", "companies", "company-1", "codex-home");
     await fs.mkdir(localCwd, { recursive: true });
     await fs.mkdir(remoteCwd, { recursive: true });
     await fs.mkdir(sourceHome, { recursive: true });
-    await fs.mkdir(sharedHostHome, { recursive: true });
     await fs.writeFile(
       path.join(sourceHome, "auth.json"),
-      subscriptionAuthJson("acct-same", NEWER_REFRESH, "sandbox-newer"),
-      { mode: 0o600 },
-    );
-    await fs.writeFile(
-      path.join(sharedHostHome, "auth.json"),
       subscriptionAuthJson("acct-same", OLDER_REFRESH, "host-older"),
       { mode: 0o600 },
     );
-    process.env.CODEX_HOME = sharedHostHome;
 
     const stagedRuntimes = new Map();
     const execute = createCodexAcpExecutor({
@@ -1137,6 +1151,14 @@ describe("codex_local ACP lane", () => {
           runner: createLocalSandboxRunner(),
         } as never,
         authToken: "real-run-jwt",
+        onMeta: async (payload: AdapterInvocationMeta) => {
+          const remappedCodexHome = String(payload.env?.CODEX_HOME ?? "");
+          await fs.writeFile(
+            path.join(remappedCodexHome, "auth.json"),
+            subscriptionAuthJson("acct-same", NEWER_REFRESH, "sandbox-newer"),
+            { mode: 0o600 },
+          );
+        },
       }),
     );
 
@@ -1147,9 +1169,191 @@ describe("codex_local ACP lane", () => {
     expect(stagedRuntimes.size).toBe(0);
     // ...yet the per-run copy-back still ran on the failure teardown path, so the
     // strictly-newer sandbox credential was not lost.
-    const hostAuth = JSON.parse(await fs.readFile(path.join(sharedHostHome, "auth.json"), "utf8"));
+    const hostAuth = JSON.parse(await fs.readFile(path.join(sourceHome, "auth.json"), "utf8"));
     expect(hostAuth.last_refresh).toBe(NEWER_REFRESH);
     expect(hostAuth.tokens.refresh_token).toBe("ref-sandbox-newer");
+  });
+
+  it("writes the sandbox's Codex auth to the selected account home", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-account-home-");
+    const localCwd = path.join(root, "worktree");
+    const remoteCwd = path.join(root, "remote-workspace");
+    // A per-account home under this company's tree, matching the shape a real
+    // device login creates (`codex-auth-cache/<accountHandle>`).
+    const accountHome = path.join(
+      root, "paperclip-home", "instances", "test", "companies", "company-1", "codex-auth-cache", "acct-handle",
+    );
+    await fs.mkdir(localCwd, { recursive: true });
+    await fs.mkdir(remoteCwd, { recursive: true });
+    await fs.mkdir(accountHome, { recursive: true });
+    await fs.writeFile(
+      path.join(accountHome, "auth.json"),
+      subscriptionAuthJson("acct-handle-id", OLDER_REFRESH, "host-older"),
+      { mode: 0o600 },
+    );
+
+    const execute = createCodexAcpExecutor({
+      createRuntime: (options: FakeRuntimeOptions) => new FakeRuntime(options) as never,
+    });
+    const result = await execute(
+      buildContext(localCwd, {
+        config: {
+          engine: "acp",
+          cwd: localCwd,
+          agentCommand: "node ./fake-acp.js",
+          stateDir: path.join(root, "state"),
+          env: { CODEX_HOME: accountHome },
+          promptTemplate: "Do the assigned work.",
+        },
+        context: {
+          issueId: "issue-1",
+          paperclipWorkspace: { cwd: localCwd, source: "project_workspace", workspaceId: "workspace-1" },
+        },
+        executionTarget: {
+          kind: "remote",
+          transport: "sandbox",
+          providerKey: "fake-plugin",
+          remoteCwd,
+          runner: createLocalSandboxRunner(),
+        } as never,
+        authToken: "real-run-jwt",
+        onMeta: async (payload: AdapterInvocationMeta) => {
+          const remappedCodexHome = String(payload.env?.CODEX_HOME ?? "");
+          await fs.writeFile(
+            path.join(remappedCodexHome, "auth.json"),
+            subscriptionAuthJson("acct-handle-id", NEWER_REFRESH, "sandbox-newer"),
+            { mode: 0o600 },
+          );
+        },
+      }),
+    );
+
+    expect(result.exitCode).toBe(0);
+    const hostAuth = JSON.parse(await fs.readFile(path.join(accountHome, "auth.json"), "utf8"));
+    expect(hostAuth.last_refresh).toBe(NEWER_REFRESH);
+    expect(hostAuth.tokens.refresh_token).toBe("ref-sandbox-newer");
+  });
+
+  it("also refreshes the per-account cache slot", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-account-slot-");
+    const localCwd = path.join(root, "worktree");
+    const remoteCwd = path.join(root, "remote-workspace");
+    const accountHome = path.join(
+      root, "paperclip-home", "instances", "test", "companies", "company-1", "codex-auth-cache", "acct-handle",
+    );
+    await fs.mkdir(localCwd, { recursive: true });
+    await fs.mkdir(remoteCwd, { recursive: true });
+    await fs.mkdir(accountHome, { recursive: true });
+    await fs.writeFile(
+      path.join(accountHome, "auth.json"),
+      subscriptionAuthJson("acct-slot-id", OLDER_REFRESH, "host-older"),
+      { mode: 0o600 },
+    );
+
+    const execute = createCodexAcpExecutor({
+      createRuntime: (options: FakeRuntimeOptions) => new FakeRuntime(options) as never,
+    });
+    const result = await execute(
+      buildContext(localCwd, {
+        config: {
+          engine: "acp",
+          cwd: localCwd,
+          agentCommand: "node ./fake-acp.js",
+          stateDir: path.join(root, "state"),
+          env: { CODEX_HOME: accountHome },
+          promptTemplate: "Do the assigned work.",
+        },
+        context: {
+          issueId: "issue-1",
+          paperclipWorkspace: { cwd: localCwd, source: "project_workspace", workspaceId: "workspace-1" },
+        },
+        executionTarget: {
+          kind: "remote",
+          transport: "sandbox",
+          providerKey: "fake-plugin",
+          remoteCwd,
+          runner: createLocalSandboxRunner(),
+        } as never,
+        authToken: "real-run-jwt",
+        onMeta: async (payload: AdapterInvocationMeta) => {
+          const remappedCodexHome = String(payload.env?.CODEX_HOME ?? "");
+          await fs.writeFile(
+            path.join(remappedCodexHome, "auth.json"),
+            subscriptionAuthJson("acct-slot-id", NEWER_REFRESH, "sandbox-newer"),
+            { mode: 0o600 },
+          );
+        },
+      }),
+    );
+
+    expect(result.exitCode).toBe(0);
+    const slotPath = resolveCodexAuthCacheEntryPath(process.env, "acct-slot-id", "company-1");
+    const slotAuth = JSON.parse(await fs.readFile(slotPath, "utf8"));
+    expect(slotAuth.tokens.refresh_token).toBe("ref-sandbox-newer");
+  });
+
+  it("writes no file for a copy-back target outside the company root", async () => {
+    const root = await makeTempRoot("paperclip-codex-acp-rejected-target-");
+    const localCwd = path.join(root, "worktree");
+    const remoteCwd = path.join(root, "remote-workspace");
+    // A CODEX_HOME override that lives outside the company-managed tree.
+    const outsideHome = path.join(root, "outside-instance-home");
+    await fs.mkdir(localCwd, { recursive: true });
+    await fs.mkdir(remoteCwd, { recursive: true });
+    await fs.mkdir(outsideHome, { recursive: true });
+
+    const logs: string[] = [];
+    const execute = createCodexAcpExecutor({
+      createRuntime: (options: FakeRuntimeOptions) => new FakeRuntime(options) as never,
+    });
+    const result = await execute(
+      buildContext(localCwd, {
+        config: {
+          engine: "acp",
+          cwd: localCwd,
+          agentCommand: "node ./fake-acp.js",
+          stateDir: path.join(root, "state"),
+          env: { CODEX_HOME: outsideHome },
+          promptTemplate: "Do the assigned work.",
+        },
+        context: {
+          issueId: "issue-1",
+          paperclipWorkspace: { cwd: localCwd, source: "project_workspace", workspaceId: "workspace-1" },
+        },
+        executionTarget: {
+          kind: "remote",
+          transport: "sandbox",
+          providerKey: "fake-plugin",
+          remoteCwd,
+          runner: createLocalSandboxRunner(),
+        } as never,
+        authToken: "real-run-jwt",
+        onMeta: async (payload: AdapterInvocationMeta) => {
+          const remappedCodexHome = String(payload.env?.CODEX_HOME ?? "");
+          await fs.writeFile(
+            path.join(remappedCodexHome, "auth.json"),
+            subscriptionAuthJson("acct-rejected", NEWER_REFRESH, "sandbox-newer"),
+            { mode: 0o600 },
+          );
+        },
+        onLog: async (stream, line) => {
+          logs.push(`${stream}:${line}`);
+        },
+      }),
+    );
+
+    // A rejected copy-back target must never fail the run.
+    expect(result.exitCode).toBe(0);
+    await expect(fs.readFile(path.join(outsideHome, "auth.json"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    expect(
+      logs.some((line) =>
+        line.includes(
+          "[paperclip] Codex auth copy-back: skipped (the configured Codex home is outside the managed directory tree).",
+        ),
+      ),
+    ).toBe(true);
   });
 
   it("passes the Codex-specific teardown messages to the shared workspace-restore-teardown factory", async () => {

--- a/packages/adapters/codex-local/src/server/acp.test.ts
+++ b/packages/adapters/codex-local/src/server/acp.test.ts
@@ -885,7 +885,7 @@ describe("codex_local ACP lane", () => {
     // A managed account home under this company's tree: the copy-back target the
     // run selected via its configured CODEX_HOME.
     const sourceHome = path.join(root, "paperclip-home", "instances", "test", "companies", "company-1", "codex-home");
-    // An unrelated fixed host location: the pre-Phase-4 copy-back target. It
+    // An unrelated fixed host location the copy-back used to target. It
     // must stay untouched now that the copy-back writes to the selected home.
     const unrelatedHostHome = path.join(root, "unrelated-host-home");
     await fs.mkdir(localCwd, { recursive: true });
@@ -955,7 +955,7 @@ describe("codex_local ACP lane", () => {
     // Mode preserved at 0600 by the atomic same-directory rename.
     const mode = (await fs.stat(path.join(sourceHome, "auth.json"))).mode & 0o777;
     expect(mode).toBe(0o600);
-    // The unrelated fixed host location the pre-Phase-4 copy-back used to write
+    // The unrelated fixed host location the copy-back used to write to. It
     // is untouched.
     expect(
       JSON.parse(await fs.readFile(path.join(unrelatedHostHome, "auth.json"), "utf8")).tokens.refresh_token,

--- a/packages/adapters/codex-local/src/server/acp.ts
+++ b/packages/adapters/codex-local/src/server/acp.ts
@@ -13,7 +13,11 @@ import {
   parseLocalProcessFilesystemScope,
   parseLocalProcessNetworkScope,
 } from "@paperclipai/adapter-utils/local-process-sandbox";
-import { assertManagedCredentialHome, inferOpenAiCompatibleBiller } from "@paperclipai/adapter-utils";
+import {
+  assertManagedCredentialHome,
+  inferOpenAiCompatibleBiller,
+  ManagedCredentialHomeRejectedError,
+} from "@paperclipai/adapter-utils";
 import {
   ensureAdapterExecutionTargetCommandResolvable,
   readAdapterExecutionTarget,
@@ -223,7 +227,10 @@ async function prepareCodexRemoteManagedHome(
               companyId,
               candidateDir: effectiveCodexHome,
             });
-          } catch {
+          } catch (error) {
+            if (!(error instanceof ManagedCredentialHomeRejectedError)) {
+              throw error;
+            }
             await onLog(
               "stderr",
               "[paperclip] Codex auth copy-back: skipped (the configured Codex home is outside the managed directory tree).\n",

--- a/packages/adapters/codex-local/src/server/acp.ts
+++ b/packages/adapters/codex-local/src/server/acp.ts
@@ -13,7 +13,7 @@ import {
   parseLocalProcessFilesystemScope,
   parseLocalProcessNetworkScope,
 } from "@paperclipai/adapter-utils/local-process-sandbox";
-import { inferOpenAiCompatibleBiller } from "@paperclipai/adapter-utils";
+import { assertManagedCredentialHome, inferOpenAiCompatibleBiller } from "@paperclipai/adapter-utils";
 import {
   ensureAdapterExecutionTargetCommandResolvable,
   readAdapterExecutionTarget,
@@ -39,10 +39,10 @@ import { createWorkspaceRestoreTeardown } from "@paperclipai/adapter-utils/works
 import { normalizeCodexModel } from "../index.js";
 import { classifyCodexAuthRefreshFailure } from "./parse.js";
 import { copyBackCodexAuth } from "./codex-auth-copyback.js";
+import { ensureCodexAuthCacheEntryDir } from "./codex-auth-cache.js";
 import { buildCodexAuthInboundProvision } from "./codex-auth-merge-scripts.js";
 import {
   evaluateCodexCredentialReadiness,
-  resolveSharedCodexHomeDir,
   stageCodexHomeForSync,
 } from "./codex-home.js";
 import { ADAPTER_AUTH_MISSING_CHECK_CODE } from "./auth-check.js";
@@ -187,7 +187,7 @@ export function buildCodexAcpConfig(config: Record<string, unknown>): Record<str
 async function prepareCodexRemoteManagedHome(
   input: AcpxRemoteManagedHomeContext,
 ): Promise<AcpxRemoteManagedHomeResult> {
-  const { env, runId, onLog } = input;
+  const { env, runId, onLog, companyId } = input;
   // The host managed Codex home the engine seeded and set on env.CODEX_HOME.
   const effectiveCodexHome = env.CODEX_HOME;
   if (!effectiveCodexHome) {
@@ -209,14 +209,39 @@ async function prepareCodexRemoteManagedHome(
         provision: buildCodexAuthInboundProvision(),
         // Outbound (sandbox→host) copy-back at teardown, under the same
         // direction-agnostic decision predicate + directory merge-lock +
-        // atomic-rename + 0600 guard. Target is the SHARED host auth.json
-        // (the symlink source managed homes point at), never an in-sandbox copy.
-        restore: async ({ assetDir, readFile }) =>
+        // atomic-rename + 0600 guard. Target is the SELECTED account home
+        // (`effectiveCodexHome`: the account home the engine seeded, or the
+        // company default home), never an in-sandbox copy.
+        // `assertManagedCredentialHome` re-checks the target is still inside
+        // this company's tree right before the write: a rejected target makes
+        // the copy-back a no-operation instead of a write to an arbitrary path.
+        restore: async ({ assetDir, readFile }) => {
+          let guardedCodexHome: string;
+          try {
+            guardedCodexHome = await assertManagedCredentialHome({
+              env: process.env,
+              companyId,
+              candidateDir: effectiveCodexHome,
+            });
+          } catch {
+            await onLog(
+              "stderr",
+              "[paperclip] Codex auth copy-back: skipped (the configured Codex home is outside the managed directory tree).\n",
+            );
+            return;
+          }
           void (await copyBackCodexAuth({
             readSandboxAuth: () => readFile(path.posix.join(assetDir, "auth.json")),
-            hostAuthPath: path.join(resolveSharedCodexHomeDir(process.env), "auth.json"),
+            hostAuthPath: path.join(guardedCodexHome, "auth.json"),
             log: (line) => onLog("stdout", `${line}\n`),
-          })),
+            // Additive cache write (sandbox to host): also refresh the sandbox
+            // subscription credential's own per-identity slot, keyed by the
+            // real `account_id`. The off-switch (default on) is read inside.
+            resolveCacheEntryPath: (accountId) =>
+              ensureCodexAuthCacheEntryDir(process.env, accountId, companyId),
+            env: process.env,
+          }));
+        },
       },
     ]);
   } catch (err) {

--- a/packages/adapters/codex-local/src/server/acp.ts
+++ b/packages/adapters/codex-local/src/server/acp.ts
@@ -13,11 +13,11 @@ import {
   parseLocalProcessFilesystemScope,
   parseLocalProcessNetworkScope,
 } from "@paperclipai/adapter-utils/local-process-sandbox";
+import { inferOpenAiCompatibleBiller } from "@paperclipai/adapter-utils";
 import {
   assertManagedCredentialHome,
-  inferOpenAiCompatibleBiller,
   ManagedCredentialHomeRejectedError,
-} from "@paperclipai/adapter-utils";
+} from "@paperclipai/adapter-utils/managed-credential-home";
 import {
   ensureAdapterExecutionTargetCommandResolvable,
   readAdapterExecutionTarget,

--- a/packages/adapters/codex-local/src/server/acp.ts
+++ b/packages/adapters/codex-local/src/server/acp.ts
@@ -233,6 +233,7 @@ async function prepareCodexRemoteManagedHome(
           void (await copyBackCodexAuth({
             readSandboxAuth: () => readFile(path.posix.join(assetDir, "auth.json")),
             hostAuthPath: path.join(guardedCodexHome, "auth.json"),
+            companyId,
             log: (line) => onLog("stdout", `${line}\n`),
             // Additive cache write (sandbox to host): also refresh the sandbox
             // subscription credential's own per-identity slot, keyed by the

--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.test.ts
@@ -837,3 +837,102 @@ describe("copyBackCodexAuth directory-swap-to-symlink protection", () => {
     ]);
   });
 });
+
+// A non-Linux host cannot pin the copy-back directory behind a `/proc/self/fd`
+// descriptor (`/proc` does not exist there), but it must still install a
+// refreshed credential: the managed-home safety checks (containment, symlink
+// rejection) do not depend on that descriptor pin. This suite forces
+// `process.platform` to a non-Linux value and proves the write still happens,
+// and that the containment re-check still blocks a target outside the tree.
+describe("copyBackCodexAuth on a non-Linux host", () => {
+  const cleanupDirs: string[] = [];
+  const originalPlatform = process.platform;
+  const COMPANY_ID = "company-a";
+
+  afterEach(async () => {
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await chmod(dir, 0o700).catch(() => undefined);
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  function subscriptionAuth(input: { accountId: string; lastRefresh?: string; marker: string }): string {
+    return JSON.stringify({
+      tokens: {
+        id_token: `id-token-${input.marker}`,
+        access_token: `access-token-${input.marker}`,
+        refresh_token: `refresh-token-${input.marker}`,
+        account_id: input.accountId,
+      },
+      ...(input.lastRefresh ? { last_refresh: input.lastRefresh } : {}),
+    });
+  }
+
+  const NEWER = "2026-07-09T02:00:00Z";
+  const OLDER = "2026-07-09T01:00:00Z";
+
+  it.each(["darwin", "win32"])(
+    "installs a strictly-newer sandbox credential onto the host on %s",
+    async (platform) => {
+      Object.defineProperty(process, "platform", { value: platform });
+      const hostDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-copyback-nonlinux-"));
+      cleanupDirs.push(hostDir);
+      const hostAuthPath = path.join(hostDir, "auth.json");
+      const hostAuth = subscriptionAuth({ accountId: "acct-same", lastRefresh: OLDER, marker: "host-older" });
+      await writeFile(hostAuthPath, hostAuth, { mode: 0o600 });
+      const sandboxAuth = subscriptionAuth({
+        accountId: "acct-same",
+        lastRefresh: NEWER,
+        marker: "sandbox-newer",
+      });
+
+      const logs: string[] = [];
+      const outcome = await copyBackCodexAuth({
+        readSandboxAuth: async () => Buffer.from(sandboxAuth, "utf8"),
+        hostAuthPath,
+        log: (line) => {
+          logs.push(line);
+        },
+      });
+
+      expect(outcome).toBe("copied");
+      expect(await readFile(hostAuthPath, "utf8")).toBe(sandboxAuth);
+      expect((await lstat(hostAuthPath)).mode & 0o777).toBe(0o600);
+      // No staging temp is left behind on the write path.
+      expect((await readdir(hostDir)).filter((name) => name !== "auth.json")).toEqual([]);
+      expect(logs.join("\n")).not.toContain("outside the managed directory tree");
+    },
+  );
+
+  it("still keeps the host, writes nothing, when the target sits outside the company's own tree", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    const homeDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-copyback-nonlinux-containment-"));
+    cleanupDirs.push(homeDir);
+    const env: NodeJS.ProcessEnv = { PAPERCLIP_HOME: homeDir, PAPERCLIP_INSTANCE_ID: "default" };
+    await mkdir(path.join(homeDir, "instances", "default", "companies", COMPANY_ID), { recursive: true });
+    const outsideDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-copyback-nonlinux-outside-"));
+    cleanupDirs.push(outsideDir);
+    const hostAuthPath = path.join(outsideDir, "auth.json");
+    const sandboxAuth = subscriptionAuth({ accountId: "acct-x", lastRefresh: NEWER, marker: "sandbox-outside" });
+
+    const logs: string[] = [];
+    const outcome = await copyBackCodexAuth({
+      readSandboxAuth: async () => Buffer.from(sandboxAuth, "utf8"),
+      hostAuthPath,
+      companyId: COMPANY_ID,
+      log: (line) => {
+        logs.push(line);
+      },
+      env,
+    });
+
+    expect(outcome).toBe("kept-host");
+    expect(await readdir(outsideDir)).toEqual([]);
+    expect(logs).toEqual([
+      "[paperclip] Codex auth copy-back: skipped (the configured Codex home is outside the managed directory tree).",
+    ]);
+  });
+});

--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.test.ts
@@ -615,3 +615,119 @@ describe("copyBackCodexAuth identity-keyed cache write", () => {
     expect(logs.some((line) => line.includes("additive cache write failed (EACCES)"))).toBe(true);
   });
 });
+
+// When a caller passes `companyId`, the copy-back re-verifies the host target's
+// containment inside the company's own directory tree immediately before the
+// write. This suite drives that re-check against a real host tmp filesystem
+// laid out to match the company tree the check expects.
+describe("copyBackCodexAuth companyId containment re-check", () => {
+  const cleanupDirs: string[] = [];
+  const COMPANY_ID = "company-a";
+
+  afterEach(async () => {
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await chmod(dir, 0o700).catch(() => undefined);
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  function subscriptionAuth(input: { accountId: string; lastRefresh?: string; marker: string }): string {
+    return JSON.stringify({
+      tokens: {
+        id_token: `id-token-${input.marker}`,
+        access_token: `access-token-${input.marker}`,
+        refresh_token: `refresh-token-${input.marker}`,
+        account_id: input.accountId,
+      },
+      ...(input.lastRefresh ? { last_refresh: input.lastRefresh } : {}),
+    });
+  }
+
+  const NEWER = "2026-07-09T02:00:00Z";
+  const OLDER = "2026-07-09T01:00:00Z";
+
+  async function setUpInstance(): Promise<{ env: NodeJS.ProcessEnv; companyRoot: string }> {
+    const homeDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-copyback-containment-"));
+    cleanupDirs.push(homeDir);
+    const env: NodeJS.ProcessEnv = { PAPERCLIP_HOME: homeDir, PAPERCLIP_INSTANCE_ID: "default" };
+    const companyRoot = path.join(homeDir, "instances", "default", "companies", COMPANY_ID);
+    await mkdir(companyRoot, { recursive: true });
+    return { env, companyRoot };
+  }
+
+  it("installs on the host when the host path sits inside the company's own tree, exactly as without companyId", async () => {
+    const { env, companyRoot } = await setUpInstance();
+    const hostDir = path.join(companyRoot, "codex-home");
+    const hostAuthPath = path.join(hostDir, "auth.json");
+    await mkdir(hostDir, { recursive: true });
+    const hostAuth = subscriptionAuth({ accountId: "acct-same", lastRefresh: OLDER, marker: "host-in-tree" });
+    await writeFile(hostAuthPath, hostAuth, { mode: 0o600 });
+    const sandboxAuth = subscriptionAuth({ accountId: "acct-same", lastRefresh: NEWER, marker: "sandbox-in-tree" });
+
+    const logs: string[] = [];
+    const outcome = await copyBackCodexAuth({
+      readSandboxAuth: async () => Buffer.from(sandboxAuth, "utf8"),
+      hostAuthPath,
+      companyId: COMPANY_ID,
+      log: (line) => {
+        logs.push(line);
+      },
+      env,
+    });
+
+    expect(outcome).toBe("copied");
+    expect(await readFile(hostAuthPath, "utf8")).toBe(sandboxAuth);
+  });
+
+  it("keeps the host, writes nothing, and logs the fixed warning when the host path sits outside the company's tree", async () => {
+    const { env } = await setUpInstance();
+    const outsideDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-copyback-outside-"));
+    cleanupDirs.push(outsideDir);
+    const hostAuthPath = path.join(outsideDir, "auth.json");
+    const sandboxAuth = subscriptionAuth({ accountId: "acct-x", lastRefresh: NEWER, marker: "sandbox-outside" });
+
+    const logs: string[] = [];
+    const outcome = await copyBackCodexAuth({
+      readSandboxAuth: async () => Buffer.from(sandboxAuth, "utf8"),
+      hostAuthPath,
+      companyId: COMPANY_ID,
+      log: (line) => {
+        logs.push(line);
+      },
+      env,
+    });
+
+    expect(outcome).toBe("kept-host");
+    expect(await readdir(outsideDir)).toEqual([]);
+    expect(logs).toEqual([
+      "[paperclip] Codex auth copy-back: skipped (the configured Codex home is outside the managed directory tree).",
+    ]);
+  });
+
+  it("stays fail-loud and does not return kept-host when the re-check fails with an error that is not a containment rejection", async () => {
+    const hostDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-copyback-broken-env-"));
+    cleanupDirs.push(hostDir);
+    const hostAuthPath = path.join(hostDir, "auth.json");
+    const hostAuth = subscriptionAuth({ accountId: "acct-same", lastRefresh: OLDER, marker: "host-broken-env" });
+    await writeFile(hostAuthPath, hostAuth, { mode: 0o600 });
+
+    // An invalid PAPERCLIP_INSTANCE_ID makes the boundary resolver throw a
+    // plain configuration error before it ever reaches a containment check.
+    const brokenEnv: NodeJS.ProcessEnv = { PAPERCLIP_HOME: hostDir, PAPERCLIP_INSTANCE_ID: "not a valid id" };
+    const sandboxAuth = subscriptionAuth({ accountId: "acct-same", lastRefresh: NEWER, marker: "sandbox-broken-env" });
+
+    await expect(
+      copyBackCodexAuth({
+        readSandboxAuth: async () => Buffer.from(sandboxAuth, "utf8"),
+        hostAuthPath,
+        companyId: COMPANY_ID,
+        log: () => {},
+        env: brokenEnv,
+      }),
+    ).rejects.toThrow(/Invalid PAPERCLIP_INSTANCE_ID/);
+
+    expect(await readFile(hostAuthPath, "utf8")).toBe(hostAuth);
+  });
+});

--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.test.ts
@@ -12,12 +12,24 @@ import {
 import { resolveSharedCodexHomeDir } from "./codex-home.js";
 
 // One-shot hook run from inside the mocked `open` below, right before the
-// real `open` call it wraps. A test arms this to swap a directory for a
-// symbolic link at the exact instant the copy-back's own next `open` call
-// runs — the narrowest point a directory-swap race could land. `null` by
-// default, so every other test in this file runs against the real `open`
-// unchanged.
-let onFirstOpenCall: (() => Promise<void>) | null = null;
+// real `open` call it wraps. It receives the exact arguments the copy-back
+// passed to `open`, so a test can act only once a specific call (for example
+// the one that creates the staging temp file) is about to run, and re-arm
+// itself for a later call otherwise. A test arms this to swap a directory
+// for a symbolic link, or replace it outright, at the exact instant the
+// copy-back's own next `open` call runs — the narrowest point a directory
+// race could land. `null` by default, so every other test in this file runs
+// against the real `open` unchanged.
+let onFirstOpenCall: ((args: unknown[]) => Promise<void>) | null = null;
+
+// One-shot hook run right AFTER a real `open` call resolves (as opposed to
+// `onFirstOpenCall`, which runs right before). A test uses this to land a
+// directory swap the instant after the copy-back pins the directory
+// descriptor — the earliest point a swap could still be caught by a later
+// identity re-check, since the swap must follow the pin to be a genuine
+// "already pinned, now replaced" race rather than a swap the pin's own
+// `O_NOFOLLOW` open would already refuse.
+let onAfterOpenCall: ((args: unknown[]) => Promise<void>) | null = null;
 
 vi.mock("node:fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs/promises")>();
@@ -27,9 +39,38 @@ vi.mock("node:fs/promises", async (importOriginal) => {
       if (onFirstOpenCall) {
         const hook = onFirstOpenCall;
         onFirstOpenCall = null;
+        await hook(args);
+      }
+      const handle = await actual.open(...args);
+      if (onAfterOpenCall) {
+        const hook = onAfterOpenCall;
+        onAfterOpenCall = null;
+        await hook(args);
+      }
+      return handle;
+    },
+  };
+});
+
+// One-shot hook run right after the real merge-decision predicate resolves.
+// The predicate runs in a separate `node` child process, so it is real
+// elapsed time a mocked `open`/`rename` hook cannot reach. A test uses this
+// to land a directory swap between the decision and the rename that follows
+// it.
+let onAfterDecideCodexAuthMerge: (() => Promise<void>) | null = null;
+
+vi.mock("./codex-auth-merge-decision.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./codex-auth-merge-decision.js")>();
+  return {
+    ...actual,
+    decideCodexAuthMerge: async (...args: Parameters<typeof actual.decideCodexAuthMerge>) => {
+      const result = await actual.decideCodexAuthMerge(...args);
+      if (onAfterDecideCodexAuthMerge) {
+        const hook = onAfterDecideCodexAuthMerge;
+        onAfterDecideCodexAuthMerge = null;
         await hook();
       }
-      return actual.open(...args);
+      return result;
     },
   };
 });
@@ -934,5 +975,120 @@ describe("copyBackCodexAuth on a non-Linux host", () => {
     expect(logs).toEqual([
       "[paperclip] Codex auth copy-back: skipped (the configured Codex home is outside the managed directory tree).",
     ]);
+  });
+});
+
+// A symbolic-link check alone cannot see a directory that a local attacker
+// removed and recreated as a fresh, PLAIN directory under the same name — the
+// replacement is still a real directory, not a link. On Linux, every write
+// addresses the directory descriptor pinned before this replacement could
+// land, so the replacement never redirects a write; on a non-Linux platform
+// the write still addresses the directory by its plain path text, so this
+// suite proves the copy-back re-checks the pinned descriptor's identity
+// (device and inode) immediately before that write and rejects instead of
+// installing into the replacement.
+describe("copyBackCodexAuth directory-replacement race protection on a non-Linux host", () => {
+  const cleanupDirs: string[] = [];
+  const originalPlatform = process.platform;
+
+  afterEach(async () => {
+    onFirstOpenCall = null;
+    onAfterOpenCall = null;
+    onAfterDecideCodexAuthMerge = null;
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await chmod(dir, 0o700).catch(() => undefined);
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  function subscriptionAuth(input: { accountId: string; lastRefresh?: string; marker: string }): string {
+    return JSON.stringify({
+      tokens: {
+        id_token: `id-token-${input.marker}`,
+        access_token: `access-token-${input.marker}`,
+        refresh_token: `refresh-token-${input.marker}`,
+        account_id: input.accountId,
+      },
+      ...(input.lastRefresh ? { last_refresh: input.lastRefresh } : {}),
+    });
+  }
+
+  const NEWER = "2026-07-09T02:00:00Z";
+  const OLDER = "2026-07-09T01:00:00Z";
+
+  it("rejects the write instead of installing into a directory removed and recreated right after the descriptor was pinned", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-copyback-replace-"));
+    cleanupDirs.push(rootDir);
+    const hostDir = path.join(rootDir, "codex-home");
+    const hostAuthPath = path.join(hostDir, "auth.json");
+    await mkdir(hostDir, { recursive: true });
+    const hostAuth = subscriptionAuth({ accountId: "acct-same", lastRefresh: OLDER, marker: "host-intact" });
+    await writeFile(hostAuthPath, hostAuth, { mode: 0o600 });
+
+    // A decoy planted in the REPLACEMENT directory: if the copy-back wrote
+    // through the plain path text without re-checking identity, this decoy
+    // would end up overwritten by the sandbox credential instead of the
+    // write being rejected. Fires right after the copy-back's directory-pin
+    // `open` call resolves — the earliest point a genuine "already pinned,
+    // now replaced" race can land.
+    const decoyAuth = subscriptionAuth({ accountId: "acct-same", lastRefresh: OLDER, marker: "decoy-after-swap" });
+    onAfterOpenCall = async () => {
+      await rm(hostDir, { recursive: true, force: true });
+      await mkdir(hostDir, { recursive: true });
+      await writeFile(path.join(hostDir, "auth.json"), decoyAuth, { mode: 0o600 });
+    };
+
+    const sandboxAuth = subscriptionAuth({ accountId: "acct-same", lastRefresh: NEWER, marker: "sandbox-newer" });
+    await expect(
+      copyBackCodexAuth({
+        readSandboxAuth: async () => Buffer.from(sandboxAuth, "utf8"),
+        hostAuthPath,
+        log: () => {},
+      }),
+    ).rejects.toThrow(/changed identity/);
+
+    // The replacement directory's own decoy is untouched — the copy-back
+    // never wrote through the replaced directory.
+    expect(await readFile(path.join(hostDir, "auth.json"), "utf8")).toBe(decoyAuth);
+    expect(await readdir(hostDir)).toEqual(["auth.json"]);
+  });
+
+  it("rejects the write when the replacement lands between the merge decision and the rename", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-copyback-replace-late-"));
+    cleanupDirs.push(rootDir);
+    const hostDir = path.join(rootDir, "codex-home");
+    const hostAuthPath = path.join(hostDir, "auth.json");
+    await mkdir(hostDir, { recursive: true });
+    const hostAuth = subscriptionAuth({ accountId: "acct-same", lastRefresh: OLDER, marker: "host-intact" });
+    await writeFile(hostAuthPath, hostAuth, { mode: 0o600 });
+
+    // The merge-decision predicate runs as a separate `node` child process —
+    // real elapsed time the create-time re-check cannot reach. Fires right
+    // after that predicate resolves with "use source" for the strictly-newer
+    // same-identity sandbox credential below, and replaces the directory
+    // with a fresh, plain one under the same name before the rename runs.
+    onAfterDecideCodexAuthMerge = async () => {
+      await rm(hostDir, { recursive: true, force: true });
+      await mkdir(hostDir, { recursive: true });
+    };
+
+    const sandboxAuth = subscriptionAuth({ accountId: "acct-same", lastRefresh: NEWER, marker: "sandbox-newer" });
+    await expect(
+      copyBackCodexAuth({
+        readSandboxAuth: async () => Buffer.from(sandboxAuth, "utf8"),
+        hostAuthPath,
+        log: () => {},
+      }),
+    ).rejects.toThrow(/changed identity/);
+
+    // The replacement directory is empty — the rename never landed there.
+    expect(await readdir(hostDir)).toEqual([]);
   });
 });

--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.test.ts
@@ -1092,3 +1092,99 @@ describe("copyBackCodexAuth directory-replacement race protection on a non-Linux
     expect(await readdir(hostDir)).toEqual([]);
   });
 });
+
+// `O_NOFOLLOW` on the directory-pin `open` call only refuses a symbolic link
+// at the FINAL path segment; the call still re-walks every ANCESTOR segment
+// of the path from the root, so a symbolic link substituted into an ancestor
+// in the gap between the lock-time containment re-check and the open call is
+// silently followed. On Linux, the copy-back closes that gap by reading the
+// opened descriptor's own kernel-resolved real path back from
+// `/proc/self/fd` and rejecting unless it still names the directory the
+// containment walk approved. This suite proves that check, not the leaf's
+// `O_NOFOLLOW` alone, is what stops a write through a swapped ancestor.
+describe("copyBackCodexAuth ancestor-directory replacement race protection on Linux", () => {
+  const cleanupDirs: string[] = [];
+  const COMPANY_ID = "company-a";
+
+  afterEach(async () => {
+    onFirstOpenCall = null;
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await chmod(dir, 0o700).catch(() => undefined);
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  function subscriptionAuth(input: { accountId: string; lastRefresh?: string; marker: string }): string {
+    return JSON.stringify({
+      tokens: {
+        id_token: `id-token-${input.marker}`,
+        access_token: `access-token-${input.marker}`,
+        refresh_token: `refresh-token-${input.marker}`,
+        account_id: input.accountId,
+      },
+      ...(input.lastRefresh ? { last_refresh: input.lastRefresh } : {}),
+    });
+  }
+
+  const NEWER = "2026-07-09T02:00:00Z";
+  const OLDER = "2026-07-09T01:00:00Z";
+
+  it("rejects the write instead of installing through an ancestor directory swapped to a symbolic link right after the containment re-check", async () => {
+    if (process.platform !== "linux") return;
+
+    const homeDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-copyback-ancestor-"));
+    cleanupDirs.push(homeDir);
+    const env: NodeJS.ProcessEnv = { PAPERCLIP_HOME: homeDir, PAPERCLIP_INSTANCE_ID: "default" };
+    const companyRoot = path.join(homeDir, "instances", "default", "companies", COMPANY_ID);
+    // An ancestor segment sits BETWEEN the company boundary and the leaf
+    // host directory, so a swap of that segment (not the leaf) is what this
+    // test needs to reach the ancestor-only gap.
+    const ancestorDir = path.join(companyRoot, "subdir");
+    const hostDir = path.join(ancestorDir, "codex-home");
+    const hostAuthPath = path.join(hostDir, "auth.json");
+    await mkdir(hostDir, { recursive: true });
+    const hostAuth = subscriptionAuth({ accountId: "acct-same", lastRefresh: OLDER, marker: "host-intact" });
+    await writeFile(hostAuthPath, hostAuth, { mode: 0o600 });
+
+    const outsideDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-copyback-ancestor-outside-"));
+    cleanupDirs.push(outsideDir);
+    const outsideHostDir = path.join(outsideDir, "codex-home");
+    await mkdir(outsideHostDir, { recursive: true });
+    // A usable, OLDER same-account decoy at the attacker's redirected
+    // target: with a real destination in place the decision predicate would
+    // pick "use source" (the sandbox copy below is newer), so a leaked
+    // write would overwrite this decoy — the clearest, byte-level proof of a
+    // leaked write, not just an early return.
+    const decoyAuth = subscriptionAuth({ accountId: "acct-same", lastRefresh: OLDER, marker: "outside-decoy" });
+    await writeFile(path.join(outsideHostDir, "auth.json"), decoyAuth, { mode: 0o600 });
+
+    // Fires right before the copy-back's directory-pin `open` call, which
+    // runs after the lock-time containment re-check already passed against
+    // the honest ancestor. Swap the ANCESTOR ("subdir"), not the leaf, for a
+    // symbolic link to `outsideDir`: the leaf path segment ("codex-home") is
+    // still a plain directory both before and after the swap, so a
+    // `O_NOFOLLOW` check on the leaf alone cannot see this.
+    onFirstOpenCall = async () => {
+      await rm(ancestorDir, { recursive: true, force: true });
+      await symlink(outsideDir, ancestorDir);
+    };
+
+    const sandboxAuth = subscriptionAuth({ accountId: "acct-same", lastRefresh: NEWER, marker: "sandbox-newer" });
+    await expect(
+      copyBackCodexAuth({
+        readSandboxAuth: async () => Buffer.from(sandboxAuth, "utf8"),
+        hostAuthPath,
+        companyId: COMPANY_ID,
+        log: () => {},
+        env,
+      }),
+    ).rejects.toThrow(/changed identity/);
+
+    // The decoy at the attacker's redirected target is untouched — the
+    // copy-back never wrote through the swapped ancestor.
+    expect(await readFile(path.join(outsideHostDir, "auth.json"), "utf8")).toBe(decoyAuth);
+    expect(await readdir(outsideHostDir)).toEqual(["auth.json"]);
+  });
+});

--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.test.ts
@@ -1,4 +1,4 @@
-import { chmod, lstat, mkdir, mkdtemp, readdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
+import { chmod, lstat, mkdir, mkdtemp, readdir, readFile, rename, rm, stat, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -1294,5 +1294,132 @@ describe("copyBackCodexAuth ancestor-directory replacement race protection on a 
     // copy-back never wrote through the swapped ancestor.
     expect(await readFile(path.join(outsideHostDir, "auth.json"), "utf8")).toBe(decoyAuth);
     expect(await readdir(outsideHostDir)).toEqual(["auth.json"]);
+  });
+});
+
+// On Linux every WRITE below the directory pin addresses the pinned
+// descriptor's own `/proc/self/fd/<fd>` alias, so a later swap of the plain
+// directory path text cannot redirect a write. The decision predicate's two
+// read arguments must resolve through that same pinned descriptor, not the
+// plain path text: a predicate that still reads the plain text after a swap
+// can compare the sandbox credential against a substituted host credential,
+// pick the wrong side, and let a write through the (correctly) pinned
+// descriptor install a stale sandbox copy over a genuinely valid, newer host
+// credential. A write-only fix cannot close this gap — only a matching
+// read-path fix can. This suite proves the read arguments resolve through
+// the pinned descriptor on Linux, the same as the write.
+describe("copyBackCodexAuth Linux decision-predicate reads through the pinned directory descriptor", () => {
+  const cleanupDirs: string[] = [];
+
+  afterEach(async () => {
+    onAfterOpenCall = null;
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await chmod(dir, 0o700).catch(() => undefined);
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  function subscriptionAuth(input: { accountId: string; lastRefresh?: string; marker: string }): string {
+    return JSON.stringify({
+      tokens: {
+        id_token: `id-token-${input.marker}`,
+        access_token: `access-token-${input.marker}`,
+        refresh_token: `refresh-token-${input.marker}`,
+        account_id: input.accountId,
+      },
+      ...(input.lastRefresh ? { last_refresh: input.lastRefresh } : {}),
+    });
+  }
+
+  const HOST_REAL_NEWEST = "2026-07-09T05:00:00Z";
+  const SANDBOX_REAL_OLDER = "2026-07-09T01:00:00Z";
+  const DECOY_HOST_OLDEST = "2026-07-09T00:00:00Z";
+
+  it("does not let a directory swap after the pin make the predicate read a decoy and overwrite a valid, newer host credential", async () => {
+    if (process.platform !== "linux") return;
+
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-copyback-pin-read-"));
+    cleanupDirs.push(rootDir);
+    const hostDir = path.join(rootDir, "codex-home");
+    // The pinned descriptor addresses the same inode no matter which name
+    // refers to it. This test renames the real, pinned-open directory aside
+    // under this name, right when the attack swaps the original name for a
+    // symbolic link, so it keeps a stable path to check the real directory's
+    // content afterward.
+    const hostDirReal = path.join(rootDir, "codex-home-real");
+    const hostAuthPath = path.join(hostDir, "auth.json");
+    await mkdir(hostDir, { recursive: true });
+    // The real host credential is genuinely the newest of the three copies in
+    // this test. It must survive untouched.
+    const hostAuth = subscriptionAuth({
+      accountId: "acct-same",
+      lastRefresh: HOST_REAL_NEWEST,
+      marker: "host-real-newest",
+    });
+    await writeFile(hostAuthPath, hostAuth, { mode: 0o600 });
+
+    const outsideDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-copyback-pin-read-outside-"));
+    cleanupDirs.push(outsideDir);
+    // A decoy destination, older than even the sandbox copy, so a predicate
+    // that reads it instead of the real, newest host copy concludes the
+    // sandbox copy is the fresher side.
+    const decoyHostAuth = subscriptionAuth({
+      accountId: "acct-same",
+      lastRefresh: DECOY_HOST_OLDEST,
+      marker: "decoy-host-oldest",
+    });
+    await writeFile(path.join(outsideDir, "auth.json"), decoyHostAuth, { mode: 0o600 });
+
+    // The genuine sandbox copy is older than the real host copy, so the
+    // correct decision is "keep host" — nothing should ever be installed.
+    const sandboxAuth = subscriptionAuth({
+      accountId: "acct-same",
+      lastRefresh: SANDBOX_REAL_OLDER,
+      marker: "sandbox-real-older",
+    });
+
+    // Fires right after the directory-pin `open` call resolves (the pin
+    // already passed the Linux real-path check). Re-arms itself so the swap
+    // lands right after the NEXT `open` call resolves instead — the one that
+    // creates the staging temp file inside the pinned directory. That is the
+    // earliest point a plain-path read can diverge from the pinned-descriptor
+    // write, so it is where a genuine "already pinned, now replaced" race
+    // would land.
+    onAfterOpenCall = async () => {
+      onAfterOpenCall = async (args: unknown[]) => {
+        const tempFileName = path.basename(String(args[0]));
+        await rename(hostDir, hostDirReal);
+        await symlink(outsideDir, hostDir);
+        // A decoy "source" at the exact staged-temp name a plain-path read
+        // would now resolve to — standing in for an attacker who learned the
+        // name, for example by watching the directory before the swap.
+        const decoySandboxAuth = subscriptionAuth({
+          accountId: "acct-same",
+          lastRefresh: SANDBOX_REAL_OLDER,
+          marker: "decoy-sandbox-source",
+        });
+        await writeFile(path.join(outsideDir, tempFileName), decoySandboxAuth, { mode: 0o600 });
+      };
+    };
+
+    const logs: string[] = [];
+    const outcome = await copyBackCodexAuth({
+      readSandboxAuth: async () => Buffer.from(sandboxAuth, "utf8"),
+      hostAuthPath,
+      log: (line) => {
+        logs.push(line);
+      },
+    });
+
+    expect(outcome).toBe("kept-host");
+    // The real, newest host credential — reachable at the name this test
+    // renamed it to, the same inode the pinned descriptor addressed
+    // throughout — is untouched.
+    expect(await readFile(path.join(hostDirReal, "auth.json"), "utf8")).toBe(hostAuth);
+    expect(await readdir(hostDirReal)).toEqual(["auth.json"]);
+    // Nothing was ever written into the attacker's directory either.
+    expect(await readFile(path.join(outsideDir, "auth.json"), "utf8")).toBe(decoyHostAuth);
   });
 });

--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.test.ts
@@ -1091,6 +1091,105 @@ describe("copyBackCodexAuth directory-replacement race protection on a non-Linux
     // The replacement directory is empty — the rename never landed there.
     expect(await readdir(hostDir)).toEqual([]);
   });
+
+  it("does not let a directory swap-and-restore around the predicate read make it compare against a decoy host credential", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-copyback-read-race-"));
+    cleanupDirs.push(rootDir);
+    const hostDir = path.join(rootDir, "codex-home");
+    const hostDirBackup = path.join(rootDir, "codex-home-backup");
+    const hostAuthPath = path.join(hostDir, "auth.json");
+    await mkdir(hostDir, { recursive: true });
+    // The real host credential is genuinely the newest of the two real
+    // copies in this test (host vs. sandbox). It must survive untouched.
+    const hostAuth = subscriptionAuth({
+      accountId: "acct-same",
+      lastRefresh: "2026-07-09T05:00:00Z",
+      marker: "host-real-newest",
+    });
+    await writeFile(hostAuthPath, hostAuth, { mode: 0o600 });
+
+    // Older than the decoy host below, so a predicate that reads the decoy
+    // wrongly concludes the sandbox copy is fresher; older than the real
+    // host too, so the correct decision is always "keep host".
+    const sandboxAuth = subscriptionAuth({
+      accountId: "acct-same",
+      lastRefresh: "2026-07-09T02:00:00Z",
+      marker: "sandbox-middle",
+    });
+    // Older than the sandbox copy above, so a predicate that reads this
+    // instead of the real host concludes the sandbox copy is fresher.
+    const decoyHostAuth = subscriptionAuth({
+      accountId: "acct-same",
+      lastRefresh: "2026-07-09T00:00:00Z",
+      marker: "decoy-host-oldest",
+    });
+
+    // Fires right after the directory-pin `open` call resolves (call 1);
+    // re-arms as a no-op for the staging-temp create (call 2); re-arms again
+    // to land the swap right after the destination-snapshot create resolves
+    // (call 3) — the moment right before the predicate spawns, after the fix
+    // has already snapshotted the real host credential. Renames the real
+    // directory aside (preserving its device and inode) and puts a fresh
+    // directory under the original name holding a decoy host credential AND
+    // a decoy source at the exact staged-temp name (standing in for an
+    // attacker who learned the name, for example by watching the directory
+    // before the swap), so a predicate that still read the live path would
+    // read both files from the decoy directory instead of failing closed on
+    // a missing source.
+    let openCallCount = 0;
+    let swapApplied = false;
+    const tempFileNames: string[] = [];
+    onAfterOpenCall = function armNext(args: unknown[]) {
+      openCallCount += 1;
+      if (openCallCount === 2) {
+        tempFileNames.push(path.basename(String(args[0])));
+      }
+      if (openCallCount < 3) {
+        onAfterOpenCall = armNext;
+        return Promise.resolve();
+      }
+      return (async () => {
+        await rename(hostDir, hostDirBackup);
+        await mkdir(hostDir, { recursive: true });
+        await writeFile(path.join(hostDir, "auth.json"), decoyHostAuth, { mode: 0o600 });
+        await writeFile(path.join(hostDir, tempFileNames[0]), sandboxAuth, { mode: 0o600 });
+        swapApplied = true;
+      })();
+    };
+    // Fires right after the predicate resolves, before the write-time
+    // identity re-check. Restores the exact original directory (same
+    // device and inode the pin addresses) under the original name, so that
+    // later re-check passes even though the predicate read the decoy.
+    let restoreApplied = false;
+    onAfterDecideCodexAuthMerge = async () => {
+      await rm(hostDir, { recursive: true, force: true });
+      await rename(hostDirBackup, hostDir);
+      restoreApplied = true;
+    };
+
+    const outcome = await copyBackCodexAuth({
+      readSandboxAuth: async () => Buffer.from(sandboxAuth, "utf8"),
+      hostAuthPath,
+      log: () => {},
+    });
+
+    // Guard the guard: if a future change removes the third `open` call (for
+    // example by reverting the destination-snapshot fix), the swap above
+    // would never fire and this test would pass for the wrong reason —
+    // trivially, by never exercising the race at all. Fail loud instead.
+    expect(swapApplied).toBe(true);
+    expect(restoreApplied).toBe(true);
+
+    // The real host credential is genuinely the newest of the two real
+    // copies, so the correct decision is "keep host" and the real file
+    // must survive untouched — never overwritten with the stale sandbox
+    // copy on the strength of a comparison against the decoy.
+    expect(outcome).toBe("kept-host");
+    expect(await readFile(hostAuthPath, "utf8")).toBe(hostAuth);
+    expect(await readdir(hostDir)).toEqual(["auth.json"]);
+  });
 });
 
 // `O_NOFOLLOW` on the directory-pin `open` call only refuses a symbolic link

--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.test.ts
@@ -1,7 +1,7 @@
-import { chmod, lstat, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, lstat, mkdir, mkdtemp, readdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { copyBackCodexAuth } from "./codex-auth-copyback.js";
 import {
@@ -10,6 +10,29 @@ import {
   resolveCodexAuthCacheEntryPath,
 } from "./codex-auth-cache.js";
 import { resolveSharedCodexHomeDir } from "./codex-home.js";
+
+// One-shot hook run from inside the mocked `open` below, right before the
+// real `open` call it wraps. A test arms this to swap a directory for a
+// symbolic link at the exact instant the copy-back's own next `open` call
+// runs — the narrowest point a directory-swap race could land. `null` by
+// default, so every other test in this file runs against the real `open`
+// unchanged.
+let onFirstOpenCall: (() => Promise<void>) | null = null;
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return {
+    ...actual,
+    open: async (...args: Parameters<typeof actual.open>) => {
+      if (onFirstOpenCall) {
+        const hook = onFirstOpenCall;
+        onFirstOpenCall = null;
+        await hook();
+      }
+      return actual.open(...args);
+    },
+  };
+});
 
 // The copy-back module reuses the exact same direction-agnostic decision
 // predicate (`codex-auth-merge-decision.cjs`) that the inbound extract path
@@ -729,5 +752,88 @@ describe("copyBackCodexAuth companyId containment re-check", () => {
     ).rejects.toThrow(/Invalid PAPERCLIP_INSTANCE_ID/);
 
     expect(await readFile(hostAuthPath, "utf8")).toBe(hostAuth);
+  });
+});
+
+// Between the lock-time re-check and the write, a local attacker who can
+// rename entries under the target's own parent could swap the target
+// directory for a symbolic link. This suite proves the copy-back closes that
+// window: it swaps the directory for a link to an OUTSIDE, attacker-chosen
+// directory at the earliest point the copy-back's own next filesystem call
+// runs, then asserts nothing ever lands in that outside directory.
+describe("copyBackCodexAuth directory-swap-to-symlink protection", () => {
+  const cleanupDirs: string[] = [];
+
+  afterEach(async () => {
+    onFirstOpenCall = null;
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await chmod(dir, 0o700).catch(() => undefined);
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  function subscriptionAuth(input: { accountId: string; lastRefresh?: string; marker: string }): string {
+    return JSON.stringify({
+      tokens: {
+        id_token: `id-token-${input.marker}`,
+        access_token: `access-token-${input.marker}`,
+        refresh_token: `refresh-token-${input.marker}`,
+        account_id: input.accountId,
+      },
+      ...(input.lastRefresh ? { last_refresh: input.lastRefresh } : {}),
+    });
+  }
+
+  const NEWER = "2026-07-09T02:00:00Z";
+  const OLDER = "2026-07-09T01:00:00Z";
+
+  it("does not write into a directory swapped to a symbolic link right after the lock-time re-check", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-copyback-swap-"));
+    cleanupDirs.push(rootDir);
+    const hostDir = path.join(rootDir, "codex-home");
+    const hostAuthPath = path.join(hostDir, "auth.json");
+    await mkdir(hostDir, { recursive: true });
+    const hostAuth = subscriptionAuth({ accountId: "acct-same", lastRefresh: OLDER, marker: "host-intact" });
+    await writeFile(hostAuthPath, hostAuth, { mode: 0o600 });
+
+    const outsideDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-copyback-outside-"));
+    cleanupDirs.push(outsideDir);
+    // A usable, OLDER same-account decoy at the attacker's target: with a
+    // real destination in place the decision predicate would pick "use
+    // source" (the sandbox copy below is newer), so an unpinned write would
+    // overwrite this decoy with the sandbox credential — the clearest,
+    // byte-level proof of a leaked write, not just an early return.
+    const outsideAuthPath = path.join(outsideDir, "auth.json");
+    const decoyAuth = subscriptionAuth({ accountId: "acct-same", lastRefresh: OLDER, marker: "outside-decoy" });
+    await writeFile(outsideAuthPath, decoyAuth, { mode: 0o600 });
+
+    // Fires right before the copy-back's own first `open` call, which is the
+    // directory-pin open: swap the real `hostDir` for a symbolic link to
+    // `outsideDir` at that exact instant.
+    onFirstOpenCall = async () => {
+      await rm(hostDir, { recursive: true, force: true });
+      await symlink(outsideDir, hostDir);
+    };
+
+    const sandboxAuth = subscriptionAuth({ accountId: "acct-same", lastRefresh: NEWER, marker: "sandbox-newer" });
+    const logs: string[] = [];
+    const outcome = await copyBackCodexAuth({
+      readSandboxAuth: async () => Buffer.from(sandboxAuth, "utf8"),
+      hostAuthPath,
+      log: (line) => {
+        logs.push(line);
+      },
+    });
+
+    expect(outcome).toBe("kept-host");
+    // The decoy at the attacker's target is untouched — the copy-back never
+    // wrote through the swapped symbolic link.
+    expect(await readFile(outsideAuthPath, "utf8")).toBe(decoyAuth);
+    expect(await readdir(outsideDir)).toEqual(["auth.json"]);
+    expect(logs).toEqual([
+      "[paperclip] Codex auth copy-back: skipped (the configured Codex home is outside the managed directory tree).",
+    ]);
   });
 });

--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.test.ts
@@ -1127,17 +1127,19 @@ describe("copyBackCodexAuth directory-replacement race protection on a non-Linux
     });
 
     // Fires right after the directory-pin `open` call resolves (call 1);
-    // re-arms as a no-op for the staging-temp create (call 2); re-arms again
-    // to land the swap right after the destination-snapshot create resolves
-    // (call 3) — the moment right before the predicate spawns, after the fix
-    // has already snapshotted the real host credential. Renames the real
-    // directory aside (preserving its device and inode) and puts a fresh
-    // directory under the original name holding a decoy host credential AND
-    // a decoy source at the exact staged-temp name (standing in for an
-    // attacker who learned the name, for example by watching the directory
-    // before the swap), so a predicate that still read the live path would
-    // read both files from the decoy directory instead of failing closed on
-    // a missing source.
+    // re-arms as a no-op for the staging-temp create (call 2) and the
+    // destination-read open (call 3) — the fix already reads the real host
+    // credential through an already-open descriptor at that point, immune
+    // to a swap that lands afterward; re-arms again to land the swap right
+    // after the destination-snapshot create resolves (call 4), the moment
+    // right before the predicate spawns. Renames the real directory aside
+    // (preserving its device and inode) and puts a fresh directory under
+    // the original name holding a decoy host credential AND a decoy source
+    // at the exact staged-temp name (standing in for an attacker who
+    // learned the name, for example by watching the directory before the
+    // swap), so a predicate that still read the live path would read both
+    // files from the decoy directory instead of failing closed on a
+    // missing source.
     let openCallCount = 0;
     let swapApplied = false;
     const tempFileNames: string[] = [];
@@ -1146,7 +1148,7 @@ describe("copyBackCodexAuth directory-replacement race protection on a non-Linux
       if (openCallCount === 2) {
         tempFileNames.push(path.basename(String(args[0])));
       }
-      if (openCallCount < 3) {
+      if (openCallCount < 4) {
         onAfterOpenCall = armNext;
         return Promise.resolve();
       }
@@ -1175,10 +1177,10 @@ describe("copyBackCodexAuth directory-replacement race protection on a non-Linux
       log: () => {},
     });
 
-    // Guard the guard: if a future change removes the third `open` call (for
-    // example by reverting the destination-snapshot fix), the swap above
-    // would never fire and this test would pass for the wrong reason —
-    // trivially, by never exercising the race at all. Fail loud instead.
+    // Guard the guard: if a future change removes the fourth `open` call
+    // (for example by reverting the destination-snapshot fix), the swap
+    // above would never fire and this test would pass for the wrong reason
+    // — trivially, by never exercising the race at all. Fail loud instead.
     expect(swapApplied).toBe(true);
     expect(restoreApplied).toBe(true);
 
@@ -1188,6 +1190,142 @@ describe("copyBackCodexAuth directory-replacement race protection on a non-Linux
     // copy on the strength of a comparison against the decoy.
     expect(outcome).toBe("kept-host");
     expect(await readFile(hostAuthPath, "utf8")).toBe(hostAuth);
+    expect(await readdir(hostDir)).toEqual(["auth.json"]);
+  });
+});
+
+// The directory-identity checks elsewhere in this suite prove the ENCLOSING
+// DIRECTORY was not replaced; they say nothing about `auth.json` itself. A
+// same-user process can replace just that file with a decoy, let the
+// decision compare the sandbox copy against the decoy, then restore the
+// exact original file afterward — the directory never changes identity at
+// all, on either platform, so a directory-only check cannot see this. This
+// suite proves the copy-back instead binds the decision to the credential
+// FILE's own identity (device, inode, and `ctime`) and rejects instead of
+// installing on the strength of a decision made against a decoy.
+describe("copyBackCodexAuth credential-file swap-and-restore protection", () => {
+  const cleanupDirs: string[] = [];
+  const originalPlatform = process.platform;
+
+  afterEach(async () => {
+    onAfterOpenCall = null;
+    onAfterDecideCodexAuthMerge = null;
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await chmod(dir, 0o700).catch(() => undefined);
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  function subscriptionAuth(input: { accountId: string; lastRefresh?: string; marker: string }): string {
+    return JSON.stringify({
+      tokens: {
+        id_token: `id-token-${input.marker}`,
+        access_token: `access-token-${input.marker}`,
+        refresh_token: `refresh-token-${input.marker}`,
+        account_id: input.accountId,
+      },
+      ...(input.lastRefresh ? { last_refresh: input.lastRefresh } : {}),
+    });
+  }
+
+  const HOST_REAL_NEWEST = "2026-07-09T05:00:00Z";
+  const SANDBOX_MIDDLE = "2026-07-09T02:00:00Z";
+  const DECOY_OLDEST = "2026-07-09T00:00:00Z";
+
+  // Fires right after the staging-temp create resolves (open call 2) — the
+  // instant before the copy-back's own destination-read `open` call, the
+  // narrowest point this race can land. Overwrites `auth.json` IN PLACE (a
+  // truncate-and-rewrite of the same directory entry, not a removal and
+  // recreation): the enclosing directory's own device and inode never
+  // change, and an in-place truncate-and-rewrite keeps the FILE's own
+  // device and inode too — only the file's `ctime`, bumped by the write
+  // itself, ever changes, so only a check bound to that, not to the
+  // directory's or even the file's dev/ino alone, can catch this.
+  async function runFileSwapRace(hostAuthPath: string): Promise<{ swapApplied: boolean; restoreApplied: boolean }> {
+    const hostAuth = subscriptionAuth({
+      accountId: "acct-same",
+      lastRefresh: HOST_REAL_NEWEST,
+      marker: "host-real-newest",
+    });
+    await writeFile(hostAuthPath, hostAuth, { mode: 0o600 });
+
+    // Older than the decoy below, so a decision that reads the decoy
+    // wrongly concludes the sandbox copy is fresher; older than the real
+    // host too, so the correct decision is always "keep host".
+    const sandboxAuth = subscriptionAuth({
+      accountId: "acct-same",
+      lastRefresh: SANDBOX_MIDDLE,
+      marker: "sandbox-middle",
+    });
+    const decoyAuth = subscriptionAuth({ accountId: "acct-same", lastRefresh: DECOY_OLDEST, marker: "decoy-oldest" });
+
+    let openCallCount = 0;
+    const result = { swapApplied: false, restoreApplied: false };
+    onAfterOpenCall = function armNext() {
+      openCallCount += 1;
+      if (openCallCount < 2) {
+        onAfterOpenCall = armNext;
+        return Promise.resolve();
+      }
+      return (async () => {
+        await writeFile(hostAuthPath, decoyAuth, { mode: 0o600 });
+        result.swapApplied = true;
+      })();
+    };
+    // Fires right after the decision resolves, before the write-time
+    // identity re-check: restores the real credential bytes, in place, at
+    // the same path.
+    onAfterDecideCodexAuthMerge = async () => {
+      await writeFile(hostAuthPath, hostAuth, { mode: 0o600 });
+      result.restoreApplied = true;
+    };
+
+    await expect(
+      copyBackCodexAuth({
+        readSandboxAuth: async () => Buffer.from(sandboxAuth, "utf8"),
+        hostAuthPath,
+        log: () => {},
+      }),
+    ).rejects.toThrow(/changed identity/);
+
+    // The real host credential — genuinely the newest of the two real
+    // copies — must survive untouched: the decision compared the sandbox
+    // copy against the decoy and would otherwise have installed it.
+    expect(await readFile(hostAuthPath, "utf8")).toBe(hostAuth);
+    return result;
+  }
+
+  it("rejects the write instead of installing on the strength of a decision read against a decoy credential file swapped in and restored in place, on a non-Linux host", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+
+    const hostDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-copyback-file-swap-"));
+    cleanupDirs.push(hostDir);
+    const hostAuthPath = path.join(hostDir, "auth.json");
+
+    const { swapApplied, restoreApplied } = await runFileSwapRace(hostAuthPath);
+
+    // Guard the guard: a future change that removes the destination-read
+    // `open` call would let this swap land somewhere else and this test
+    // would pass for the wrong reason. Fail loud instead.
+    expect(swapApplied).toBe(true);
+    expect(restoreApplied).toBe(true);
+    expect(await readdir(hostDir)).toEqual(["auth.json"]);
+  });
+
+  it("rejects the write instead of installing on the strength of a decision read against a decoy credential file swapped in and restored in place, on Linux", async () => {
+    if (process.platform !== "linux") return;
+
+    const hostDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-copyback-file-swap-linux-"));
+    cleanupDirs.push(hostDir);
+    const hostAuthPath = path.join(hostDir, "auth.json");
+
+    const { swapApplied, restoreApplied } = await runFileSwapRace(hostAuthPath);
+
+    expect(swapApplied).toBe(true);
+    expect(restoreApplied).toBe(true);
     expect(await readdir(hostDir)).toEqual(["auth.json"]);
   });
 });

--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.test.ts
@@ -1188,3 +1188,111 @@ describe("copyBackCodexAuth ancestor-directory replacement race protection on Li
     expect(await readdir(outsideHostDir)).toEqual(["auth.json"]);
   });
 });
+
+// `O_NOFOLLOW` on the directory-pin `open` call only refuses a symbolic link
+// at the FINAL path segment; the call still re-walks every ANCESTOR segment
+// of the path from the root, so a symbolic link substituted into an ancestor
+// in the gap between the lock-time containment re-check and the open call is
+// silently followed. On Linux the copy-back closes that gap by reading the
+// opened descriptor's own kernel-resolved real path back from
+// `/proc/self/fd`, but `/proc` does not exist on a non-Linux host. There, a
+// plain `lstat` of the LEAF path alone cannot see an ancestor left swapped:
+// resolved through the same swapped ancestor, it reports the same identity
+// as the (attacker-pointing) pinned descriptor, so a leaf-only identity
+// check agrees with the pin and wrongly passes. This suite proves the
+// copy-back instead re-checks every recorded ANCESTOR segment's identity
+// right after the pin `open` call, and rejects instead of installing
+// through the swapped ancestor even when the leaf-only check would not
+// have caught it.
+describe("copyBackCodexAuth ancestor-directory replacement race protection on a non-Linux host", () => {
+  const cleanupDirs: string[] = [];
+  const originalPlatform = process.platform;
+  const COMPANY_ID = "company-a";
+
+  afterEach(async () => {
+    onFirstOpenCall = null;
+    Object.defineProperty(process, "platform", { value: originalPlatform });
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await chmod(dir, 0o700).catch(() => undefined);
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  function subscriptionAuth(input: { accountId: string; lastRefresh?: string; marker: string }): string {
+    return JSON.stringify({
+      tokens: {
+        id_token: `id-token-${input.marker}`,
+        access_token: `access-token-${input.marker}`,
+        refresh_token: `refresh-token-${input.marker}`,
+        account_id: input.accountId,
+      },
+      ...(input.lastRefresh ? { last_refresh: input.lastRefresh } : {}),
+    });
+  }
+
+  const NEWER = "2026-07-09T02:00:00Z";
+  const OLDER = "2026-07-09T01:00:00Z";
+
+  it("rejects the write instead of installing through an ancestor directory swapped to a symbolic link right before the directory-pin open", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin" });
+
+    const homeDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-copyback-nonlinux-ancestor-"));
+    cleanupDirs.push(homeDir);
+    const env: NodeJS.ProcessEnv = { PAPERCLIP_HOME: homeDir, PAPERCLIP_INSTANCE_ID: "default" };
+    const companyRoot = path.join(homeDir, "instances", "default", "companies", COMPANY_ID);
+    // An ancestor segment sits BETWEEN the company boundary and the leaf
+    // host directory, so a swap of that segment (not the leaf) is what this
+    // test needs to reach the ancestor-only gap.
+    const ancestorDir = path.join(companyRoot, "subdir");
+    const hostDir = path.join(ancestorDir, "codex-home");
+    const hostAuthPath = path.join(hostDir, "auth.json");
+    await mkdir(hostDir, { recursive: true });
+    const hostAuth = subscriptionAuth({ accountId: "acct-same", lastRefresh: OLDER, marker: "host-intact" });
+    await writeFile(hostAuthPath, hostAuth, { mode: 0o600 });
+
+    const outsideDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-copyback-nonlinux-ancestor-outside-"));
+    cleanupDirs.push(outsideDir);
+    const outsideHostDir = path.join(outsideDir, "codex-home");
+    // A real, same-named leaf directory at the redirected target, so the
+    // directory-pin `open` call itself succeeds once the ancestor is
+    // swapped — only the new ancestor-identity re-check must catch this,
+    // not the open call's own `O_NOFOLLOW` refusal.
+    await mkdir(outsideHostDir, { recursive: true });
+    // A usable, OLDER same-account decoy at the attacker's redirected
+    // target: with a real destination in place the decision predicate would
+    // pick "use source" (the sandbox copy below is newer), so a leaked
+    // write would overwrite this decoy — the clearest, byte-level proof of a
+    // leaked write, not just an early return.
+    const decoyAuth = subscriptionAuth({ accountId: "acct-same", lastRefresh: OLDER, marker: "outside-decoy" });
+    await writeFile(path.join(outsideHostDir, "auth.json"), decoyAuth, { mode: 0o600 });
+
+    // Fires right before the copy-back's directory-pin `open` call, which
+    // runs after the lock-time containment re-check already passed against
+    // the honest ancestor. Swap the ANCESTOR ("subdir"), not the leaf, for a
+    // symbolic link to `outsideDir`, and leave it swapped: the leaf path
+    // segment ("codex-home") is still a plain directory both before and
+    // after the swap, so a leaf-only identity check cannot see this.
+    onFirstOpenCall = async () => {
+      await rm(ancestorDir, { recursive: true, force: true });
+      await symlink(outsideDir, ancestorDir);
+    };
+
+    const sandboxAuth = subscriptionAuth({ accountId: "acct-same", lastRefresh: NEWER, marker: "sandbox-newer" });
+    await expect(
+      copyBackCodexAuth({
+        readSandboxAuth: async () => Buffer.from(sandboxAuth, "utf8"),
+        hostAuthPath,
+        companyId: COMPANY_ID,
+        log: () => {},
+        env,
+      }),
+    ).rejects.toThrow(/changed identity/);
+
+    // The decoy at the attacker's redirected target is untouched — the
+    // copy-back never wrote through the swapped ancestor.
+    expect(await readFile(path.join(outsideHostDir, "auth.json"), "utf8")).toBe(decoyAuth);
+    expect(await readdir(outsideHostDir)).toEqual(["auth.json"]);
+  });
+});

--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
@@ -1,5 +1,6 @@
 import { constants as fsConstants } from "node:fs";
 import { mkdir, open, rename, rm } from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 import {
@@ -92,26 +93,29 @@ export interface CopyBackCodexAuthInput {
  *      boundary, so this step is skipped.
  *   3. Inside the lock, re-verify a THIRD time against the real path
  *      `withDirectoryMergeLock` itself just resolved (`fs.realpath` on
- *      `hostDir`, taken at lock-acquisition time) and use that real path —
- *      not the literal `hostDir` — for every write below. This closes the
- *      gap the second check leaves open: the `mkdir` call and the lock
- *      acquisition wait both still await, and either can straddle a
- *      symbolic-link swap; re-checking against a path resolved at the
- *      instant the lock was acquired, with no further `await` before it is
- *      used, is the narrowest window the standard library allows. Every one
- *      of the three checks treats only a containment rejection as benign: it
- *      writes no file, emits one warning line, and resolves to `kept-host`
- *      exactly like the sandbox-read ENOENT case above. Every other error —
- *      a permission fault, an unexpected read fault — stays fail-loud.
- *   4. Stage the bytes to a `0600` temp file on the **same filesystem** as
- *      the host target (its directory), which doubles as the predicate
- *      `source`. The open uses `O_EXCL` so it fails instead of following or
+ *      `hostDir`, taken at lock-acquisition time). Immediately after — with
+ *      no further `await` in between — open that real directory with
+ *      `O_DIRECTORY | O_NOFOLLOW` and pin it behind the returned file
+ *      descriptor. This single open call is itself a fourth, atomic
+ *      re-check: it fails outright instead of opening a symbolic link, so a
+ *      swap in the gap the third check cannot see (between that check
+ *      returning and this open running) is still caught. Every write below
+ *      then resolves through this descriptor's `/proc/self/fd/<fd>` alias,
+ *      never through the plain directory path string again, so a LATER swap
+ *      of that string cannot redirect a write the way it could when a write
+ *      only ever re-used a path already re-walked from the root. `/proc` is
+ *      Linux-only, so this step also fails closed — `kept-host`, no write —
+ *      on any other platform, exactly like a containment rejection.
+ *   4. Stage the bytes to a `0600` temp file inside the pinned directory
+ *      (same filesystem as the host target, which doubles as the predicate
+ *      `source`). The open uses `O_EXCL` so it fails instead of following or
  *      overwriting an existing entry, and `O_NOFOLLOW` so it refuses outright
  *      if the temp name is (or became) a symbolic link.
  *   5. Run the newer-wins decision predicate (`source` = sandbox temp,
  *      `destination` = host). Exit 10 → adopt the sandbox copy; exit 20 →
  *      keep the host copy.
- *   6. On exit 10, `rename` the staged temp over the host target. `rename`
+ *   6. On exit 10, `rename` the staged temp over the host target, both
+ *      addressed through the pinned directory's descriptor alias. `rename`
  *      never follows a destination symbolic link — it replaces the link
  *      entry itself — so even a `hostAuthPath` swapped to a symbolic link in
  *      this window is overwritten in place, never written through. This is
@@ -121,12 +125,14 @@ export interface CopyBackCodexAuthInput {
  * finally cleans it up otherwise), so a failure never leaves a partial file.
  * Never logs token bytes — only the decision outcome.
  *
- * Residual risk: Node.js exposes no `openat`, `mkdirat`, or `renameat`, so
- * step 3's re-verification and step 4's `open` are still two separate calls,
- * not one atomic, directory-file-descriptor-pinned operation. A mutable
- * ancestor rebound in that specific gap — after the lock-time `realpath`,
- * before `open` — is not caught. This is the strongest containment the
- * standard library supports without a native dependency.
+ * The decision predicate (step 5) still reads its two files by plain path,
+ * not through the pinned descriptor: it runs in a separate `node` child
+ * process, and a file descriptor pinned in this process is not addressable
+ * from that child's own `/proc/self/fd`. That read is comparison-only — it
+ * can at most skew which side the predicate picks, never place attacker
+ * bytes anywhere — so the descriptor pin is reserved for the two operations
+ * that actually write: the temp-file create in step 4 and the `rename` in
+ * step 6.
  */
 export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<CopyBackCodexAuthOutcome> {
   const { readSandboxAuth, hostAuthPath, companyId, log, resolveCacheEntryPath, env } = input;
@@ -200,50 +206,96 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
         }
       }
 
-      const canonicalHostAuthPath = path.join(canonicalHostDir, hostAuthFileName);
-
-      // Stage on the same filesystem as the host target so both the predicate read
-      // and the final rename stay device-local (rename across devices is not
-      // atomic and would fail with EXDEV).
-      const stagedTempPath = path.join(
-        canonicalHostDir,
-        `.auth.json.copyback-${process.pid}-${randomUUID()}.tmp`,
-      );
-      // `O_CREAT | O_EXCL` creates the temp private and fails instead of
-      // following or overwriting an existing entry; `O_NOFOLLOW` additionally
-      // refuses outright if that entry is a symbolic link.
-      const handle = await open(
-        stagedTempPath,
-        fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
-        0o600,
-      );
-      try {
-        await handle.writeFile(sandboxAuthBytes);
-        await handle.close();
-
-        const decision = await decideCodexAuthMerge(stagedTempPath, canonicalHostAuthPath, {
-          errorLabel: "codex auth copy-back",
-        });
-        if (decision === USE_SOURCE_EXIT) {
-          // Atomic same-directory swap; rename preserves the temp's 0600 mode.
-          await rename(stagedTempPath, canonicalHostAuthPath);
-          await log(
-            "[paperclip] Codex auth copy-back: sandbox credential is strictly newer for the same subscription identity; installed to the host at mode 0600.",
-          );
-          return "copied";
-        }
-
-        await log(
-          "[paperclip] Codex auth copy-back: host credential kept (sandbox copy is not a strictly-newer same-identity subscription credential).",
-        );
+      // Pin `canonicalHostDir` behind a file descriptor, immediately, with no
+      // further `await` before it is used. `O_DIRECTORY | O_NOFOLLOW` makes
+      // this open call a fourth, atomic re-check: it fails with `ELOOP` or
+      // `ENOTDIR` instead of opening a symbolic link or a non-directory, so a
+      // swap that lands in the gap the check above cannot see is still
+      // caught here. Every write below resolves through this descriptor's
+      // `/proc/self/fd/<fd>` alias, not the plain `canonicalHostDir` text
+      // used until now, so a swap of that text AFTER this point can no
+      // longer redirect a write. `/proc` is Linux-only: on another platform,
+      // atomic containment cannot be guaranteed, so this fails closed the
+      // same way a containment rejection does, before any byte is staged.
+      if (process.platform !== "linux") {
+        await log(skippedOutsideTreeLog);
         return "kept-host";
+      }
+      let pinnedDir: FileHandle;
+      try {
+        pinnedDir = await open(
+          canonicalHostDir,
+          fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
+        );
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException | null)?.code;
+        if (code !== "ELOOP" && code !== "ENOTDIR") {
+          throw error;
+        }
+        await log(skippedOutsideTreeLog);
+        return "kept-host";
+      }
+      const pinnedDirPath = `/proc/self/fd/${pinnedDir.fd}`;
+
+      try {
+        const canonicalHostAuthPath = path.join(canonicalHostDir, hostAuthFileName);
+
+        // Stage on the same filesystem as the host target so both the predicate read
+        // and the final rename stay device-local (rename across devices is not
+        // atomic and would fail with EXDEV). Both the create below and the rename
+        // that follows address the file through the pinned directory descriptor,
+        // never through the plain `canonicalHostDir` text.
+        const tempFileName = `.auth.json.copyback-${process.pid}-${randomUUID()}.tmp`;
+        const stagedTempPath = path.join(canonicalHostDir, tempFileName);
+        const pinnedStagedTempPath = path.join(pinnedDirPath, tempFileName);
+        const pinnedHostAuthPath = path.join(pinnedDirPath, hostAuthFileName);
+
+        // `O_CREAT | O_EXCL` creates the temp private and fails instead of
+        // following or overwriting an existing entry; `O_NOFOLLOW` additionally
+        // refuses outright if that entry is a symbolic link.
+        const handle = await open(
+          pinnedStagedTempPath,
+          fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
+          0o600,
+        );
+        try {
+          await handle.writeFile(sandboxAuthBytes);
+          await handle.close();
+
+          // The decision predicate runs in a separate `node` child process, so
+          // it cannot address a descriptor pinned in this process — it reads
+          // both files by plain path. That read only feeds a comparison; it
+          // can skew which side the predicate picks but never places
+          // attacker-controlled bytes anywhere, so the descriptor pin above is
+          // reserved for the create and the rename below, the two operations
+          // that actually write.
+          const decision = await decideCodexAuthMerge(stagedTempPath, canonicalHostAuthPath, {
+            errorLabel: "codex auth copy-back",
+          });
+          if (decision === USE_SOURCE_EXIT) {
+            // Atomic same-directory swap through the pinned descriptor; rename
+            // preserves the temp's 0600 mode.
+            await rename(pinnedStagedTempPath, pinnedHostAuthPath);
+            await log(
+              "[paperclip] Codex auth copy-back: sandbox credential is strictly newer for the same subscription identity; installed to the host at mode 0600.",
+            );
+            return "copied";
+          }
+
+          await log(
+            "[paperclip] Codex auth copy-back: host credential kept (sandbox copy is not a strictly-newer same-identity subscription credential).",
+          );
+          return "kept-host";
+        } finally {
+          // Close is idempotent-safe to skip after an explicit close; the temp is the
+          // thing that must never linger. On the copy path rename already consumed it
+          // (force makes the removal a no-op); on every other path this deletes the
+          // staged credential bytes.
+          await handle.close().catch(() => undefined);
+          await rm(pinnedStagedTempPath, { force: true }).catch(() => undefined);
+        }
       } finally {
-        // Close is idempotent-safe to skip after an explicit close; the temp is the
-        // thing that must never linger. On the copy path rename already consumed it
-        // (force makes the removal a no-op); on every other path this deletes the
-        // staged credential bytes.
-        await handle.close().catch(() => undefined);
-        await rm(stagedTempPath, { force: true }).catch(() => undefined);
+        await pinnedDir.close().catch(() => undefined);
       }
     },
     env,

--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
@@ -7,7 +7,7 @@ import {
   assertNoSymlinkInManagedCredentialPath,
   ManagedCredentialHomeRejectedError,
   resolveManagedCredentialHomeBoundary,
-} from "@paperclipai/adapter-utils";
+} from "@paperclipai/adapter-utils/managed-credential-home";
 import { withDirectoryMergeLock } from "@paperclipai/adapter-utils/workspace-restore-merge";
 import {
   isCodexAuthCacheEnabled,

--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
@@ -93,19 +93,23 @@ export interface CopyBackCodexAuthInput {
  *      boundary, so this step is skipped.
  *   3. Inside the lock, re-verify a THIRD time against the real path
  *      `withDirectoryMergeLock` itself just resolved (`fs.realpath` on
- *      `hostDir`, taken at lock-acquisition time). Immediately after — with
- *      no further `await` in between — open that real directory with
- *      `O_DIRECTORY | O_NOFOLLOW` and pin it behind the returned file
- *      descriptor. This single open call is itself a fourth, atomic
- *      re-check: it fails outright instead of opening a symbolic link, so a
- *      swap in the gap the third check cannot see (between that check
- *      returning and this open running) is still caught. Every write below
- *      then resolves through this descriptor's `/proc/self/fd/<fd>` alias,
- *      never through the plain directory path string again, so a LATER swap
- *      of that string cannot redirect a write the way it could when a write
- *      only ever re-used a path already re-walked from the root. `/proc` is
- *      Linux-only, so this step also fails closed — `kept-host`, no write —
- *      on any other platform, exactly like a containment rejection.
+ *      `hostDir`, taken at lock-acquisition time). On Linux, immediately
+ *      after — with no further `await` in between — open that real
+ *      directory with `O_DIRECTORY | O_NOFOLLOW` and pin it behind the
+ *      returned file descriptor. This single open call is itself a fourth,
+ *      atomic re-check: it fails outright instead of opening a symbolic
+ *      link, so a swap in the gap the third check cannot see (between that
+ *      check returning and this open running) is still caught. Every write
+ *      below then resolves through this descriptor's `/proc/self/fd/<fd>`
+ *      alias, never through the plain directory path string again, so a
+ *      LATER swap of that string cannot redirect a write the way it could
+ *      when a write only ever re-used a path already re-walked from the
+ *      root. `/proc` does not exist on a non-Linux platform, so there the
+ *      writes below instead address the plain `hostDir` text the three
+ *      checks above already re-verified — the strongest containment the
+ *      standard library supports without a Linux-only descriptor pin, and
+ *      the same approach this function used before the descriptor pin was
+ *      added.
  *   4. Stage the bytes to a `0600` temp file inside the pinned directory
  *      (same filesystem as the host target, which doubles as the predicate
  *      `source`). The open uses `O_EXCL` so it fails instead of following or
@@ -206,36 +210,37 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
         }
       }
 
-      // Pin `canonicalHostDir` behind a file descriptor, immediately, with no
-      // further `await` before it is used. `O_DIRECTORY | O_NOFOLLOW` makes
-      // this open call a fourth, atomic re-check: it fails with `ELOOP` or
-      // `ENOTDIR` instead of opening a symbolic link or a non-directory, so a
-      // swap that lands in the gap the check above cannot see is still
-      // caught here. Every write below resolves through this descriptor's
-      // `/proc/self/fd/<fd>` alias, not the plain `canonicalHostDir` text
-      // used until now, so a swap of that text AFTER this point can no
-      // longer redirect a write. `/proc` is Linux-only: on another platform,
-      // atomic containment cannot be guaranteed, so this fails closed the
-      // same way a containment rejection does, before any byte is staged.
-      if (process.platform !== "linux") {
-        await log(skippedOutsideTreeLog);
-        return "kept-host";
-      }
-      let pinnedDir: FileHandle;
-      try {
-        pinnedDir = await open(
-          canonicalHostDir,
-          fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
-        );
-      } catch (error) {
-        const code = (error as NodeJS.ErrnoException | null)?.code;
-        if (code !== "ELOOP" && code !== "ENOTDIR") {
-          throw error;
+      // On Linux, pin `canonicalHostDir` behind a file descriptor,
+      // immediately, with no further `await` before it is used.
+      // `O_DIRECTORY | O_NOFOLLOW` makes this open call a fourth, atomic
+      // re-check: it fails with `ELOOP` or `ENOTDIR` instead of opening a
+      // symbolic link or a non-directory, so a swap that lands in the gap
+      // the check above cannot see is still caught here. Every write below
+      // then resolves through this descriptor's `/proc/self/fd/<fd>` alias,
+      // not the plain `canonicalHostDir` text used until now, so a swap of
+      // that text AFTER this point can no longer redirect a write. `/proc`
+      // does not exist on a non-Linux platform, so there `writeDirPath`
+      // below stays the plain, already-re-verified `canonicalHostDir` text —
+      // this function's original approach, before the Linux-only descriptor
+      // pin was added.
+      let pinnedDir: FileHandle | undefined;
+      let writeDirPath = canonicalHostDir;
+      if (process.platform === "linux") {
+        try {
+          pinnedDir = await open(
+            canonicalHostDir,
+            fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
+          );
+        } catch (error) {
+          const code = (error as NodeJS.ErrnoException | null)?.code;
+          if (code !== "ELOOP" && code !== "ENOTDIR") {
+            throw error;
+          }
+          await log(skippedOutsideTreeLog);
+          return "kept-host";
         }
-        await log(skippedOutsideTreeLog);
-        return "kept-host";
+        writeDirPath = `/proc/self/fd/${pinnedDir.fd}`;
       }
-      const pinnedDirPath = `/proc/self/fd/${pinnedDir.fd}`;
 
       try {
         const canonicalHostAuthPath = path.join(canonicalHostDir, hostAuthFileName);
@@ -243,18 +248,20 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
         // Stage on the same filesystem as the host target so both the predicate read
         // and the final rename stay device-local (rename across devices is not
         // atomic and would fail with EXDEV). Both the create below and the rename
-        // that follows address the file through the pinned directory descriptor,
-        // never through the plain `canonicalHostDir` text.
+        // that follows address the file through `writeDirPath` — the pinned
+        // directory descriptor on Linux, the plain re-verified directory text
+        // everywhere else — never through the original `canonicalHostDir` text
+        // again on Linux.
         const tempFileName = `.auth.json.copyback-${process.pid}-${randomUUID()}.tmp`;
         const stagedTempPath = path.join(canonicalHostDir, tempFileName);
-        const pinnedStagedTempPath = path.join(pinnedDirPath, tempFileName);
-        const pinnedHostAuthPath = path.join(pinnedDirPath, hostAuthFileName);
+        const writeStagedTempPath = path.join(writeDirPath, tempFileName);
+        const writeHostAuthPath = path.join(writeDirPath, hostAuthFileName);
 
         // `O_CREAT | O_EXCL` creates the temp private and fails instead of
         // following or overwriting an existing entry; `O_NOFOLLOW` additionally
         // refuses outright if that entry is a symbolic link.
         const handle = await open(
-          pinnedStagedTempPath,
+          writeStagedTempPath,
           fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
           0o600,
         );
@@ -266,16 +273,16 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
           // it cannot address a descriptor pinned in this process — it reads
           // both files by plain path. That read only feeds a comparison; it
           // can skew which side the predicate picks but never places
-          // attacker-controlled bytes anywhere, so the descriptor pin above is
-          // reserved for the create and the rename below, the two operations
-          // that actually write.
+          // attacker-controlled bytes anywhere, so the descriptor pin (on
+          // Linux) is reserved for the create and the rename below, the two
+          // operations that actually write.
           const decision = await decideCodexAuthMerge(stagedTempPath, canonicalHostAuthPath, {
             errorLabel: "codex auth copy-back",
           });
           if (decision === USE_SOURCE_EXIT) {
-            // Atomic same-directory swap through the pinned descriptor; rename
+            // Atomic same-directory swap through `writeDirPath`; rename
             // preserves the temp's 0600 mode.
-            await rename(pinnedStagedTempPath, pinnedHostAuthPath);
+            await rename(writeStagedTempPath, writeHostAuthPath);
             await log(
               "[paperclip] Codex auth copy-back: sandbox credential is strictly newer for the same subscription identity; installed to the host at mode 0600.",
             );
@@ -292,10 +299,10 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
           // (force makes the removal a no-op); on every other path this deletes the
           // staged credential bytes.
           await handle.close().catch(() => undefined);
-          await rm(pinnedStagedTempPath, { force: true }).catch(() => undefined);
+          await rm(writeStagedTempPath, { force: true }).catch(() => undefined);
         }
       } finally {
-        await pinnedDir.close().catch(() => undefined);
+        await pinnedDir?.close().catch(() => undefined);
       }
     },
     env,

--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { randomUUID } from "node:crypto";
 import {
   assertNoSymlinkInManagedCredentialPath,
+  ManagedCredentialHomeRejectedError,
   resolveManagedCredentialHomeBoundary,
 } from "@paperclipai/adapter-utils";
 import { withDirectoryMergeLock } from "@paperclipai/adapter-utils/workspace-restore-merge";
@@ -87,10 +88,13 @@ export interface CopyBackCodexAuthInput {
  *      can be rebound to a symbolic link in that window, so this function
  *      re-resolves the company boundary and re-walks every existing path
  *      segment with a no-follow `lstat` immediately before it creates
- *      anything. A rejection here writes no file, emits one warning line,
- *      and resolves to `kept-host` exactly like the sandbox-read ENOENT
- *      case above. A caller that omits `companyId` guards its target
- *      through a different, unmanaged boundary, so this step is skipped.
+ *      anything. Only a containment rejection is benign here: it writes no
+ *      file, emits one warning line, and resolves to `kept-host` exactly
+ *      like the sandbox-read ENOENT case above. Every other error from this
+ *      step — a permission fault, an unexpected read fault — stays
+ *      fail-loud, matching the sandbox-read handling above. A caller that
+ *      omits `companyId` guards its target through a different, unmanaged
+ *      boundary, so this step is skipped.
  *   3. Stage the bytes to a `0600` temp file on the **same filesystem** as
  *      the host target (its directory), which doubles as the predicate
  *      `source`. The open uses `O_EXCL` so it fails instead of following or
@@ -143,14 +147,19 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
   // Re-verify right before the write. Do not trust `hostAuthPath` on the
   // strength of a caller's earlier check alone — re-resolve the boundary and
   // re-walk the path with a no-follow `lstat` here, as close to the `mkdir`
-  // below as possible. A caller that omits `companyId` guards its target
-  // through a different, unmanaged boundary, so there is no company
+  // below as possible. Only a containment rejection is a benign "outside the
+  // managed tree" outcome; every other error stays fail-loud, matching the
+  // sandbox-read handling above. A caller that omits `companyId` guards its
+  // target through a different, unmanaged boundary, so there is no company
   // containment to re-check here.
   if (companyId) {
     try {
       const boundary = await resolveManagedCredentialHomeBoundary({ env, companyId });
       await assertNoSymlinkInManagedCredentialPath(boundary, hostDir);
-    } catch {
+    } catch (error) {
+      if (!(error instanceof ManagedCredentialHomeRejectedError)) {
+        throw error;
+      }
       await log(
         "[paperclip] Codex auth copy-back: skipped (the configured Codex home is outside the managed directory tree).",
       );

--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
@@ -83,27 +83,35 @@ export interface CopyBackCodexAuthInput {
  *   2. When the caller passes `companyId`, re-verify `hostAuthPath`'s
  *      directory right before the write. A caller validates `hostAuthPath`
  *      before it calls this function, but time passes between that check
- *      and this write — the sandbox read above, the directory-lock wait,
- *      and the decision predicate all await. A mutable ancestor directory
- *      can be rebound to a symbolic link in that window, so this function
- *      re-resolves the company boundary and re-walks every existing path
- *      segment with a no-follow `lstat` immediately before it creates
- *      anything. Only a containment rejection is benign here: it writes no
- *      file, emits one warning line, and resolves to `kept-host` exactly
- *      like the sandbox-read ENOENT case above. Every other error from this
- *      step — a permission fault, an unexpected read fault — stays
- *      fail-loud, matching the sandbox-read handling above. A caller that
- *      omits `companyId` guards its target through a different, unmanaged
+ *      and this write — the sandbox read above and the directory-lock wait
+ *      both await. A mutable ancestor directory can be rebound to a symbolic
+ *      link in that window, so this function re-resolves the company
+ *      boundary and re-walks every existing path segment with a no-follow
+ *      `lstat` immediately before it creates anything. A caller that omits
+ *      `companyId` guards its target through a different, unmanaged
  *      boundary, so this step is skipped.
- *   3. Stage the bytes to a `0600` temp file on the **same filesystem** as
+ *   3. Inside the lock, re-verify a THIRD time against the real path
+ *      `withDirectoryMergeLock` itself just resolved (`fs.realpath` on
+ *      `hostDir`, taken at lock-acquisition time) and use that real path —
+ *      not the literal `hostDir` — for every write below. This closes the
+ *      gap the second check leaves open: the `mkdir` call and the lock
+ *      acquisition wait both still await, and either can straddle a
+ *      symbolic-link swap; re-checking against a path resolved at the
+ *      instant the lock was acquired, with no further `await` before it is
+ *      used, is the narrowest window the standard library allows. Every one
+ *      of the three checks treats only a containment rejection as benign: it
+ *      writes no file, emits one warning line, and resolves to `kept-host`
+ *      exactly like the sandbox-read ENOENT case above. Every other error —
+ *      a permission fault, an unexpected read fault — stays fail-loud.
+ *   4. Stage the bytes to a `0600` temp file on the **same filesystem** as
  *      the host target (its directory), which doubles as the predicate
  *      `source`. The open uses `O_EXCL` so it fails instead of following or
  *      overwriting an existing entry, and `O_NOFOLLOW` so it refuses outright
  *      if the temp name is (or became) a symbolic link.
- *   4. Run the newer-wins decision predicate (`source` = sandbox temp,
+ *   5. Run the newer-wins decision predicate (`source` = sandbox temp,
  *      `destination` = host). Exit 10 → adopt the sandbox copy; exit 20 →
  *      keep the host copy.
- *   5. On exit 10, `rename` the staged temp over the host target. `rename`
+ *   6. On exit 10, `rename` the staged temp over the host target. `rename`
  *      never follows a destination symbolic link — it replaces the link
  *      entry itself — so even a `hostAuthPath` swapped to a symbolic link in
  *      this window is overwritten in place, never written through. This is
@@ -114,11 +122,11 @@ export interface CopyBackCodexAuthInput {
  * Never logs token bytes — only the decision outcome.
  *
  * Residual risk: Node.js exposes no `openat`, `mkdirat`, or `renameat`, so
- * step 2's re-verification and step 3's `mkdir`/`open` are still two
- * separate calls, not one atomic, directory-file-descriptor-pinned
- * operation. A mutable ancestor rebound in that specific gap is not caught.
- * This is the strongest containment the standard library supports without a
- * native dependency.
+ * step 3's re-verification and step 4's `open` are still two separate calls,
+ * not one atomic, directory-file-descriptor-pinned operation. A mutable
+ * ancestor rebound in that specific gap — after the lock-time `realpath`,
+ * before `open` — is not caught. This is the strongest containment the
+ * standard library supports without a native dependency.
  */
 export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<CopyBackCodexAuthOutcome> {
   const { readSandboxAuth, hostAuthPath, companyId, log, resolveCacheEntryPath, env } = input;
@@ -143,6 +151,10 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
   }
 
   const hostDir = path.dirname(hostAuthPath);
+  const hostAuthFileName = path.basename(hostAuthPath);
+
+  const skippedOutsideTreeLog =
+    "[paperclip] Codex auth copy-back: skipped (the configured Codex home is outside the managed directory tree).";
 
   // Re-verify right before the write. Do not trust `hostAuthPath` on the
   // strength of a caller's earlier check alone — re-resolve the boundary and
@@ -152,17 +164,16 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
   // sandbox-read handling above. A caller that omits `companyId` guards its
   // target through a different, unmanaged boundary, so there is no company
   // containment to re-check here.
+  let boundary: string | undefined;
   if (companyId) {
     try {
-      const boundary = await resolveManagedCredentialHomeBoundary({ env, companyId });
+      boundary = await resolveManagedCredentialHomeBoundary({ env, companyId });
       await assertNoSymlinkInManagedCredentialPath(boundary, hostDir);
     } catch (error) {
       if (!(error instanceof ManagedCredentialHomeRejectedError)) {
         throw error;
       }
-      await log(
-        "[paperclip] Codex auth copy-back: skipped (the configured Codex home is outside the managed directory tree).",
-      );
+      await log(skippedOutsideTreeLog);
       return "kept-host";
     }
   }
@@ -170,11 +181,34 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
   await mkdir(hostDir, { recursive: true });
   const hostOutcome = await withDirectoryMergeLock(
     hostDir,
-    async () => {
+    async (canonicalHostDir) => {
+      // `withDirectoryMergeLock` resolved `hostDir`'s real path to compute
+      // the lock key, at the instant the lock was acquired. Re-verify
+      // against that fresh resolution — not the literal `hostDir` above —
+      // with no `await` in between, and use it for every write below. This
+      // catches a symbolic-link swap that happened during the `mkdir` call
+      // or the lock-acquisition wait, the gap the check above cannot see.
+      if (boundary) {
+        try {
+          await assertNoSymlinkInManagedCredentialPath(boundary, canonicalHostDir);
+        } catch (error) {
+          if (!(error instanceof ManagedCredentialHomeRejectedError)) {
+            throw error;
+          }
+          await log(skippedOutsideTreeLog);
+          return "kept-host";
+        }
+      }
+
+      const canonicalHostAuthPath = path.join(canonicalHostDir, hostAuthFileName);
+
       // Stage on the same filesystem as the host target so both the predicate read
       // and the final rename stay device-local (rename across devices is not
       // atomic and would fail with EXDEV).
-      const stagedTempPath = path.join(hostDir, `.auth.json.copyback-${process.pid}-${randomUUID()}.tmp`);
+      const stagedTempPath = path.join(
+        canonicalHostDir,
+        `.auth.json.copyback-${process.pid}-${randomUUID()}.tmp`,
+      );
       // `O_CREAT | O_EXCL` creates the temp private and fails instead of
       // following or overwriting an existing entry; `O_NOFOLLOW` additionally
       // refuses outright if that entry is a symbolic link.
@@ -187,12 +221,12 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
         await handle.writeFile(sandboxAuthBytes);
         await handle.close();
 
-        const decision = await decideCodexAuthMerge(stagedTempPath, hostAuthPath, {
+        const decision = await decideCodexAuthMerge(stagedTempPath, canonicalHostAuthPath, {
           errorLabel: "codex auth copy-back",
         });
         if (decision === USE_SOURCE_EXIT) {
           // Atomic same-directory swap; rename preserves the temp's 0600 mode.
-          await rename(stagedTempPath, hostAuthPath);
+          await rename(stagedTempPath, canonicalHostAuthPath);
           await log(
             "[paperclip] Codex auth copy-back: sandbox credential is strictly newer for the same subscription identity; installed to the host at mode 0600.",
           );

--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
@@ -1,5 +1,5 @@
 import { constants as fsConstants } from "node:fs";
-import { lstat, mkdir, open, readlink, rename, rm } from "node:fs/promises";
+import { lstat, mkdir, open, readFile, readlink, rename, rm } from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
@@ -276,8 +276,13 @@ async function assertManagedCredentialAncestorsStillLive(
  *      `source`). The open uses `O_EXCL` so it fails instead of following or
  *      overwriting an existing entry, and `O_NOFOLLOW` so it refuses outright
  *      if the temp name is (or became) a symbolic link.
- *   5. Run the newer-wins decision predicate (`source` = sandbox temp,
- *      `destination` = host). Exit 10 → adopt the sandbox copy; exit 20 →
+ *   5. On a non-Linux platform, snapshot the CURRENT host credential bytes
+ *      into a second private temp file, immediately after one more identity
+ *      re-check with no other `await` in between, and hand the predicate
+ *      that frozen snapshot instead of the live host path — see the
+ *      module-level note after this list for why. Then run the newer-wins
+ *      decision predicate (`source` = sandbox temp, `destination` = host, or
+ *      its non-Linux snapshot). Exit 10 → adopt the sandbox copy; exit 20 →
  *      keep the host copy.
  *   6. On exit 10, `rename` the staged temp over the host target, both
  *      addressed through the pinned directory's descriptor alias. `rename`
@@ -286,9 +291,10 @@ async function assertManagedCredentialAncestorsStillLive(
  *      this window is overwritten in place, never written through. This is
  *      an atomic same-directory swap that preserves mode `0600`. On exit 20,
  *      discard the temp file.
- * The staged temp is always removed (rename consumes it on the copy path; the
- * finally cleans it up otherwise), so a failure never leaves a partial file.
- * Never logs token bytes — only the decision outcome.
+ * The staged temp and, on a non-Linux platform, the destination snapshot are
+ * always removed (rename consumes the staged temp on the copy path; the
+ * finally cleans up both otherwise), so a failure never leaves a partial
+ * file. Never logs token bytes — only the decision outcome.
  *
  * The decision predicate (step 5) runs in a separate `node` child process, so
  * it cannot use this process's `/proc/self/fd` alias — `self` inside that
@@ -298,10 +304,28 @@ async function assertManagedCredentialAncestorsStillLive(
  * kernel-maintained record any process with the same user id can read — so
  * the read side resolves through the exact same pinned directory the write
  * side (step 4's create and step 6's `rename`) already uses, and a later swap
- * of the plain directory path text cannot make the two sides disagree. On a
- * non-Linux platform, where `/proc` does not exist, the predicate still reads
- * both files by the plain, re-verified directory path text, matching that
- * platform's write side.
+ * of the plain directory path text cannot make the two sides disagree.
+ *
+ * On a non-Linux platform, where `/proc` does not exist, the predicate's read
+ * of the sandbox temp still uses the plain, re-verified directory path text —
+ * safe, because the temp's name is a value this function only just generated
+ * with a random id, so a local process cannot pre-stage a decoy under that
+ * exact name before this function creates the real one; substituting the
+ * whole directory to defeat that name check breaks the temp lookup outright,
+ * which the predicate treats as an unusable source and fails closed to
+ * "keep destination". The predicate's read of the HOST credential is
+ * different: `hostAuthPath` is a fixed, standing name a local process already
+ * knows, so it cannot rely on an unguessable name the same way. Reading it
+ * live, by plain path text, at whatever moment the predicate's own child
+ * process happens to open it, would let a directory swap-and-restore around
+ * that read compare the predicate against a decoy while the write side, re-
+ * verified right before the `rename`, ends up addressing the genuine,
+ * restored directory — so the decision and the write would silently disagree
+ * about which host credential they each saw. Step 5 above closes this by
+ * reading the host credential itself, in this process, immediately next to
+ * an identity re-check, and handing the predicate a frozen snapshot in place
+ * of the live path — so a later directory swap-and-restore can no longer
+ * change what the predicate reads, on either side.
  */
 export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<CopyBackCodexAuthOutcome> {
   const { readSandboxAuth, hostAuthPath, companyId, log, resolveCacheEntryPath, env } = input;
@@ -490,19 +514,76 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
           fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
           0o600,
         );
+        // On a non-Linux platform, the decision predicate reads its two
+        // arguments inside a separate `node` child process, at whatever
+        // moment THAT process happens to open them — real elapsed time no
+        // identity check in this parent can bracket, because the read never
+        // happens here. A local process could swap `canonicalHostDir` for a
+        // directory holding a decoy host credential, let the predicate read
+        // the decoy, then restore the exact original directory (same device
+        // and inode) before the write-time re-check that follows — a check
+        // that only compares directory identity, so a perfectly restored
+        // original passes it even though the predicate compared against the
+        // decoy. Snapshot the CURRENT host credential bytes into a private,
+        // unguessable temp file right here instead, immediately after a
+        // fresh identity re-check with no other `await` in between, and hand
+        // the predicate that frozen snapshot in place of the live path. A
+        // later swap-and-restore of `canonicalHostDir` can then no longer
+        // change what the predicate reads, because it no longer reads the
+        // live path at all. On Linux this step is unnecessary: the predicate
+        // already reads through the pinned descriptor's own
+        // `/proc/<pid>/fd/<fd>` alias, immune to a directory-level swap the
+        // same way every write already is.
+        let predicateDestinationPath = canonicalHostAuthPath;
+        let destinationSnapshotPath: string | undefined;
         try {
           await handle.writeFile(sandboxAuthBytes);
           await handle.close();
 
+          if (process.platform !== "linux") {
+            await assertPinnedDirectoryStillLive(pinnedDir, canonicalHostDir);
+            destinationSnapshotPath = path.join(
+              writeDirPath,
+              `.auth.json.copyback-dest-${process.pid}-${randomUUID()}.tmp`,
+            );
+            let destinationBytes: Buffer | undefined;
+            try {
+              destinationBytes = await readFile(canonicalHostAuthPath);
+            } catch (error) {
+              if ((error as NodeJS.ErrnoException | null)?.code !== "ENOENT") {
+                throw error;
+              }
+              // Genuinely absent: leave `destinationSnapshotPath` unwritten so
+              // the predicate's own read of it also reports absent, matching
+              // the live path's true state without reading the live path a
+              // second time.
+            }
+            if (destinationBytes !== undefined) {
+              const destinationHandle = await open(
+                destinationSnapshotPath,
+                fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
+                0o600,
+              );
+              try {
+                await destinationHandle.writeFile(destinationBytes);
+              } finally {
+                await destinationHandle.close();
+              }
+            }
+            predicateDestinationPath = destinationSnapshotPath;
+          }
+
           // The decision predicate runs in a separate `node` child process, so
           // it cannot address `writeDirPath`'s `/proc/self/fd` alias — `self`
-          // would name the CHILD's own descriptor table. `stagedTempPath` and
-          // `canonicalHostAuthPath` instead use `readDirPath`, which on Linux
-          // names this parent process's real pid, so the child reads through
-          // the same pinned descriptor every write above uses. That read only
-          // feeds a comparison; it can skew which side the predicate picks
-          // but never places attacker-controlled bytes anywhere on its own.
-          const decision = await decideCodexAuthMerge(stagedTempPath, canonicalHostAuthPath, {
+          // would name the CHILD's own descriptor table. `stagedTempPath`
+          // instead uses `readDirPath`, which on Linux names this parent
+          // process's real pid, so the child reads through the same pinned
+          // descriptor every write above uses; on a non-Linux platform,
+          // `predicateDestinationPath` is the frozen snapshot above instead
+          // of the live path. That read only feeds a comparison; it can skew
+          // which side the predicate picks but never places attacker-controlled
+          // bytes anywhere on its own.
+          const decision = await decideCodexAuthMerge(stagedTempPath, predicateDestinationPath, {
             errorLabel: "codex auth copy-back",
           });
           if (decision === USE_SOURCE_EXIT) {
@@ -533,6 +614,9 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
           // staged credential bytes.
           await handle.close().catch(() => undefined);
           await rm(writeStagedTempPath, { force: true }).catch(() => undefined);
+          if (destinationSnapshotPath) {
+            await rm(destinationSnapshotPath, { force: true }).catch(() => undefined);
+          }
         }
       } finally {
         await pinnedDir?.close().catch(() => undefined);

--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
@@ -1,5 +1,5 @@
 import { constants as fsConstants } from "node:fs";
-import { lstat, mkdir, open, readFile, readlink, rename, rm } from "node:fs/promises";
+import { lstat, mkdir, open, readlink, rename, rm } from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
@@ -71,6 +71,113 @@ export interface CopyBackCodexAuthInput {
   resolveCacheEntryPath?: (accountId: string) => Promise<string>;
   /** Environment for the cache off-switch read. Defaults to `process.env`. */
   env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Identity of an open credential file: the device and inode its descriptor's
+ * own `fstat` reports, plus the inode's change time (`ctime`). `ctime`
+ * updates on every write to the file's own content, even one that keeps the
+ * same device and inode (an in-place truncate-and-rewrite), and no syscall
+ * lets a same-user process set `ctime` back to an earlier value the way
+ * `utimes` can forge `mtime` — so a mismatch on any one of the three fields
+ * proves the file changed since this identity was captured.
+ */
+interface CredentialFileIdentity {
+  readonly dev: number;
+  readonly ino: number;
+  readonly ctimeMs: number;
+}
+
+/**
+ * Opens the host credential with `O_NOFOLLOW`, then reads its bytes back
+ * through that SAME descriptor and returns the descriptor's own `fstat`
+ * identity alongside those bytes — one atomic open-then-read, so the bytes
+ * this hands to the merge decision and the identity checked later by
+ * {@link assertHostCredentialIdentityUnchanged} always describe the exact
+ * same file object, never two separate reads of a name a local process
+ * could repoint in between. Returns `undefined` when the host credential is
+ * genuinely absent (`ENOENT`); every other open or read error stays
+ * fail-loud, including a symbolic link at the credential's own path
+ * (`ELOOP`) — the shared host credential must always be a plain file.
+ */
+async function readHostCredentialSnapshot(
+  hostAuthFilePath: string,
+): Promise<{ bytes: Buffer; identity: CredentialFileIdentity } | undefined> {
+  let handle: FileHandle;
+  try {
+    handle = await open(hostAuthFilePath, fsConstants.O_RDONLY | fsConstants.O_NOFOLLOW);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | null)?.code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+  try {
+    const stat = await handle.stat();
+    const bytes = await handle.readFile();
+    return { bytes, identity: { dev: stat.dev, ino: stat.ino, ctimeMs: stat.ctimeMs } };
+  } finally {
+    await handle.close();
+  }
+}
+
+/**
+ * Thrown only when the host credential FILE's identity no longer matches
+ * the identity {@link readHostCredentialSnapshot} captured when it fed the
+ * merge decision. The directory-identity checks elsewhere in this module
+ * prove the ENCLOSING DIRECTORY was not replaced; they say nothing about
+ * `auth.json` itself. A same-user process can replace it with a decoy right
+ * after the decision read, let the decision compare the sandbox copy
+ * against that decoy, then restore the original file before the write that
+ * follows — a restore that a directory-only identity check cannot see,
+ * because the directory itself never changed. A caller must not catch this
+ * as benign; it must stay fail-loud like every other unexpected write
+ * error.
+ */
+export class CopyBackCredentialReplacedError extends Error {
+  constructor() {
+    super(
+      "Codex auth copy-back: the host credential changed identity between the decision read and the write.",
+    );
+    this.name = "CopyBackCredentialReplacedError";
+  }
+}
+
+/**
+ * Compares a fresh, no-follow read of the host credential's identity against
+ * the identity {@link readHostCredentialSnapshot} captured when it fed the
+ * merge decision. A device, inode, or `ctime` mismatch — or the credential
+ * turning into a symbolic link, or existing now when it was absent then, or
+ * the reverse — all mean something replaced `auth.json` since the decision
+ * read it, so this rejects instead of letting the write below proceed on a
+ * decision made against a different file. Call this immediately before the
+ * write that follows, with no other `await` in between.
+ */
+async function assertHostCredentialIdentityUnchanged(
+  hostAuthFilePath: string,
+  expectedIdentity: CredentialFileIdentity | undefined,
+): Promise<void> {
+  let liveStat;
+  try {
+    liveStat = await lstat(hostAuthFilePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException | null)?.code === "ENOENT") {
+      if (expectedIdentity !== undefined) {
+        throw new CopyBackCredentialReplacedError();
+      }
+      return;
+    }
+    throw error;
+  }
+  if (
+    expectedIdentity === undefined ||
+    liveStat.isSymbolicLink() ||
+    liveStat.dev !== expectedIdentity.dev ||
+    liveStat.ino !== expectedIdentity.ino ||
+    liveStat.ctimeMs !== expectedIdentity.ctimeMs
+  ) {
+    throw new CopyBackCredentialReplacedError();
+  }
 }
 
 /**
@@ -276,56 +383,71 @@ async function assertManagedCredentialAncestorsStillLive(
  *      `source`). The open uses `O_EXCL` so it fails instead of following or
  *      overwriting an existing entry, and `O_NOFOLLOW` so it refuses outright
  *      if the temp name is (or became) a symbolic link.
- *   5. On a non-Linux platform, snapshot the CURRENT host credential bytes
- *      into a second private temp file, immediately after one more identity
- *      re-check with no other `await` in between, and hand the predicate
- *      that frozen snapshot instead of the live host path — see the
- *      module-level note after this list for why. Then run the newer-wins
- *      decision predicate (`source` = sandbox temp, `destination` = host, or
- *      its non-Linux snapshot). Exit 10 → adopt the sandbox copy; exit 20 →
- *      keep the host copy.
- *   6. On exit 10, `rename` the staged temp over the host target, both
+ *   5. On every platform, snapshot the CURRENT host credential bytes into a
+ *      second private temp file, together with the identity
+ *      {@link readHostCredentialSnapshot} reads back from the very
+ *      descriptor it read those bytes through, and hand the predicate that
+ *      frozen snapshot instead of the live host path — see the module-level
+ *      note after this list for why. Then run the newer-wins decision
+ *      predicate (`source` = sandbox temp, `destination` = the snapshot).
+ *      Exit 10 → adopt the sandbox copy; exit 20 → keep the host copy.
+ *   6. On exit 10, re-verify the host credential's identity — device, inode,
+ *      and `ctime` — against the one step 5 captured, with no other `await`
+ *      in between; see {@link assertHostCredentialIdentityUnchanged}. Only
+ *      once that passes, `rename` the staged temp over the host target, both
  *      addressed through the pinned directory's descriptor alias. `rename`
  *      never follows a destination symbolic link — it replaces the link
  *      entry itself — so even a `hostAuthPath` swapped to a symbolic link in
  *      this window is overwritten in place, never written through. This is
  *      an atomic same-directory swap that preserves mode `0600`. On exit 20,
  *      discard the temp file.
- * The staged temp and, on a non-Linux platform, the destination snapshot are
- * always removed (rename consumes the staged temp on the copy path; the
- * finally cleans up both otherwise), so a failure never leaves a partial
- * file. Never logs token bytes — only the decision outcome.
+ * The staged temp and the destination snapshot are always removed (rename
+ * consumes the staged temp on the copy path; the finally cleans up both
+ * otherwise), so a failure never leaves a partial file. Never logs token
+ * bytes — only the decision outcome.
  *
  * The decision predicate (step 5) runs in a separate `node` child process, so
  * it cannot use this process's `/proc/self/fd` alias — `self` inside that
  * child would name the CHILD's own descriptor table, not this parent's. On
- * Linux the predicate's two read arguments instead name the pinned
+ * Linux the predicate's sandbox-side read argument instead names the pinned
  * descriptor through this parent process's real pid, `/proc/<pid>/fd/<fd>`, a
  * kernel-maintained record any process with the same user id can read — so
  * the read side resolves through the exact same pinned directory the write
  * side (step 4's create and step 6's `rename`) already uses, and a later swap
- * of the plain directory path text cannot make the two sides disagree.
+ * of the plain directory path text cannot make the two sides disagree. The
+ * predicate's destination-side read argument is the frozen snapshot from
+ * step 5, on every platform.
  *
- * On a non-Linux platform, where `/proc` does not exist, the predicate's read
- * of the sandbox temp still uses the plain, re-verified directory path text —
- * safe, because the temp's name is a value this function only just generated
- * with a random id, so a local process cannot pre-stage a decoy under that
- * exact name before this function creates the real one; substituting the
- * whole directory to defeat that name check breaks the temp lookup outright,
- * which the predicate treats as an unusable source and fails closed to
- * "keep destination". The predicate's read of the HOST credential is
- * different: `hostAuthPath` is a fixed, standing name a local process already
- * knows, so it cannot rely on an unguessable name the same way. Reading it
- * live, by plain path text, at whatever moment the predicate's own child
- * process happens to open it, would let a directory swap-and-restore around
- * that read compare the predicate against a decoy while the write side, re-
+ * On a non-Linux platform, the predicate's read of the sandbox temp still
+ * uses the plain, re-verified directory path text — safe, because the temp's
+ * name is a value this function only just generated with a random id, so a
+ * local process cannot pre-stage a decoy under that exact name before this
+ * function creates the real one; substituting the whole directory to defeat
+ * that name check breaks the temp lookup outright, which the predicate
+ * treats as an unusable source and fails closed to "keep destination".
+ *
+ * The predicate's read of the HOST credential is different in kind, on every
+ * platform: `hostAuthPath` is a fixed, standing name a local process already
+ * knows, so it cannot rely on an unguessable name the way the sandbox temp
+ * does. Reading it live, by name, at whatever moment the predicate's own
+ * child process happens to open it, would let a swap-and-restore around that
+ * read compare the predicate against a decoy while the write side, re-
  * verified right before the `rename`, ends up addressing the genuine,
- * restored directory — so the decision and the write would silently disagree
- * about which host credential they each saw. Step 5 above closes this by
- * reading the host credential itself, in this process, immediately next to
- * an identity re-check, and handing the predicate a frozen snapshot in place
- * of the live path — so a later directory swap-and-restore can no longer
- * change what the predicate reads, on either side.
+ * restored target — so the decision and the write would silently disagree
+ * about which host credential they each saw. This applies at two different
+ * levels: a non-Linux platform can have its ENCLOSING DIRECTORY swapped and
+ * restored around the read (a gap the pinned descriptor alone does not
+ * close there); on every platform, `auth.json` itself can be swapped and
+ * restored around the read without the enclosing directory ever changing
+ * identity at all — a gap no directory-identity check, on any platform, was
+ * ever positioned to see. Step 5 above closes both by reading the host
+ * credential itself, through an opened descriptor, immediately next to an
+ * `fstat` read of that same descriptor, and handing the predicate a frozen
+ * snapshot in place of the live path; step 6 then re-verifies that captured
+ * identity — not just the enclosing directory's — right before the write
+ * that follows, so a later swap-and-restore, of the directory or of the
+ * credential file alone, can no longer make the decision and the write
+ * silently disagree about which host credential they each saw.
  */
 export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<CopyBackCodexAuthOutcome> {
   const { readSandboxAuth, hostAuthPath, companyId, log, resolveCacheEntryPath, env } = input;
@@ -514,86 +636,96 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
           fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
           0o600,
         );
-        // On a non-Linux platform, the decision predicate reads its two
-        // arguments inside a separate `node` child process, at whatever
-        // moment THAT process happens to open them — real elapsed time no
-        // identity check in this parent can bracket, because the read never
-        // happens here. A local process could swap `canonicalHostDir` for a
+        // The decision predicate reads its two arguments inside a separate
+        // `node` child process, at whatever moment THAT process happens to
+        // open them — real elapsed time no identity check in this parent can
+        // bracket, because the read never happens here. On a non-Linux
+        // platform a local process could swap `canonicalHostDir` for a
         // directory holding a decoy host credential, let the predicate read
         // the decoy, then restore the exact original directory (same device
-        // and inode) before the write-time re-check that follows — a check
-        // that only compares directory identity, so a perfectly restored
-        // original passes it even though the predicate compared against the
-        // decoy. Snapshot the CURRENT host credential bytes into a private,
-        // unguessable temp file right here instead, immediately after a
-        // fresh identity re-check with no other `await` in between, and hand
-        // the predicate that frozen snapshot in place of the live path. A
-        // later swap-and-restore of `canonicalHostDir` can then no longer
-        // change what the predicate reads, because it no longer reads the
-        // live path at all. On Linux this step is unnecessary: the predicate
-        // already reads through the pinned descriptor's own
-        // `/proc/<pid>/fd/<fd>` alias, immune to a directory-level swap the
-        // same way every write already is.
-        let predicateDestinationPath = canonicalHostAuthPath;
+        // and inode) before a directory-only re-check — a check that only
+        // compares directory identity, so a perfectly restored original
+        // passes it even though the predicate compared against the decoy. On
+        // every platform, independent of any directory-level swap, a local
+        // process could instead replace just `auth.json` itself with a decoy
+        // and restore it afterward: the directory never changes at all, so a
+        // directory-identity check cannot see this either — on Linux, the
+        // pinned descriptor's own `/proc/<pid>/fd/<fd>` alias still performs
+        // a fresh by-name lookup of `auth.json` inside that directory on
+        // every read, so it is no defense against a swap of the entry itself.
+        // `readHostCredentialSnapshot` closes both gaps at once: it opens the
+        // host credential once, reads its bytes back through that same
+        // descriptor, and returns the descriptor's own `fstat` identity
+        // alongside those bytes, so the bytes handed to the predicate and the
+        // identity {@link assertHostCredentialIdentityUnchanged} checks later
+        // always describe one same file, on every platform. Freeze those
+        // bytes into a private, unguessable temp file and hand the predicate
+        // that frozen snapshot instead of the live host path: a later
+        // swap-and-restore, of the directory or of the credential file alone,
+        // can then no longer change what the predicate reads, because it no
+        // longer reads the live path at all.
         let destinationSnapshotPath: string | undefined;
+        let destinationIdentity: CredentialFileIdentity | undefined;
         try {
           await handle.writeFile(sandboxAuthBytes);
           await handle.close();
 
           if (process.platform !== "linux") {
             await assertPinnedDirectoryStillLive(pinnedDir, canonicalHostDir);
-            destinationSnapshotPath = path.join(
-              writeDirPath,
-              `.auth.json.copyback-dest-${process.pid}-${randomUUID()}.tmp`,
-            );
-            let destinationBytes: Buffer | undefined;
-            try {
-              destinationBytes = await readFile(canonicalHostAuthPath);
-            } catch (error) {
-              if ((error as NodeJS.ErrnoException | null)?.code !== "ENOENT") {
-                throw error;
-              }
-              // Genuinely absent: leave `destinationSnapshotPath` unwritten so
-              // the predicate's own read of it also reports absent, matching
-              // the live path's true state without reading the live path a
-              // second time.
-            }
-            if (destinationBytes !== undefined) {
-              const destinationHandle = await open(
-                destinationSnapshotPath,
-                fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
-                0o600,
-              );
-              try {
-                await destinationHandle.writeFile(destinationBytes);
-              } finally {
-                await destinationHandle.close();
-              }
-            }
-            predicateDestinationPath = destinationSnapshotPath;
           }
+
+          const destinationSnapshot = await readHostCredentialSnapshot(canonicalHostAuthPath);
+          destinationIdentity = destinationSnapshot?.identity;
+          // Built from `readDirPath`, not `writeDirPath`: the decision
+          // predicate below reads this path from a separate `node` CHILD
+          // process, where `/proc/self/fd` would name the CHILD's own
+          // descriptor table, not this parent's. `readDirPath` names this
+          // parent process's real pid on Linux, so the child reads through
+          // the same pinned descriptor this parent just wrote through; this
+          // parent can read and remove the same path just as well, since
+          // its own real pid resolves for it exactly as `/proc/self` would.
+          destinationSnapshotPath = path.join(
+            readDirPath,
+            `.auth.json.copyback-dest-${process.pid}-${randomUUID()}.tmp`,
+          );
+          if (destinationSnapshot !== undefined) {
+            const destinationHandle = await open(
+              destinationSnapshotPath,
+              fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
+              0o600,
+            );
+            try {
+              await destinationHandle.writeFile(destinationSnapshot.bytes);
+            } finally {
+              await destinationHandle.close();
+            }
+          }
+          // Else genuinely absent: leave `destinationSnapshotPath` unwritten
+          // so the predicate's own read of it also reports absent, matching
+          // the live path's true state without reading the live path again.
 
           // The decision predicate runs in a separate `node` child process, so
           // it cannot address `writeDirPath`'s `/proc/self/fd` alias — `self`
           // would name the CHILD's own descriptor table. `stagedTempPath`
           // instead uses `readDirPath`, which on Linux names this parent
           // process's real pid, so the child reads through the same pinned
-          // descriptor every write above uses; on a non-Linux platform,
-          // `predicateDestinationPath` is the frozen snapshot above instead
-          // of the live path. That read only feeds a comparison; it can skew
-          // which side the predicate picks but never places attacker-controlled
+          // descriptor every write above uses; `destinationSnapshotPath` is
+          // the frozen snapshot above instead of the live path, on every
+          // platform. That read only feeds a comparison; it can skew which
+          // side the predicate picks but never places attacker-controlled
           // bytes anywhere on its own.
-          const decision = await decideCodexAuthMerge(stagedTempPath, predicateDestinationPath, {
+          const decision = await decideCodexAuthMerge(stagedTempPath, destinationSnapshotPath, {
             errorLabel: "codex auth copy-back",
           });
           if (decision === USE_SOURCE_EXIT) {
             // The decision predicate above awaited a separate child process —
-            // real time enough for a non-Linux directory swap the earlier
-            // check could not see. Re-verify immediately before this write,
-            // the same way as before the create above.
+            // real time enough for a directory swap or a credential-file swap
+            // the earlier checks could not see. Re-verify both immediately
+            // before this write, with no other `await` in between.
             if (process.platform !== "linux") {
               await assertPinnedDirectoryStillLive(pinnedDir, canonicalHostDir);
             }
+            await assertHostCredentialIdentityUnchanged(writeHostAuthPath, destinationIdentity);
             // Atomic same-directory swap through `writeDirPath`; rename
             // preserves the temp's 0600 mode.
             await rename(writeStagedTempPath, writeHostAuthPath);

--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
@@ -1,5 +1,5 @@
 import { constants as fsConstants } from "node:fs";
-import { mkdir, open, rename, rm } from "node:fs/promises";
+import { lstat, mkdir, open, rename, rm } from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
@@ -72,6 +72,43 @@ export interface CopyBackCodexAuthInput {
 }
 
 /**
+ * Thrown only when the pinned host directory's identity (its device and
+ * inode) no longer matches a fresh, no-follow read of the same path taken
+ * immediately before a write. This means something removed and recreated
+ * the directory since it was pinned — a directory-replacement race, not a
+ * benign "target is outside the managed tree" outcome. A caller must not
+ * catch this as benign; it must stay fail-loud like every other unexpected
+ * write error.
+ */
+export class CopyBackDirectoryReplacedError extends Error {
+  constructor() {
+    super(
+      "Codex auth copy-back: the host directory changed identity between the last check and the write.",
+    );
+    this.name = "CopyBackDirectoryReplacedError";
+  }
+}
+
+/**
+ * Compares the pinned directory descriptor's identity to a fresh, no-follow
+ * read of the plain directory path. A Linux write addresses the pinned
+ * descriptor itself (through its `/proc/self/fd` alias), so a later swap of
+ * the plain path text cannot redirect it; a non-Linux write still addresses
+ * that plain path text directly, so it needs this last check. A directory
+ * removed and recreated under the same name carries a new device/inode pair
+ * even though it is a plain directory, not a symbolic link — a check for
+ * "not a symbolic link" alone cannot see that swap, so this call compares
+ * identity instead. Call this immediately before each write that follows,
+ * with no other `await` in between.
+ */
+async function assertPinnedDirectoryStillLive(pinnedDir: FileHandle, plainDirPath: string): Promise<void> {
+  const [pinnedStat, liveStat] = await Promise.all([pinnedDir.stat(), lstat(plainDirPath)]);
+  if (pinnedStat.dev !== liveStat.dev || pinnedStat.ino !== liveStat.ino) {
+    throw new CopyBackDirectoryReplacedError();
+  }
+}
+
+/**
  * Guards, locks, and atomically installs a strictly-newer sandbox Codex
  * `auth.json` onto the shared host credential at teardown.
  *
@@ -93,23 +130,29 @@ export interface CopyBackCodexAuthInput {
  *      boundary, so this step is skipped.
  *   3. Inside the lock, re-verify a THIRD time against the real path
  *      `withDirectoryMergeLock` itself just resolved (`fs.realpath` on
- *      `hostDir`, taken at lock-acquisition time). On Linux, immediately
- *      after — with no further `await` in between — open that real
- *      directory with `O_DIRECTORY | O_NOFOLLOW` and pin it behind the
- *      returned file descriptor. This single open call is itself a fourth,
- *      atomic re-check: it fails outright instead of opening a symbolic
- *      link, so a swap in the gap the third check cannot see (between that
- *      check returning and this open running) is still caught. Every write
- *      below then resolves through this descriptor's `/proc/self/fd/<fd>`
- *      alias, never through the plain directory path string again, so a
- *      LATER swap of that string cannot redirect a write the way it could
- *      when a write only ever re-used a path already re-walked from the
- *      root. `/proc` does not exist on a non-Linux platform, so there the
- *      writes below instead address the plain `hostDir` text the three
- *      checks above already re-verified — the strongest containment the
- *      standard library supports without a Linux-only descriptor pin, and
- *      the same approach this function used before the descriptor pin was
- *      added.
+ *      `hostDir`, taken at lock-acquisition time). Immediately after — with
+ *      no further `await` in between — open that real directory with
+ *      `O_DIRECTORY | O_NOFOLLOW` and pin it behind the returned file
+ *      descriptor, on every platform. This single open call is itself a
+ *      fourth, atomic re-check: it fails outright instead of opening a
+ *      symbolic link, so a swap in the gap the third check cannot see
+ *      (between that check returning and this open running) is still
+ *      caught. On Linux, every write below then resolves through this
+ *      descriptor's `/proc/self/fd/<fd>` alias, never through the plain
+ *      directory path string again, so a LATER swap of that string cannot
+ *      redirect a write the way it could when a write only ever re-used a
+ *      path already re-walked from the root. `/proc` does not exist on a
+ *      non-Linux platform, so there the writes below instead address the
+ *      plain `hostDir` text — but immediately before each of those writes,
+ *      with no other `await` in between, the pinned descriptor's identity
+ *      (device and inode) is compared against a fresh, no-follow read of
+ *      that same plain text. A directory removed and recreated under the
+ *      same name is still caught this way even though it is a plain
+ *      directory, not a symbolic link, and so cannot be caught by a
+ *      symbolic-link-only check. Node.js exposes no `openat` or `renameat`,
+ *      so this identity check — immediately before the write it guards —
+ *      is the strongest containment the standard library supports without
+ *      a Linux-only descriptor pin.
  *   4. Stage the bytes to a `0600` temp file inside the pinned directory
  *      (same filesystem as the host target, which doubles as the predicate
  *      `source`). The open uses `O_EXCL` so it fails instead of following or
@@ -210,37 +253,36 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
         }
       }
 
-      // On Linux, pin `canonicalHostDir` behind a file descriptor,
-      // immediately, with no further `await` before it is used.
-      // `O_DIRECTORY | O_NOFOLLOW` makes this open call a fourth, atomic
-      // re-check: it fails with `ELOOP` or `ENOTDIR` instead of opening a
-      // symbolic link or a non-directory, so a swap that lands in the gap
-      // the check above cannot see is still caught here. Every write below
-      // then resolves through this descriptor's `/proc/self/fd/<fd>` alias,
-      // not the plain `canonicalHostDir` text used until now, so a swap of
-      // that text AFTER this point can no longer redirect a write. `/proc`
-      // does not exist on a non-Linux platform, so there `writeDirPath`
-      // below stays the plain, already-re-verified `canonicalHostDir` text —
-      // this function's original approach, before the Linux-only descriptor
-      // pin was added.
-      let pinnedDir: FileHandle | undefined;
-      let writeDirPath = canonicalHostDir;
-      if (process.platform === "linux") {
-        try {
-          pinnedDir = await open(
-            canonicalHostDir,
-            fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
-          );
-        } catch (error) {
-          const code = (error as NodeJS.ErrnoException | null)?.code;
-          if (code !== "ELOOP" && code !== "ENOTDIR") {
-            throw error;
-          }
-          await log(skippedOutsideTreeLog);
-          return "kept-host";
+      // Pin `canonicalHostDir` behind a file descriptor on every platform,
+      // immediately, with no further `await` before it is used. `O_DIRECTORY
+      // | O_NOFOLLOW` makes this open call a fourth, atomic re-check: it
+      // fails with `ELOOP` or `ENOTDIR` instead of opening a symbolic link or
+      // a non-directory, so a swap that lands in the gap the check above
+      // cannot see is still caught here.
+      let pinnedDir: FileHandle;
+      try {
+        pinnedDir = await open(
+          canonicalHostDir,
+          fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
+        );
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException | null)?.code;
+        if (code !== "ELOOP" && code !== "ENOTDIR") {
+          throw error;
         }
-        writeDirPath = `/proc/self/fd/${pinnedDir.fd}`;
+        await log(skippedOutsideTreeLog);
+        return "kept-host";
       }
+      // On Linux, every write below resolves through this descriptor's
+      // `/proc/self/fd/<fd>` alias, not the plain `canonicalHostDir` text
+      // used until now, so a swap of that text AFTER this point can no
+      // longer redirect a write. `/proc` does not exist on a non-Linux
+      // platform, so there `writeDirPath` stays the plain `canonicalHostDir`
+      // text, and each write below calls {@link assertPinnedDirectoryStillLive}
+      // immediately beforehand to re-verify that text still names the
+      // SAME directory `pinnedDir` was opened against.
+      const writeDirPath =
+        process.platform === "linux" ? `/proc/self/fd/${pinnedDir.fd}` : canonicalHostDir;
 
       try {
         const canonicalHostAuthPath = path.join(canonicalHostDir, hostAuthFileName);
@@ -256,6 +298,15 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
         const stagedTempPath = path.join(canonicalHostDir, tempFileName);
         const writeStagedTempPath = path.join(writeDirPath, tempFileName);
         const writeHostAuthPath = path.join(writeDirPath, hostAuthFileName);
+
+        // A non-Linux write addresses `canonicalHostDir` by plain text, not
+        // through `pinnedDir` itself, so re-verify the text still names the
+        // directory `pinnedDir` was opened against, immediately before the
+        // first write that uses it. Linux writes through `pinnedDir`'s own
+        // `/proc/self/fd` alias, so this check is unnecessary there.
+        if (process.platform !== "linux") {
+          await assertPinnedDirectoryStillLive(pinnedDir, canonicalHostDir);
+        }
 
         // `O_CREAT | O_EXCL` creates the temp private and fails instead of
         // following or overwriting an existing entry; `O_NOFOLLOW` additionally
@@ -280,6 +331,13 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
             errorLabel: "codex auth copy-back",
           });
           if (decision === USE_SOURCE_EXIT) {
+            // The decision predicate above awaited a separate child process —
+            // real time enough for a non-Linux directory swap the earlier
+            // check could not see. Re-verify immediately before this write,
+            // the same way as before the create above.
+            if (process.platform !== "linux") {
+              await assertPinnedDirectoryStillLive(pinnedDir, canonicalHostDir);
+            }
             // Atomic same-directory swap through `writeDirPath`; rename
             // preserves the temp's 0600 mode.
             await rename(writeStagedTempPath, writeHostAuthPath);

--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
@@ -1,5 +1,5 @@
 import { constants as fsConstants } from "node:fs";
-import { lstat, mkdir, open, rename, rm } from "node:fs/promises";
+import { lstat, mkdir, open, readlink, rename, rm } from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
@@ -72,13 +72,16 @@ export interface CopyBackCodexAuthInput {
 }
 
 /**
- * Thrown only when the pinned host directory's identity (its device and
- * inode) no longer matches a fresh, no-follow read of the same path taken
- * immediately before a write. This means something removed and recreated
- * the directory since it was pinned — a directory-replacement race, not a
- * benign "target is outside the managed tree" outcome. A caller must not
- * catch this as benign; it must stay fail-loud like every other unexpected
- * write error.
+ * Thrown only when the host directory's identity no longer matches what an
+ * earlier check approved: either the pinned descriptor's device and inode no
+ * longer match a fresh, no-follow read of the same path taken immediately
+ * before a write, or (Linux only) the descriptor's own kernel-resolved real
+ * path, read back right after it was opened, does not match the directory
+ * the containment walk approved. Either case means something replaced a
+ * directory — the target itself, or one of its ancestors — since the last
+ * check, a directory-replacement race, not a benign "target is outside the
+ * managed tree" outcome. A caller must not catch this as benign; it must
+ * stay fail-loud like every other unexpected write error.
  */
 export class CopyBackDirectoryReplacedError extends Error {
   constructor() {
@@ -104,6 +107,38 @@ export class CopyBackDirectoryReplacedError extends Error {
 async function assertPinnedDirectoryStillLive(pinnedDir: FileHandle, plainDirPath: string): Promise<void> {
   const [pinnedStat, liveStat] = await Promise.all([pinnedDir.stat(), lstat(plainDirPath)]);
   if (pinnedStat.dev !== liveStat.dev || pinnedStat.ino !== liveStat.ino) {
+    throw new CopyBackDirectoryReplacedError();
+  }
+}
+
+/**
+ * Verifies, on Linux only, that an `O_NOFOLLOW`-opened directory descriptor
+ * actually addresses `expectedRealDir` — the exact real path a containment
+ * walk already approved.
+ *
+ * `open(path, O_NOFOLLOW)` still resolves every ANCESTOR segment of `path`
+ * by re-walking the plain path text from the root; `O_NOFOLLOW` only refuses
+ * a symbolic link at the FINAL segment. A symbolic link substituted into an
+ * ancestor segment in the gap between a containment walk and this open call
+ * is silently followed by the kernel, so the open call can succeed while
+ * `pinnedDir` addresses a directory outside the managed tree entirely — an
+ * outcome the open call's own success cannot reveal.
+ *
+ * `/proc/self/fd/<fd>` is a kernel-maintained record of what the descriptor
+ * actually addresses, built from the same dentry the open call resolved to —
+ * not a second re-walk of the same attacker-reachable path text — so reading
+ * it back and comparing against the approved real path closes that gap:
+ * whatever the open call actually landed on, this either confirms it is the
+ * approved directory or rejects it. `/proc` does not exist on a non-Linux
+ * platform, so this additional proof is Linux-only; the pinned-identity
+ * re-checks before each write remain the containment there.
+ */
+async function assertOpenedDirectoryMatchesRealPath(
+  pinnedDir: FileHandle,
+  expectedRealDir: string,
+): Promise<void> {
+  const openedRealDir = await readlink(`/proc/self/fd/${pinnedDir.fd}`);
+  if (openedRealDir !== expectedRealDir) {
     throw new CopyBackDirectoryReplacedError();
   }
 }
@@ -135,24 +170,37 @@ async function assertPinnedDirectoryStillLive(pinnedDir: FileHandle, plainDirPat
  *      `O_DIRECTORY | O_NOFOLLOW` and pin it behind the returned file
  *      descriptor, on every platform. This single open call is itself a
  *      fourth, atomic re-check: it fails outright instead of opening a
- *      symbolic link, so a swap in the gap the third check cannot see
+ *      non-directory or a symbolic link at the FINAL path segment, so a
+ *      swap of that final segment in the gap the third check cannot see
  *      (between that check returning and this open running) is still
- *      caught. On Linux, every write below then resolves through this
- *      descriptor's `/proc/self/fd/<fd>` alias, never through the plain
- *      directory path string again, so a LATER swap of that string cannot
- *      redirect a write the way it could when a write only ever re-used a
- *      path already re-walked from the root. `/proc` does not exist on a
- *      non-Linux platform, so there the writes below instead address the
- *      plain `hostDir` text — but immediately before each of those writes,
- *      with no other `await` in between, the pinned descriptor's identity
- *      (device and inode) is compared against a fresh, no-follow read of
- *      that same plain text. A directory removed and recreated under the
- *      same name is still caught this way even though it is a plain
- *      directory, not a symbolic link, and so cannot be caught by a
- *      symbolic-link-only check. Node.js exposes no `openat` or `renameat`,
- *      so this identity check — immediately before the write it guards —
- *      is the strongest containment the standard library supports without
- *      a Linux-only descriptor pin.
+ *      caught. `O_NOFOLLOW` says nothing about an ANCESTOR segment, though:
+ *      the open call still re-walks the full path from the root, so a
+ *      symbolic link substituted into an ancestor segment in that same gap
+ *      is silently followed, and the open call can succeed while the
+ *      descriptor addresses a directory outside the managed tree. On Linux,
+ *      a fifth check closes that gap: read the descriptor's own
+ *      kernel-resolved real path back from `/proc/self/fd/<fd>` and reject
+ *      unless it still names the exact directory the third check approved —
+ *      a record built from the same dentry the open call resolved to, not a
+ *      second re-walk of the same attacker-reachable path text. Only once
+ *      that check passes do writes below resolve through this descriptor's
+ *      `/proc/self/fd/<fd>` alias, never through the plain directory path
+ *      string again, so a LATER swap of that string cannot redirect a write
+ *      the way it could when a write only ever re-used a path already
+ *      re-walked from the root. `/proc` does not exist on a non-Linux
+ *      platform, so there the fifth check is skipped and the writes below
+ *      instead address the plain `hostDir` text — but immediately before
+ *      each of those writes, with no other `await` in between, the pinned
+ *      descriptor's identity (device and inode) is compared against a
+ *      fresh, no-follow read of that same plain text. A directory removed
+ *      and recreated under the same name is still caught this way even
+ *      though it is a plain directory, not a symbolic link, and so cannot
+ *      be caught by a symbolic-link-only check. Node.js exposes no
+ *      `openat` or `renameat`, so this identity check — immediately before
+ *      the write it guards — is the strongest containment the standard
+ *      library supports without a Linux-only descriptor pin, and an
+ *      ancestor swap landing before the fourth check on a non-Linux
+ *      platform remains an accepted, documented residual risk.
  *   4. Stage the bytes to a `0600` temp file inside the pinned directory
  *      (same filesystem as the host target, which doubles as the predicate
  *      `source`). The open uses `O_EXCL` so it fails instead of following or
@@ -273,18 +321,36 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
         await log(skippedOutsideTreeLog);
         return "kept-host";
       }
-      // On Linux, every write below resolves through this descriptor's
-      // `/proc/self/fd/<fd>` alias, not the plain `canonicalHostDir` text
-      // used until now, so a swap of that text AFTER this point can no
-      // longer redirect a write. `/proc` does not exist on a non-Linux
-      // platform, so there `writeDirPath` stays the plain `canonicalHostDir`
-      // text, and each write below calls {@link assertPinnedDirectoryStillLive}
-      // immediately beforehand to re-verify that text still names the
-      // SAME directory `pinnedDir` was opened against.
-      const writeDirPath =
-        process.platform === "linux" ? `/proc/self/fd/${pinnedDir.fd}` : canonicalHostDir;
 
       try {
+        // `open()` still resolves every ANCESTOR segment of `canonicalHostDir`
+        // by re-walking the plain path text from the root; `O_NOFOLLOW` above
+        // only refused a symbolic link at the FINAL segment. A symbolic link
+        // substituted into an ancestor segment in the gap between the
+        // containment walk above and the open call just now would be
+        // silently followed by the kernel, so the open call above could have
+        // succeeded while `pinnedDir` addresses a directory outside the
+        // managed tree — an outcome the open call's own success cannot
+        // reveal. Close that gap on Linux by reading the descriptor's own
+        // kernel-resolved real path back and rejecting unless it is still
+        // the exact directory the containment walk approved. `/proc` does
+        // not exist on a non-Linux platform, so this additional proof is
+        // Linux-only.
+        if (process.platform === "linux") {
+          await assertOpenedDirectoryMatchesRealPath(pinnedDir, canonicalHostDir);
+        }
+
+        // On Linux, every write below resolves through this descriptor's
+        // `/proc/self/fd/<fd>` alias, not the plain `canonicalHostDir` text
+        // used until now, so a swap of that text AFTER this point can no
+        // longer redirect a write. `/proc` does not exist on a non-Linux
+        // platform, so there `writeDirPath` stays the plain `canonicalHostDir`
+        // text, and each write below calls {@link assertPinnedDirectoryStillLive}
+        // immediately beforehand to re-verify that text still names the
+        // SAME directory `pinnedDir` was opened against.
+        const writeDirPath =
+          process.platform === "linux" ? `/proc/self/fd/${pinnedDir.fd}` : canonicalHostDir;
+
         const canonicalHostAuthPath = path.join(canonicalHostDir, hostAuthFileName);
 
         // Stage on the same filesystem as the host target so both the predicate read

--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
@@ -290,14 +290,18 @@ async function assertManagedCredentialAncestorsStillLive(
  * finally cleans it up otherwise), so a failure never leaves a partial file.
  * Never logs token bytes — only the decision outcome.
  *
- * The decision predicate (step 5) still reads its two files by plain path,
- * not through the pinned descriptor: it runs in a separate `node` child
- * process, and a file descriptor pinned in this process is not addressable
- * from that child's own `/proc/self/fd`. That read is comparison-only — it
- * can at most skew which side the predicate picks, never place attacker
- * bytes anywhere — so the descriptor pin is reserved for the two operations
- * that actually write: the temp-file create in step 4 and the `rename` in
- * step 6.
+ * The decision predicate (step 5) runs in a separate `node` child process, so
+ * it cannot use this process's `/proc/self/fd` alias — `self` inside that
+ * child would name the CHILD's own descriptor table, not this parent's. On
+ * Linux the predicate's two read arguments instead name the pinned
+ * descriptor through this parent process's real pid, `/proc/<pid>/fd/<fd>`, a
+ * kernel-maintained record any process with the same user id can read — so
+ * the read side resolves through the exact same pinned directory the write
+ * side (step 4's create and step 6's `rename`) already uses, and a later swap
+ * of the plain directory path text cannot make the two sides disagree. On a
+ * non-Linux platform, where `/proc` does not exist, the predicate still reads
+ * both files by the plain, re-verified directory path text, matching that
+ * platform's write side.
  */
 export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<CopyBackCodexAuthOutcome> {
   const { readSandboxAuth, hostAuthPath, companyId, log, resolveCacheEntryPath, env } = input;
@@ -438,17 +442,34 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
         const writeDirPath =
           process.platform === "linux" ? `/proc/self/fd/${pinnedDir.fd}` : canonicalHostDir;
 
-        const canonicalHostAuthPath = path.join(canonicalHostDir, hostAuthFileName);
+        // The decision predicate below runs in a separate `node` child
+        // process, so `/proc/self/fd` would name that CHILD's own descriptor
+        // table, not this parent's — `writeDirPath` above is unusable for a
+        // path this process hands to a different process. `/proc/<pid>/fd/<fd>`
+        // (this process's own real pid, not `self`) is a kernel-maintained
+        // record any process with the same user id can read, so it lets the
+        // child address the exact directory `pinnedDir` was opened against.
+        // On Linux this makes both predicate read arguments below resolve
+        // through the pinned descriptor, the same as every write above — a
+        // swap of the plain `canonicalHostDir` text after this point can no
+        // longer make the read side see a different directory than the write
+        // side. `/proc` does not exist on a non-Linux platform, so there
+        // `readDirPath` stays the plain `canonicalHostDir` text, unchanged
+        // from the write side's own non-Linux behavior.
+        const readDirPath =
+          process.platform === "linux" ? `/proc/${process.pid}/fd/${pinnedDir.fd}` : canonicalHostDir;
+
+        const canonicalHostAuthPath = path.join(readDirPath, hostAuthFileName);
 
         // Stage on the same filesystem as the host target so both the predicate read
         // and the final rename stay device-local (rename across devices is not
         // atomic and would fail with EXDEV). Both the create below and the rename
-        // that follows address the file through `writeDirPath` — the pinned
-        // directory descriptor on Linux, the plain re-verified directory text
-        // everywhere else — never through the original `canonicalHostDir` text
-        // again on Linux.
+        // that follows address the file through `writeDirPath`; the predicate read
+        // below addresses it through `readDirPath` instead — the pinned directory
+        // descriptor on Linux for both, the plain re-verified directory text
+        // everywhere else.
         const tempFileName = `.auth.json.copyback-${process.pid}-${randomUUID()}.tmp`;
-        const stagedTempPath = path.join(canonicalHostDir, tempFileName);
+        const stagedTempPath = path.join(readDirPath, tempFileName);
         const writeStagedTempPath = path.join(writeDirPath, tempFileName);
         const writeHostAuthPath = path.join(writeDirPath, hostAuthFileName);
 
@@ -474,12 +495,13 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
           await handle.close();
 
           // The decision predicate runs in a separate `node` child process, so
-          // it cannot address a descriptor pinned in this process — it reads
-          // both files by plain path. That read only feeds a comparison; it
-          // can skew which side the predicate picks but never places
-          // attacker-controlled bytes anywhere, so the descriptor pin (on
-          // Linux) is reserved for the create and the rename below, the two
-          // operations that actually write.
+          // it cannot address `writeDirPath`'s `/proc/self/fd` alias — `self`
+          // would name the CHILD's own descriptor table. `stagedTempPath` and
+          // `canonicalHostAuthPath` instead use `readDirPath`, which on Linux
+          // names this parent process's real pid, so the child reads through
+          // the same pinned descriptor every write above uses. That read only
+          // feeds a comparison; it can skew which side the predicate picks
+          // but never places attacker-controlled bytes anywhere on its own.
           const decision = await decideCodexAuthMerge(stagedTempPath, canonicalHostAuthPath, {
             errorLabel: "codex auth copy-back",
           });

--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
@@ -1,6 +1,11 @@
+import { constants as fsConstants } from "node:fs";
 import { mkdir, open, rename, rm } from "node:fs/promises";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
+import {
+  assertNoSymlinkInManagedCredentialPath,
+  resolveManagedCredentialHomeBoundary,
+} from "@paperclipai/adapter-utils";
 import { withDirectoryMergeLock } from "@paperclipai/adapter-utils/workspace-restore-merge";
 import {
   isCodexAuthCacheEnabled,
@@ -32,9 +37,21 @@ export interface CopyBackCodexAuthInput {
   /**
    * Absolute path of the shared host credential to (maybe) overwrite — the
    * symlink *source* the managed Codex homes point their `auth.json` at, never
-   * an in-sandbox or per-agent symlink.
+   * an in-sandbox or per-agent symlink. This path was validated once by a
+   * caller before this function ran; that earlier check is not proof enough
+   * on its own — see the re-verification note on {@link copyBackCodexAuth}.
    */
   hostAuthPath: string;
+  /**
+   * The company that owns `hostAuthPath`. When present, this function
+   * independently re-resolves the company's containment boundary right
+   * before the write, so it does not trust `hostAuthPath` on the strength of
+   * an earlier caller's check alone. Omit only for a target this function's
+   * caller already guards through a different, unmanaged boundary (for
+   * example a run-scoped proof home): the re-verification is skipped, not
+   * defaulted to a guess.
+   */
+  companyId?: string;
   /** Non-leaking progress sink: receives decision/outcome lines only. */
   log: (line: string) => void | Promise<void>;
   /**
@@ -62,18 +79,45 @@ export interface CopyBackCodexAuthInput {
  *      `auth.json` (ENOENT) means there is simply nothing to copy back, so it
  *      resolves to `kept-host` (benign no-op, host untouched); every other read
  *      error stays fail-loud.
- *   2. Stage them to a `0600` temp file on the **same filesystem** as the host
- *      target (its directory), which doubles as the predicate `source`.
- *   3. Run the Phase-3 decision predicate (`source` = sandbox temp, `destination`
- *      = host). Exit 10 → adopt the sandbox copy; exit 20 → keep the host copy.
- *   4. On exit 10, `rename` the staged temp over the host target — an atomic
- *      same-directory swap that preserves mode `0600`. On exit 20, discard it.
+ *   2. When the caller passes `companyId`, re-verify `hostAuthPath`'s
+ *      directory right before the write. A caller validates `hostAuthPath`
+ *      before it calls this function, but time passes between that check
+ *      and this write — the sandbox read above, the directory-lock wait,
+ *      and the decision predicate all await. A mutable ancestor directory
+ *      can be rebound to a symbolic link in that window, so this function
+ *      re-resolves the company boundary and re-walks every existing path
+ *      segment with a no-follow `lstat` immediately before it creates
+ *      anything. A rejection here writes no file, emits one warning line,
+ *      and resolves to `kept-host` exactly like the sandbox-read ENOENT
+ *      case above. A caller that omits `companyId` guards its target
+ *      through a different, unmanaged boundary, so this step is skipped.
+ *   3. Stage the bytes to a `0600` temp file on the **same filesystem** as
+ *      the host target (its directory), which doubles as the predicate
+ *      `source`. The open uses `O_EXCL` so it fails instead of following or
+ *      overwriting an existing entry, and `O_NOFOLLOW` so it refuses outright
+ *      if the temp name is (or became) a symbolic link.
+ *   4. Run the newer-wins decision predicate (`source` = sandbox temp,
+ *      `destination` = host). Exit 10 → adopt the sandbox copy; exit 20 →
+ *      keep the host copy.
+ *   5. On exit 10, `rename` the staged temp over the host target. `rename`
+ *      never follows a destination symbolic link — it replaces the link
+ *      entry itself — so even a `hostAuthPath` swapped to a symbolic link in
+ *      this window is overwritten in place, never written through. This is
+ *      an atomic same-directory swap that preserves mode `0600`. On exit 20,
+ *      discard the temp file.
  * The staged temp is always removed (rename consumes it on the copy path; the
  * finally cleans it up otherwise), so a failure never leaves a partial file.
  * Never logs token bytes — only the decision outcome.
+ *
+ * Residual risk: Node.js exposes no `openat`, `mkdirat`, or `renameat`, so
+ * step 2's re-verification and step 3's `mkdir`/`open` are still two
+ * separate calls, not one atomic, directory-file-descriptor-pinned
+ * operation. A mutable ancestor rebound in that specific gap is not caught.
+ * This is the strongest containment the standard library supports without a
+ * native dependency.
  */
 export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<CopyBackCodexAuthOutcome> {
-  const { readSandboxAuth, hostAuthPath, log, resolveCacheEntryPath, env } = input;
+  const { readSandboxAuth, hostAuthPath, companyId, log, resolveCacheEntryPath, env } = input;
 
   // Read first (outside the lock) — a read never mutates the host, so there is
   // nothing to serialize yet. A genuinely absent sandbox `auth.json` (ENOENT —
@@ -95,6 +139,25 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
   }
 
   const hostDir = path.dirname(hostAuthPath);
+
+  // Re-verify right before the write. Do not trust `hostAuthPath` on the
+  // strength of a caller's earlier check alone — re-resolve the boundary and
+  // re-walk the path with a no-follow `lstat` here, as close to the `mkdir`
+  // below as possible. A caller that omits `companyId` guards its target
+  // through a different, unmanaged boundary, so there is no company
+  // containment to re-check here.
+  if (companyId) {
+    try {
+      const boundary = await resolveManagedCredentialHomeBoundary({ env, companyId });
+      await assertNoSymlinkInManagedCredentialPath(boundary, hostDir);
+    } catch {
+      await log(
+        "[paperclip] Codex auth copy-back: skipped (the configured Codex home is outside the managed directory tree).",
+      );
+      return "kept-host";
+    }
+  }
+
   await mkdir(hostDir, { recursive: true });
   const hostOutcome = await withDirectoryMergeLock(
     hostDir,
@@ -103,9 +166,14 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
       // and the final rename stay device-local (rename across devices is not
       // atomic and would fail with EXDEV).
       const stagedTempPath = path.join(hostDir, `.auth.json.copyback-${process.pid}-${randomUUID()}.tmp`);
-      // `wx` + explicit mode create the temp private (0600) and fail if it somehow
-      // already exists, so we never write through a pre-existing symlink.
-      const handle = await open(stagedTempPath, "wx", 0o600);
+      // `O_CREAT | O_EXCL` creates the temp private and fails instead of
+      // following or overwriting an existing entry; `O_NOFOLLOW` additionally
+      // refuses outright if that entry is a symbolic link.
+      const handle = await open(
+        stagedTempPath,
+        fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW,
+        0o600,
+      );
       try {
         await handle.writeFile(sandboxAuthBytes);
         await handle.close();

--- a/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-copyback.ts
@@ -5,9 +5,11 @@ import path from "node:path";
 import { randomUUID } from "node:crypto";
 import {
   assertNoSymlinkInManagedCredentialPath,
+  assertNoSymlinkInManagedCredentialPathAndCaptureAncestors,
   ManagedCredentialHomeRejectedError,
   resolveManagedCredentialHomeBoundary,
 } from "@paperclipai/adapter-utils/managed-credential-home";
+import type { ManagedCredentialAncestorIdentity } from "@paperclipai/adapter-utils/managed-credential-home";
 import { withDirectoryMergeLock } from "@paperclipai/adapter-utils/workspace-restore-merge";
 import {
   isCodexAuthCacheEnabled,
@@ -73,15 +75,21 @@ export interface CopyBackCodexAuthInput {
 
 /**
  * Thrown only when the host directory's identity no longer matches what an
- * earlier check approved: either the pinned descriptor's device and inode no
- * longer match a fresh, no-follow read of the same path taken immediately
- * before a write, or (Linux only) the descriptor's own kernel-resolved real
- * path, read back right after it was opened, does not match the directory
- * the containment walk approved. Either case means something replaced a
- * directory — the target itself, or one of its ancestors — since the last
- * check, a directory-replacement race, not a benign "target is outside the
- * managed tree" outcome. A caller must not catch this as benign; it must
- * stay fail-loud like every other unexpected write error.
+ * earlier check approved:
+ * - the pinned descriptor's device and inode no longer match a fresh,
+ *   no-follow read of the same path, taken immediately before a write; or
+ * - (Linux only) the descriptor's own kernel-resolved real path, read back
+ *   right after it was opened, does not match the directory the containment
+ *   walk approved; or
+ * - (every other platform) one of the containment walk's recorded ancestor
+ *   segments no longer matches a fresh, no-follow read of that same
+ *   ancestor path, taken right after the directory-pin open call succeeded.
+ *
+ * Each case means something replaced a directory — the target itself, or
+ * one of its ancestors — since the last check, a directory-replacement
+ * race, not a benign "target is outside the managed tree" outcome. A caller
+ * must not catch this as benign; it must stay fail-loud like every other
+ * unexpected write error.
  */
 export class CopyBackDirectoryReplacedError extends Error {
   constructor() {
@@ -144,6 +152,59 @@ async function assertOpenedDirectoryMatchesRealPath(
 }
 
 /**
+ * Verifies, on a non-Linux platform only, that every ancestor segment
+ * {@link assertNoSymlinkInManagedCredentialPathAndCaptureAncestors} recorded
+ * during the lock-time containment walk still carries the SAME device and
+ * inode.
+ *
+ * `open(path, O_NOFOLLOW)` still resolves every ANCESTOR segment of `path`
+ * by re-walking the plain path text from the root; `O_NOFOLLOW` only
+ * refuses a symbolic link at the FINAL segment. A symbolic link substituted
+ * into an ancestor segment in the gap between the containment walk and the
+ * directory-pin open call is silently followed by the kernel, so that open
+ * call can succeed while the pinned descriptor addresses a directory
+ * outside the managed tree — an outcome its own success cannot reveal. When
+ * the attacker LEAVES that ancestor swapped in place, a plain `lstat` of
+ * the LEAF path alone cannot see it either: resolved through the same
+ * swapped ancestor, it reports the same identity as the (attacker-pointing)
+ * pinned descriptor, so a leaf-only identity check agrees with the pin and
+ * passes. Comparing each ANCESTOR segment's identity instead catches this:
+ * a symbolic link substituted into an ancestor reports the symbolic link's
+ * OWN identity here, not the real directory's it stood in for, so the
+ * comparison fails and this rejects. An ancestor swap that is instead
+ * RESTORED before a write is caught the other way: the pinned descriptor
+ * still addresses the attacker's directory while the leaf path now resolves
+ * through the restored ancestor to the real one, so the leaf identity check
+ * a caller runs before each write (see the module-level `copyBackCodexAuth`
+ * documentation) rejects that case. Call this once, immediately after the
+ * pin `open` call succeeds, with no other `await` in between.
+ */
+async function assertManagedCredentialAncestorsStillLive(
+  ancestorIdentities: readonly ManagedCredentialAncestorIdentity[],
+): Promise<void> {
+  const liveStats = await Promise.all(ancestorIdentities.map((identity) => lstat(identity.path)));
+  for (const [index, identity] of ancestorIdentities.entries()) {
+    const liveStat = liveStats[index];
+    // A symbolic link substituted at this ancestor is rejected on file type
+    // alone, never on device/inode alone: a freshly created filesystem
+    // object CAN be handed back the exact device/inode pair a just-removed
+    // directory held (some filesystems reuse a just-freed inode number
+    // immediately), so a symbolic link swapped in could coincidentally
+    // match the recorded identity even though it is no longer a directory
+    // at all. Checking the live entry is still a plain directory closes
+    // that gap independently of any such reuse.
+    if (
+      liveStat.isSymbolicLink() ||
+      !liveStat.isDirectory() ||
+      liveStat.dev !== identity.dev ||
+      liveStat.ino !== identity.ino
+    ) {
+      throw new CopyBackDirectoryReplacedError();
+    }
+  }
+}
+
+/**
  * Guards, locks, and atomically installs a strictly-newer sandbox Codex
  * `auth.json` onto the shared host credential at teardown.
  *
@@ -188,19 +249,28 @@ async function assertOpenedDirectoryMatchesRealPath(
  *      string again, so a LATER swap of that string cannot redirect a write
  *      the way it could when a write only ever re-used a path already
  *      re-walked from the root. `/proc` does not exist on a non-Linux
- *      platform, so there the fifth check is skipped and the writes below
- *      instead address the plain `hostDir` text — but immediately before
- *      each of those writes, with no other `await` in between, the pinned
- *      descriptor's identity (device and inode) is compared against a
- *      fresh, no-follow read of that same plain text. A directory removed
- *      and recreated under the same name is still caught this way even
- *      though it is a plain directory, not a symbolic link, and so cannot
- *      be caught by a symbolic-link-only check. Node.js exposes no
- *      `openat` or `renameat`, so this identity check — immediately before
- *      the write it guards — is the strongest containment the standard
- *      library supports without a Linux-only descriptor pin, and an
- *      ancestor swap landing before the fourth check on a non-Linux
- *      platform remains an accepted, documented residual risk.
+ *      platform, so there the fifth check instead re-verifies every ancestor
+ *      segment the second check (step 2) recorded the device and inode of,
+ *      with a fresh, no-follow `lstat` of each: an ancestor symbolic link
+ *      substituted in the same gap and LEFT in place reports its own
+ *      identity here, not the real directory's, so this still catches it
+ *      even though the leaf path alone — resolved through that same swapped
+ *      ancestor — would report the same identity as the (attacker-pointing)
+ *      descriptor and so cannot. The writes below then still address the
+ *      plain `hostDir` text — but immediately before each of those writes,
+ *      with no other `await` in between, the pinned descriptor's identity
+ *      (device and inode) is compared against a fresh, no-follow read of
+ *      that same plain text. A directory removed and recreated under the
+ *      same name is still caught this way even though it is a plain
+ *      directory, not a symbolic link, and so cannot be caught by a
+ *      symbolic-link-only check; an ancestor swap that is RESTORED before a
+ *      write — the case the fifth check's one-time, right-after-open
+ *      comparison cannot see — is caught here instead, because the pinned
+ *      descriptor still addresses the attacker's directory while the leaf
+ *      path now resolves through the restored ancestor to the real one.
+ *      Node.js exposes no `openat` or `renameat`, so together these two
+ *      identity checks are the strongest containment the standard library
+ *      supports without a Linux-only descriptor pin.
  *   4. Stage the bytes to a `0600` temp file inside the pinned directory
  *      (same filesystem as the host target, which doubles as the predicate
  *      `source`). The open uses `O_EXCL` so it fails instead of following or
@@ -289,9 +359,19 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
       // with no `await` in between, and use it for every write below. This
       // catches a symbolic-link swap that happened during the `mkdir` call
       // or the lock-acquisition wait, the gap the check above cannot see.
+      // Recording the ancestor identities here, alongside the symlink
+      // re-check, lets the pinned-open path below re-verify each of them
+      // after the open succeeds — see
+      // `assertManagedCredentialAncestorsStillLive`. A caller that omits
+      // `companyId` has no `boundary`, so `ancestorIdentities` stays empty
+      // and that later re-check becomes a no-op for it, same as this walk.
+      let ancestorIdentities: ManagedCredentialAncestorIdentity[] = [];
       if (boundary) {
         try {
-          await assertNoSymlinkInManagedCredentialPath(boundary, canonicalHostDir);
+          ancestorIdentities = await assertNoSymlinkInManagedCredentialPathAndCaptureAncestors(
+            boundary,
+            canonicalHostDir,
+          );
         } catch (error) {
           if (!(error instanceof ManagedCredentialHomeRejectedError)) {
             throw error;
@@ -334,10 +414,17 @@ export async function copyBackCodexAuth(input: CopyBackCodexAuthInput): Promise<
         // reveal. Close that gap on Linux by reading the descriptor's own
         // kernel-resolved real path back and rejecting unless it is still
         // the exact directory the containment walk approved. `/proc` does
-        // not exist on a non-Linux platform, so this additional proof is
-        // Linux-only.
+        // not exist on a non-Linux platform, so there this instead
+        // re-verifies every ancestor segment the containment walk above
+        // recorded: a symbolic link substituted into an ancestor and LEFT in
+        // place carries its own identity, not the real directory's, so that
+        // comparison still catches it even though a plain `lstat` of the
+        // LEAF path alone — resolved through the same swapped ancestor —
+        // cannot. See `assertManagedCredentialAncestorsStillLive`.
         if (process.platform === "linux") {
           await assertOpenedDirectoryMatchesRealPath(pinnedDir, canonicalHostDir);
+        } else {
+          await assertManagedCredentialAncestorsStillLive(ancestorIdentities);
         }
 
         // On Linux, every write below resolves through this descriptor's

--- a/packages/adapters/codex-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/codex-local/src/server/execute.remote.test.ts
@@ -709,7 +709,7 @@ describe("codex remote auth copy-back target selection", () => {
       { mode: 0o600 },
     );
 
-    // A fixed host location the old (Phase 3) copy-back used to target. Stub the
+    // The fixed shared host home the copy-back no longer targets. Stub the
     // OS-level CODEX_HOME so a regression back to that target is observable.
     vi.stubEnv("PAPERCLIP_HOME", paperclipHome);
     vi.stubEnv("PAPERCLIP_INSTANCE_ID", "default");

--- a/packages/adapters/codex-local/src/server/execute.remote.test.ts
+++ b/packages/adapters/codex-local/src/server/execute.remote.test.ts
@@ -618,3 +618,224 @@ describe("codex remote execution", () => {
     expect(call?.[3].remoteExecution?.remoteCwd).toBe("/app");
   });
 });
+
+describe("codex remote auth copy-back target selection", () => {
+  const cleanupDirs: string[] = [];
+  const OLDER = "2026-07-09T01:00:00Z";
+  const NEWER = "2026-07-09T02:00:00Z";
+
+  afterEach(async () => {
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  function subscriptionAuth(input: { accountId: string; lastRefresh: string; marker: string }): string {
+    return JSON.stringify({
+      tokens: {
+        id_token: `id-token-${input.marker}`,
+        access_token: `access-token-${input.marker}`,
+        refresh_token: `refresh-token-${input.marker}`,
+        account_id: input.accountId,
+      },
+      last_refresh: input.lastRefresh,
+    });
+  }
+
+  async function runExecuteAgainstConfiguredHome(input: {
+    workspaceDir: string;
+    companyId: string;
+    configuredCodexHome: string;
+    sandboxAuth: string;
+  }): Promise<{ logs: string[] }> {
+    const logs: string[] = [];
+    runSshCommand.mockImplementationOnce(async () => ({
+      stdout: Buffer.from(input.sandboxAuth, "utf8").toString("base64"),
+      stderr: "",
+    }));
+    await execute({
+      runId: "run-copyback-target",
+      agent: {
+        id: "agent-1",
+        companyId: input.companyId,
+        name: "CodexCoder",
+        adapterType: "codex_local",
+        adapterConfig: {},
+      },
+      runtime: { sessionId: null, sessionParams: null, sessionDisplayId: null, taskKey: null },
+      config: {
+        command: "codex",
+        env: { CODEX_HOME: input.configuredCodexHome },
+      },
+      context: { paperclipWorkspace: { cwd: input.workspaceDir, source: "project_primary" } },
+      executionTransport: {
+        remoteExecution: {
+          host: "127.0.0.1",
+          port: 2222,
+          username: "fixture",
+          remoteWorkspacePath: "/remote/workspace",
+          remoteCwd: "/remote/workspace",
+          privateKey: "PRIVATE KEY",
+          knownHosts: "[127.0.0.1]:2222 ssh-ed25519 AAAA",
+          strictHostKeyChecking: true,
+        },
+      },
+      onLog: async (stream, line) => {
+        logs.push(`${stream}:${line}`);
+      },
+    });
+    return { logs };
+  }
+
+  it("writes the selected account home, not the shared host home", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-selected-home-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    await mkdir(workspaceDir, { recursive: true });
+    const paperclipHome = path.join(rootDir, "paperclip-home");
+    const accountHome = path.join(
+      paperclipHome, "instances", "default", "companies", "company-1", "codex-auth-cache", "acct-handle",
+    );
+    const legacySharedHome = path.join(rootDir, "legacy-shared-home");
+    await mkdir(accountHome, { recursive: true });
+    await mkdir(legacySharedHome, { recursive: true });
+    await writeFile(
+      path.join(accountHome, "auth.json"),
+      subscriptionAuth({ accountId: "acct-1", lastRefresh: OLDER, marker: "old" }),
+      { mode: 0o600 },
+    );
+
+    // A fixed host location the old (Phase 3) copy-back used to target. Stub the
+    // OS-level CODEX_HOME so a regression back to that target is observable.
+    vi.stubEnv("PAPERCLIP_HOME", paperclipHome);
+    vi.stubEnv("PAPERCLIP_INSTANCE_ID", "default");
+    vi.stubEnv("CODEX_HOME", legacySharedHome);
+
+    const sandboxAuth = subscriptionAuth({ accountId: "acct-1", lastRefresh: NEWER, marker: "sandbox" });
+    await runExecuteAgainstConfiguredHome({
+      workspaceDir,
+      companyId: "company-1",
+      configuredCodexHome: accountHome,
+      sandboxAuth,
+    });
+
+    expect(await readFile(path.join(accountHome, "auth.json"), "utf8")).toBe(sandboxAuth);
+    await expect(readFile(path.join(legacySharedHome, "auth.json"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("still writes the company default home when no account home is selected", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-default-home-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    await mkdir(workspaceDir, { recursive: true });
+    const paperclipHome = path.join(rootDir, "paperclip-home");
+    const defaultHome = path.join(paperclipHome, "instances", "default", "companies", "company-1", "codex-home");
+    const emptySharedHome = path.join(rootDir, "empty-shared-home");
+    await mkdir(defaultHome, { recursive: true });
+    await mkdir(emptySharedHome, { recursive: true });
+    await writeFile(
+      path.join(defaultHome, "auth.json"),
+      subscriptionAuth({ accountId: "acct-default", lastRefresh: OLDER, marker: "old" }),
+      { mode: 0o600 },
+    );
+
+    vi.stubEnv("PAPERCLIP_HOME", paperclipHome);
+    vi.stubEnv("PAPERCLIP_INSTANCE_ID", "default");
+    vi.stubEnv("CODEX_HOME", emptySharedHome);
+
+    const sandboxAuth = subscriptionAuth({ accountId: "acct-default", lastRefresh: NEWER, marker: "sandbox" });
+    await runExecuteAgainstConfiguredHome({
+      workspaceDir,
+      companyId: "company-1",
+      configuredCodexHome: defaultHome,
+      sandboxAuth,
+    });
+
+    expect(await readFile(path.join(defaultHome, "auth.json"), "utf8")).toBe(sandboxAuth);
+  });
+
+  it("writes no file when the configured home is outside the company root", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-outside-root-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    await mkdir(workspaceDir, { recursive: true });
+    const paperclipHome = path.join(rootDir, "paperclip-home");
+    const outsideHome = path.join(rootDir, "outside-instance-home");
+
+    vi.stubEnv("PAPERCLIP_HOME", paperclipHome);
+    vi.stubEnv("PAPERCLIP_INSTANCE_ID", "default");
+
+    const sandboxAuth = subscriptionAuth({ accountId: "acct-outside", lastRefresh: NEWER, marker: "sandbox" });
+    const { logs } = await runExecuteAgainstConfiguredHome({
+      workspaceDir,
+      companyId: "company-1",
+      configuredCodexHome: outsideHome,
+      sandboxAuth,
+    });
+
+    await expect(readFile(path.join(outsideHome, "auth.json"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    expect(logs.some((line) => line.includes("Codex auth copy-back: skipped"))).toBe(true);
+  });
+
+  it("writes no file when the configured home is under another company", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-other-company-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    await mkdir(workspaceDir, { recursive: true });
+    const paperclipHome = path.join(rootDir, "paperclip-home");
+    const otherCompanyHome = path.join(
+      paperclipHome, "instances", "default", "companies", "company-2", "codex-home",
+    );
+
+    vi.stubEnv("PAPERCLIP_HOME", paperclipHome);
+    vi.stubEnv("PAPERCLIP_INSTANCE_ID", "default");
+
+    const sandboxAuth = subscriptionAuth({ accountId: "acct-other", lastRefresh: NEWER, marker: "sandbox" });
+    await runExecuteAgainstConfiguredHome({
+      workspaceDir,
+      companyId: "company-1",
+      configuredCodexHome: otherCompanyHome,
+      sandboxAuth,
+    });
+
+    await expect(readFile(path.join(otherCompanyHome, "auth.json"), "utf8")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("logs one fixed warning and keeps the run result when the copy-back target is rejected", async () => {
+    const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-rejected-target-"));
+    cleanupDirs.push(rootDir);
+    const workspaceDir = path.join(rootDir, "workspace");
+    await mkdir(workspaceDir, { recursive: true });
+    const paperclipHome = path.join(rootDir, "paperclip-home");
+    const outsideHome = path.join(rootDir, "outside-instance-home");
+
+    vi.stubEnv("PAPERCLIP_HOME", paperclipHome);
+    vi.stubEnv("PAPERCLIP_INSTANCE_ID", "default");
+
+    const sandboxAuth = subscriptionAuth({ accountId: "acct-rejected", lastRefresh: NEWER, marker: "sandbox" });
+    // execute() resolving (not rejecting) is itself evidence that a rejected
+    // copy-back target never fails the run.
+    const { logs } = await runExecuteAgainstConfiguredHome({
+      workspaceDir,
+      companyId: "company-1",
+      configuredCodexHome: outsideHome,
+      sandboxAuth,
+    });
+
+    const warnings = logs.filter((line) => line.startsWith("stderr:") && line.includes("Codex auth copy-back"));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain(
+      "[paperclip] Codex auth copy-back: skipped (the configured Codex home is outside the managed directory tree).",
+    );
+  });
+});

--- a/packages/adapters/codex-local/src/server/execute.test.ts
+++ b/packages/adapters/codex-local/src/server/execute.test.ts
@@ -62,8 +62,8 @@ vi.mock("@paperclipai/adapter-utils/execution-target", async () => {
   };
 });
 
-vi.mock("@paperclipai/adapter-utils", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@paperclipai/adapter-utils")>();
+vi.mock("@paperclipai/adapter-utils/managed-credential-home", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@paperclipai/adapter-utils/managed-credential-home")>();
   // Default implementation is the real guard; a test overrides it once with
   // `assertManagedCredentialHome.mockRejectedValueOnce(...)`.
   assertManagedCredentialHome.mockImplementation(actual.assertManagedCredentialHome);

--- a/packages/adapters/codex-local/src/server/execute.test.ts
+++ b/packages/adapters/codex-local/src/server/execute.test.ts
@@ -18,6 +18,7 @@ const {
   resolveCommandForLogs,
   prepareAdapterExecutionTargetRuntime,
   startAdapterExecutionTargetPaperclipBridge,
+  assertManagedCredentialHome,
 } = vi.hoisted(() => ({
   runChildProcess: vi.fn(async () => ({
     exitCode: 0,
@@ -32,6 +33,10 @@ const {
   resolveCommandForLogs: vi.fn(async () => "/usr/bin/codex"),
   prepareAdapterExecutionTargetRuntime: vi.fn(),
   startAdapterExecutionTargetPaperclipBridge: vi.fn(async () => null),
+  // Wraps the real `assertManagedCredentialHome` by default (set below, once
+  // the actual module is available); a test overrides it for one call with
+  // `mockRejectedValueOnce` to simulate an operational guard failure.
+  assertManagedCredentialHome: vi.fn(),
 }));
 
 vi.mock("@paperclipai/adapter-utils/server-utils", async () => {
@@ -54,6 +59,17 @@ vi.mock("@paperclipai/adapter-utils/execution-target", async () => {
     ...actual,
     prepareAdapterExecutionTargetRuntime,
     startAdapterExecutionTargetPaperclipBridge,
+  };
+});
+
+vi.mock("@paperclipai/adapter-utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@paperclipai/adapter-utils")>();
+  // Default implementation is the real guard; a test overrides it once with
+  // `assertManagedCredentialHome.mockRejectedValueOnce(...)`.
+  assertManagedCredentialHome.mockImplementation(actual.assertManagedCredentialHome);
+  return {
+    ...actual,
+    assertManagedCredentialHome,
   };
 });
 
@@ -83,9 +99,12 @@ prepareAdapterExecutionTargetRuntime.mockImplementation(async (input: { assets?:
   };
 });
 
+const COPYBACK_COMPANY_ID = "company-1";
+
 describe("codex execute — outbound auth copy-back restore contribution", () => {
   const cleanupDirs: string[] = [];
   let savedCodexHomeEnv: string | undefined;
+  let savedPaperclipHomeEnv: string | undefined;
 
   afterEach(async () => {
     vi.clearAllMocks();
@@ -93,6 +112,11 @@ describe("codex execute — outbound auth copy-back restore contribution", () =>
       delete process.env.CODEX_HOME;
     } else {
       process.env.CODEX_HOME = savedCodexHomeEnv;
+    }
+    if (savedPaperclipHomeEnv === undefined) {
+      delete process.env.PAPERCLIP_HOME;
+    } else {
+      process.env.PAPERCLIP_HOME = savedPaperclipHomeEnv;
     }
     while (cleanupDirs.length > 0) {
       const dir = cleanupDirs.pop();
@@ -120,14 +144,19 @@ describe("codex execute — outbound auth copy-back restore contribution", () =>
   async function runTeardown(input: {
     sandboxAuth: string;
     hostAuth: string;
-  }): Promise<{ finalHostAuth: string; finalHostMode: number }> {
+  }): Promise<{ finalHostAuth: string; finalHostMode: number; logs: string[] }> {
     const rootDir = await mkdtemp(path.join(os.tmpdir(), "paperclip-codex-copyback-e2e-"));
     cleanupDirs.push(rootDir);
     const workspaceDir = path.join(rootDir, "workspace");
-    // The shared host home is what `resolveSharedCodexHomeDir` returns
-    // (process.env.CODEX_HOME) — the copy-back target. Point it at a tmp dir so
-    // the round-trip never touches the real host credential.
-    const sharedHostHome = path.join(rootDir, "shared-codex-home");
+    // The copy-back guard requires its target to sit under the Paperclip-
+    // managed company tree (`<PAPERCLIP_HOME>/instances/default/companies/<id>`),
+    // so this points PAPERCLIP_HOME at a tmp dir and places the shared host home
+    // — what `resolveSharedCodexHomeDir` returns via process.env.CODEX_HOME, and
+    // the copy-back target — inside that company's managed tree. The round-trip
+    // never touches the real host credential.
+    const paperclipHome = path.join(rootDir, "paperclip-home");
+    const companyDir = path.join(paperclipHome, "instances", "default", "companies", COPYBACK_COMPANY_ID);
+    const sharedHostHome = path.join(companyDir, "codex-home");
     await mkdir(workspaceDir, { recursive: true });
     await mkdir(sharedHostHome, { recursive: true });
     const hostAuthPath = path.join(sharedHostHome, "auth.json");
@@ -135,13 +164,17 @@ describe("codex execute — outbound auth copy-back restore contribution", () =>
 
     savedCodexHomeEnv = process.env.CODEX_HOME;
     process.env.CODEX_HOME = sharedHostHome;
+    savedPaperclipHomeEnv = process.env.PAPERCLIP_HOME;
+    process.env.PAPERCLIP_HOME = paperclipHome;
     sandboxAuthFixture.bytes = Buffer.from(input.sandboxAuth, "utf8");
+
+    const logs: string[] = [];
 
     await execute({
       runId: "run-copyback-e2e",
       agent: {
         id: "agent-1",
-        companyId: "company-1",
+        companyId: COPYBACK_COMPANY_ID,
         name: "CodexCoder",
         adapterType: "codex_local",
         adapterConfig: {},
@@ -150,8 +183,9 @@ describe("codex execute — outbound auth copy-back restore contribution", () =>
       config: {
         command: "codex",
         engine: "cli",
-        // External CODEX_HOME (outside the managed company tree) so no managed
-        // seeding rewrites auth.json before teardown; equals the shared host home.
+        // A configured CODEX_HOME equal to process.env.CODEX_HOME (the shared
+        // source `resolveSharedCodexHomeDir` reads) makes managed seeding a
+        // self-copy no-op, so it never rewrites auth.json before teardown.
         env: { CODEX_HOME: sharedHostHome },
       },
       context: {
@@ -172,12 +206,15 @@ describe("codex execute — outbound auth copy-back restore contribution", () =>
           strictHostKeyChecking: true,
         },
       },
-      onLog: async () => {},
+      onLog: async (_stream, line) => {
+        logs.push(line);
+      },
     });
 
     return {
       finalHostAuth: await readFile(hostAuthPath, "utf8"),
       finalHostMode: (await lstat(hostAuthPath)).mode & 0o777,
+      logs,
     };
   }
 
@@ -230,5 +267,31 @@ describe("codex execute — outbound auth copy-back restore contribution", () =>
       expect(result.finalHostAuth, entry.name).toBe(entry.hostAuth);
       expect(result.finalHostMode, entry.name).toBe(0o600);
     }
+  });
+
+  it("surfaces the real error instead of a misleading containment message when the managed-home guard fails operationally", async () => {
+    const sandboxAuth = subscriptionAuth({
+      accountId: "acct-op-error",
+      lastRefresh: "2026-07-09T02:00:00Z",
+      marker: "sandbox",
+    });
+    const hostAuth = subscriptionAuth({
+      accountId: "acct-op-error",
+      lastRefresh: "2026-07-09T01:00:00Z",
+      marker: "host",
+    });
+
+    // A permission fault, an I/O error, or a symlink loop reading the guard's
+    // own directory tree is not a containment rejection: the copy-back must
+    // not treat it as benign "outside the managed tree" and must not silently
+    // keep the (stale) host credential without saying why.
+    const operationalError = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+    assertManagedCredentialHome.mockRejectedValueOnce(operationalError);
+
+    const result = await runTeardown({ sandboxAuth, hostAuth });
+
+    expect(result.finalHostAuth).toBe(hostAuth);
+    expect(result.logs.some((line) => line.includes("EACCES: permission denied"))).toBe(true);
+    expect(result.logs.some((line) => line.includes("outside the managed directory tree"))).toBe(false);
   });
 });

--- a/packages/adapters/codex-local/src/server/execute.test.ts
+++ b/packages/adapters/codex-local/src/server/execute.test.ts
@@ -105,6 +105,7 @@ describe("codex execute — outbound auth copy-back restore contribution", () =>
   const cleanupDirs: string[] = [];
   let savedCodexHomeEnv: string | undefined;
   let savedPaperclipHomeEnv: string | undefined;
+  let savedPaperclipInstanceIdEnv: string | undefined;
 
   afterEach(async () => {
     vi.clearAllMocks();
@@ -117,6 +118,11 @@ describe("codex execute — outbound auth copy-back restore contribution", () =>
       delete process.env.PAPERCLIP_HOME;
     } else {
       process.env.PAPERCLIP_HOME = savedPaperclipHomeEnv;
+    }
+    if (savedPaperclipInstanceIdEnv === undefined) {
+      delete process.env.PAPERCLIP_INSTANCE_ID;
+    } else {
+      process.env.PAPERCLIP_INSTANCE_ID = savedPaperclipInstanceIdEnv;
     }
     while (cleanupDirs.length > 0) {
       const dir = cleanupDirs.pop();
@@ -149,11 +155,15 @@ describe("codex execute — outbound auth copy-back restore contribution", () =>
     cleanupDirs.push(rootDir);
     const workspaceDir = path.join(rootDir, "workspace");
     // The copy-back guard requires its target to sit under the Paperclip-
-    // managed company tree (`<PAPERCLIP_HOME>/instances/default/companies/<id>`),
+    // managed company tree (`<PAPERCLIP_HOME>/instances/<instanceId>/companies/<id>`),
     // so this points PAPERCLIP_HOME at a tmp dir and places the shared host home
     // — what `resolveSharedCodexHomeDir` returns via process.env.CODEX_HOME, and
     // the copy-back target — inside that company's managed tree. The round-trip
-    // never touches the real host credential.
+    // never touches the real host credential. `PAPERCLIP_INSTANCE_ID` is pinned
+    // to the literal "default" segment used below: the guard reads that env var
+    // and falls back to "default" only when it is UNSET, so a suite runner that
+    // sets it ambiently (for its own test isolation) would otherwise point the
+    // guard's boundary at an instance directory this test never creates.
     const paperclipHome = path.join(rootDir, "paperclip-home");
     const companyDir = path.join(paperclipHome, "instances", "default", "companies", COPYBACK_COMPANY_ID);
     const sharedHostHome = path.join(companyDir, "codex-home");
@@ -166,6 +176,8 @@ describe("codex execute — outbound auth copy-back restore contribution", () =>
     process.env.CODEX_HOME = sharedHostHome;
     savedPaperclipHomeEnv = process.env.PAPERCLIP_HOME;
     process.env.PAPERCLIP_HOME = paperclipHome;
+    savedPaperclipInstanceIdEnv = process.env.PAPERCLIP_INSTANCE_ID;
+    process.env.PAPERCLIP_INSTANCE_ID = "default";
     sandboxAuthFixture.bytes = Buffer.from(input.sandboxAuth, "utf8");
 
     const logs: string[] = [];

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -2,12 +2,14 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
-  assertManagedCredentialHome,
   inferOpenAiCompatibleBiller,
-  ManagedCredentialHomeRejectedError,
   type AdapterExecutionContext,
   type AdapterExecutionResult,
 } from "@paperclipai/adapter-utils";
+import {
+  assertManagedCredentialHome,
+  ManagedCredentialHomeRejectedError,
+} from "@paperclipai/adapter-utils/managed-credential-home";
 import { buildCodexAuthInboundProvision } from "./codex-auth-merge-scripts.js";
 import { copyBackCodexAuth } from "./codex-auth-copyback.js";
 import {

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import {
   assertManagedCredentialHome,
   inferOpenAiCompatibleBiller,
+  ManagedCredentialHomeRejectedError,
   type AdapterExecutionContext,
   type AdapterExecutionResult,
 } from "@paperclipai/adapter-utils";
@@ -844,7 +845,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
                       companyId: agent.companyId,
                       candidateDir: effectiveCodexHome,
                     });
-                  } catch {
+                  } catch (error) {
+                    if (!(error instanceof ManagedCredentialHomeRejectedError)) {
+                      throw error;
+                    }
                     await onLog(
                       "stderr",
                       "[paperclip] Codex auth copy-back: skipped (the configured Codex home is outside the managed directory tree).\n",

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -1,7 +1,12 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { inferOpenAiCompatibleBiller, type AdapterExecutionContext, type AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  assertManagedCredentialHome,
+  inferOpenAiCompatibleBiller,
+  type AdapterExecutionContext,
+  type AdapterExecutionResult,
+} from "@paperclipai/adapter-utils";
 import { buildCodexAuthInboundProvision } from "./codex-auth-merge-scripts.js";
 import { copyBackCodexAuth } from "./codex-auth-copyback.js";
 import {
@@ -822,16 +827,33 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
                 // Outbound (sandbox→host) auth copy-back contribution: at
                 // teardown, read the sandbox's `auth.json` and — guarded by the
                 // same direction-agnostic decision predicate under a directory
-                // lock — atomically install it onto the shared host credential
-                // when it is a strictly-newer same-identity subscription copy.
-                // The sandbox core stays adapter-agnostic; it just awaits this
-                // generic `restore` seam per asset before destroying the sandbox.
-                // Target is the shared symlink SOURCE (what managed homes point
-                // `auth.json` at), not the in-sandbox symlink.
-                restore: async ({ assetDir, readFile }) =>
+                // lock — atomically install it onto the SELECTED account home
+                // (`effectiveCodexHome`: the configured account home, or the
+                // company default home) when it is a strictly-newer same-
+                // identity subscription copy. The sandbox core stays adapter-
+                // agnostic; it just awaits this generic `restore` seam per asset
+                // before destroying the sandbox. `assertManagedCredentialHome`
+                // re-checks the target is still inside this company's tree right
+                // before the write: a rejected target makes the copy-back a
+                // no-operation instead of a write to an arbitrary path.
+                restore: async ({ assetDir, readFile }) => {
+                  let guardedCodexHome: string;
+                  try {
+                    guardedCodexHome = await assertManagedCredentialHome({
+                      env: process.env,
+                      companyId: agent.companyId,
+                      candidateDir: effectiveCodexHome,
+                    });
+                  } catch {
+                    await onLog(
+                      "stderr",
+                      "[paperclip] Codex auth copy-back: skipped (the configured Codex home is outside the managed directory tree).\n",
+                    );
+                    return;
+                  }
                   void (await copyBackCodexAuth({
                     readSandboxAuth: () => readFile(path.posix.join(assetDir, "auth.json")),
-                    hostAuthPath: path.join(resolveSharedCodexHomeDir(process.env), "auth.json"),
+                    hostAuthPath: path.join(guardedCodexHome, "auth.json"),
                     log: (line) => onLog("stdout", `${line}\n`),
                     // Additive cache write (sandbox to host): also cache the
                     // sandbox subscription credential in its per-identity slot,
@@ -841,7 +863,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
                     resolveCacheEntryPath: (accountId) =>
                       ensureCodexAuthCacheEntryDir(process.env, accountId, agent.companyId),
                     env: process.env,
-                  })),
+                  }));
+                },
                 // No `exclude` denylist: `stagedCodexHomeDir` already contains
                 // ONLY the allowlisted files (auth/config/skills), so there is
                 // nothing to filter out.

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -854,6 +854,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
                   void (await copyBackCodexAuth({
                     readSandboxAuth: () => readFile(path.posix.join(assetDir, "auth.json")),
                     hostAuthPath: path.join(guardedCodexHome, "auth.json"),
+                    companyId: agent.companyId,
                     log: (line) => onLog("stdout", `${line}\n`),
                     // Additive cache write (sandbox to host): also cache the
                     // sandbox subscription credential in its per-identity slot,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The Codex local adapter manages credentials for remote Codex runs
> - A Codex login copied credentials to one fixed host home
> - A second account could overwrite the first account credential
> - This pull request copies credentials to the selected account home and checks the target path
> - The benefit is account isolation with a bounded copy-back path

## Linked Issues or Issue Description

This pull request addresses a bug in Codex credential copy-back.

**What happened?**

A remote Codex run copied refreshed credentials to one fixed host home. A second account could overwrite the first account credential.

**Expected behavior**

The copy-back writes to the account home selected by `CODEX_HOME`, or to the company default home when no account home exists. The write stays inside the company's managed directory.

**Steps to reproduce**

1. Run Codex authentication for two accounts on one host.
2. Select a different `CODEX_HOME` for each account.
3. Complete authentication for both accounts.
4. Check each account home for its credential file.

**Paperclip version or commit**

`6b60a8aafb2596b1322babac686f2d114b8d5e35`.

**Deployment mode**

Built from source with the Codex local adapter.

Related pull request: #10005 handles a missing shared host credential store. This pull request handles account-home selection and path containment.

## What Changed

- Add a managed credential-home guard in `packages/adapter-utils`.
- Select the account home for Codex credential copy-back.
- Reject missing, non-directory, symbolic-link, and out-of-tree company paths.
- Re-check existing path segments before the write.
- Create staging files with exclusive and no-follow flags.
- Add focused adapter and utility tests.

## Verification

- `codex-auth-copyback.test.ts`: 20 of 20 tests pass.
- `managed-credential-home.test.ts`: 11 of 11 tests pass.
- The full `codex-local` package suite passes: 377 of 377 tests.
- TypeScript checks pass for both changed packages.
- `git diff --check` passes.
- Continuous integration and Greptile checks must pass before merge.

## Risks

The final path check and file creation cannot run as one atomic operation because Node.js does not expose the required descriptor-relative calls. The code records this residual risk. The guard limits writes to the company's managed directory and uses no-follow checks and exclusive file creation.

## Model Used

OpenAI Codex, GPT-5, tool use and code execution enabled. The implementation author used this model to assist with repository changes and tests.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs: #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge