### PR TITLE
fix(recovery): continue productive successful handoffs

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -4663,8 +4663,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     ).toBe(true);
   });
 
-  it("escalates an exhausted successful handoff run that still leaves no disposition", async () => {
-    const { companyId, agentId, runId, issueId } =
+  it("requeues a productive exhausted successful handoff through the bounded continuation path", async () => {
+    const { agentId, runId, issueId } =
       await seedStrandedIssueFixture({
         status: "in_progress",
         runStatus: "succeeded",
@@ -4691,25 +4691,39 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const heartbeat = heartbeatService(db);
 
     const result = await heartbeat.reconcileStrandedAssignedIssues();
-    expect(result.continuationRequeued).toBe(0);
+    expect(result.continuationRequeued).toBe(1);
     expect(result.successfulContinuationObserved).toBe(0);
-    expect(result.successfulRunHandoffEscalated).toBe(1);
+    expect(result.successfulRunHandoffEscalated).toBe(0);
+    expect(result.escalated).toBe(0);
+    expect(result.issueIds).toEqual([issueId]);
 
-    const recoveryAction = await expectSourceScopedStrandedRecoveryAction({
-      companyId,
-      agentId,
+    const issue = await db
+      .select()
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    const retryRun = runs.find((row) => row.id !== runId);
+    expect(
+      retryRun?.contextSnapshot as Record<string, unknown> | undefined,
+    ).toMatchObject({
       issueId,
-      runId,
-      previousStatus: "in_progress",
-      retryReason: null,
-      cause: SUCCESSFUL_RUN_MISSING_STATE_REASON,
-      kind: "missing_disposition",
+      taskId: issueId,
+      retryReason: "issue_continuation_needed",
+      retryOfRunId: runId,
+      source: "issue.productive_terminal_continuation_recovery",
     });
-    expect(recoveryAction.evidence).toMatchObject({
-      sourceRunId,
-      latestRunStatus: "succeeded",
-      missingDisposition: "clear_next_step",
-    });
+
+    const recoveryActions = await db
+      .select()
+      .from(issueRecoveryActions)
+      .where(eq(issueRecoveryActions.sourceIssueId, issueId));
+    expect(recoveryActions).toHaveLength(0);
   });
 
   it("converts a continuation parked for review into a dependency wait on its open sub-tasks", async () => {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -4037,20 +4037,26 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           continue;
         }
 
-        const updated = await escalateStrandedAssignedIssue({
-          issue,
-          previousStatus: "in_progress",
-          latestRun,
-          recoveryCause: SUCCESSFUL_RUN_MISSING_STATE_REASON,
-          successfulRunHandoffEvidence: handoffEvidence,
-        });
-        if (updated) {
-          result.successfulRunHandoffEscalated += 1;
-          result.issueIds.push(issue.id);
-        } else {
-          result.skipped += 1;
+        if (!isProductiveContinuationRun(latestRun)) {
+          const updated = await escalateStrandedAssignedIssue({
+            issue,
+            previousStatus: "in_progress",
+            latestRun,
+            recoveryCause: SUCCESSFUL_RUN_MISSING_STATE_REASON,
+            successfulRunHandoffEvidence: handoffEvidence,
+          });
+          if (updated) {
+            result.successfulRunHandoffEscalated += 1;
+            result.issueIds.push(issue.id);
+          } else {
+            result.skipped += 1;
+          }
+          continue;
         }
-        continue;
+
+        // A productive handoff run has a normal continuation path. Let the
+        // bounded continuation recovery below queue its one normal-model wake.
+        // Failed or nonproductive handoffs still need a board recovery.
       }
       if (isSuccessfulInProgressContinuationRun(latestRun)) {
         const successfulRun = latestRun;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is an open-source app that manages AI agents for work.
> - The server recovery service keeps assigned in-progress work on a live execution path.
> - A successful-run handoff gives an agent one corrective wake when a productive run has no valid issue disposition.
> - The old exhausted-handoff branch moved all corrective handoff results to board recovery.
> - A productive corrective run can use the existing bounded normal continuation path instead.
> - This pull request keeps failed or nonproductive handoffs on the existing board-recovery path.
> - The benefit is one useful continuation without an unbounded retry loop.

## Linked Issues or Issue Description

**What happened?**

A productive corrective handoff with no issue disposition moved directly to board recovery after its single handoff attempt. The server did not use the existing bounded normal continuation path.

**Expected behavior**

A productive corrective handoff should receive one normal-model continuation. A later productive continuation with no disposition must use the existing bounded escalation rule.

**Steps to reproduce**

1. Create an assigned issue in `in_progress`.
2. Record a succeeded, productive run with an exhausted successful-run-handoff context.
3. Run assigned-issue recovery.
4. Observe that the old code creates board recovery instead of a normal continuation wake.

**Paperclip version or commit**

`8c89340444cfcf7438ac81c211d243f189cedd1d`

**Deployment mode**

Self-hosted server.

**Agent adapter(s) involved**

This is server recovery logic. It is not specific to one adapter.

**Database mode**

This behavior does not depend on the database mode.

Refs #12603

Refs #11529

Refs #11275

Refs #12604

The related pull requests provide handoff instructions or structured dispositions. This pull request fixes the recovery decision after a productive corrective handoff. It does not duplicate those changes.

## What Changed

- Allow an exhausted productive successful-run handoff to fall through to the existing bounded continuation recovery path.
- Keep failed and nonproductive exhausted handoffs on the existing board-recovery path.
- Replace the previous escalation regression test with a continuation-context test.
- Retain the existing regression test that blocks a second productive continuation without a disposition.

## Verification

- Confirmed the new regression test failed before the service change.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-process-recovery.test.ts --testNamePattern='productive exhausted successful handoff'` passed after the service change.
- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-process-recovery.test.ts` passed: 120 tests.
- `pnpm --filter @paperclipai/server exec vitest run src/services/recovery/successful-run-handoff.test.ts` passed: 32 tests.
- `pnpm --filter @paperclipai/server exec tsc --noEmit` passed after the required plugin build dependencies were prepared.
- `pnpm test:run` is running locally at PR creation time. The full workspace `typecheck` and `build` commands need Cargo for the runner binary. Cargo is not available in this local environment. GitHub Actions must run those checks.

## Risks

Low risk. The change applies only to a succeeded and productive exhausted handoff. It queues one existing normal continuation wake. The existing repeat guard moves a later productive continuation with no disposition to board recovery. Failed and nonproductive handoffs keep their current recovery behavior. This change has no schema, migration, or data change.

## Model Used

Provider: OpenAI Codex.

Model: gpt-5.6-terra.

Capabilities: source analysis, terminal use, test execution, Git, and GitHub CLI.

Context window: not verified.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run focused local tests and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes. No documentation change is needed. This fixes the existing recovery behavior.
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
