### PR TITLE
fix(issues): validate issue list UUID filters

### DIFF
--- a/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
+++ b/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
@@ -1128,6 +1128,12 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
     const app = createApp(companyId);
     const listPath = `/api/companies/${companyId}/issues`;
     const countPath = `/api/companies/${companyId}/issues/count`;
+    // `parentIssueId` is in these lists on purpose. It is not a member of
+    // `ISSUE_LIST_UUID_FILTER_NAMES` — it is the `parentId` alias, normalized by
+    // its own second `.trim()`/`isUuidLike` pair in the guard's alias branch.
+    // Nothing in the main name loop reaches that branch, so it is only pinned if
+    // the value axis walks the alias by name. It is last in each list because
+    // `parentId` must stay absent from the same request for the alias to be read.
     const listParams = [
       "assigneeAgentId",
       "participantAgentId",
@@ -1139,6 +1145,7 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
       "parentId",
       "descendantOf",
       "labelId",
+      "parentIssueId",
     ] as const;
     const countParams = [
       "assigneeAgentId",
@@ -1149,6 +1156,7 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
       "parentId",
       "descendantOf",
       "labelId",
+      "parentIssueId",
     ] as const;
     const errorFor = (param: string) =>
       param === "assigneeAgentId" ? "assigneeAgentId must be a UUID or 'null'" : `${param} must be a UUID`;
@@ -1179,10 +1187,12 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
       }
     }
     for (const param of countParams) {
-      const res = await request(app).get(countPath).query({ attention: "blocked", [param]: " " });
-      const label = `${param}: ${JSON.stringify(res.body)}`;
-      expect(res.status, label).toBe(200);
-      expect(res.body.count, label).toBe(baselineCount);
+      for (const value of [" ", "\t\n"]) {
+        const res = await request(app).get(countPath).query({ attention: "blocked", [param]: value });
+        const label = `${param}=${JSON.stringify(value)}: ${JSON.stringify(res.body)}`;
+        expect(res.status, label).toBe(200);
+        expect(res.body.count, label).toBe(baselineCount);
+      }
     }
 
     // Class 2 — a valid UUID with surrounding whitespace. `isUuidLike` trims
@@ -1206,10 +1216,12 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
       const value = randomUUID();
       const clean = await request(app).get(countPath).query({ attention: "blocked", [param]: value });
       expect(clean.status, `${param}: ${JSON.stringify(clean.body)}`).toBe(200);
-      const res = await request(app).get(countPath).query({ attention: "blocked", [param]: `${value} ` });
-      const label = `${param}=padded: ${JSON.stringify(res.body)}`;
-      expect(res.status, label).toBe(200);
-      expect(res.body, label).toEqual(clean.body);
+      for (const padded of [`${value} `, ` ${value}`]) {
+        const res = await request(app).get(countPath).query({ attention: "blocked", [param]: padded });
+        const label = `${param}=${JSON.stringify(padded)}: ${JSON.stringify(res.body)}`;
+        expect(res.status, label).toBe(200);
+        expect(res.body, label).toEqual(clean.body);
+      }
     }
 
     // Class 3 — non-empty text that is not a UUID. `"x"` is length 1 and
@@ -1255,6 +1267,24 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
       expect(res.status, label).toBe(400);
       expect(res.body, label).toMatchObject({ error: errorFor(param) });
       expect(res.body, label).not.toHaveProperty("count");
+    }
+
+    // Class 5 — the `null` token is case-folded. `assigneeAgentId` is the one
+    // filter that accepts a non-UUID value, and it accepts it only through
+    // `.toLowerCase()`. Drop that call and `NULL` stops being the null token,
+    // falls through to `isUuidLike`, and 400s a request that returns 200 today.
+    // Compare against the lowercase response so the pin holds whatever the
+    // null-assignee page contains.
+    for (const path of [listPath, countPath] as const) {
+      const base = path === listPath ? { status: "todo", limit: "20" } : { attention: "blocked" };
+      const lower = await request(app).get(path).query({ ...base, assigneeAgentId: "null" });
+      expect(lower.status, `${path}: ${JSON.stringify(lower.body)}`).toBe(200);
+      for (const token of ["NULL", "Null"]) {
+        const res = await request(app).get(path).query({ ...base, assigneeAgentId: token });
+        const label = `${path} assigneeAgentId=${token}: ${JSON.stringify(res.body)}`;
+        expect(res.status, label).toBe(200);
+        expect(res.body, label).toEqual(lower.body);
+      }
     }
   });
 

--- a/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
+++ b/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
@@ -3,7 +3,22 @@ import express from "express";
 import request from "supertest";
 import { eq } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
-import { activityLog, agents, companies, companyMemberships, createDb, heartbeatRuns, issues, principalPermissionGrants } from "@paperclipai/db";
+import {
+  activityLog,
+  agents,
+  companies,
+  companyMemberships,
+  createDb,
+  executionWorkspaces,
+  goals,
+  heartbeatRuns,
+  issueLabels,
+  issues,
+  labels,
+  principalPermissionGrants,
+  projects,
+  projectWorkspaces,
+} from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
@@ -39,10 +54,16 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
 
   afterEach(async () => {
     __clearIssueListResponseCacheForTests();
+    await db.delete(issueLabels);
     await db.delete(issues);
+    await db.delete(labels);
+    await db.delete(executionWorkspaces);
+    await db.delete(projectWorkspaces);
+    await db.delete(projects);
     await db.delete(activityLog);
     await db.delete(heartbeatRuns);
     await db.delete(agents);
+    await db.delete(goals);
     await db.delete(principalPermissionGrants);
     await db.delete(companyMemberships);
     await db.delete(companies);
@@ -763,7 +784,7 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
     expect(res.body.map((issue: { id: string }) => issue.id)).toEqual([assignedIssueId]);
   });
 
-  it("returns 422 for malformed assigneeAgentId filters", async () => {
+  it("returns 400 for malformed UUID issue list filters", async () => {
     const companyId = randomUUID();
     await db.insert(companies).values({
       id: companyId,
@@ -774,14 +795,269 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
     await seedCloudTenantMember(companyId);
 
     const app = createApp(companyId);
+    const params = [
+      "assigneeAgentId",
+      "participantAgentId",
+      "projectId",
+      "workspaceId",
+      "executionWorkspaceId",
+      "parentId",
+      "descendantOf",
+      "labelId",
+    ] as const;
+
+    for (const param of params) {
+      const res = await request(app)
+        .get(`/api/companies/${companyId}/issues`)
+        .query({ status: "todo", [param]: "bad", limit: "20" });
+
+      expect(res.status, `${param}: ${JSON.stringify(res.body)}`).toBe(400);
+      expect(res.body).toMatchObject({
+        error: param === "assigneeAgentId"
+          ? "assigneeAgentId must be a UUID or 'null'"
+          : `${param} must be a UUID`,
+      });
+      expect(res.body).not.toHaveProperty("issues");
+    }
+  });
+
+  it("keeps valid UUID filters working with status, limit, and search", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const projectId = randomUUID();
+    const workspaceId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    const parentId = randomUUID();
+    const rootId = randomUUID();
+    const labelId = randomUUID();
+    const matchingIssueId = randomUUID();
+    const otherIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: uniqueIssuePrefix(),
+      requireBoardApprovalForNewAgents: false,
+    });
+    await seedCloudTenantMember(companyId);
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Assignee",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Filtered project",
+      status: "in_progress",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: workspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      sourceType: "local_path",
+      cwd: "/tmp/paperclip-issue-list-project",
+      isPrimary: true,
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      projectWorkspaceId: workspaceId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Execution workspace",
+      status: "active",
+      providerType: "local_fs",
+      cwd: "/tmp/paperclip-issue-list-execution",
+    });
+    await db.insert(issues).values([
+      {
+        id: rootId,
+        companyId,
+        title: "Root",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: parentId,
+        companyId,
+        title: "Parent",
+        status: "todo",
+        priority: "medium",
+        parentId: rootId,
+      },
+      {
+        id: matchingIssueId,
+        companyId,
+        title: "Needle issue",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        createdByAgentId: agentId,
+        projectId,
+        projectWorkspaceId: workspaceId,
+        executionWorkspaceId,
+        parentId,
+      },
+      {
+        id: otherIssueId,
+        companyId,
+        title: "Needle issue other",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+        createdByAgentId: agentId,
+        projectId,
+        projectWorkspaceId: workspaceId,
+        executionWorkspaceId,
+        parentId,
+      },
+    ]);
+    await db.insert(labels).values({
+      id: labelId,
+      companyId,
+      name: "Needle",
+      color: "#2563eb",
+    });
+    await db.insert(activityLog).values({
+      companyId,
+      actorType: "agent",
+      actorId: agentId,
+      action: "issue.updated",
+      entityType: "issue",
+      entityId: matchingIssueId,
+      agentId,
+    });
+    await db.insert(issueLabels).values({ companyId, issueId: matchingIssueId, labelId });
+
+    const app = createApp(companyId);
     const res = await request(app)
       .get(`/api/companies/${companyId}/issues`)
-      .query({ status: "todo", assigneeAgentId: "bad", limit: "20" });
+      .query({
+        status: "todo",
+        assigneeAgentId: agentId,
+        participantAgentId: agentId,
+        projectId,
+        workspaceId,
+        executionWorkspaceId,
+        parentId,
+        descendantOf: rootId,
+        labelId,
+        q: "Needle",
+        limit: "20",
+      });
 
-    expect(res.status).toBe(422);
-    expect(res.body).toMatchObject({
-      error: "assigneeAgentId must be a UUID or 'null'",
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.map((issue: { id: string }) => issue.id)).toEqual([matchingIssueId]);
+  });
+
+  it("filters issue lists by goalId and createdByAgentId", async () => {
+    const companyId = randomUUID();
+    const goalId = randomUUID();
+    const otherGoalId = randomUUID();
+    const creatorAgentId = randomUUID();
+    const otherAgentId = randomUUID();
+    const matchingIssueId = randomUUID();
+    const wrongGoalIssueId = randomUUID();
+    const wrongCreatorIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: uniqueIssuePrefix(),
+      requireBoardApprovalForNewAgents: false,
     });
