### PR TITLE
fix(tools): retry MCP initialize handshake when session-less tools/list returns 404

### DIFF
--- a/server/src/__tests__/tool-access-service.test.ts
+++ b/server/src/__tests__/tool-access-service.test.ts
@@ -4156,6 +4156,26 @@ describeEmbeddedPostgres("tool access service", () => {
     expect(requests.filter(({ method }) => method === "initialize").length).toBeGreaterThanOrEqual(1);
   });
 
+  it("does not treat a 404 that survives the handshake as a session requirement", async () => {
+    const company = await createCompany(db);
+    const service = createTestToolAccessService(db);
+    const methods: string[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      const payload = JSON.parse(String(init?.body ?? "{}")) as { method?: string };
+      methods.push(payload.method ?? "");
+      // A wrong endpoint 404s everything, the handshake included, so the
+      // original failure must survive rather than being retried forever.
+      return new Response("Not Found", { status: 404, headers: { "content-type": "text/plain" } });
+    });
+
+    await expect(service.connectGalleryApp(company.id, {
+      link: "https://missing.example/mcp",
+      name: "Missing MCP",
+    }, { actorType: "user", actorId: "board" })).rejects.toThrow();
+
+    expect(methods.filter((method) => method === "tools/list").length).toBe(1);
+  });
+
   it("serves persisted MCP actions until the cache expires and then refreshes them", async () => {
     const company = await createCompany(db);
     let currentTime = new Date("2026-08-20T12:00:00.000Z");

--- a/server/src/__tests__/tool-access-service.test.ts
+++ b/server/src/__tests__/tool-access-service.test.ts
@@ -4099,6 +4099,63 @@ describeEmbeddedPostgres("tool access service", () => {
       .toBe(requests.filter(({ method }) => method === "initialize").length);
   });
 
+  it("initializes servers that answer 404 for a session-less tools/list", async () => {
+    const company = await createCompany(db);
+    const service = createTestToolAccessService(db);
+    const requests: Array<{ method: string; sessionId: string | null }> = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      const payload = JSON.parse(String(init?.body ?? "{}")) as { method?: string; id?: string };
+      const requestHeaders = new Headers(init?.headers);
+      requests.push({ method: payload.method ?? "", sessionId: requestHeaders.get("mcp-session-id") });
+      if (payload.method === "initialize") {
+        return new Response(JSON.stringify({
+          jsonrpc: "2.0",
+          id: payload.id,
+          result: {
+            protocolVersion: "2025-06-18",
+            capabilities: { tools: {} },
+            serverInfo: { name: "stateful-404", version: "1" },
+          },
+        }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "mcp-session-id": "session-404",
+          },
+        });
+      }
+      if (payload.method === "notifications/initialized") {
+        expect(requestHeaders.get("mcp-session-id")).toBeTruthy();
+        return new Response(null, { status: 202 });
+      }
+      if (payload.method === "tools/list" && !requestHeaders.get("mcp-session-id")) {
+        // Session-required servers following the Streamable HTTP spec answer
+        // 404 (session missing or expired) instead of 400 (#12697).
+        return new Response(JSON.stringify({ message: "Unknown session" }), {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return mcpHttpResponse({
+        jsonrpc: "2.0",
+        id: payload.id,
+        result: { tools: [{ name: "list_state", annotations: { readOnlyHint: true } }] },
+      });
+    });
+
+    const result = await service.connectGalleryApp(company.id, {
+      link: "https://stateful-404.example/mcp",
+      name: "Stateful 404 MCP",
+    }, { actorType: "user", actorId: "board" });
+
+    expect(result.connection.config).toMatchObject({ mcpSessionRequired: true });
+    expect(result.actions.readOnly).toEqual([
+      expect.objectContaining({ toolName: "list_state", riskLevel: "read" }),
+    ]);
+    expect(requests[0]).toEqual({ method: "tools/list", sessionId: null });
+    expect(requests.filter(({ method }) => method === "initialize").length).toBeGreaterThanOrEqual(1);
+  });
+
   it("serves persisted MCP actions until the cache expires and then refreshes them", async () => {
     const company = await createCompany(db);
     let currentTime = new Date("2026-08-20T12:00:00.000Z");

--- a/server/src/services/tool-access.ts
+++ b/server/src/services/tool-access.ts
@@ -4843,10 +4843,13 @@ export function toolAccessService(db: Db, options: ToolAccessServiceOptions = {}
       response = await sendToolsList(sessionHeaders);
     } else {
       response = await sendToolsList(headers);
-      // `tools/list` is read-only, so a 400 can safely be retried after the MCP
-      // initialize handshake. Stateful servers such as Supabase require the
-      // returned Mcp-Session-Id on every non-initialization request.
-      if (response.status === 400) {
+      // `tools/list` is read-only, so a client-error status that can mean
+      // "missing session" can safely be retried after the MCP initialize
+      // handshake. Stateful servers such as Supabase answer 400, while
+      // session-expired or session-required servers following the Streamable
+      // HTTP spec answer 404 (see #12697). Both require the returned
+      // Mcp-Session-Id on every non-initialization request.
+      if (response.status === 400 || response.status === 404) {
         try {
           const sessionHeaders = await initializeMcpHttpSession({
             send: sendRemote,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Paperclip connects agents to remote MCP (Model Context Protocol) tool servers through managed tool connections, and a catalog refresh lists the tools a server exposes
> - A catalog refresh against a stateful Streamable HTTP MCP server first sends a session-less `tools/list`, then retries after an `initialize` handshake only when the server answers HTTP 400
> - Servers that follow the MCP Streamable HTTP spec answer 404 for a missing or expired session, so the retry never ran and the connection stayed permanently unusable (issue #12697)
> - This pull request accepts 404 alongside 400 for the read-only `tools/list` retry, so the initialize handshake also runs for spec-compliant 404 servers
> - The benefit is that `mcp_remote` connections to session-required servers (for example self-hosted servers behind gateways) connect instead of failing with 502

## Linked Issues or Issue Description

Refs #12697

## What Changed

- `server/src/services/tool-access.ts`: the session-less `tools/list` retry in `remoteTools` now triggers on HTTP 400 or 404, with a comment that explains both status codes
- `server/src/__tests__/tool-access-service.test.ts`: new test that mocks a server answering 404 for a session-less `tools/list`, and asserts the initialize handshake runs and `mcpSessionRequired: true` is persisted

## Verification

- `node server/node_modules/vitest/vitest.mjs run --root server src/__tests__/tool-access-service.test.ts` — all 216 tests pass, including the new 404 case
- The existing 400-retry test ("initializes stateful Streamable HTTP servers...") still passes unchanged

## Risks

- Low risk. `tools/list` is read-only, so the extra initialize round-trip cannot mutate server state. A genuine 404 (wrong URL) now costs one extra initialize request before surfacing the original error, and `mcpSessionRequired` is only persisted when the retry succeeds.
- Scope note: the tool-gateway `tools/call` path still only auto-initializes when `mcpSessionRequired` is already set. This PR covers it indirectly, because a successful catalog refresh persists that flag.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

Codex (OpenAI) — GPT-5-based coding agent running in the Codex CLI automation, with shell tool use, repository file access, and iterative test runs. Human operator scheduled the automation and reviewed the final diff.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