+    await seedCloudTenantMember(companyId);
+    await db.insert(goals).values([
+      {
+        id: goalId,
+        companyId,
+        title: "Goal",
+        status: "active",
+        level: "company",
+      },
+      {
+        id: otherGoalId,
+        companyId,
+        title: "Other goal",
+        status: "active",
+        level: "company",
+      },
+    ]);
+    await db.insert(agents).values([
+      {
+        id: creatorAgentId,
+        companyId,
+        name: "Creator",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: otherAgentId,
+        companyId,
+        name: "Other",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(issues).values([
+      {
+        id: matchingIssueId,
+        companyId,
+        title: "Matching issue",
+        status: "todo",
+        priority: "medium",
+        goalId,
+        createdByAgentId: creatorAgentId,
+      },
+      {
+        id: wrongGoalIssueId,
+        companyId,
+        title: "Wrong goal issue",
+        status: "todo",
+        priority: "medium",
+        goalId: otherGoalId,
+        createdByAgentId: creatorAgentId,
+      },
+      {
+        id: wrongCreatorIssueId,
+        companyId,
+        title: "Wrong creator issue",
+        status: "todo",
+        priority: "medium",
+        goalId,
+        createdByAgentId: otherAgentId,
+      },
+    ]);
+
+    const app = createApp(companyId);
+    const filtered = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ status: "todo", goalId, createdByAgentId: creatorAgentId, limit: "20" });
+    const nonexistent = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ status: "todo", goalId: randomUUID(), limit: "20" });
+
+    expect(filtered.status, JSON.stringify(filtered.body)).toBe(200);
+    expect(filtered.body.map((issue: { id: string }) => issue.id)).toEqual([matchingIssueId]);
+    expect(nonexistent.status, JSON.stringify(nonexistent.body)).toBe(200);
+    expect(nonexistent.body).toEqual([]);
   });
 
   it("returns opt-in live descendant counts for offscreen live descendants only", async () => {

--- a/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
+++ b/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
@@ -907,6 +907,18 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
       .query({ attention: "blocked", assigneeAgentId: "null" });
     expect(nullAssigneeRes.status, JSON.stringify(nullAssigneeRes.body)).toBe(200);
     expect(nullAssigneeRes.body).toMatchObject({ count: 0 });
+
+    // Pin that asymmetry as an assertion rather than only as the comment above.
+    // Adding either name to `ISSUE_COUNT_UUID_FILTER_NAMES` turns each of these
+    // long-standing 200s into a 400 — a caller-visible contract change that has
+    // to be a deliberate edit to this test, not a silent widening.
+    for (const unguarded of ["goalId", "createdByAgentId"] as const) {
+      const res = await request(app)
+        .get(`/api/companies/${companyId}/issues/count`)
+        .query({ attention: "blocked", [unguarded]: "bad" });
+      expect(res.status, `${unguarded}: ${JSON.stringify(res.body)}`).toBe(200);
+      expect(res.body).toMatchObject({ count: 0 });
+    }
   });
 
   it("treats an empty UUID filter value as absent on both routes", async () => {
@@ -1058,6 +1070,191 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
       await expect(
         svc.list(companyId, { status: "todo", [name]: " ", limit: 20 }),
       ).rejects.toThrow(`${name} must be a UUID`);
+    }
+  });
+
+  it("pins every UUID filter value class on both routes", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const blockedIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: uniqueIssuePrefix(),
+      requireBoardApprovalForNewAgents: false,
+    });
+    await seedCloudTenantMember(companyId);
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Assignee",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values([
+      {
+        id: issueId,
+        companyId,
+        title: "Visible issue",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+      {
+        id: blockedIssueId,
+        companyId,
+        title: "Blocked issue",
+        status: "blocked",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+    ]);
+    // The blocked-inbox count only counts issues carrying blocked attention, so
+    // the count control needs a real `blocks` edge to be non-zero.
+    await db.insert(issueRelations).values({
+      id: randomUUID(),
+      companyId,
+      issueId,
+      relatedIssueId: blockedIssueId,
+      type: "blocks",
+    });
+
+    const app = createApp(companyId);
+    const listPath = `/api/companies/${companyId}/issues`;
+    const countPath = `/api/companies/${companyId}/issues/count`;
+    const listParams = [
+      "assigneeAgentId",
+      "participantAgentId",
+      "goalId",
+      "createdByAgentId",
+      "projectId",
+      "workspaceId",
+      "executionWorkspaceId",
+      "parentId",
+      "descendantOf",
+      "labelId",
+    ] as const;
+    const countParams = [
+      "assigneeAgentId",
+      "participantAgentId",
+      "projectId",
+      "workspaceId",
+      "executionWorkspaceId",
+      "parentId",
+      "descendantOf",
+      "labelId",
+    ] as const;
+    const errorFor = (param: string) =>
+      param === "assigneeAgentId" ? "assigneeAgentId must be a UUID or 'null'" : `${param} must be a UUID`;
+
+    // The name axis is already covered by the tests above. This one walks the
+    // value axis, which is where the guard actually decides: blank, padded-valid,
+    // non-empty-invalid, and non-string. Each class below kills a mutation that
+    // the name loops leave alive.
+    const listBaseline = await request(app).get(listPath).query({ status: "todo", limit: "20" });
+    expect(listBaseline.status, JSON.stringify(listBaseline.body)).toBe(200);
+    const baselineIds = listBaseline.body.map((issue: { id: string }) => issue.id);
+    expect(baselineIds).toEqual([issueId]);
+
+    const countBaseline = await request(app).get(countPath).query({ attention: "blocked" });
+    expect(countBaseline.status, JSON.stringify(countBaseline.body)).toBe(200);
+    const baselineCount = countBaseline.body.count as number;
+    expect(baselineCount).toBeGreaterThan(0);
+
+    // Class 1 — blank. These all trim to empty, so the guard must read them as
+    // "filter absent" and return the same unfiltered 200 the empty string gets.
+    // Delete the guard's `.trim()` and ` ` is a length-1 non-UUID: 400 instead.
+    for (const param of listParams) {
+      for (const value of [" ", "\t\n"]) {
+        const res = await request(app).get(listPath).query({ status: "todo", [param]: value, limit: "20" });
+        const label = `${param}=${JSON.stringify(value)}: ${JSON.stringify(res.body)}`;
+        expect(res.status, label).toBe(200);
+        expect(res.body.map((issue: { id: string }) => issue.id), label).toEqual(baselineIds);
+      }
+    }
+    for (const param of countParams) {
+      const res = await request(app).get(countPath).query({ attention: "blocked", [param]: " " });
+      const label = `${param}: ${JSON.stringify(res.body)}`;
+      expect(res.status, label).toBe(200);
+      expect(res.body.count, label).toBe(baselineCount);
+    }
+
+    // Class 2 — a valid UUID with surrounding whitespace. `isUuidLike` trims
+    // internally and returns true, so without the guard's own `.trim()` the
+    // padded string is what reaches Postgres: `22P02 invalid input syntax for
+    // type uuid`, surfaced as a 500. Compare against the unpadded response
+    // rather than an expected page, so the pin holds whatever each filter
+    // matches today.
+    for (const param of listParams) {
+      const value = randomUUID();
+      const clean = await request(app).get(listPath).query({ status: "todo", [param]: value, limit: "20" });
+      expect(clean.status, `${param}: ${JSON.stringify(clean.body)}`).toBe(200);
+      for (const padded of [`${value} `, ` ${value}`]) {
+        const res = await request(app).get(listPath).query({ status: "todo", [param]: padded, limit: "20" });
+        const label = `${param}=${JSON.stringify(padded)}: ${JSON.stringify(res.body)}`;
+        expect(res.status, label).toBe(200);
+        expect(res.body, label).toEqual(clean.body);
+      }
+    }
+    for (const param of countParams) {
+      const value = randomUUID();
+      const clean = await request(app).get(countPath).query({ attention: "blocked", [param]: value });
+      expect(clean.status, `${param}: ${JSON.stringify(clean.body)}`).toBe(200);
+      const res = await request(app).get(countPath).query({ attention: "blocked", [param]: `${value} ` });
+      const label = `${param}=padded: ${JSON.stringify(res.body)}`;
+      expect(res.status, label).toBe(200);
+      expect(res.body, label).toEqual(clean.body);
+    }
+
+    // Class 3 — non-empty text that is not a UUID. `"x"` is length 1 and
+    // `"undefined"` is the other token an over-wide empty-skip swallows; both
+    // have to 400 rather than drop the filter. (`"null"` is pinned above.)
+    for (const value of ["x", "undefined"]) {
+      for (const param of listParams) {
+        const res = await request(app).get(listPath).query({ status: "todo", [param]: value, limit: "20" });
+        const label = `${param}=${value}: ${JSON.stringify(res.body)}`;
+        expect(res.status, label).toBe(400);
+        expect(res.body, label).toMatchObject({ error: errorFor(param) });
+        expect(res.body, label).not.toHaveProperty("issues");
+      }
+      for (const param of countParams) {
+        const res = await request(app).get(countPath).query({ attention: "blocked", [param]: value });
+        const label = `${param}=${value}: ${JSON.stringify(res.body)}`;
+        expect(res.status, label).toBe(400);
+        expect(res.body, label).toMatchObject({ error: errorFor(param) });
+        expect(res.body, label).not.toHaveProperty("count");
+      }
+    }
+
+    // Class 4 — a repeated query param. Express parses `?projectId=a&projectId=b`
+    // into an array, and the non-string arm is the only thing between that array
+    // and a dropped filter: turn its 400 into a `continue` and the request comes
+    // back 200 with the filter silently gone.
+    for (const param of listParams) {
+      const res = await request(app)
+        .get(listPath)
+        .query({ status: "todo", limit: "20" })
+        .query(`${param}=${randomUUID()}&${param}=${randomUUID()}`);
+      const label = `${param} repeated: ${JSON.stringify(res.body)}`;
+      expect(res.status, label).toBe(400);
+      expect(res.body, label).toMatchObject({ error: errorFor(param) });
+      expect(res.body, label).not.toHaveProperty("issues");
+    }
+    for (const param of countParams) {
+      const res = await request(app)
+        .get(countPath)
+        .query({ attention: "blocked" })
+        .query(`${param}=${randomUUID()}&${param}=${randomUUID()}`);
+      const label = `${param} repeated: ${JSON.stringify(res.body)}`;
+      expect(res.status, label).toBe(400);
+      expect(res.body, label).toMatchObject({ error: errorFor(param) });
+      expect(res.body, label).not.toHaveProperty("count");
     }
   });
 

--- a/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
+++ b/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
@@ -1032,6 +1032,11 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
       await expect(
         svc.list(companyId, { status: "todo", [name]: "bad", limit: 20 }),
       ).rejects.toThrow(`${name} must be a UUID`);
+      // A whitespace-only value is truthy, so the query builders would send it
+      // to a uuid comparison as-is. It has to be rejected, not exempted.
+      await expect(
+        svc.list(companyId, { status: "todo", [name]: " ", limit: 20 }),
+      ).rejects.toThrow(`${name} must be a UUID`);
     }
   });
 

--- a/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
+++ b/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
@@ -800,6 +800,8 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
     const params = [
       "assigneeAgentId",
       "participantAgentId",
+      "goalId",
+      "createdByAgentId",
       "projectId",
       "workspaceId",
       "executionWorkspaceId",
@@ -820,6 +822,20 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
           : `${param} must be a UUID`,
       });
       expect(res.body).not.toHaveProperty("issues");
+    }
+
+    // The empty skip exempts one value and only one. `"null"` is the token most
+    // likely to be folded into it — `assigneeAgentId` genuinely does accept it —
+    // and a skip widened that far turns each of these into a silently ignored
+    // filter instead of a 400.
+    for (const param of params) {
+      if (param === "assigneeAgentId") continue;
+      const res = await request(app)
+        .get(`/api/companies/${companyId}/issues`)
+        .query({ status: "todo", [param]: "null", limit: "20" });
+
+      expect(res.status, `${param}: ${JSON.stringify(res.body)}`).toBe(400);
+      expect(res.body).toMatchObject({ error: `${param} must be a UUID` });
     }
   });
 
@@ -843,6 +859,9 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
     expect(baseline.status, JSON.stringify(baseline.body)).toBe(200);
     expect(baseline.body).toMatchObject({ count: 0 });
 
+    // `goalId` and `createdByAgentId` are deliberately absent: they are in
+    // `ISSUE_LIST_UUID_FILTER_NAMES` but not `ISSUE_COUNT_UUID_FILTER_NAMES`, so
+    // the count route never parses them and `?goalId=bad` is a 200 here.
     const params = [
       "assigneeAgentId",
       "participantAgentId",
@@ -946,6 +965,8 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
     const params = [
       "assigneeAgentId",
       "participantAgentId",
+      "goalId",
+      "createdByAgentId",
       "projectId",
       "workspaceId",
       "executionWorkspaceId",

--- a/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
+++ b/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
@@ -821,17 +821,95 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
     }
   });
 
+  it("returns 400 for malformed UUID issue count filters", async () => {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: uniqueIssuePrefix(),
+      requireBoardApprovalForNewAgents: false,
+    });
+    await seedCloudTenantMember(companyId);
+
+    const app = createApp(companyId);
+
+    // Control: the same route without a UUID filter must stay green, otherwise
+    // a blanket 400 would make the loop below prove nothing.
+    const baseline = await request(app)
+      .get(`/api/companies/${companyId}/issues/count`)
+      .query({ attention: "blocked" });
+    expect(baseline.status, JSON.stringify(baseline.body)).toBe(200);
+    expect(baseline.body).toMatchObject({ count: 0 });
+
+    const params = [
+      "assigneeAgentId",
+      "participantAgentId",
+      "projectId",
+      "workspaceId",
+      "executionWorkspaceId",
+      "parentId",
+      "descendantOf",
+      "labelId",
+    ] as const;
+
+    for (const param of params) {
+      const res = await request(app)
+        .get(`/api/companies/${companyId}/issues/count`)
+        .query({ attention: "blocked", [param]: "bad" });
+
+      expect(res.status, `${param}: ${JSON.stringify(res.body)}`).toBe(400);
+      expect(res.body).toMatchObject({
+        error: param === "assigneeAgentId"
+          ? "assigneeAgentId must be a UUID or 'null'"
+          : `${param} must be a UUID`,
+      });
+      expect(res.body).not.toHaveProperty("count");
+    }
+
+    const aliasRes = await request(app)
+      .get(`/api/companies/${companyId}/issues/count`)
+      .query({ attention: "blocked", parentIssueId: "bad" });
+    expect(aliasRes.status, JSON.stringify(aliasRes.body)).toBe(400);
+    expect(aliasRes.body).toMatchObject({ error: "parentIssueId must be a UUID" });
+
+    const nullAssigneeRes = await request(app)
+      .get(`/api/companies/${companyId}/issues/count`)
+      .query({ attention: "blocked", assigneeAgentId: "null" });
+    expect(nullAssigneeRes.status, JSON.stringify(nullAssigneeRes.body)).toBe(200);
+    expect(nullAssigneeRes.body).toMatchObject({ count: 0 });
+  });
+
   it("keeps valid UUID filters working with status, limit, and search", async () => {
     const companyId = randomUUID();
-    const agentId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    const participantAgentId = randomUUID();
+    const otherAgentId = randomUUID();
     const projectId = randomUUID();
+    const otherProjectId = randomUUID();
     const workspaceId = randomUUID();
+    const otherWorkspaceId = randomUUID();
     const executionWorkspaceId = randomUUID();
-    const parentId = randomUUID();
-    const rootId = randomUUID();
+    const otherExecutionWorkspaceId = randomUUID();
     const labelId = randomUUID();
+    const otherLabelId = randomUUID();
+    const rootId = randomUUID();
+    const parentId = randomUUID();
+    const siblingParentId = randomUUID();
+    const outsideParentId = randomUUID();
     const matchingIssueId = randomUUID();
-    const otherIssueId = randomUUID();
+    // One decoy per filter. Each decoy differs from the matching issue on
+    // exactly the one column its filter reads, so dropping any single filter's
+    // wiring lets that decoy through and turns this test red.
+    const decoyIssueIds = {
+      assigneeAgentId: randomUUID(),
+      participantAgentId: randomUUID(),
+      projectId: randomUUID(),
+      workspaceId: randomUUID(),
+      executionWorkspaceId: randomUUID(),
+      parentId: randomUUID(),
+      descendantOf: randomUUID(),
+      labelId: randomUUID(),
+    } as const;
 
     await db.insert(companies).values({
       id: companyId,
@@ -840,111 +918,211 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
       requireBoardApprovalForNewAgents: false,
     });
     await seedCloudTenantMember(companyId);
-    await db.insert(agents).values({
-      id: agentId,
-      companyId,
-      name: "Assignee",
-      role: "engineer",
-      status: "active",
-      adapterType: "codex_local",
-      adapterConfig: {},
-      runtimeConfig: {},
-      permissions: {},
-    });
-    await db.insert(projects).values({
-      id: projectId,
-      companyId,
-      name: "Filtered project",
-      status: "in_progress",
-    });
-    await db.insert(projectWorkspaces).values({
-      id: workspaceId,
-      companyId,
-      projectId,
-      name: "Primary",
-      sourceType: "local_path",
-      cwd: "/tmp/paperclip-issue-list-project",
-      isPrimary: true,
-    });
-    await db.insert(executionWorkspaces).values({
-      id: executionWorkspaceId,
-      companyId,
-      projectId,
-      projectWorkspaceId: workspaceId,
-      mode: "isolated_workspace",
-      strategyType: "git_worktree",
-      name: "Execution workspace",
-      status: "active",
-      providerType: "local_fs",
-      cwd: "/tmp/paperclip-issue-list-execution",
-    });
-    await db.insert(issues).values([
+    await db.insert(agents).values([
       {
-        id: rootId,
+        id: assigneeAgentId,
         companyId,
-        title: "Root",
-        status: "todo",
-        priority: "medium",
+        name: "Assignee",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
       },
       {
-        id: parentId,
+        id: participantAgentId,
         companyId,
-        title: "Parent",
+        name: "Participant",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+      {
+        id: otherAgentId,
+        companyId,
+        name: "Other",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: {},
+        permissions: {},
+      },
+    ]);
+    await db.insert(projects).values([
+      { id: projectId, companyId, name: "Filtered project", status: "in_progress" },
+      { id: otherProjectId, companyId, name: "Other project", status: "in_progress" },
+    ]);
+    await db.insert(projectWorkspaces).values([
+      {
+        id: workspaceId,
+        companyId,
+        projectId,
+        name: "Primary",
+        sourceType: "local_path",
+        cwd: "/tmp/paperclip-issue-list-project",
+        isPrimary: true,
+      },
+      {
+        id: otherWorkspaceId,
+        companyId,
+        projectId: otherProjectId,
+        name: "Other primary",
+        sourceType: "local_path",
+        cwd: "/tmp/paperclip-issue-list-project-other",
+        isPrimary: true,
+      },
+    ]);
+    await db.insert(executionWorkspaces).values([
+      {
+        id: executionWorkspaceId,
+        companyId,
+        projectId,
+        projectWorkspaceId: workspaceId,
+        mode: "isolated_workspace",
+        strategyType: "git_worktree",
+        name: "Execution workspace",
+        status: "active",
+        providerType: "local_fs",
+        cwd: "/tmp/paperclip-issue-list-execution",
+      },
+      {
+        id: otherExecutionWorkspaceId,
+        companyId,
+        projectId: otherProjectId,
+        projectWorkspaceId: otherWorkspaceId,
+        mode: "isolated_workspace",
+        strategyType: "git_worktree",
+        name: "Other execution workspace",
+        status: "active",
+        providerType: "local_fs",
+        cwd: "/tmp/paperclip-issue-list-execution-other",
+      },
+    ]);
+
+    const matchingShape = {
+      companyId,
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId,
+      createdByAgentId: assigneeAgentId,
+      projectId,
+      projectWorkspaceId: workspaceId,
+      executionWorkspaceId,
+      parentId,
+    } as const;
+
+    await db.insert(issues).values([
+      { id: rootId, companyId, title: "Root", status: "todo", priority: "medium" },
+      { id: parentId, companyId, title: "Parent", status: "todo", priority: "medium", parentId: rootId },
+      {
+        id: siblingParentId,
+        companyId,
+        title: "Sibling parent",
         status: "todo",
         priority: "medium",
         parentId: rootId,
       },
+      { id: outsideParentId, companyId, title: "Outside parent", status: "todo", priority: "medium" },
+      { ...matchingShape, id: matchingIssueId, title: "Needle issue" },
+      // differs only on assigneeAgentId
       {
-        id: matchingIssueId,
-        companyId,
-        title: "Needle issue",
-        status: "todo",
-        priority: "medium",
-        assigneeAgentId: agentId,
-        createdByAgentId: agentId,
-        projectId,
-        projectWorkspaceId: workspaceId,
-        executionWorkspaceId,
-        parentId,
+        ...matchingShape,
+        id: decoyIssueIds.assigneeAgentId,
+        title: "Needle decoy assignee",
+        assigneeAgentId: otherAgentId,
       },
+      // differs only in having no activity from participantAgentId (added below)
+      { ...matchingShape, id: decoyIssueIds.participantAgentId, title: "Needle decoy participant" },
+      // differs only on projectId
       {
-        id: otherIssueId,
+        ...matchingShape,
+        id: decoyIssueIds.projectId,
+        title: "Needle decoy project",
+        projectId: otherProjectId,
+      },
+      // differs only on projectWorkspaceId, which is what workspaceId reads
+      {
+        ...matchingShape,
+        id: decoyIssueIds.workspaceId,
+        title: "Needle decoy workspace",
+        projectWorkspaceId: otherWorkspaceId,
+      },
+      // differs only on executionWorkspaceId
+      {
+        ...matchingShape,
+        id: decoyIssueIds.executionWorkspaceId,
+        title: "Needle decoy execution workspace",
+        executionWorkspaceId: otherExecutionWorkspaceId,
+      },
+      // differs only on parentId, and stays inside rootId's subtree so
+      // descendantOf cannot mask a dropped parentId filter
+      {
+        ...matchingShape,
+        id: decoyIssueIds.parentId,
+        title: "Needle decoy parent",
+        parentId: siblingParentId,
+      },
+      // sits outside rootId's subtree; only descendantOf excludes it once
+      // parentId is dropped from the query below
+      {
+        ...matchingShape,
+        id: decoyIssueIds.descendantOf,
+        title: "Needle decoy descendant",
+        parentId: outsideParentId,
+      },
+      // differs only in carrying otherLabelId instead of labelId (added below)
+      { ...matchingShape, id: decoyIssueIds.labelId, title: "Needle decoy label" },
+    ]);
+    await db.insert(labels).values([
+      { id: labelId, companyId, name: "Needle", color: "#2563eb" },
+      { id: otherLabelId, companyId, name: "Haystack", color: "#dc2626" },
+    ]);
+
+    const decoyIssueIdList = Object.values(decoyIssueIds);
+    // Every row except the participant decoy has activity from participantAgentId,
+    // so participantAgentId is the only filter that removes that decoy.
+    await db.insert(activityLog).values([
+      ...[matchingIssueId, ...decoyIssueIdList]
+        .filter((issueId) => issueId !== decoyIssueIds.participantAgentId)
+        .map((issueId) => ({
+          companyId,
+          actorType: "agent" as const,
+          actorId: participantAgentId,
+          action: "issue.updated",
+          entityType: "issue",
+          entityId: issueId,
+          agentId: participantAgentId,
+        })),
+      {
         companyId,
-        title: "Needle issue other",
-        status: "todo",
-        priority: "medium",
-        assigneeAgentId: agentId,
-        createdByAgentId: agentId,
-        projectId,
-        projectWorkspaceId: workspaceId,
-        executionWorkspaceId,
-        parentId,
+        actorType: "agent" as const,
+        actorId: otherAgentId,
+        action: "issue.updated",
+        entityType: "issue",
+        entityId: decoyIssueIds.participantAgentId,
+        agentId: otherAgentId,
       },
     ]);
-    await db.insert(labels).values({
-      id: labelId,
-      companyId,
-      name: "Needle",
-      color: "#2563eb",
-    });
-    await db.insert(activityLog).values({
-      companyId,
-      actorType: "agent",
-      actorId: agentId,
-      action: "issue.updated",
-      entityType: "issue",
-      entityId: matchingIssueId,
-      agentId,
-    });
-    await db.insert(issueLabels).values({ companyId, issueId: matchingIssueId, labelId });
+    // Same shape for labelId: only the label decoy is missing the filtered label.
+    await db.insert(issueLabels).values([
+      ...[matchingIssueId, ...decoyIssueIdList]
+        .filter((issueId) => issueId !== decoyIssueIds.labelId)
+        .map((issueId) => ({ companyId, issueId, labelId })),
+      { companyId, issueId: decoyIssueIds.labelId, labelId: otherLabelId },
+    ]);
 
     const app = createApp(companyId);
     const res = await request(app)
       .get(`/api/companies/${companyId}/issues`)
       .query({
         status: "todo",
-        assigneeAgentId: agentId,
-        participantAgentId: agentId,
+        assigneeAgentId,
+        participantAgentId,
         projectId,
         workspaceId,
         executionWorkspaceId,
@@ -957,6 +1135,30 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
 
     expect(res.status, JSON.stringify(res.body)).toBe(200);
     expect(res.body.map((issue: { id: string }) => issue.id)).toEqual([matchingIssueId]);
+
+    // descendantOf and parentId both read issues.parentId, so a descendantOf
+    // decoy cannot differ from the matching issue on descendantOf alone. Drop
+    // parentId from the query and descendantOf becomes the only filter that
+    // excludes the out-of-subtree decoy.
+    const withoutParentIdRes = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({
+        status: "todo",
+        assigneeAgentId,
+        participantAgentId,
+        projectId,
+        workspaceId,
+        executionWorkspaceId,
+        descendantOf: rootId,
+        labelId,
+        q: "Needle",
+        limit: "20",
+      });
+
+    expect(withoutParentIdRes.status, JSON.stringify(withoutParentIdRes.body)).toBe(200);
+    expect(withoutParentIdRes.body.map((issue: { id: string }) => issue.id).sort()).toEqual(
+      [matchingIssueId, decoyIssueIds.parentId].sort(),
+    );
   });
 
   it("keeps parentId precedence over the parentIssueId alias when both are present", async () => {

--- a/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
+++ b/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
@@ -872,6 +872,15 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
     expect(aliasRes.status, JSON.stringify(aliasRes.body)).toBe(400);
     expect(aliasRes.body).toMatchObject({ error: "parentIssueId must be a UUID" });
 
+    // A malformed `parentIssueId` that `parentId` supersedes is never read, so it
+    // must stay 200 exactly as it was before this guard existed. Validating it
+    // would 400 a request that has always succeeded.
+    const supersededAliasRes = await request(app)
+      .get(`/api/companies/${companyId}/issues/count`)
+      .query({ attention: "blocked", parentId: randomUUID(), parentIssueId: "bad" });
+    expect(supersededAliasRes.status, JSON.stringify(supersededAliasRes.body)).toBe(200);
+    expect(supersededAliasRes.body).toMatchObject({ count: 0 });
+
     const nullAssigneeRes = await request(app)
       .get(`/api/companies/${companyId}/issues/count`)
       .query({ attention: "blocked", assigneeAgentId: "null" });
@@ -1215,6 +1224,26 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
 
     expect(res.status, JSON.stringify(res.body)).toBe(200);
     expect(res.body.map((issue: { id: string }) => issue.id)).toEqual([parentChildIssueId]);
+
+    // Precedence also decides validation: a malformed alias that `parentId`
+    // supersedes is never read, so it must not turn a 200 into a 400.
+    const malformedAliasRes = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ status: "todo", parentId, parentIssueId: "bad", limit: "20" });
+
+    expect(malformedAliasRes.status, JSON.stringify(malformedAliasRes.body)).toBe(200);
+    expect(malformedAliasRes.body.map((issue: { id: string }) => issue.id)).toEqual([
+      parentChildIssueId,
+    ]);
+
+    // But with no canonical `parentId` to supersede it, the alias is the value
+    // that reaches the query, so it must still be rejected at the boundary.
+    const aliasOnlyRes = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ status: "todo", parentIssueId: "bad", limit: "20" });
+
+    expect(aliasOnlyRes.status, JSON.stringify(aliasOnlyRes.body)).toBe(400);
+    expect(aliasOnlyRes.body).toMatchObject({ error: "parentIssueId must be a UUID" });
   });
 
   it("filters issue lists by goalId and createdByAgentId", async () => {

--- a/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
+++ b/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
@@ -13,6 +13,7 @@ import {
   goals,
   heartbeatRuns,
   issueLabels,
+  issueRelations,
   issues,
   labels,
   principalPermissionGrants,
@@ -31,6 +32,7 @@ import {
   issueRoutes,
 } from "../routes/issues.js";
 import { issueRecoveryActionService } from "../services/issue-recovery-actions.js";
+import { issueService } from "../services/issues.js";
 import { ensureHumanRoleDefaultGrants } from "../services/principal-access-compatibility.js";
 import { resolveRequiredSuccessfulRunHandoffOnValidPath } from "../services/successful-run-handoff-state.js";
 
@@ -886,6 +888,151 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
       .query({ attention: "blocked", assigneeAgentId: "null" });
     expect(nullAssigneeRes.status, JSON.stringify(nullAssigneeRes.body)).toBe(200);
     expect(nullAssigneeRes.body).toMatchObject({ count: 0 });
+  });
+
+  it("treats an empty UUID filter value as absent on both routes", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const blockedIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: uniqueIssuePrefix(),
+      requireBoardApprovalForNewAgents: false,
+    });
+    await seedCloudTenantMember(companyId);
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Assignee",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values([
+      {
+        id: issueId,
+        companyId,
+        title: "Visible issue",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+      {
+        id: blockedIssueId,
+        companyId,
+        title: "Blocked issue",
+        status: "blocked",
+        priority: "medium",
+        assigneeAgentId: agentId,
+      },
+    ]);
+    // The blocked-inbox count only counts issues that carry blocked attention,
+    // so the count control below needs a real `blocks` edge to be non-zero.
+    await db.insert(issueRelations).values({
+      id: randomUUID(),
+      companyId,
+      issueId,
+      relatedIssueId: blockedIssueId,
+      type: "blocks",
+    });
+
+    const app = createApp(companyId);
+    const params = [
+      "assigneeAgentId",
+      "participantAgentId",
+      "projectId",
+      "workspaceId",
+      "executionWorkspaceId",
+      "parentId",
+      "descendantOf",
+      "labelId",
+    ] as const;
+
+    // Control: the unfiltered responses must be non-empty, or "empty value means
+    // absent" and "empty value filtered everything out" would look identical.
+    const listBaseline = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ status: "todo", limit: "20" });
+    expect(listBaseline.status, JSON.stringify(listBaseline.body)).toBe(200);
+    const baselineIds = listBaseline.body.map((issue: { id: string }) => issue.id);
+    expect(baselineIds).toEqual([issueId]);
+
+    for (const param of params) {
+      const res = await request(app)
+        .get(`/api/companies/${companyId}/issues`)
+        .query({ status: "todo", [param]: "", limit: "20" });
+
+      expect(res.status, `${param}: ${JSON.stringify(res.body)}`).toBe(200);
+      expect(res.body.map((issue: { id: string }) => issue.id), param).toEqual(baselineIds);
+    }
+
+    // `parentId ?? parentIssueId` resolves on presence, not on emptiness: a
+    // present-but-empty `parentId` suppresses the alias, so this shape has
+    // always been the unfiltered 200.
+    const supersededAliasRes = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ status: "todo", parentId: "", parentIssueId: randomUUID(), limit: "20" });
+    expect(supersededAliasRes.status, JSON.stringify(supersededAliasRes.body)).toBe(200);
+    expect(supersededAliasRes.body.map((issue: { id: string }) => issue.id)).toEqual(baselineIds);
+
+    const countBaseline = await request(app)
+      .get(`/api/companies/${companyId}/issues/count`)
+      .query({ attention: "blocked" });
+    expect(countBaseline.status, JSON.stringify(countBaseline.body)).toBe(200);
+    const baselineCount = countBaseline.body.count as number;
+    expect(baselineCount).toBeGreaterThan(0);
+
+    for (const param of params) {
+      const res = await request(app)
+        .get(`/api/companies/${companyId}/issues/count`)
+        .query({ attention: "blocked", [param]: "" });
+
+      expect(res.status, `${param}: ${JSON.stringify(res.body)}`).toBe(200);
+      expect(res.body.count, param).toBe(baselineCount);
+    }
+
+    const countAliasRes = await request(app)
+      .get(`/api/companies/${companyId}/issues/count`)
+      .query({ attention: "blocked", parentId: "", parentIssueId: randomUUID() });
+    expect(countAliasRes.status, JSON.stringify(countAliasRes.body)).toBe(200);
+    expect(countAliasRes.body.count).toBe(baselineCount);
+
+    // The empty value must drop the filter, not become a filter that matches
+    // nothing: a real UUID on the same param still bites.
+    const filteredRes = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ status: "todo", projectId: randomUUID(), limit: "20" });
+    expect(filteredRes.status, JSON.stringify(filteredRes.body)).toBe(200);
+    expect(filteredRes.body).toEqual([]);
+
+    // The service is reachable directly, not only through these two routes, so
+    // `assertValidUuidFilter` has to agree with the query builders next to it:
+    // empty is absent, non-empty text still throws.
+    const svc = issueService(db);
+    const serviceFilterNames = [
+      "participantAgentId",
+      "goalId",
+      "createdByAgentId",
+      "projectId",
+      "workspaceId",
+      "executionWorkspaceId",
+      "parentId",
+      "descendantOf",
+      "labelId",
+    ] as const;
+    for (const name of serviceFilterNames) {
+      const rows = await svc.list(companyId, { status: "todo", [name]: "", limit: 20 });
+      expect(rows.map((row: { id: string }) => row.id), name).toEqual([issueId]);
+      await expect(
+        svc.list(companyId, { status: "todo", [name]: "bad", limit: 20 }),
+      ).rejects.toThrow(`${name} must be a UUID`);
+    }
   });
 
   it("keeps valid UUID filters working with status, limit, and search", async () => {

--- a/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
+++ b/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
@@ -959,6 +959,62 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
     expect(res.body.map((issue: { id: string }) => issue.id)).toEqual([matchingIssueId]);
   });
 
+  it("keeps parentId precedence over the parentIssueId alias when both are present", async () => {
+    const companyId = randomUUID();
+    const parentId = randomUUID();
+    const aliasParentId = randomUUID();
+    const parentChildIssueId = randomUUID();
+    const aliasChildIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: uniqueIssuePrefix(),
+      requireBoardApprovalForNewAgents: false,
+    });
+    await seedCloudTenantMember(companyId);
+    await db.insert(issues).values([
+      {
+        id: parentId,
+        companyId,
+        title: "Canonical parent",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: aliasParentId,
+        companyId,
+        title: "Alias parent",
+        status: "todo",
+        priority: "medium",
+      },
+      {
+        id: parentChildIssueId,
+        companyId,
+        title: "Canonical child",
+        status: "todo",
+        priority: "medium",
+        parentId,
+      },
+      {
+        id: aliasChildIssueId,
+        companyId,
+        title: "Alias child",
+        status: "todo",
+        priority: "medium",
+        parentId: aliasParentId,
+      },
+    ]);
+
+    const app = createApp(companyId);
+    const res = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ status: "todo", parentId, parentIssueId: aliasParentId, limit: "20" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.map((issue: { id: string }) => issue.id)).toEqual([parentChildIssueId]);
+  });
+
   it("filters issue lists by goalId and createdByAgentId", async () => {
     const companyId = randomUUID();
     const goalId = randomUUID();

--- a/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
+++ b/server/src/__tests__/issue-list-assignee-filter-routes.test.ts
@@ -1076,8 +1076,16 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
   it("pins every UUID filter value class on both routes", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();
+    const goalId = randomUUID();
+    const projectId = randomUUID();
+    const workspaceId = randomUUID();
+    const executionWorkspaceId = randomUUID();
+    const labelId = randomUUID();
+    const rootId = randomUUID();
+    const parentId = randomUUID();
     const issueId = randomUUID();
     const blockedIssueId = randomUUID();
+    const unassignedBlockedIssueId = randomUUID();
 
     await db.insert(companies).values({
       id: companyId,
@@ -1097,33 +1105,116 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
       runtimeConfig: {},
       permissions: {},
     });
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Goal",
+      status: "active",
+      level: "company",
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Filtered project",
+      status: "in_progress",
+    });
+    await db.insert(projectWorkspaces).values({
+      id: workspaceId,
+      companyId,
+      projectId,
+      name: "Primary",
+      sourceType: "local_path",
+      cwd: "/tmp/paperclip-issue-list-value-class",
+      isPrimary: true,
+    });
+    await db.insert(executionWorkspaces).values({
+      id: executionWorkspaceId,
+      companyId,
+      projectId,
+      projectWorkspaceId: workspaceId,
+      mode: "isolated_workspace",
+      strategyType: "git_worktree",
+      name: "Execution workspace",
+      status: "active",
+      providerType: "local_fs",
+      cwd: "/tmp/paperclip-issue-list-value-class-execution",
+    });
+    await db.insert(labels).values({ id: labelId, companyId, name: "Needle", color: "#2563eb" });
+    // Both matched rows carry every filterable column, so each param below has a
+    // value that actually *selects*. Without that, `?param=<random uuid>` matches
+    // nothing, and the class-2/class-5 comparisons are empty-to-empty: they pin
+    // the status code and nothing else, and a mutation that trimmed to some other
+    // valid UUID would survive every one of them.
+    const matchedShape = {
+      companyId,
+      priority: "medium" as const,
+      assigneeAgentId: agentId,
+      createdByAgentId: agentId,
+      goalId,
+      projectId,
+      projectWorkspaceId: workspaceId,
+      executionWorkspaceId,
+      parentId,
+    };
     await db.insert(issues).values([
+      { id: rootId, companyId, title: "Root", status: "todo", priority: "medium" },
+      // Not `todo`: `descendantOf: rootId` reaches this row too, and the class-2
+      // pin below wants exactly one matched row per param.
       {
-        id: issueId,
+        id: parentId,
         companyId,
-        title: "Visible issue",
-        status: "todo",
+        title: "Parent",
+        status: "done",
         priority: "medium",
-        assigneeAgentId: agentId,
+        parentId: rootId,
       },
+      { ...matchedShape, id: issueId, title: "Visible issue", status: "todo" },
+      { ...matchedShape, id: blockedIssueId, title: "Blocked issue", status: "blocked" },
+      // Class 5 asks for `assigneeAgentId=null` on both routes, so the null-token
+      // page has to be non-empty on both. `rootId`/`parentId` cover the list side;
+      // this row is the count side.
       {
-        id: blockedIssueId,
+        id: unassignedBlockedIssueId,
         companyId,
-        title: "Blocked issue",
+        title: "Unassigned blocked issue",
         status: "blocked",
         priority: "medium",
-        assigneeAgentId: agentId,
       },
     ]);
+    await db.insert(issueLabels).values([
+      { companyId, issueId, labelId },
+      { companyId, issueId: blockedIssueId, labelId },
+    ]);
+    // participantAgentId reads activity, not a column on the issue row.
+    await db.insert(activityLog).values(
+      [issueId, blockedIssueId].map((entityId) => ({
+        companyId,
+        actorType: "agent" as const,
+        actorId: agentId,
+        action: "issue.updated",
+        entityType: "issue",
+        entityId,
+        agentId,
+      })),
+    );
     // The blocked-inbox count only counts issues carrying blocked attention, so
     // the count control needs a real `blocks` edge to be non-zero.
-    await db.insert(issueRelations).values({
-      id: randomUUID(),
-      companyId,
-      issueId,
-      relatedIssueId: blockedIssueId,
-      type: "blocks",
-    });
+    await db.insert(issueRelations).values([
+      {
+        id: randomUUID(),
+        companyId,
+        issueId,
+        relatedIssueId: blockedIssueId,
+        type: "blocks",
+      },
+      {
+        id: randomUUID(),
+        companyId,
+        issueId,
+        relatedIssueId: unassignedBlockedIssueId,
+        type: "blocks",
+      },
+    ]);
 
     const app = createApp(companyId);
     const listPath = `/api/companies/${companyId}/issues`;
@@ -1160,6 +1251,25 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
     ] as const;
     const errorFor = (param: string) =>
       param === "assigneeAgentId" ? "assigneeAgentId must be a UUID or 'null'" : `${param} must be a UUID`;
+    // Per param, a value that selects the seeded rows. Keyed by every name in
+    // both lists, so adding a param without a selecting value fails to compile
+    // rather than silently reintroducing an empty-to-empty comparison.
+    const selectingValue: Record<
+      (typeof listParams)[number] | (typeof countParams)[number],
+      string
+    > = {
+      assigneeAgentId: agentId,
+      participantAgentId: agentId,
+      goalId,
+      createdByAgentId: agentId,
+      projectId,
+      workspaceId,
+      executionWorkspaceId,
+      parentId,
+      descendantOf: rootId,
+      labelId,
+      parentIssueId: parentId,
+    };
 
     // The name axis is already covered by the tests above. This one walks the
     // value axis, which is where the guard actually decides: blank, padded-valid,
@@ -1168,7 +1278,9 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
     const listBaseline = await request(app).get(listPath).query({ status: "todo", limit: "20" });
     expect(listBaseline.status, JSON.stringify(listBaseline.body)).toBe(200);
     const baselineIds = listBaseline.body.map((issue: { id: string }) => issue.id);
-    expect(baselineIds).toEqual([issueId]);
+    // Equality, not `toContain`: a superset satisfies presence, so the class-1
+    // comparisons below would still hold for a guard that dropped a filter.
+    expect(baselineIds.slice().sort()).toEqual([issueId, rootId].sort());
 
     const countBaseline = await request(app).get(countPath).query({ attention: "blocked" });
     expect(countBaseline.status, JSON.stringify(countBaseline.body)).toBe(200);
@@ -1198,13 +1310,19 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
     // Class 2 — a valid UUID with surrounding whitespace. `isUuidLike` trims
     // internally and returns true, so without the guard's own `.trim()` the
     // padded string is what reaches Postgres: `22P02 invalid input syntax for
-    // type uuid`, surfaced as a 500. Compare against the unpadded response
-    // rather than an expected page, so the pin holds whatever each filter
-    // matches today.
+    // type uuid`, surfaced as a 500. Each param is sent a value that selects the
+    // seeded row, so the unpadded page is pinned by equality first and the padded
+    // one is then compared against it.
     for (const param of listParams) {
-      const value = randomUUID();
+      const value = selectingValue[param];
       const clean = await request(app).get(listPath).query({ status: "todo", [param]: value, limit: "20" });
       expect(clean.status, `${param}: ${JSON.stringify(clean.body)}`).toBe(200);
+      // The comparison below only carries selection if the compared page has
+      // rows in it. Empty-to-empty would hold for any implementation that
+      // returned nothing, including one that trimmed to a different UUID.
+      expect(clean.body.map((issue: { id: string }) => issue.id), `${param}: ${JSON.stringify(clean.body)}`).toEqual([
+        issueId,
+      ]);
       for (const padded of [`${value} `, ` ${value}`]) {
         const res = await request(app).get(listPath).query({ status: "todo", [param]: padded, limit: "20" });
         const label = `${param}=${JSON.stringify(padded)}: ${JSON.stringify(res.body)}`;
@@ -1213,9 +1331,10 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
       }
     }
     for (const param of countParams) {
-      const value = randomUUID();
+      const value = selectingValue[param];
       const clean = await request(app).get(countPath).query({ attention: "blocked", [param]: value });
       expect(clean.status, `${param}: ${JSON.stringify(clean.body)}`).toBe(200);
+      expect(clean.body.count, `${param}: ${JSON.stringify(clean.body)}`).toBe(1);
       for (const padded of [`${value} `, ` ${value}`]) {
         const res = await request(app).get(countPath).query({ attention: "blocked", [param]: padded });
         const label = `${param}=${JSON.stringify(padded)}: ${JSON.stringify(res.body)}`;
@@ -1279,6 +1398,18 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
       const base = path === listPath ? { status: "todo", limit: "20" } : { attention: "blocked" };
       const lower = await request(app).get(path).query({ ...base, assigneeAgentId: "null" });
       expect(lower.status, `${path}: ${JSON.stringify(lower.body)}`).toBe(200);
+      // Same reason as class 2, and the pin is an equality rather than a
+      // non-empty check: the null token has to mean "assignee is null", not
+      // "filter absent". Both routes seed an unassigned row and an assigned one,
+      // so an implementation that dropped the filter returns a strictly larger
+      // page and fails here.
+      if (path === listPath) {
+        expect(lower.body.map((issue: { id: string }) => issue.id), `${path}: ${JSON.stringify(lower.body)}`).toEqual([
+          rootId,
+        ]);
+      } else {
+        expect(lower.body.count, `${path}: ${JSON.stringify(lower.body)}`).toBe(1);
+      }
       for (const token of ["NULL", "Null"]) {
         const res = await request(app).get(path).query({ ...base, assigneeAgentId: token });
         const label = `${path} assigneeAgentId=${token}: ${JSON.stringify(res.body)}`;
@@ -1644,6 +1775,21 @@ describeEmbeddedPostgres("issue list routes assigneeAgentId filter", () => {
 
     expect(aliasOnlyRes.status, JSON.stringify(aliasOnlyRes.body)).toBe(400);
     expect(aliasOnlyRes.body).toMatchObject({ error: "parentIssueId must be a UUID" });
+
+    // Validating the alias is not the same as applying it. With no `parentId`
+    // to supersede it, a valid `parentIssueId` is the value that reaches the
+    // query, so the page must narrow to exactly that parent's children. Drop
+    // the alias branch's `filters[parentIdName] = trimmedAlias` and this
+    // returns the whole company list instead — a 200 the 400 pins above and
+    // the precedence assertions all still accept.
+    const aliasAppliedRes = await request(app)
+      .get(`/api/companies/${companyId}/issues`)
+      .query({ status: "todo", parentIssueId: aliasParentId, limit: "20" });
+
+    expect(aliasAppliedRes.status, JSON.stringify(aliasAppliedRes.body)).toBe(200);
+    expect(aliasAppliedRes.body.map((issue: { id: string }) => issue.id)).toEqual([
+      aliasChildIssueId,
+    ]);
   });
 
   it("filters issue lists by goalId and createdByAgentId", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2859,6 +2859,81 @@ function logIssueListRequest(input: {
   });
 }
 
+const ISSUE_LIST_UUID_FILTER_NAMES = [
+  "participantAgentId",
+  "goalId",
+  "createdByAgentId",
+  "projectId",
+  "workspaceId",
+  "executionWorkspaceId",
+  "parentId",
+  "descendantOf",
+  "labelId",
+] as const;
+
+type IssueUuidFilterName = typeof ISSUE_LIST_UUID_FILTER_NAMES[number];
+
+const ISSUE_COUNT_UUID_FILTER_NAMES = [
+  "participantAgentId",
+  "projectId",
+  "workspaceId",
+  "executionWorkspaceId",
+  "parentId",
+  "descendantOf",
+  "labelId",
+] as const;
+
+type IssueUuidFilterResult<Name extends IssueUuidFilterName> =
+  | { ok: true; filters: Partial<Record<Name, string>> }
+  | { ok: false; error: string };
+
+/**
+ * Validates every UUID-typed query filter at the route boundary so a malformed
+ * value never reaches Postgres as `22P02 invalid input syntax for type uuid`.
+ * Shared by the issue list and issue count routes: the count route reaches the
+ * same service-layer filters, so it needs the identical guard.
+ */
+function parseIssueUuidFilters<Name extends IssueUuidFilterName>(
+  query: Request["query"],
+  names: readonly Name[],
+): IssueUuidFilterResult<Name> {
+  const filters: Partial<Record<Name, string>> = {};
+  for (const name of names) {
+    const rawValue = query[name];
+    if (rawValue === undefined) continue;
+    if (typeof rawValue !== "string" || !isUuidLike(rawValue.trim())) {
+      return { ok: false, error: `${name} must be a UUID` };
+    }
+    filters[name] = rawValue.trim();
+  }
+  const parentIdName = "parentId" as Name;
+  if (names.includes(parentIdName)) {
+    const rawParentIssueId = query.parentIssueId;
+    if (rawParentIssueId !== undefined) {
+      if (typeof rawParentIssueId !== "string" || !isUuidLike(rawParentIssueId.trim())) {
+        return { ok: false, error: "parentIssueId must be a UUID" };
+      }
+      if (filters[parentIdName] === undefined) {
+        filters[parentIdName] = rawParentIssueId.trim();
+      }
+    }
+  }
+  return { ok: true, filters };
+}
+
+function parseIssueAssigneeAgentIdFilter(
+  rawValue: unknown,
+): { ok: true; value: string | null | undefined } | { ok: false; error: string } {
+  if (rawValue === undefined) return { ok: true, value: undefined };
+  const rejected = { ok: false as const, error: "assigneeAgentId must be a UUID or 'null'" };
+  if (typeof rawValue !== "string") return rejected;
+  const normalized = rawValue.trim();
+  if (normalized.length === 0) return rejected;
+  if (normalized.toLowerCase() === "null") return { ok: true, value: null };
+  if (!isUuidLike(normalized)) return rejected;
+  return { ok: true, value: normalized };
+}
+
 export function issueRoutes(
   db: Db,
   storage: StorageService,
@@ -6489,40 +6564,13 @@ export function issueRoutes(
     const hasPlanDocument = parseOptionalBooleanQuery(req.query.hasPlanDocument);
     const includeLiveDescendantSummary = parseOptionalBooleanQuery(req.query.includeLiveDescendantSummary);
     const assigneeAgentFilterRaw = req.query.assigneeAgentId;
-    let assigneeAgentId: string | null | undefined;
     const rawUpdatedSince = req.query.updatedSince as string | undefined;
-    const uuidFilterNames = [
-      "participantAgentId",
-      "goalId",
-      "createdByAgentId",
-      "projectId",
-      "workspaceId",
-      "executionWorkspaceId",
-      "parentId",
-      "descendantOf",
-      "labelId",
-    ] as const;
-    const uuidFilters: Partial<Record<typeof uuidFilterNames[number], string>> = {};
-
-    for (const name of uuidFilterNames) {
-      const rawValue = req.query[name];
-      if (rawValue === undefined) continue;
-      if (typeof rawValue !== "string" || !isUuidLike(rawValue.trim())) {
-        res.status(400).json({ error: `${name} must be a UUID` });
-        return;
-      }
-      uuidFilters[name] = rawValue.trim();
+    const uuidFilterResult = parseIssueUuidFilters(req.query, ISSUE_LIST_UUID_FILTER_NAMES);
+    if (!uuidFilterResult.ok) {
+      res.status(400).json({ error: uuidFilterResult.error });
+      return;
     }
-    const rawParentIssueId = req.query.parentIssueId;
-    if (rawParentIssueId !== undefined) {
-      if (typeof rawParentIssueId !== "string" || !isUuidLike(rawParentIssueId.trim())) {
-        res.status(400).json({ error: "parentIssueId must be a UUID" });
-        return;
-      }
-      if (uuidFilters.parentId === undefined) {
-        uuidFilters.parentId = rawParentIssueId.trim();
-      }
-    }
+    const uuidFilters = uuidFilterResult.filters;
 
     if (assigneeUserFilterRaw === "me" && (!assigneeUserId || req.actor.type !== "board")) {
       res.status(403).json({ error: "assigneeUserId=me requires board authentication" });
@@ -6572,24 +6620,12 @@ export function issueRoutes(
       res.status(400).json({ error: "includeLiveDescendantSummary must be true or false when provided" });
       return;
     }
-    if (assigneeAgentFilterRaw !== undefined) {
-      if (typeof assigneeAgentFilterRaw !== "string") {
-        res.status(400).json({ error: "assigneeAgentId must be a UUID or 'null'" });
-        return;
-      }
-      const normalizedAssigneeAgentFilter = assigneeAgentFilterRaw.trim();
-      if (normalizedAssigneeAgentFilter.length === 0) {
-        res.status(400).json({ error: "assigneeAgentId must be a UUID or 'null'" });
-        return;
-      } else if (normalizedAssigneeAgentFilter.toLowerCase() === "null") {
-        assigneeAgentId = null;
-      } else if (isUuidLike(normalizedAssigneeAgentFilter)) {
-        assigneeAgentId = normalizedAssigneeAgentFilter;
-      } else {
-        res.status(400).json({ error: "assigneeAgentId must be a UUID or 'null'" });
-        return;
-      }
+    const assigneeAgentFilterResult = parseIssueAssigneeAgentIdFilter(assigneeAgentFilterRaw);
+    if (!assigneeAgentFilterResult.ok) {
+      res.status(400).json({ error: assigneeAgentFilterResult.error });
+      return;
     }
+    const assigneeAgentId = assigneeAgentFilterResult.value;
     if (rawUpdatedSince !== undefined && !Number.isFinite(new Date(rawUpdatedSince).getTime())) {
       res.status(400).json({ error: "updatedSince must be a valid ISO 8601 timestamp when provided" });
       return;
@@ -6793,19 +6829,30 @@ export function issueRoutes(
       res.status(400).json({ error: "hasPlanDocument must be true or false when provided" });
       return;
     }
+    const countAssigneeAgentFilter = parseIssueAssigneeAgentIdFilter(req.query.assigneeAgentId);
+    if (!countAssigneeAgentFilter.ok) {
+      res.status(400).json({ error: countAssigneeAgentFilter.error });
+      return;
+    }
+    const countUuidFilterResult = parseIssueUuidFilters(req.query, ISSUE_COUNT_UUID_FILTER_NAMES);
+    if (!countUuidFilterResult.ok) {
+      res.status(400).json({ error: countUuidFilterResult.error });
+      return;
+    }
+    const countUuidFilters = countUuidFilterResult.filters;
 
     const blockedCountFilters = {
       attention: "blocked",
       status: req.query.status as string | string[] | undefined,
-      assigneeAgentId: req.query.assigneeAgentId as string | undefined,
-      participantAgentId: req.query.participantAgentId as string | undefined,
+      assigneeAgentId: countAssigneeAgentFilter.value === null ? "null" : countAssigneeAgentFilter.value,
+      participantAgentId: countUuidFilters.participantAgentId,
       assigneeUserId: req.query.assigneeUserId as string | undefined,
-      projectId: req.query.projectId as string | undefined,
-      workspaceId: req.query.workspaceId as string | undefined,
-      executionWorkspaceId: req.query.executionWorkspaceId as string | undefined,
-      parentId: (req.query.parentId ?? req.query.parentIssueId) as string | undefined,
-      descendantOf: req.query.descendantOf as string | undefined,
-      labelId: req.query.labelId as string | undefined,
+      projectId: countUuidFilters.projectId,
+      workspaceId: countUuidFilters.workspaceId,
+      executionWorkspaceId: countUuidFilters.executionWorkspaceId,
+      parentId: countUuidFilters.parentId,
+      descendantOf: countUuidFilters.descendantOf,
+      labelId: countUuidFilters.labelId,
       originKind: req.query.originKind as string | undefined,
       originKindPrefix: req.query.originKindPrefix as string | undefined,
       originId: req.query.originId as string | undefined,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -6491,6 +6491,36 @@ export function issueRoutes(
     const assigneeAgentFilterRaw = req.query.assigneeAgentId;
     let assigneeAgentId: string | null | undefined;
     const rawUpdatedSince = req.query.updatedSince as string | undefined;
+    const uuidFilterNames = [
+      "participantAgentId",
+      "goalId",
+      "createdByAgentId",
+      "projectId",
+      "workspaceId",
+      "executionWorkspaceId",
+      "parentId",
+      "descendantOf",
+      "labelId",
+    ] as const;
+    const uuidFilters: Partial<Record<typeof uuidFilterNames[number], string>> = {};
+
+    for (const name of uuidFilterNames) {
+      const rawValue = req.query[name];
+      if (rawValue === undefined) continue;
+      if (typeof rawValue !== "string" || !isUuidLike(rawValue.trim())) {
+        res.status(400).json({ error: `${name} must be a UUID` });
+        return;
+      }
+      uuidFilters[name] = rawValue.trim();
+    }
+    const rawParentIssueId = req.query.parentIssueId;
+    if (rawParentIssueId !== undefined) {
+      if (typeof rawParentIssueId !== "string" || !isUuidLike(rawParentIssueId.trim())) {
+        res.status(400).json({ error: "parentIssueId must be a UUID" });
+        return;
+      }
+      uuidFilters.parentId = rawParentIssueId.trim();
+    }
 
     if (assigneeUserFilterRaw === "me" && (!assigneeUserId || req.actor.type !== "board")) {
       res.status(403).json({ error: "assigneeUserId=me requires board authentication" });
@@ -6542,18 +6572,19 @@ export function issueRoutes(
     }
     if (assigneeAgentFilterRaw !== undefined) {
       if (typeof assigneeAgentFilterRaw !== "string") {
-        res.status(422).json({ error: "assigneeAgentId must be a UUID or 'null'" });
+        res.status(400).json({ error: "assigneeAgentId must be a UUID or 'null'" });
         return;
       }
       const normalizedAssigneeAgentFilter = assigneeAgentFilterRaw.trim();
       if (normalizedAssigneeAgentFilter.length === 0) {
-        assigneeAgentId = undefined;
+        res.status(400).json({ error: "assigneeAgentId must be a UUID or 'null'" });
+        return;
       } else if (normalizedAssigneeAgentFilter.toLowerCase() === "null") {
         assigneeAgentId = null;
       } else if (isUuidLike(normalizedAssigneeAgentFilter)) {
         assigneeAgentId = normalizedAssigneeAgentFilter;
       } else {
-        res.status(422).json({ error: "assigneeAgentId must be a UUID or 'null'" });
+        res.status(400).json({ error: "assigneeAgentId must be a UUID or 'null'" });
         return;
       }
     }
@@ -6567,17 +6598,19 @@ export function issueRoutes(
       attention: attention === "blocked" ? "blocked" : undefined,
       status: req.query.status as string | string[] | undefined,
       assigneeAgentId,
-      participantAgentId: req.query.participantAgentId as string | undefined,
+      participantAgentId: uuidFilters.participantAgentId,
       assigneeUserId,
       touchedByUserId,
       inboxArchivedByUserId,
       unreadForUserId,
-      projectId: req.query.projectId as string | undefined,
-      workspaceId: req.query.workspaceId as string | undefined,
-      executionWorkspaceId: req.query.executionWorkspaceId as string | undefined,
-      parentId: (req.query.parentId ?? req.query.parentIssueId) as string | undefined,
-      descendantOf: req.query.descendantOf as string | undefined,
-      labelId: req.query.labelId as string | undefined,
+      goalId: uuidFilters.goalId,
+      createdByAgentId: uuidFilters.createdByAgentId,
+      projectId: uuidFilters.projectId,
+      workspaceId: uuidFilters.workspaceId,
+      executionWorkspaceId: uuidFilters.executionWorkspaceId,
+      parentId: uuidFilters.parentId,
+      descendantOf: uuidFilters.descendantOf,
+      labelId: uuidFilters.labelId,
       originKind: req.query.originKind as string | undefined,
       originKindPrefix: req.query.originKindPrefix as string | undefined,
       originId: req.query.originId as string | undefined,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2908,14 +2908,15 @@ function parseIssueUuidFilters<Name extends IssueUuidFilterName>(
   }
   const parentIdName = "parentId" as Name;
   if (names.includes(parentIdName)) {
+    // `parentId ?? parentIssueId` is the long-standing precedence on both routes.
+    // Only validate the alias when it is the value that will actually be used —
+    // validating a superseded alias would 400 a request that has always been 200.
     const rawParentIssueId = query.parentIssueId;
-    if (rawParentIssueId !== undefined) {
+    if (filters[parentIdName] === undefined && rawParentIssueId !== undefined) {
       if (typeof rawParentIssueId !== "string" || !isUuidLike(rawParentIssueId.trim())) {
         return { ok: false, error: "parentIssueId must be a UUID" };
       }
-      if (filters[parentIdName] === undefined) {
-        filters[parentIdName] = rawParentIssueId.trim();
-      }
+      filters[parentIdName] = rawParentIssueId.trim();
     }
   }
   return { ok: true, filters };

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2901,22 +2901,39 @@ function parseIssueUuidFilters<Name extends IssueUuidFilterName>(
   for (const name of names) {
     const rawValue = query[name];
     if (rawValue === undefined) continue;
-    if (typeof rawValue !== "string" || !isUuidLike(rawValue.trim())) {
+    if (typeof rawValue !== "string") {
       return { ok: false, error: `${name} must be a UUID` };
     }
-    filters[name] = rawValue.trim();
+    const trimmed = rawValue.trim();
+    // An empty value means "filter absent", not "filter malformed". Every query
+    // builder in `services/issues.ts` gates on a falsy filter, so `?projectId=`
+    // has always returned the unfiltered 200. Only non-empty text is validated.
+    if (trimmed.length === 0) continue;
+    if (!isUuidLike(trimmed)) {
+      return { ok: false, error: `${name} must be a UUID` };
+    }
+    filters[name] = trimmed;
   }
   const parentIdName = "parentId" as Name;
   if (names.includes(parentIdName)) {
     // `parentId ?? parentIssueId` is the long-standing precedence on both routes.
-    // Only validate the alias when it is the value that will actually be used —
-    // validating a superseded alias would 400 a request that has always been 200.
+    // `??` resolves on presence, not on emptiness: a present-but-empty `parentId`
+    // already suppressed the alias, so read the raw query value here rather than
+    // the parsed filter. Only validate the alias when it is the value that will
+    // actually be used — validating a superseded alias would 400 a request that
+    // has always been 200.
     const rawParentIssueId = query.parentIssueId;
-    if (filters[parentIdName] === undefined && rawParentIssueId !== undefined) {
-      if (typeof rawParentIssueId !== "string" || !isUuidLike(rawParentIssueId.trim())) {
+    if (query[parentIdName] === undefined && rawParentIssueId !== undefined) {
+      if (typeof rawParentIssueId !== "string") {
         return { ok: false, error: "parentIssueId must be a UUID" };
       }
-      filters[parentIdName] = rawParentIssueId.trim();
+      const trimmedAlias = rawParentIssueId.trim();
+      if (trimmedAlias.length > 0) {
+        if (!isUuidLike(trimmedAlias)) {
+          return { ok: false, error: "parentIssueId must be a UUID" };
+        }
+        filters[parentIdName] = trimmedAlias;
+      }
     }
   }
   return { ok: true, filters };
@@ -2929,7 +2946,9 @@ function parseIssueAssigneeAgentIdFilter(
   const rejected = { ok: false as const, error: "assigneeAgentId must be a UUID or 'null'" };
   if (typeof rawValue !== "string") return rejected;
   const normalized = rawValue.trim();
-  if (normalized.length === 0) return rejected;
+  // Empty means "filter absent" — `services/issues.ts` normalizes `""` to
+  // `undefined` for this filter, and the route did the same before this guard.
+  if (normalized.length === 0) return { ok: true, value: undefined };
   if (normalized.toLowerCase() === "null") return { ok: true, value: null };
   if (!isUuidLike(normalized)) return rejected;
   return { ok: true, value: normalized };

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -6519,7 +6519,9 @@ export function issueRoutes(
         res.status(400).json({ error: "parentIssueId must be a UUID" });
         return;
       }
-      uuidFilters.parentId = rawParentIssueId.trim();
+      if (uuidFilters.parentId === undefined) {
+        uuidFilters.parentId = rawParentIssueId.trim();
+      }
     }
 
     if (assigneeUserFilterRaw === "me" && (!assigneeUserId || req.actor.type !== "board")) {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -596,6 +596,8 @@ export interface IssueFilters {
   touchedByUserId?: string;
   inboxArchivedByUserId?: string;
   unreadForUserId?: string;
+  goalId?: string;
+  createdByAgentId?: string;
   projectId?: string;
   workspaceId?: string;
   executionWorkspaceId?: string;
@@ -4243,6 +4245,12 @@ function assertValidAssigneeAgentFilter(assigneeAgentFilter: string | null | und
   }
 }
 
+function assertValidUuidFilter(name: string, value: string | undefined) {
+  if (typeof value === "string" && !isUuidLike(value)) {
+    throw unprocessable(`${name} must be a UUID`);
+  }
+}
+
 async function blockedInboxIssueConditions(
   dbOrTx: any,
   companyId: string,
@@ -4294,6 +4302,8 @@ async function blockedInboxIssueConditions(
   if (touchedByUserId) conditions.push(touchedByUserCondition(companyId, touchedByUserId));
   if (inboxArchivedByUserId) conditions.push(inboxVisibleForUserCondition(companyId, inboxArchivedByUserId));
   if (unreadForUserId) conditions.push(unreadForUserCondition(companyId, unreadForUserId));
+  if (filters?.goalId) conditions.push(eq(issues.goalId, filters.goalId));
+  if (filters?.createdByAgentId) conditions.push(eq(issues.createdByAgentId, filters.createdByAgentId));
   if (filters?.projectId) conditions.push(eq(issues.projectId, filters.projectId));
   if (filters?.workspaceId) {
     conditions.push(or(
@@ -5641,6 +5651,15 @@ export function issueService(db: Db) {
       const conditions = [eq(issues.companyId, companyId), visibleIssueCondition()];
       const assigneeAgentFilter = parseIssueAssigneeAgentFilter(filters?.assigneeAgentId);
       assertValidAssigneeAgentFilter(assigneeAgentFilter);
+      assertValidUuidFilter("participantAgentId", filters?.participantAgentId);
+      assertValidUuidFilter("goalId", filters?.goalId);
+      assertValidUuidFilter("createdByAgentId", filters?.createdByAgentId);
+      assertValidUuidFilter("projectId", filters?.projectId);
+      assertValidUuidFilter("workspaceId", filters?.workspaceId);
+      assertValidUuidFilter("executionWorkspaceId", filters?.executionWorkspaceId);
+      assertValidUuidFilter("parentId", filters?.parentId);
+      assertValidUuidFilter("descendantOf", filters?.descendantOf);
+      assertValidUuidFilter("labelId", filters?.labelId);
       const limit = typeof filters?.limit === "number" && Number.isFinite(filters.limit)
         ? Math.max(1, Math.floor(filters.limit))
         : undefined;
@@ -5720,6 +5739,8 @@ export function issueService(db: Db) {
       if (unreadForUserId) {
         conditions.push(unreadForUserCondition(companyId, unreadForUserId));
       }
+      if (filters?.goalId) conditions.push(eq(issues.goalId, filters.goalId));
+      if (filters?.createdByAgentId) conditions.push(eq(issues.createdByAgentId, filters.createdByAgentId));
       if (filters?.projectId) conditions.push(eq(issues.projectId, filters.projectId));
       if (filters?.workspaceId) {
         conditions.push(or(
@@ -5904,12 +5925,23 @@ export function issueService(db: Db) {
       else if (statuses.length > 1) conditions.push(inArray(issues.status, statuses));
       const assigneeAgentFilter = parseIssueAssigneeAgentFilter(filters?.assigneeAgentId);
       assertValidAssigneeAgentFilter(assigneeAgentFilter);
+      assertValidUuidFilter("participantAgentId", filters?.participantAgentId);
+      assertValidUuidFilter("goalId", filters?.goalId);
+      assertValidUuidFilter("createdByAgentId", filters?.createdByAgentId);
+      assertValidUuidFilter("projectId", filters?.projectId);
+      assertValidUuidFilter("workspaceId", filters?.workspaceId);
+      assertValidUuidFilter("executionWorkspaceId", filters?.executionWorkspaceId);
+      assertValidUuidFilter("parentId", filters?.parentId);
+      assertValidUuidFilter("descendantOf", filters?.descendantOf);
+      assertValidUuidFilter("labelId", filters?.labelId);
       if (assigneeAgentFilter === null) {
         conditions.push(isNull(issues.assigneeAgentId));
       } else if (assigneeAgentFilter) {
         conditions.push(eq(issues.assigneeAgentId, assigneeAgentFilter));
       }
       if (filters?.assigneeUserId) conditions.push(eq(issues.assigneeUserId, filters.assigneeUserId));
+      if (filters?.goalId) conditions.push(eq(issues.goalId, filters.goalId));
+      if (filters?.createdByAgentId) conditions.push(eq(issues.createdByAgentId, filters.createdByAgentId));
       if (filters?.projectId) conditions.push(eq(issues.projectId, filters.projectId));
       if (filters?.workspaceId) {
         conditions.push(or(

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -4249,7 +4249,13 @@ function assertValidUuidFilter(name: string, value: string | undefined) {
   // An empty value means "filter absent" — every query builder below gates on a
   // falsy filter, and `parseIssueAssigneeAgentFilter` normalizes `""` the same
   // way. Rejecting it here would disagree with both.
-  if (typeof value === "string" && value.trim() !== "" && !isUuidLike(value)) {
+  //
+  // The exemption is exactly `""`, not "blank after trimming". This function
+  // does not own the value it validates, so a whitespace-only string it waved
+  // through would still reach the query builders, which test the *original*
+  // string for truthiness and compare it against a uuid column — 22P02, the
+  // exact 500 this guard exists to prevent.
+  if (typeof value === "string" && value !== "" && !isUuidLike(value)) {
     throw unprocessable(`${name} must be a UUID`);
   }
 }

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -4256,6 +4256,19 @@ async function blockedInboxIssueConditions(
   companyId: string,
   filters?: IssueFilters,
 ) {
+  // The blocked-inbox branch is reached before svc.list/svc.count run their own
+  // filter asserts, so it has to validate the same set here or a malformed UUID
+  // reaches Postgres as 22P02 and surfaces as a 500.
+  assertValidAssigneeAgentFilter(parseIssueAssigneeAgentFilter(filters?.assigneeAgentId));
+  assertValidUuidFilter("participantAgentId", filters?.participantAgentId);
+  assertValidUuidFilter("goalId", filters?.goalId);
+  assertValidUuidFilter("createdByAgentId", filters?.createdByAgentId);
+  assertValidUuidFilter("projectId", filters?.projectId);
+  assertValidUuidFilter("workspaceId", filters?.workspaceId);
+  assertValidUuidFilter("executionWorkspaceId", filters?.executionWorkspaceId);
+  assertValidUuidFilter("parentId", filters?.parentId);
+  assertValidUuidFilter("descendantOf", filters?.descendantOf);
+  assertValidUuidFilter("labelId", filters?.labelId);
   const conditions = [
     eq(issues.companyId, companyId),
     visibleIssueCondition(),

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -4246,7 +4246,10 @@ function assertValidAssigneeAgentFilter(assigneeAgentFilter: string | null | und
 }
 
 function assertValidUuidFilter(name: string, value: string | undefined) {
-  if (typeof value === "string" && !isUuidLike(value)) {
+  // An empty value means "filter absent" — every query builder below gates on a
+  // falsy filter, and `parseIssueAssigneeAgentFilter` normalizes `""` the same
+  // way. Rejecting it here would disagree with both.
+  if (typeof value === "string" && value.trim() !== "" && !isUuidLike(value)) {
     throw unprocessable(`${name} must be a UUID`);
   }
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The issue list API lets users and scripts filter company issues
> - Several UUID query filters reached SQL without route validation
> - Bad UUID text could become a database error instead of a client error
> - Two real issue fields were accepted by callers but did not filter rows
> - This pull request validates UUID filters at the route boundary
> - It also wires the creator and goal filters into the issue service
> - The benefit is that bad filters fail loud and valid filters return scoped rows

## Linked Issues or Issue Description

Fixes #11857
Refs #1966
Refs #6327
Refs #7432

## What Changed

- Return `400` for malformed UUID query values on the company issue list route.
- Preserve the `assigneeAgentId=null` sentinel for unassigned issues.
- Add `goalId` and `createdByAgentId` to the issue filter contract.
- Apply those two filters in normal lists, blocked inbox lists, and counts.
- Add route tests for malformed UUID params, valid combined UUID filters, and the new goal and creator filters.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-list-assignee-filter-routes.test.ts --no-file-parallelism --maxWorkers=1` passed. It ran 20 tests.
- Six mutation probes against the new empty-value test, one at a time, each reverted after: dropping the empty-skip in `parseIssueUuidFilters`; restoring the empty rejection in `parseIssueAssigneeAgentIdFilter`; moving the alias gate back onto the parsed filter; restoring the empty rejection in `assertValidUuidFilter`; and widening that exemption to "blank after trimming", which dies on a raw `Failed query` from Postgres. Five go red. One survivor, reported: writing the empty string through as the filter value stays green, because every consumer of that value gates on truthiness, so it is observationally equivalent.
- `pnpm exec vitest run server/src/__tests__/issues-service.test.ts --no-file-parallelism --maxWorkers=1` passed. It ran 123 tests.
- `git diff --check` passed.
- `pnpm --filter @paperclipai/server typecheck` did not reach server `tsc` because this machine does not have `cargo`, and the runner vendor build requires it.
- After building `@paperclipai/plugin-sdk`, direct `pnpm --filter @paperclipai/server exec tsc --noEmit` still fails on an existing Sentry type mismatch in `src/sentry.ts`.

## Risks

- Low risk for valid UUID callers. The tests cover valid combined filters with status, limit, and search.
- Existing callers that sent malformed UUID text now get `400` instead of a server error or empty result.
- **Status-code change, declared:** a malformed `assigneeAgentId` on `GET /issues` returned `422` before this PR and now returns `400`. The other seven UUID params returned `500` (or an empty result) before, so `400` is new for them either way. Callers that switch on `422` for this one param need updating.
- `assertValidUuidFilter` exempts exactly `""`, not "blank after trimming". It does not own the value it validates, so a whitespace-only string it waved through would still reach the query builders, which test the original string for truthiness and compare it against a uuid column — the 22P02 this PR exists to prevent. `" "` is asserted to throw on all nine service filters.
- **Empty values are unchanged:** `?projectId=` and its eight siblings, and `?parentId=&parentIssueId=<uuid>`, still return the unfiltered `200` on both `/issues` and `/issues/count`. An empty value means "filter absent", not "filter malformed" — it is the reading every query builder in `services/issues.ts` already implements. A new test pins that on both routes and at the service layer.
- Existing callers that sent `goalId` or `createdByAgentId` now get filtered rows instead of the full list.
- This server change cannot protect clients that ignore HTTP status codes. A separate private ops-script follow-up is filed for status checks before row parsing.

## Model Used

OpenAI Codex, GPT-5 coding agent, with terminal and repository editing tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge


