### PR TITLE
feat(ui): refine streamlined workspace surfaces

### DIFF
--- a/packages/shared/src/feature-catalog.ts
+++ b/packages/shared/src/feature-catalog.ts
@@ -81,6 +81,14 @@ export const INSTANCE_FEATURE_CATALOG: Record<InstanceFeatureKey, FeatureCatalog
     cloudDefault: true,
     selfHostedDefault: true,
   },
+  enableStreamlinedUi: {
+    title: "Streamlined UI",
+    description:
+      "Use the streamlined application shell, shared task collections, focused task detail layout, contextual navigation, and simplified main sidebar.",
+    tier: "preference",
+    cloudDefault: true,
+    selfHostedDefault: true,
+  },
   enableApps: {
     title: "Apps (compatibility)",
     description:

--- a/packages/shared/src/types/instance.ts
+++ b/packages/shared/src/types/instance.ts
@@ -54,6 +54,12 @@ export interface InstanceExperimentalSettings {
   enableManagedSandboxOnly: boolean;
   enableIsolatedWorkspaces: boolean;
   enableStreamlinedLeftNavigation: boolean;
+  /**
+   * Use the streamlined shell, navigation, and contextual-sidebar experience.
+   * Missing legacy values default on; the retired left-navigation preference
+   * remains separate so an old opt-out cannot disable the broader UI.
+   */
+  enableStreamlinedUi: boolean;
   /** @deprecated Compatibility key only. Apps is always enabled. */
   enableApps: boolean;
   enablePipelines: boolean;

--- a/packages/shared/src/validators/instance.test.ts
+++ b/packages/shared/src/validators/instance.test.ts
@@ -5,6 +5,13 @@ import {
 } from "./instance.js";
 
 describe("instance experimental settings validators", () => {
+  it("defaults the streamlined UI on and accepts an explicit patch", () => {
+    expect(instanceExperimentalSettingsSchema.parse({}).enableStreamlinedUi).toBe(true);
+    expect(
+      patchInstanceExperimentalSettingsSchema.parse({ enableStreamlinedUi: false }),
+    ).toEqual({ enableStreamlinedUi: false });
+  });
+
   it("defaults the server info debug view off", () => {
     const settings = instanceExperimentalSettingsSchema.parse({});
 

--- a/packages/shared/src/validators/instance.ts
+++ b/packages/shared/src/validators/instance.ts
@@ -45,6 +45,7 @@ export const instanceExperimentalSettingsSchema = z.object({
   enableManagedSandboxOnly: z.boolean().default(false),
   enableIsolatedWorkspaces: z.boolean().default(false),
   enableStreamlinedLeftNavigation: z.boolean().default(true),
+  enableStreamlinedUi: z.boolean().default(true),
   // Deprecated compatibility key. Apps is a standard product surface and is
   // always enabled; this remains accepted so older stored rows and managed
   // configs continue to load during upgrades.

--- a/server/src/__tests__/instance-settings-routes.test.ts
+++ b/server/src/__tests__/instance-settings-routes.test.ts
@@ -270,6 +270,24 @@ describe("instance settings routes", () => {
       .expect(404);
   });
 
+  it("accepts the instance-wide Streamlined UI preference", async () => {
+    const app = await createApp({
+      type: "board",
+      userId: "local-board",
+      source: "local_implicit",
+      isInstanceAdmin: true,
+    });
+
+    await request(app)
+      .patch("/api/instance/settings/experimental")
+      .send({ enableStreamlinedUi: false })
+      .expect(200);
+
+    expect(mockInstanceSettingsService.updateExperimental).toHaveBeenCalledWith({
+      enableStreamlinedUi: false,
+    });
+  });
+
   it("strips server-managed worktree run execution fields before updating experimental settings", async () => {
     const app = await createApp({
       type: "board",

--- a/server/src/__tests__/instance-settings-service.test.ts
+++ b/server/src/__tests__/instance-settings-service.test.ts
@@ -29,6 +29,7 @@ describe("instance settings service", () => {
       enableManagedSandboxOnly: false,
       enableIsolatedWorkspaces: true,
       enableStreamlinedLeftNavigation: true,
+      enableStreamlinedUi: true,
       enableApps: true,
       enableConferenceRoomChat: false,
       enableClassicTaskInterface: false,
@@ -57,6 +58,15 @@ describe("instance settings service", () => {
       worktreeRunExecutionActivatedAt: null,
       worktreeRunExecutionActivationInstanceId: null,
     });
+  });
+
+  it("defaults streamlined UI on without inheriting the retired navigation preference", () => {
+    expect(normalizeExperimentalSettings(undefined).enableStreamlinedUi).toBe(true);
+    expect(normalizeExperimentalSettings({}).enableStreamlinedUi).toBe(true);
+    expect(
+      normalizeExperimentalSettings({ enableStreamlinedLeftNavigation: false }).enableStreamlinedUi,
+    ).toBe(true);
+    expect(normalizeExperimentalSettings({ enableStreamlinedUi: false }).enableStreamlinedUi).toBe(false);
   });
 
   it("keeps Apps on for empty, legacy, and explicitly disabled stored settings", () => {

--- a/server/src/services/instance-settings.ts
+++ b/server/src/services/instance-settings.ts
@@ -224,6 +224,7 @@ export function normalizeExperimentalSettings(raw: unknown): InstanceExperimenta
       enableManagedSandboxOnly: parsed.data.enableManagedSandboxOnly ?? false,
       enableIsolatedWorkspaces: parsed.data.enableIsolatedWorkspaces ?? false,
       enableStreamlinedLeftNavigation: parsed.data.enableStreamlinedLeftNavigation ?? true,
+      enableStreamlinedUi: parsed.data.enableStreamlinedUi ?? true,
       // Apps graduated from Experimental. Ignore historical off values while
       // continuing to accept the compatibility key in stored settings.
       enableApps: true,
@@ -262,6 +263,7 @@ export function normalizeExperimentalSettings(raw: unknown): InstanceExperimenta
     enableManagedSandboxOnly: false,
     enableIsolatedWorkspaces: false,
     enableStreamlinedLeftNavigation: true,
+    enableStreamlinedUi: true,
     enableApps: true,
     enablePipelines: false,
     enableCases: false,

--- a/tests/e2e/apps-dark-mode-shots.spec.ts
+++ b/tests/e2e/apps-dark-mode-shots.spec.ts
@@ -161,7 +161,7 @@ test.describe.serial("dark-mode Apps surfaces", () => {
     await expect(page.locator('a[href$="/apps/advanced/gateways"]', { hasText: "Gateways" })).toHaveCount(0);
     await expect(page.locator('a[href$="/apps/advanced/profiles"]', { hasText: "Profiles" })).toHaveCount(0);
     await expect(page.locator('a[href$="/apps/advanced/audit"]', { hasText: "Activity" })).toHaveCount(0);
-    await expect(page.locator('a[href$="/activity"]', { hasText: "Activity" })).toBeVisible();
+    await expect(page.locator('a[href$="/activity"]', { hasText: "Audit" })).toBeVisible();
     await expect(page.getByRole("link", { name: "Applications", exact: true })).toHaveCount(0);
     // Apps section lives in the same sidebar now.
     await expect(page.locator('a[href$="/apps"]', { hasText: "Connectors" })).toBeVisible();

--- a/tests/e2e/sidebar-takeover.spec.ts
+++ b/tests/e2e/sidebar-takeover.spec.ts
@@ -88,23 +88,17 @@ test.describe("Contextual sidebar companion", () => {
     expect(labelBox!.width).toBeGreaterThan(20);
   });
 
-  test("preserves an expanded global preference across contextual navigation", async ({ page }) => {
-    await page.addInitScript(
-      ({ key }) => window.localStorage.setItem(key, "0"),
-      { key: COLLAPSED_STORAGE_KEY },
-    );
-
+  test("keeps the retired collapse control absent across contextual navigation", async ({ page }) => {
     await page.goto(`/${prefix}/company/settings`);
     await expect(page.locator('[data-contextual-sidebar="settings"]')).toBeVisible();
     await expect(page.getByRole("link", { name: "Dashboard" })).toBeVisible();
+    await expect(page.getByLabel(APP_SIDEBAR_EXPANDED_MARKER)).toHaveCount(0);
 
     await page.goto(`/${prefix}/dashboard`);
 
     await expect(page.locator("[data-contextual-sidebar]")).toHaveCount(0);
     await expect(page.getByRole("link", { name: "Dashboard" })).toBeVisible();
-    await expect(page.getByLabel(APP_SIDEBAR_EXPANDED_MARKER)).toBeVisible();
-    await expect.poll(() => page.evaluate((key) => window.localStorage.getItem(key), COLLAPSED_STORAGE_KEY))
-      .toBe("0");
+    await expect(page.getByLabel(APP_SIDEBAR_EXPANDED_MARKER)).toHaveCount(0);
   });
 
   test("uses Dashboard as the safe fallback for a direct Settings link", async ({ page }) => {

--- a/tests/e2e/sidebar-takeover.spec.ts
+++ b/tests/e2e/sidebar-takeover.spec.ts
@@ -1,12 +1,11 @@
 import { test, expect, request as pwRequest, type APIRequestContext } from "@playwright/test";
 
 /**
- * E2E: contextual sidebar replacement model.
+ * E2E: contextual sidebar companion model.
  *
- * Contextual routes render their navigation inside the one stable sidebar
- * shell. The global company navigation is absent while the contextual surface
- * is active, the account menu remains available, and leaving the surface
- * restores the user's global sidebar preference.
+ * Contextual routes render their navigation beside the stable global sidebar.
+ * The global company navigation and account menu remain available, and leaving
+ * the surface restores the user's global sidebar preference.
  *
  * Plugin route sidebars share the same Layout path. A live plugin-route test
  * requires a plugin fixture, so that branch remains covered by Layout tests.
@@ -37,7 +36,7 @@ async function createCompany(board: APIRequestContext): Promise<{ id: string; pr
   };
 }
 
-test.describe("Contextual sidebar replacement", () => {
+test.describe("Contextual sidebar companion", () => {
   let board: APIRequestContext;
   let companyId: string;
   let prefix: string;
@@ -61,7 +60,7 @@ test.describe("Contextual sidebar replacement", () => {
     }, COLLAPSED_STORAGE_KEY);
   });
 
-  test("replaces global navigation with Settings in the one sidebar shell", async ({ page }) => {
+  test("shows Settings beside the global navigation", async ({ page }) => {
     await page.goto(`/${prefix}/company/settings`);
 
     const contextual = page.locator('[data-contextual-sidebar="settings"]');
@@ -74,7 +73,7 @@ test.describe("Contextual sidebar replacement", () => {
     await expect(page.getByRole("button", { name: "Back from Settings" })).toBeVisible();
     await expect(page.getByRole("button", { name: "Open account menu" })).toBeVisible();
 
-    await expect(page.getByRole("link", { name: "Dashboard" })).toHaveCount(0);
+    await expect(page.getByRole("link", { name: "Dashboard" })).toBeVisible();
     await expect(page.getByLabel(APP_SIDEBAR_EXPANDED_MARKER)).toHaveCount(0);
   });
 
@@ -97,7 +96,7 @@ test.describe("Contextual sidebar replacement", () => {
 
     await page.goto(`/${prefix}/company/settings`);
     await expect(page.locator('[data-contextual-sidebar="settings"]')).toBeVisible();
-    await expect(page.getByRole("link", { name: "Dashboard" })).toHaveCount(0);
+    await expect(page.getByRole("link", { name: "Dashboard" })).toBeVisible();
 
     await page.goto(`/${prefix}/dashboard`);
 

--- a/tests/e2e/sidebar-takeover.spec.ts
+++ b/tests/e2e/sidebar-takeover.spec.ts
@@ -1,37 +1,21 @@
 import { test, expect, request as pwRequest, type APIRequestContext } from "@playwright/test";
 
 /**
- * E2E: Sidebar takeover model (PAP-10695).
+ * E2E: contextual sidebar replacement model.
  *
- * Takeover routes (company settings, plugin `routeSidebar`) no longer *replace*
- * the main app sidebar. Instead the host collapses the app `<Sidebar/>` to its
- * 64px rail (still peek-able) and renders the contextual sidebar in a second
- * pane → `[ app rail ][ secondary ~240px ][ content ]`.
+ * Contextual routes render their navigation inside the one stable sidebar
+ * shell. The global company navigation is absent while the contextual surface
+ * is active, the account menu remains available, and leaving the surface
+ * restores the user's global sidebar preference.
  *
- * These specs assert the rail + secondary pane coexist on a company settings
- * route, and that an explicit user pin (expanded) wins over the route-driven
- * collapse (pin precedence).
- *
- * The plugin `routeSidebar` half of this behavior shares the exact same Layout
- * code path (one `secondarySidebar`/`hasSecondarySidebar` resolver drives both
- * company-settings and plugin routes) and is covered by the unit tests in
- * `ui/src/components/Layout.test.tsx`. A live plugin-route e2e requires the
- * `plugin-llm-wiki` plugin to be installed in the throwaway e2e instance, which
- * is out of scope for this default local_trusted run; visual QA of both panes
- * is delegated to the QA child issue.
+ * Plugin route sidebars share the same Layout path. A live plugin-route test
+ * requires a plugin fixture, so that branch remains covered by Layout tests.
  */
 
 const PORT = Number(process.env.PAPERCLIP_E2E_PORT ?? 3199);
 const BASE_URL = `http://127.0.0.1:${PORT}`;
 const COMPANY_NAME_PREFIX = "E2E-SidebarTakeover";
 const COLLAPSED_STORAGE_KEY = "paperclip.sidebar.collapsed";
-
-// The sidebar header's "Collapse sidebar" toggle only renders when the app
-// sidebar is expanded (pinned, desktop, not takeover-locked); in the collapsed
-// rail and on takeover routes it is hidden. Its presence/absence is therefore
-// a stable proxy for the app sidebar's collapsed state (see Sidebar.tsx).
-// (Previously "Open search", but the header search icon moved into the nav,
-// where it renders in the rail too.)
 const APP_SIDEBAR_EXPANDED_MARKER = "Collapse sidebar";
 
 async function createCompany(board: APIRequestContext): Promise<{ id: string; prefix: string }> {
@@ -53,7 +37,7 @@ async function createCompany(board: APIRequestContext): Promise<{ id: string; pr
   };
 }
 
-test.describe("Sidebar takeover (collapse + secondary pane)", () => {
+test.describe("Contextual sidebar replacement", () => {
   let board: APIRequestContext;
   let companyId: string;
   let prefix: string;
@@ -71,93 +55,65 @@ test.describe("Sidebar takeover (collapse + secondary pane)", () => {
   });
 
   test.beforeEach(async ({ page }) => {
-    // Start each test from a clean (unpinned) sidebar state so the route-driven
-    // collapse is the only thing acting on it.
     await page.addInitScript((key) => {
       window.localStorage.removeItem(key);
+      window.sessionStorage.clear();
     }, COLLAPSED_STORAGE_KEY);
   });
 
-  test("collapses the app sidebar to its rail and shows the settings sidebar beside it", async ({ page }) => {
+  test("replaces global navigation with Settings in the one sidebar shell", async ({ page }) => {
     await page.goto(`/${prefix}/company/settings`);
 
-    // The contextual (secondary) pane is present...
-    const secondary = page.locator("[data-secondary-sidebar]");
-    await expect(secondary).toBeVisible();
-    await expect(secondary).toHaveCount(1);
+    const contextual = page.locator('[data-contextual-sidebar="settings"]');
+    await expect(contextual).toBeVisible();
+    await expect(contextual).toHaveCount(1);
+    await expect(page.locator("[data-secondary-sidebar]")).toHaveCount(1);
 
-    // ...and it is ~240px wide (w-60), distinct from the 64px app rail.
-    const secondaryBox = await secondary.boundingBox();
-    expect(secondaryBox).not.toBeNull();
-    expect(secondaryBox!.width).toBeGreaterThan(180);
+    await expect(contextual.getByRole("link", { name: "General" })).toBeVisible();
+    await expect(contextual.getByText("Environments", { exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Back from Settings" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Open account menu" })).toBeVisible();
 
-    // The app sidebar is NOT replaced — its company nav still renders...
-    await expect(page.getByRole("link", { name: "Dashboard" })).toBeVisible();
-
-    // ...but it is collapsed to its rail: the expanded-only "Open search"
-    // header control is hidden.
+    await expect(page.getByRole("link", { name: "Dashboard" })).toHaveCount(0);
     await expect(page.getByLabel(APP_SIDEBAR_EXPANDED_MARKER)).toHaveCount(0);
   });
 
-  test("renders the secondary pane nav labels at full width despite the app rail collapse", async ({ page }) => {
-    // Regression (PAP-10700): the secondary pane is 240px wide, but its
-    // SidebarNavItem children read the *global* collapsed state and used to
-    // render icon-only (label `w-0 text-transparent`), making the settings nav
-    // unreadable in the default takeover state. The pane must force full labels.
+  test("renders contextual labels at full width", async ({ page }) => {
     await page.goto(`/${prefix}/company/settings`);
 
-    const secondary = page.locator("[data-secondary-sidebar]");
-    await expect(secondary).toBeVisible();
-
-    // App sidebar is collapsed to its rail (default unpinned takeover state)...
-    await expect(page.getByLabel(APP_SIDEBAR_EXPANDED_MARKER)).toHaveCount(0);
-
-    // ...yet a settings nav label renders at its full text width, not clipped to
-    // zero. "Environments" is unique to the company-settings nav.
-    const envLabel = secondary.getByText("Environments", { exact: true });
+    const contextual = page.locator('[data-contextual-sidebar="settings"]');
+    const envLabel = contextual.getByText("Environments", { exact: true });
     await expect(envLabel).toBeVisible();
     const labelBox = await envLabel.boundingBox();
     expect(labelBox).not.toBeNull();
     expect(labelBox!.width).toBeGreaterThan(20);
   });
 
-  test("settings force-collapse overrides an expanded pin without mutating it", async ({ page }) => {
-    // User has pinned the sidebar expanded ("0"). Company settings is a hard
-    // secondary-sidebar takeover route, so forceCollapsed wins while the route is
-    // active (force > pin > route request > default) but must not mutate the pin.
+  test("preserves an expanded global preference across contextual navigation", async ({ page }) => {
     await page.addInitScript(
-      ({ key }) => {
-        window.localStorage.setItem(key, "0");
-      },
+      ({ key }) => window.localStorage.setItem(key, "0"),
       { key: COLLAPSED_STORAGE_KEY },
     );
 
     await page.goto(`/${prefix}/company/settings`);
-
-    // Secondary pane still shows on the takeover route.
-    await expect(page.locator("[data-secondary-sidebar]")).toBeVisible();
-
-    // The app sidebar is hard-collapsed despite the stored expanded pin.
-    await expect(page.getByLabel(APP_SIDEBAR_EXPANDED_MARKER)).toHaveCount(0);
+    await expect(page.locator('[data-contextual-sidebar="settings"]')).toBeVisible();
+    await expect(page.getByRole("link", { name: "Dashboard" })).toHaveCount(0);
 
     await page.goto(`/${prefix}/dashboard`);
 
-    // Leaving the takeover route clears the force and restores the user's
-    // persisted expanded pin.
-    await expect(page.locator("[data-secondary-sidebar]")).toHaveCount(0);
+    await expect(page.locator("[data-contextual-sidebar]")).toHaveCount(0);
+    await expect(page.getByRole("link", { name: "Dashboard" })).toBeVisible();
     await expect(page.getByLabel(APP_SIDEBAR_EXPANDED_MARKER)).toBeVisible();
+    await expect.poll(() => page.evaluate((key) => window.localStorage.getItem(key), COLLAPSED_STORAGE_KEY))
+      .toBe("0");
   });
 
-  test("leaving the takeover route removes the secondary pane and restores the sidebar", async ({ page }) => {
+  test("uses Dashboard as the safe fallback for a direct Settings link", async ({ page }) => {
     await page.goto(`/${prefix}/company/settings`);
-    await expect(page.locator("[data-secondary-sidebar]")).toBeVisible();
-    await expect(page.getByLabel(APP_SIDEBAR_EXPANDED_MARKER)).toHaveCount(0);
+    await page.getByRole("button", { name: "Back from Settings" }).click();
 
-    // Navigate to a plain (non-takeover) route.
-    await page.goto(`/${prefix}/dashboard`);
-
-    // No secondary pane, and the app sidebar is no longer force-collapsed.
-    await expect(page.locator("[data-secondary-sidebar]")).toHaveCount(0);
-    await expect(page.getByLabel(APP_SIDEBAR_EXPANDED_MARKER)).toBeVisible();
+    await expect(page).toHaveURL(new RegExp(`/${prefix}/dashboard$`));
+    await expect(page.locator("[data-contextual-sidebar]")).toHaveCount(0);
+    await expect(page.getByRole("link", { name: "Dashboard" })).toBeVisible();
   });
 });

--- a/ui/src/App.activity-routing.test.tsx
+++ b/ui/src/App.activity-routing.test.tsx
@@ -69,6 +69,13 @@ vi.mock("./pages/audit/CompanyActivity", () => ({
   },
 }));
 
+vi.mock("./pages/audit/AuditHub", () => ({
+  AuditHub: ({ section }: { section: string }) => {
+    const location = useLocation();
+    return <div>{`AUDIT_${section.toUpperCase()}@${location.pathname}${location.search}`}</div>;
+  },
+}));
+
 vi.mock("./pages/Issues", () => ({
   Issues: () => {
     const location = useLocation();
@@ -149,6 +156,18 @@ describe("App Activity routing (PAP-16302)", () => {
     const root = renderAppAt(container, "/PAP/activity");
     await waitForRoute(container, "ACTIVITY_PAGE@/PAP/activity");
     expect(container.textContent).not.toContain("No organization matches prefix");
+    flushSync(() => root.unmount());
+  });
+
+  it("serves organization and entity-scoped run history beneath Activity", async () => {
+    const root = renderAppAt(
+      container,
+      "/PAP/activity/runs?entityType=routine&entityId=routine-1",
+    );
+    await waitForRoute(
+      container,
+      "AUDIT_RUNS@/PAP/activity/runs?entityType=routine&entityId=routine-1",
+    );
     flushSync(() => root.unmount());
   });
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -50,6 +50,7 @@ import { Approvals } from "./pages/Approvals";
 import { ApprovalDetail } from "./pages/ApprovalDetail";
 import { Costs } from "./pages/Costs";
 import { CompanyActivity } from "./pages/audit/CompanyActivity";
+import { AuditHub } from "./pages/audit/AuditHub";
 import { Inbox } from "./pages/Inbox";
 import { WhatNeedsMe } from "./pages/WhatNeedsMe";
 import { DecisionQueuePage } from "./pages/DecisionQueuePage";
@@ -325,6 +326,10 @@ function boardRoutes() {
       <Route path="approvals/:approvalId" element={<ApprovalDetail />} />
       <Route path="costs" element={<Costs />} />
       <Route path="activity" element={<CompanyActivity />} />
+      <Route path="activity/runs" element={<AuditHub section="runs" />} />
+      <Route path="activity/costs" element={<AuditHub section="costs" />} />
+      <Route path="activity/budgets" element={<AuditHub section="budgets" />} />
+      <Route path="activity/timeline" element={<AuditHub section="timeline" />} />
       {/* `/audit` merged into the single Activity page (PAP-16302). Existing deep
           links keep working, preset to the agent-actions scope. */}
       <Route path="audit" element={<Navigate to="/activity?mode=agents" replace />} />

--- a/ui/src/components/AgentContextualSidebar.test.tsx
+++ b/ui/src/components/AgentContextualSidebar.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import { AgentContextualSidebar } from "./AgentContextualSidebar";
+
+vi.mock("@/context/CompanyContext", () => ({
+  useCompany: () => ({ selectedCompanyId: "company-1" }),
+}));
+
+vi.mock("./ContextualSidebarFrame", () => ({
+  ContextualSidebarFrame: ({
+    title,
+    showHeader,
+    className,
+    children,
+  }: {
+    title: string;
+    showHeader?: boolean;
+    className?: string;
+    children: React.ReactNode;
+  }) => (
+    <aside data-title={title} data-show-header={String(showHeader)} className={className}>
+      {children}
+    </aside>
+  ),
+}));
+
+vi.mock("./SidebarNavItem", () => ({
+  SidebarNavItem: ({ to, label }: { to: string; label: string }) => <a href={to}>{label}</a>,
+}));
+
+describe("AgentContextualSidebar", () => {
+  it("renders local definition/runtime/governance links and scoped Audit links", () => {
+    const queryClient = new QueryClient();
+    const markup = renderToStaticMarkup(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={["/agents/codexcoder/runtime"]}>
+          <AgentContextualSidebar agentRef="codexcoder" agentId="agent-1" agentName="Codex Coder" />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(markup).toContain("Codex Coder");
+    expect(markup).toContain('data-show-header="false"');
+    expect(markup).toContain("border-r border-border bg-background");
+    expect(markup).toContain('data-slot="contextual-sidebar-nav"');
+    expect(markup).toContain('href="/agents/codexcoder/overview"');
+    expect(markup).toContain('href="/agents/codexcoder/permissions"');
+    expect(markup).toContain('href="/agents/codexcoder/api-keys"');
+    expect(markup).toContain('href="/activity?mode=agents&amp;agentId=agent-1"');
+    expect(markup).toContain('href="/activity/runs?agentId=agent-1"');
+    expect(markup).toContain("Harness / Runtime");
+    expect(markup).toContain("Permissions / Trust");
+  });
+});

--- a/ui/src/components/AgentContextualSidebar.tsx
+++ b/ui/src/components/AgentContextualSidebar.tsx
@@ -1,0 +1,131 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  Activity,
+  BadgeDollarSign,
+  BookOpenText,
+  History,
+  KeyRound,
+  Library,
+  PlayCircle,
+  ReceiptText,
+  Settings2,
+  ShieldCheck,
+  Sparkles,
+  Wrench,
+} from "lucide-react";
+import { agentsApi } from "@/api/agents";
+import { useCompany } from "@/context/CompanyContext";
+import { queryKeys } from "@/lib/queryKeys";
+import { ContextualSidebarFrame } from "./ContextualSidebarFrame";
+import { SidebarNavItem } from "./SidebarNavItem";
+import { contextualSidebarStyles } from "./contextual-sidebar-styles";
+import {
+  AGENT_DETAIL_NAVIGATION,
+  agentDetailHref,
+  agentScopedAuditHref,
+  type AgentLocalDetailView,
+} from "@/pages/agent-detail-navigation";
+
+const localIcons = {
+  overview: Sparkles,
+  instructions: BookOpenText,
+  skills: Library,
+  runtime: Settings2,
+  secrets: ShieldCheck,
+  tools: Wrench,
+  permissions: ShieldCheck,
+  "api-keys": KeyRound,
+  revisions: History,
+} satisfies Record<AgentLocalDetailView, typeof Sparkles>;
+
+const auditItems = [
+  { section: "activity", label: "Activity", icon: Activity },
+  { section: "runs", label: "Runs", icon: PlayCircle },
+  { section: "costs", label: "Costs", icon: ReceiptText },
+  { section: "budgets", label: "Budgets", icon: BadgeDollarSign },
+] as const;
+
+export function AgentContextualSidebar({
+  agentRef,
+  agentId,
+  agentName,
+}: {
+  agentRef: string;
+  agentId?: string;
+  agentName?: string;
+}) {
+  const { selectedCompanyId } = useCompany();
+  const shouldResolveAgent = !agentId || !agentName;
+  const { data: resolvedAgent } = useQuery({
+    queryKey: [...queryKeys.agents.detail(agentRef), selectedCompanyId ?? null, "contextual-sidebar"],
+    queryFn: () => agentsApi.get(agentRef, selectedCompanyId ?? undefined),
+    enabled: shouldResolveAgent && Boolean(agentRef && selectedCompanyId),
+  });
+  const resolvedId = agentId ?? resolvedAgent?.id;
+  const resolvedName = agentName ?? resolvedAgent?.name ?? "Agent";
+
+  return (
+    <ContextualSidebarFrame
+      surface="agent"
+      title={resolvedName}
+      fallbackTo="/agents/all"
+      showHeader={false}
+      className="border-r border-border bg-background"
+    >
+      <nav
+        aria-label={`${resolvedName} navigation`}
+        data-slot="contextual-sidebar-nav"
+        className={contextualSidebarStyles.nav}
+      >
+        {AGENT_DETAIL_NAVIGATION.map((section) => (
+          <div
+            key={section.label}
+            data-slot="contextual-sidebar-section"
+            className={contextualSidebarStyles.section}
+          >
+            <p
+              data-slot="contextual-sidebar-section-label"
+              className={contextualSidebarStyles.sectionLabel}
+            >
+              {section.label}
+            </p>
+            <div data-slot="contextual-sidebar-group" className={contextualSidebarStyles.group}>
+              {section.items.map((item) => {
+                const href = agentDetailHref(agentRef, item.value);
+                return (
+                  <SidebarNavItem
+                    key={item.value}
+                    to={href}
+                    label={item.label}
+                    icon={localIcons[item.value]}
+                  />
+                );
+              })}
+            </div>
+          </div>
+        ))}
+
+        <div data-slot="contextual-sidebar-section" className={contextualSidebarStyles.section}>
+          <p
+            data-slot="contextual-sidebar-section-label"
+            className={contextualSidebarStyles.sectionLabel}
+          >
+            Audit
+          </p>
+          <div data-slot="contextual-sidebar-group" className={contextualSidebarStyles.group}>
+            {resolvedId ? auditItems.map((item) => (
+              <SidebarNavItem
+                key={item.section}
+                to={agentScopedAuditHref(resolvedId, item.section)}
+                label={item.label}
+                icon={item.icon}
+              />
+            )) : (
+              <p className="px-2 py-1.5 text-xs text-muted-foreground">Loading audit links…</p>
+            )}
+          </div>
+        </div>
+      </nav>
+    </ContextualSidebarFrame>
+  );
+}

--- a/ui/src/components/AppConnectionSidebar.production.tsx
+++ b/ui/src/components/AppConnectionSidebar.production.tsx
@@ -1,0 +1,154 @@
+import { ChevronLeft } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import { humanizeConnectionDisplayName } from "@paperclipai/shared";
+import type { ToolApplication, ToolConnection } from "@paperclipai/shared";
+import { Link } from "@/lib/router";
+import { toolsApi } from "@/api/tools";
+import { useCompany } from "@/context/CompanyContext";
+import { useSidebar } from "@/context/SidebarContext";
+import { queryKeys } from "@/lib/queryKeys";
+import {
+  APP_TABS,
+  CONNECTED_ONLY_APP_TABS,
+  appApplicationTabHref,
+  appTabHref,
+  type AppTabKey,
+} from "@/pages/apps/app-tabs";
+import { AppLogo } from "@/pages/apps/AppLogo";
+import {
+  appDefinitionLogoUrl,
+  appDefinitionName,
+  appDefinitionSlug,
+  type AppGalleryDisplayEntry,
+} from "@/pages/apps/app-definition-display";
+import { SidebarNavItem } from "./SidebarNavItem.production";
+
+type AppDetailSidebarProps =
+  | { kind: "connection"; connectionId: string }
+  | { kind: "application"; applicationId: string };
+
+export function AppDetailSidebar(props: AppDetailSidebarProps) {
+  const { selectedCompanyId } = useCompany();
+  const { isMobile, setSidebarOpen } = useSidebar();
+
+  const connectionQuery = useQuery({
+    queryKey: queryKeys.tools.connection(props.kind === "connection" ? props.connectionId : "__none__"),
+    queryFn: () => toolsApi.getConnection(props.kind === "connection" ? props.connectionId : ""),
+    enabled: props.kind === "connection" && !!props.connectionId,
+  });
+  const applicationsQuery = useQuery({
+    queryKey: queryKeys.tools.applications(selectedCompanyId ?? "__none__"),
+    queryFn: () => toolsApi.listApplications(selectedCompanyId!),
+    enabled: props.kind === "application" && !!selectedCompanyId,
+  });
+  const connectionsQuery = useQuery({
+    queryKey: queryKeys.tools.connections(selectedCompanyId ?? "__none__"),
+    queryFn: () => toolsApi.listConnections(selectedCompanyId!),
+    enabled: props.kind === "application" && !!selectedCompanyId,
+  });
+  const galleryQuery = useQuery({
+    queryKey: queryKeys.apps.gallery(selectedCompanyId ?? "__none__"),
+    queryFn: () => toolsApi.listGallery(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+  });
+  const attentionQuery = useQuery({
+    queryKey: queryKeys.apps.attention(selectedCompanyId ?? "__none__"),
+    queryFn: () => toolsApi.listAppsAttention(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+    refetchInterval: 30_000,
+  });
+
+  const connection = connectionQuery.data;
+  const application = props.kind === "application"
+    ? (applicationsQuery.data?.applications ?? []).find((app) => app.id === props.applicationId)
+    : null;
+  const appConnections = props.kind === "application"
+    ? (connectionsQuery.data?.connections ?? []).filter((candidate) => candidate.applicationId === props.applicationId)
+    : [];
+  const previousConnection = latestArchivedConnection(appConnections);
+  const appName = connection ? humanizeConnectionDisplayName(connection) : application?.name ?? "App";
+  const logoEntry = galleryEntryFor(
+    (galleryQuery.data?.apps ?? []) as AppGalleryDisplayEntry[],
+    connection,
+    application ?? undefined,
+  );
+  const reviewConnectionId = connection?.id ?? previousConnection?.id ?? null;
+  const attentionItem = reviewConnectionId
+    ? attentionQuery.data?.apps.find((app) => app.connection.id === reviewConnectionId)
+    : null;
+  const reviewCount =
+    (attentionItem?.pendingActionRequestCount ?? 0) +
+    ((attentionItem?.quarantinedCatalogEntryCount ?? 0) > 0 ? 1 : 0);
+
+  return (
+    <aside className="flex h-full min-h-0 w-full flex-col border-r border-border bg-background">
+      <div className="flex shrink-0 flex-col gap-3 px-3 py-3">
+        <Link
+          to="/apps/connections"
+          onClick={() => {
+            if (isMobile) setSidebarOpen(false);
+          }}
+          className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+        >
+          <ChevronLeft className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate">All apps</span>
+        </Link>
+        <div className="flex min-w-0 items-center gap-2 px-2 py-1">
+          <AppLogo name={appName} logoUrl={appDefinitionLogoUrl(logoEntry)} size={28} />
+          <span className="flex-1 truncate text-sm font-bold text-foreground">{appName}</span>
+        </div>
+      </div>
+
+      <nav className="scrollbar-auto-hide min-h-0 flex-1 overflow-y-auto px-3 py-2">
+        <div className="flex flex-col gap-0.5">
+          {APP_TABS.filter(
+            (tab) => props.kind === "connection" || !CONNECTED_ONLY_APP_TABS.has(tab.key),
+          ).map((tab) => (
+            <SidebarNavItem
+              key={tab.key}
+              to={tabHref(props, tab.key)}
+              label={tab.label}
+              icon={tab.icon}
+              end
+              badge={tab.key === "review" && reviewCount > 0 ? reviewCount : undefined}
+              badgeTone="danger"
+              badgeLabel="needing review"
+            />
+          ))}
+        </div>
+      </nav>
+    </aside>
+  );
+}
+
+function tabHref(props: AppDetailSidebarProps, tab: AppTabKey): string {
+  return props.kind === "connection"
+    ? appTabHref(props.connectionId, tab)
+    : appApplicationTabHref(props.applicationId, tab);
+}
+
+function galleryEntryFor(
+  apps: AppGalleryDisplayEntry[],
+  connection: ToolConnection | undefined,
+  application: ToolApplication | undefined,
+): AppGalleryDisplayEntry | null {
+  if (application?.applicationKey) {
+    const keyed = apps.find((app) => appDefinitionSlug(app) === application.applicationKey);
+    if (keyed) return keyed;
+  }
+  const name = (connection?.name ?? application?.name)?.toLowerCase();
+  if (!name) return null;
+  return apps.find((app) => appDefinitionName(app).toLowerCase() === name) ??
+    apps.find((app) => appDefinitionSlug(app) === name) ??
+    null;
+}
+
+function latestArchivedConnection(connections: ToolConnection[]): ToolConnection | null {
+  const archived = connections.filter((connection) => connection.status === "archived");
+  if (archived.length === 0) return null;
+  return archived.reduce((latest, connection) => {
+    const latestTime = new Date(latest.updatedAt ?? latest.createdAt ?? 0).getTime();
+    const connectionTime = new Date(connection.updatedAt ?? connection.createdAt ?? 0).getTime();
+    return connectionTime > latestTime ? connection : latest;
+  });
+}

--- a/ui/src/components/AppsSidebar.production.tsx
+++ b/ui/src/components/AppsSidebar.production.tsx
@@ -1,0 +1,92 @@
+import { ChevronLeft, AppWindow, Store, ShieldQuestion } from "lucide-react";
+import { Link } from "@/lib/router";
+import { useCompany } from "@/context/CompanyContext";
+import { useSidebar } from "@/context/SidebarContext";
+import { DEVELOPER_TABS, advancedTabHref, isExperimentalToolTab } from "@/pages/tools/tool-tabs";
+import { useSmokeLabEnabled } from "@/hooks/useSmokeLabEnabled";
+import { useReviewCount } from "@/pages/apps/useReviewCount";
+import { SidebarNavItem } from "./SidebarNavItem.production";
+
+/**
+ * Secondary sidebar for the prosumer Apps area (PAP-10856; three-door IA
+ * PAP-13254 / U3).
+ *
+ *   ← Back · APPS: Browse / Review (n)
+ *   DEVELOPER: Connections / Gateways / Profiles / Rules / Health / Activity
+ *
+ * "Browse" is the store and "Review" holds decisions waiting on the user's
+ * OK. Connection management lives with the Developer tools.
+ * "Needs attention" is no longer a door: health/error triage folds into
+ * Connections as a status filter + banner, so approvals are never buried
+ * behind an error label. The Developer section was folded in from the retired
+ * ToolsSidebar (PAP-10915) so the whole Apps area shares one sidebar; a
+ * one-line caption frames who it's for (Finding A). "Run your own" and "Paste a
+ * config" moved out of the sidebar into rows on the Connect-an-app page
+ * (PAP-10922).
+ */
+export function AppsSidebar() {
+  const { selectedCompany } = useCompany();
+  const { isMobile, setSidebarOpen } = useSidebar();
+
+  const reviewCount = useReviewCount();
+  const { enabled: smokeLabEnabled } = useSmokeLabEnabled();
+  const developerTabs = DEVELOPER_TABS.filter(
+    (tab) => !isExperimentalToolTab(tab.key) || smokeLabEnabled,
+  );
+
+  return (
+    <aside className="w-full h-full min-h-0 border-r border-border bg-background flex flex-col">
+      <div className="flex flex-col gap-1 px-3 py-3 shrink-0">
+        <Link
+          to="/dashboard"
+          onClick={() => {
+            if (isMobile) setSidebarOpen(false);
+          }}
+          className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+        >
+          <ChevronLeft className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate">{selectedCompany?.name ?? "Company"}</span>
+        </Link>
+        <div className="flex items-center gap-2 px-2 py-1">
+          <AppWindow className="h-4 w-4 text-muted-foreground shrink-0" />
+          <span className="flex-1 truncate text-sm font-bold text-foreground">Apps</span>
+        </div>
+      </div>
+
+      <nav className="flex-1 min-h-0 overflow-y-auto scrollbar-auto-hide px-3 py-2">
+        <div className="px-3 pb-1 text-(length:--text-micro) font-semibold uppercase tracking-wide text-muted-foreground">
+          Apps
+        </div>
+        <div className="flex flex-col gap-0.5">
+          <SidebarNavItem to="/apps" label="Browse" icon={Store} end />
+          <SidebarNavItem
+            to="/apps/review"
+            label="Review"
+            icon={ShieldQuestion}
+            badge={reviewCount > 0 ? reviewCount : undefined}
+            badgeTone="warning"
+            badgeLabel="waiting for your OK"
+          />
+        </div>
+        <div className="px-3 pb-1 pt-4 text-(length:--text-micro) font-semibold uppercase tracking-wide text-muted-foreground">
+          Developer
+        </div>
+        <p className="px-3 pb-1.5 text-(length:--text-micro) leading-snug text-muted-foreground/70">
+          Advanced setup for developers. Most teams never open this.
+        </p>
+        <div className="flex flex-col gap-0.5">
+          <SidebarNavItem to="/apps/connections" label="Connections" icon={AppWindow} end />
+          {developerTabs.map((tab) => (
+            <SidebarNavItem
+              key={tab.key}
+              to={advancedTabHref(tab.key)}
+              label={tab.label}
+              icon={tab.icon}
+              end
+            />
+          ))}
+        </div>
+      </nav>
+    </aside>
+  );
+}

--- a/ui/src/components/AppsSidebar.test.tsx
+++ b/ui/src/components/AppsSidebar.test.tsx
@@ -5,6 +5,7 @@ import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AppsSidebar } from "./AppsSidebar";
+import { contextualSidebarStyles } from "./contextual-sidebar-styles";
 
 const sidebarNavItemMock = vi.hoisted(() => vi.fn());
 const mockToolsApi = vi.hoisted(() => ({
@@ -97,7 +98,7 @@ describe("AppsSidebar", () => {
     vi.clearAllMocks();
   });
 
-  it("renders the consolidated connector and review doors without retired developer links", async () => {
+  it("renders the consolidated connector and review doors without a redundant contextual heading", async () => {
     const root = createRoot(container);
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
@@ -112,7 +113,7 @@ describe("AppsSidebar", () => {
     });
     await flushReact();
 
-    expect(container.textContent).toContain("Apps");
+    expect(container.textContent).not.toContain("Apps");
     expect(container.textContent).not.toContain("Developer");
     expect(container.textContent).not.toContain("Advanced setup for developers");
     expect(container.textContent).not.toContain("Most teams");
@@ -152,6 +153,14 @@ describe("AppsSidebar", () => {
     expect(sidebarNavItemMock).not.toHaveBeenCalledWith(
       expect.objectContaining({ to: "/apps/advanced/audit" }),
     );
+    expect(container.querySelector('[data-slot="contextual-sidebar-nav"]')?.className).toBe(
+      contextualSidebarStyles.nav,
+    );
+    expect(
+      Array.from(container.querySelectorAll('[data-slot="contextual-sidebar-group"]')).every(
+        (group) => group.className === contextualSidebarStyles.group,
+      ),
+    ).toBe(true);
 
     await act(async () => {
       root.unmount();

--- a/ui/src/components/AppsSidebar.tsx
+++ b/ui/src/components/AppsSidebar.tsx
@@ -1,25 +1,18 @@
-import { ChevronLeft, AppWindow, Store, ShieldQuestion } from "lucide-react";
-import { Link } from "@/lib/router";
-import { useCompany } from "@/context/CompanyContext";
-import { useSidebar } from "@/context/SidebarContext";
+import { Store, ShieldQuestion } from "lucide-react";
 import { DEVELOPER_TABS, advancedTabHref, isExperimentalToolTab } from "@/pages/tools/tool-tabs";
 import { useSmokeLabEnabled } from "@/hooks/useSmokeLabEnabled";
 import { useReviewCount } from "@/pages/apps/useReviewCount";
 import { SidebarNavItem } from "./SidebarNavItem";
+import { contextualSidebarStyles } from "./contextual-sidebar-styles";
 
 /**
  * Secondary sidebar for the Apps area.
  *
- *   ← Back · APPS: Connectors / Review (n)
- *
- * The landing page combines connector discovery, account management, and
- * connection health. Review keeps governed actions waiting on the user's OK.
- * Advanced developer surfaces remain hidden unless one is explicitly enabled.
+ * Connectors combines discovery, account management, and connection health.
+ * Review keeps governed actions waiting on the user's approval. Advanced
+ * developer surfaces remain hidden unless one is explicitly enabled.
  */
 export function AppsSidebar() {
-  const { selectedCompany } = useCompany();
-  const { isMobile, setSidebarOpen } = useSidebar();
-
   const reviewCount = useReviewCount();
   const { enabled: smokeLabEnabled } = useSmokeLabEnabled();
   const developerTabs = DEVELOPER_TABS.filter((tab) => {
@@ -31,28 +24,12 @@ export function AppsSidebar() {
 
   return (
     <aside className="w-full h-full min-h-0 border-r border-border bg-background flex flex-col">
-      <div className="flex flex-col gap-1 px-3 py-3 shrink-0">
-        <Link
-          to="/dashboard"
-          onClick={() => {
-            if (isMobile) setSidebarOpen(false);
-          }}
-          className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
-        >
-          <ChevronLeft className="h-3.5 w-3.5 shrink-0" />
-          <span className="truncate">{selectedCompany?.name ?? "Organization"}</span>
-        </Link>
-        <div className="flex items-center gap-2 px-2 py-1">
-          <AppWindow className="h-4 w-4 text-muted-foreground shrink-0" />
-          <span className="flex-1 truncate text-sm font-bold text-foreground">Apps</span>
-        </div>
-      </div>
-
-      <nav className="flex-1 min-h-0 overflow-y-auto scrollbar-auto-hide px-3 py-2">
-        <div className="px-3 pb-1 text-(length:--text-micro) font-semibold uppercase tracking-wide text-muted-foreground">
-          Apps
-        </div>
-        <div className="flex flex-col gap-0.5">
+      <nav
+        aria-label="Apps"
+        data-slot="contextual-sidebar-nav"
+        className={contextualSidebarStyles.nav}
+      >
+        <div data-slot="contextual-sidebar-group" className={contextualSidebarStyles.group}>
           <SidebarNavItem to="/apps" label="Connectors" icon={Store} end />
           <SidebarNavItem
             to="/apps/review"
@@ -64,14 +41,20 @@ export function AppsSidebar() {
           />
         </div>
         {developerTabs.length > 0 ? (
-          <>
-            <div className="px-3 pb-1 pt-4 text-(length:--text-micro) font-semibold uppercase tracking-wide text-muted-foreground">
+          <div data-slot="contextual-sidebar-section" className={contextualSidebarStyles.section}>
+            <div
+              data-slot="contextual-sidebar-section-label"
+              className={contextualSidebarStyles.sectionLabel}
+            >
               Developer
             </div>
-            <p className="px-3 pb-1.5 text-(length:--text-micro) leading-snug text-muted-foreground/70">
+            <p
+              data-slot="contextual-sidebar-section-description"
+              className={contextualSidebarStyles.sectionDescription}
+            >
               Advanced setup for developers.
             </p>
-            <div className="flex flex-col gap-0.5">
+            <div data-slot="contextual-sidebar-group" className={contextualSidebarStyles.group}>
               {developerTabs.map((tab) => (
                 <SidebarNavItem
                   key={tab.key}
@@ -82,7 +65,7 @@ export function AppsSidebar() {
                 />
               ))}
             </div>
-          </>
+          </div>
         ) : null}
       </nav>
     </aside>

--- a/ui/src/components/BreadcrumbBar.production.tsx
+++ b/ui/src/components/BreadcrumbBar.production.tsx
@@ -1,0 +1,160 @@
+import { Link } from "@/lib/router";
+import { Menu } from "lucide-react";
+import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { useSidebar } from "../context/SidebarContext";
+import { useCompany } from "../context/CompanyContext";
+import { Button } from "@/components/ui/button";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { Fragment, useMemo } from "react";
+import { PluginSlotOutlet, usePluginSlots } from "@/plugins/slots";
+import { PluginLauncherOutlet, usePluginLaunchers } from "@/plugins/launchers";
+
+type GlobalToolbarContext = { companyId: string | null; companyPrefix: string | null };
+
+/** Task identifier rendered in gray monospace between the glyph and the title. */
+function CrumbIdentifier({ identifier }: { identifier?: string }) {
+  if (!identifier) return null;
+  return <span className="shrink-0 font-mono text-muted-foreground">{identifier}</span>;
+}
+
+function GlobalToolbar({ context }: { context: GlobalToolbarContext }) {
+  const { slots } = usePluginSlots({ slotTypes: ["globalToolbarButton"], companyId: context.companyId });
+  const { launchers } = usePluginLaunchers({ placementZones: ["globalToolbarButton"], companyId: context.companyId, enabled: !!context.companyId });
+  return (
+    <div className="ml-auto flex shrink-0 items-center gap-1 pl-2 empty:hidden">
+      {slots.length > 0 ? (
+        <PluginSlotOutlet slotTypes={["globalToolbarButton"]} context={context} className="flex items-center gap-1" />
+      ) : null}
+      {launchers.length > 0 ? (
+        <PluginLauncherOutlet placementZones={["globalToolbarButton"]} context={context} className="flex items-center gap-1" />
+      ) : null}
+    </div>
+  );
+}
+
+export function BreadcrumbBar() {
+  const { breadcrumbs, mobileToolbar } = useBreadcrumbs();
+  const { toggleSidebar, isMobile } = useSidebar();
+  const { selectedCompanyId, selectedCompany } = useCompany();
+
+  const globalToolbarSlotContext = useMemo(
+    () => ({
+      companyId: selectedCompanyId ?? null,
+      companyPrefix: selectedCompany?.issuePrefix ?? null,
+    }),
+    [selectedCompanyId, selectedCompany?.issuePrefix],
+  );
+
+  const globalToolbarSlots = <GlobalToolbar context={globalToolbarSlotContext} />;
+
+  if (isMobile && mobileToolbar) {
+    return (
+      <div className="border-b border-border px-2 h-12 shrink-0 flex items-center">
+        {mobileToolbar}
+      </div>
+    );
+  }
+
+  if (breadcrumbs.length === 0) {
+    return (
+      <div className="border-b border-border px-4 md:px-6 h-12 shrink-0 flex items-center justify-end">
+        {globalToolbarSlots}
+      </div>
+    );
+  }
+
+  const menuButton = isMobile && (
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      className="mr-2 shrink-0"
+      onClick={toggleSidebar}
+      aria-label="Open sidebar"
+    >
+      <Menu className="h-5 w-5" />
+    </Button>
+  );
+
+  // Single breadcrumb = page title (uppercase)
+  if (breadcrumbs.length === 1) {
+    return (
+      <div className="border-b border-border px-4 md:px-6 h-12 shrink-0 flex items-center">
+        {menuButton}
+        <div className="min-w-0 overflow-hidden flex-1">
+          {breadcrumbs[0].leading || breadcrumbs[0].identifier ? (
+            <h1 className="flex items-center gap-1.5 text-sm font-semibold uppercase tracking-wider">
+              {breadcrumbs[0].leading && (
+                <span className="flex shrink-0 items-center">{breadcrumbs[0].leading}</span>
+              )}
+              <CrumbIdentifier identifier={breadcrumbs[0].identifier} />
+              <span className="truncate">{breadcrumbs[0].label}</span>
+            </h1>
+          ) : (
+            <h1 className="text-sm font-semibold uppercase tracking-wider truncate">
+              {breadcrumbs[0].label}
+            </h1>
+          )}
+        </div>
+        {globalToolbarSlots}
+      </div>
+    );
+  }
+
+  // Multiple breadcrumbs = breadcrumb trail
+  return (
+    <div className="border-b border-border px-4 md:px-6 h-12 shrink-0 flex items-center">
+      {menuButton}
+      <div className="min-w-0 overflow-hidden flex-1">
+        <Breadcrumb className="min-w-0 overflow-hidden">
+          <BreadcrumbList className="flex-nowrap">
+            {breadcrumbs.map((crumb, i) => {
+              const isLast = i === breadcrumbs.length - 1;
+              return (
+                <Fragment key={i}>
+                  {i > 0 && <BreadcrumbSeparator />}
+                  <BreadcrumbItem className={isLast ? "min-w-0" : "shrink-0"}>
+                    {isLast || !crumb.href ? (
+                      crumb.leading || crumb.identifier ? (
+                        <BreadcrumbPage className="flex min-w-0 items-center gap-1.5">
+                          {crumb.leading && (
+                            <span className="flex shrink-0 items-center">{crumb.leading}</span>
+                          )}
+                          <CrumbIdentifier identifier={crumb.identifier} />
+                          <span className="truncate">{crumb.label}</span>
+                        </BreadcrumbPage>
+                      ) : (
+                        <BreadcrumbPage className="truncate">{crumb.label}</BreadcrumbPage>
+                      )
+                    ) : (
+                      <BreadcrumbLink asChild>
+                        {crumb.leading || crumb.identifier ? (
+                          <Link to={crumb.href} className="flex items-center gap-1.5">
+                            {crumb.leading && (
+                              <span className="flex shrink-0 items-center">{crumb.leading}</span>
+                            )}
+                            <CrumbIdentifier identifier={crumb.identifier} />
+                            <span className="truncate">{crumb.label}</span>
+                          </Link>
+                        ) : (
+                          <Link to={crumb.href}>{crumb.label}</Link>
+                        )}
+                      </BreadcrumbLink>
+                    )}
+                  </BreadcrumbItem>
+                </Fragment>
+              );
+            })}
+          </BreadcrumbList>
+        </Breadcrumb>
+      </div>
+      {globalToolbarSlots}
+    </div>
+  );
+}

--- a/ui/src/components/BreadcrumbBar.test.tsx
+++ b/ui/src/components/BreadcrumbBar.test.tsx
@@ -7,17 +7,26 @@ import { BreadcrumbProvider, useBreadcrumbs } from "../context/BreadcrumbContext
 import { BreadcrumbBar } from "./BreadcrumbBar";
 
 vi.mock("@/lib/router", () => ({
-  Link: ({ children, to }: { children: ReactNode; to: string }) => (
-    <a href={to}>{children}</a>
+  Link: ({ children, className, to }: { children: ReactNode; className?: string; to: string }) => (
+    <a className={className} href={to}>{children}</a>
   ),
 }));
 
 vi.mock("../context/SidebarContext", () => ({
-  useSidebar: () => ({ isMobile: false, toggleSidebar: vi.fn() }),
+  useSidebar: () => ({
+    collapsed: false,
+    isMobile: false,
+    toggleCollapsed: vi.fn(),
+    toggleSidebar: vi.fn(),
+  }),
 }));
 
 vi.mock("../context/CompanyContext", () => ({
-  useCompany: () => ({ selectedCompanyId: "company-1", selectedCompany: { issuePrefix: "PAP" } }),
+  useCompany: () => ({ selectedCompanyId: "company-1", selectedCompany: { issuePrefix: "TES" } }),
+}));
+
+vi.mock("../context/PanelContext", () => ({
+  usePanel: () => ({ panelVisible: true, togglePanelVisible: vi.fn() }),
 }));
 
 vi.mock("@/plugins/slots", () => ({
@@ -30,24 +39,58 @@ vi.mock("@/plugins/launchers", () => ({
   PluginLauncherOutlet: () => null,
 }));
 
-function TaskBreadcrumbs({ onOpen }: { onOpen: () => void }) {
-  const { setBreadcrumbs, setBreadcrumbToolbar } = useBreadcrumbs();
+function TaskBreadcrumbs({
+  onOpen,
+  panelControl,
+  taskDetailLayout = false,
+  identifier = "PAP-16679",
+}: {
+  onOpen?: () => void;
+  panelControl?: { open: boolean; onToggle: () => void };
+  taskDetailLayout?: boolean;
+  identifier?: string;
+}) {
+  const {
+    setBreadcrumbs,
+    setBreadcrumbToolbar,
+    setBreadcrumbPanelControl,
+  } = useBreadcrumbs();
 
   useEffect(() => {
     setBreadcrumbs([
-      { label: "Tasks", href: "/tasks" },
-      { label: "Keep the panel launcher available", identifier: "PAP-16679" },
+      { label: "Tasks", href: "/issues" },
+      {
+        label: "Hire your first engineer and create a hiring plan",
+        identifier,
+        leading: "status",
+      },
     ]);
     setBreadcrumbToolbar(
-      <button type="button" aria-label="Show task side panel" onClick={onOpen}>
-        Show panel
-      </button>,
+      onOpen ? (
+        <button type="button" aria-label="Show task side panel" onClick={onOpen}>
+          Show panel
+        </button>
+      ) : null,
     );
-    return () => setBreadcrumbToolbar(null);
-  }, [onOpen, setBreadcrumbToolbar, setBreadcrumbs]);
+    setBreadcrumbPanelControl(panelControl ?? null);
+    return () => {
+      setBreadcrumbToolbar(null);
+      setBreadcrumbPanelControl(null);
+    };
+  }, [
+    identifier,
+    onOpen,
+    panelControl,
+    setBreadcrumbPanelControl,
+    setBreadcrumbToolbar,
+    setBreadcrumbs,
+  ]);
 
-  return <BreadcrumbBar />;
+  return <BreadcrumbBar taskDetailLayout={taskDetailLayout} />;
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
 describe("BreadcrumbBar", () => {
   let container: HTMLDivElement;
@@ -78,9 +121,103 @@ describe("BreadcrumbBar", () => {
       'button[aria-label="Show task side panel"]',
     );
     expect(launcher).not.toBeNull();
-    expect(launcher?.closest(".h-12")?.textContent).toContain("PAP-16679");
+    expect(launcher?.closest(".h-\\(--sz-60px\\)")?.textContent).toContain("PAP-16679");
 
     act(() => launcher?.click());
     expect(onOpen).toHaveBeenCalledOnce();
+  });
+
+  it("appends the task identifier to the task title in the task-detail header", async () => {
+    await act(async () => {
+      root.render(
+        <BreadcrumbProvider>
+          <TaskBreadcrumbs taskDetailLayout identifier="TES-1" />
+        </BreadcrumbProvider>,
+      );
+    });
+
+    const identifier = container.querySelector('[data-slot="task-title-identifier"]');
+    expect(identifier).toBeTruthy();
+    expect(identifier?.className).not.toContain("absolute");
+    expect(identifier?.closest(".relative")?.className).toContain("border-b");
+    expect(identifier?.closest(".relative")?.className).toContain("border-border");
+    expect(identifier?.closest(".relative")?.className).toContain("h-(--sz-60px)");
+
+    const title = Array.from(container.querySelectorAll("span"))
+      .find((element) => element.textContent === "Hire your first engineer and create a hiring plan");
+    const tasksLink = container.querySelector<HTMLAnchorElement>('a[href="/issues"]');
+    const header = tasksLink?.closest(".relative");
+    expect(header?.classList).toContain("px-4");
+    expect(header?.classList).toContain("md:px-6");
+    expect(header?.classList).not.toContain("px-3");
+    expect(tasksLink?.classList).toContain("font-semibold");
+    expect(tasksLink?.classList).toContain("tracking-wider");
+    expect(tasksLink?.classList).toContain("text-muted-foreground");
+    expect(tasksLink?.classList).toContain("hover:text-foreground");
+    expect(tasksLink?.classList).not.toContain("font-bold");
+    expect(title?.className).toContain("truncate");
+    expect(title?.nextElementSibling).toBe(identifier);
+    expect(identifier?.textContent).toBe("TES-1");
+  });
+
+  it("styles the root crumb as an uppercase muted header on every detail view", async () => {
+    await act(async () => {
+      root.render(
+        <BreadcrumbProvider>
+          <TaskBreadcrumbs />
+        </BreadcrumbProvider>,
+      );
+    });
+
+    const rootCrumb = container.querySelector<HTMLAnchorElement>('a[href="/issues"]');
+    expect(rootCrumb?.classList).toContain("font-semibold");
+    expect(rootCrumb?.classList).toContain("uppercase");
+    expect(rootCrumb?.classList).toContain("tracking-wider");
+    expect(rootCrumb?.classList).toContain("text-muted-foreground");
+    expect(rootCrumb?.classList).toContain("hover:text-foreground");
+  });
+
+  it("routes the single task-detail panel button through a page override", async () => {
+    const onToggle = vi.fn();
+    const panelControl = { open: false, onToggle };
+    await act(async () => {
+      root.render(
+        <BreadcrumbProvider>
+          <TaskBreadcrumbs taskDetailLayout panelControl={panelControl} />
+        </BreadcrumbProvider>,
+      );
+    });
+
+    const launcher = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Show properties"]',
+    );
+    expect(launcher).not.toBeNull();
+    expect(container.querySelector('button[aria-label="Hide properties"]')).toBeNull();
+
+    act(() => launcher?.click());
+    expect(onToggle).toHaveBeenCalledOnce();
+  });
+
+  it("omits the retired sidebar control and keeps the properties control", async () => {
+    await act(async () => {
+      root.render(
+        <BreadcrumbProvider>
+          <TaskBreadcrumbs taskDetailLayout />
+        </BreadcrumbProvider>,
+      );
+    });
+
+    const leftControl = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Collapse sidebar"]',
+    );
+    const rightControl = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Hide properties"]',
+    );
+
+    expect(leftControl).toBeNull();
+    expect(container.querySelector('button[aria-label="Expand sidebar"]')).toBeNull();
+    expect(rightControl?.className).toContain("size-9");
+    expect(rightControl?.className).not.toContain("rounded-none");
+    expect(rightControl?.className).not.toContain("h-full");
   });
 });

--- a/ui/src/components/BreadcrumbBar.tsx
+++ b/ui/src/components/BreadcrumbBar.tsx
@@ -1,8 +1,9 @@
 import { Link } from "@/lib/router";
-import { Menu } from "lucide-react";
+import { Menu, PanelRightClose, PanelRightOpen } from "lucide-react";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { useSidebar } from "../context/SidebarContext";
 import { useCompany } from "../context/CompanyContext";
+import { usePanel } from "../context/PanelContext";
 import { Button } from "@/components/ui/button";
 import {
   Breadcrumb,
@@ -15,13 +16,18 @@ import {
 import { Fragment, useMemo, type ReactNode } from "react";
 import { PluginSlotOutlet, usePluginSlots } from "@/plugins/slots";
 import { PluginLauncherOutlet, usePluginLaunchers } from "@/plugins/launchers";
+import { cn } from "../lib/utils";
 
 type GlobalToolbarContext = { companyId: string | null; companyPrefix: string | null };
 
-/** Task identifier rendered in gray monospace between the glyph and the title. */
+/** Task identifier rendered in gray monospace beside its breadcrumb label. */
 function CrumbIdentifier({ identifier }: { identifier?: string }) {
   if (!identifier) return null;
-  return <span className="shrink-0 font-mono text-muted-foreground">{identifier}</span>;
+  return (
+    <span data-slot="task-title-identifier" className="shrink-0 font-mono text-muted-foreground">
+      {identifier}
+    </span>
+  );
 }
 
 function GlobalToolbar({
@@ -46,10 +52,18 @@ function GlobalToolbar({
   );
 }
 
-export function BreadcrumbBar() {
-  const { breadcrumbs, breadcrumbToolbar, mobileToolbar } = useBreadcrumbs();
+export function BreadcrumbBar({ taskDetailLayout = false }: { taskDetailLayout?: boolean }) {
+  const {
+    breadcrumbs,
+    breadcrumbToolbar,
+    breadcrumbPanelControl,
+    mobileToolbar,
+  } = useBreadcrumbs();
   const { toggleSidebar, isMobile } = useSidebar();
+  const { panelVisible, togglePanelVisible } = usePanel();
   const { selectedCompanyId, selectedCompany } = useCompany();
+  const taskPanelOpen = breadcrumbPanelControl?.open ?? panelVisible;
+  const toggleTaskPanel = breadcrumbPanelControl?.onToggle ?? togglePanelVisible;
 
   const globalToolbarSlotContext = useMemo(
     () => ({
@@ -68,7 +82,7 @@ export function BreadcrumbBar() {
 
   if (isMobile && mobileToolbar) {
     return (
-      <div className="border-b border-border px-2 h-12 shrink-0 flex items-center">
+      <div className="h-(--sz-60px) shrink-0 flex items-center border-b border-border px-2">
         {mobileToolbar}
       </div>
     );
@@ -76,7 +90,7 @@ export function BreadcrumbBar() {
 
   if (breadcrumbs.length === 0) {
     return (
-      <div className="border-b border-border px-4 md:px-6 h-12 shrink-0 flex items-center justify-end">
+      <div className="h-(--sz-60px) shrink-0 flex items-center justify-end border-b border-border px-4 md:px-6">
         {globalToolbarSlots}
       </div>
     );
@@ -94,10 +108,72 @@ export function BreadcrumbBar() {
     </Button>
   );
 
+  const breadcrumbTrail = (
+    <div className="min-w-0 overflow-hidden flex-1">
+      <Breadcrumb className="min-w-0 overflow-hidden">
+        <BreadcrumbList className="flex-nowrap">
+          {breadcrumbs.map((crumb, i) => {
+            const isLast = i === breadcrumbs.length - 1;
+            return (
+              <Fragment key={i}>
+                {i > 0 && <BreadcrumbSeparator />}
+                <BreadcrumbItem className={isLast ? "min-w-0" : "shrink-0"}>
+                  {isLast || !crumb.href ? (
+                    crumb.leading || crumb.identifier ? (
+                      <BreadcrumbPage className="flex min-w-0 items-center gap-1.5">
+                        {crumb.leading && (
+                          <span className="flex shrink-0 items-center">{crumb.leading}</span>
+                        )}
+                        {!taskDetailLayout ? <CrumbIdentifier identifier={crumb.identifier} /> : null}
+                        <span className="min-w-0 truncate">{crumb.label}</span>
+                        {taskDetailLayout && isLast ? <CrumbIdentifier identifier={crumb.identifier} /> : null}
+                      </BreadcrumbPage>
+                    ) : (
+                      <BreadcrumbPage className="truncate">{crumb.label}</BreadcrumbPage>
+                    )
+                  ) : (
+                    <BreadcrumbLink asChild>
+                      {crumb.leading || crumb.identifier ? (
+                        <Link
+                          to={crumb.href}
+                          className={cn(
+                            "flex min-w-0 items-center gap-1.5",
+                            i === 0 && "font-semibold uppercase tracking-wider text-muted-foreground hover:text-foreground",
+                          )}
+                        >
+                          {crumb.leading && (
+                            <span className="flex shrink-0 items-center">{crumb.leading}</span>
+                          )}
+                          {!taskDetailLayout ? <CrumbIdentifier identifier={crumb.identifier} /> : null}
+                          <span className="min-w-0 truncate">{crumb.label}</span>
+                          {taskDetailLayout && isLast ? <CrumbIdentifier identifier={crumb.identifier} /> : null}
+                        </Link>
+                      ) : (
+                        <Link
+                          to={crumb.href}
+                          className={cn(
+                            "min-w-0 truncate",
+                            i === 0 && "font-semibold uppercase tracking-wider text-muted-foreground hover:text-foreground",
+                          )}
+                        >
+                          {crumb.label}
+                        </Link>
+                      )}
+                    </BreadcrumbLink>
+                  )}
+                </BreadcrumbItem>
+              </Fragment>
+            );
+          })}
+        </BreadcrumbList>
+      </Breadcrumb>
+    </div>
+  );
+
   // Single breadcrumb = page title (uppercase)
   if (breadcrumbs.length === 1) {
     return (
-      <div className="border-b border-border px-4 md:px-6 h-12 shrink-0 flex items-center">
+      <div className="h-(--sz-60px) shrink-0 flex items-center border-b border-border px-4 md:px-6">
         {menuButton}
         <div className="min-w-0 overflow-hidden flex-1">
           {breadcrumbs[0].leading || breadcrumbs[0].identifier ? (
@@ -121,52 +197,27 @@ export function BreadcrumbBar() {
 
   // Multiple breadcrumbs = breadcrumb trail
   return (
-    <div className="border-b border-border px-4 md:px-6 h-12 shrink-0 flex items-center">
+    <div
+      className={cn(
+        "relative h-(--sz-60px) shrink-0 flex items-center border-b border-border",
+        "px-4 md:px-6",
+      )}
+    >
       {menuButton}
-      <div className="min-w-0 overflow-hidden flex-1">
-        <Breadcrumb className="min-w-0 overflow-hidden">
-          <BreadcrumbList className="flex-nowrap">
-            {breadcrumbs.map((crumb, i) => {
-              const isLast = i === breadcrumbs.length - 1;
-              return (
-                <Fragment key={i}>
-                  {i > 0 && <BreadcrumbSeparator />}
-                  <BreadcrumbItem className={isLast ? "min-w-0" : "shrink-0"}>
-                    {isLast || !crumb.href ? (
-                      crumb.leading || crumb.identifier ? (
-                        <BreadcrumbPage className="flex min-w-0 items-center gap-1.5">
-                          {crumb.leading && (
-                            <span className="flex shrink-0 items-center">{crumb.leading}</span>
-                          )}
-                          <CrumbIdentifier identifier={crumb.identifier} />
-                          <span className="truncate">{crumb.label}</span>
-                        </BreadcrumbPage>
-                      ) : (
-                        <BreadcrumbPage className="truncate">{crumb.label}</BreadcrumbPage>
-                      )
-                    ) : (
-                      <BreadcrumbLink asChild>
-                        {crumb.leading || crumb.identifier ? (
-                          <Link to={crumb.href} className="flex items-center gap-1.5">
-                            {crumb.leading && (
-                              <span className="flex shrink-0 items-center">{crumb.leading}</span>
-                            )}
-                            <CrumbIdentifier identifier={crumb.identifier} />
-                            <span className="truncate">{crumb.label}</span>
-                          </Link>
-                        ) : (
-                          <Link to={crumb.href}>{crumb.label}</Link>
-                        )}
-                      </BreadcrumbLink>
-                    )}
-                  </BreadcrumbItem>
-                </Fragment>
-              );
-            })}
-          </BreadcrumbList>
-        </Breadcrumb>
-      </div>
+      {breadcrumbTrail}
       {globalToolbarSlots}
+      {taskDetailLayout ? (
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="ml-5 size-9 shrink-0 text-muted-foreground"
+          onClick={toggleTaskPanel}
+          aria-label={taskPanelOpen ? "Hide properties" : "Show properties"}
+          title={taskPanelOpen ? "Hide properties" : "Show properties"}
+        >
+          {taskPanelOpen ? <PanelRightClose className="h-4 w-4" /> : <PanelRightOpen className="h-4 w-4" />}
+        </Button>
+      ) : null}
     </div>
   );
 }

--- a/ui/src/components/CollectionToolbar.test.tsx
+++ b/ui/src/components/CollectionToolbar.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+
+import { createRoot } from "react-dom/client";
+import { flushSync } from "react-dom";
+import { afterEach, describe, expect, it } from "vitest";
+import { CollectionToolbar } from "./CollectionToolbar";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("CollectionToolbar", () => {
+  let container: HTMLDivElement | null = null;
+  let root: ReturnType<typeof createRoot> | null = null;
+
+  afterEach(() => {
+    if (root) flushSync(() => root?.unmount());
+    container?.remove();
+    root = null;
+    container = null;
+  });
+
+  it("keeps collection controls in stable semantic slots", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    flushSync(() => {
+      root?.render(
+        <CollectionToolbar
+          ariaLabel="Task list controls"
+          context={<span>Mine</span>}
+          search={<input aria-label="Search tasks" />}
+          controls={<button type="button">Filter</button>}
+          actions={<button type="button">New task</button>}
+          feedback={<span>Status: active</span>}
+        />,
+      );
+    });
+
+    const toolbar = container.querySelector('[role="toolbar"]');
+    expect(toolbar?.getAttribute("aria-label")).toBe("Task list controls");
+    expect(toolbar?.querySelector('[data-slot="collection-toolbar-context"]')?.textContent).toBe("Mine");
+    expect(toolbar?.querySelector('[data-slot="collection-toolbar-search"] input')).not.toBeNull();
+    expect(toolbar?.querySelector('[data-slot="collection-toolbar-controls"]')?.textContent).toBe("Filter");
+    expect(toolbar?.querySelector('[data-slot="collection-toolbar-actions"]')?.textContent).toBe("New task");
+    expect(toolbar?.querySelector('[data-slot="collection-toolbar-feedback"]')?.textContent).toBe("Status: active");
+  });
+
+  it("omits empty optional slots", () => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    flushSync(() => root?.render(<CollectionToolbar search={<span>Search</span>} />));
+
+    expect(container.querySelector('[data-slot="collection-toolbar-context"]')).toBeNull();
+    expect(container.querySelector('[data-slot="collection-toolbar-controls"]')).toBeNull();
+    expect(container.querySelector('[data-slot="collection-toolbar-actions"]')).toBeNull();
+    expect(container.querySelector('[data-slot="collection-toolbar-feedback"]')).toBeNull();
+  });
+});

--- a/ui/src/components/CollectionToolbar.tsx
+++ b/ui/src/components/CollectionToolbar.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export interface CollectionToolbarProps {
+  /** Primary context such as tabs, a view title, or a result count. */
+  context?: ReactNode;
+  /** The collection's canonical search control. */
+  search?: ReactNode;
+  /** Filter, sort, column, density, and view controls. */
+  controls?: ReactNode;
+  /** Collection-specific actions such as create or bulk operations. */
+  actions?: ReactNode;
+  /** Optional second row for active-filter chips or selection feedback. */
+  feedback?: ReactNode;
+  className?: string;
+  ariaLabel?: string;
+}
+
+/**
+ * Presentation-only shell for list and board controls.
+ *
+ * State, queries, and control behavior stay with the consuming surface. Keeping
+ * this component slot-based lets Inbox, Tasks, routine runs, and scoped task
+ * lists share geometry without coupling their data models.
+ */
+export function CollectionToolbar({
+  context,
+  search,
+  controls,
+  actions,
+  feedback,
+  className,
+  ariaLabel = "Collection controls",
+}: CollectionToolbarProps) {
+  return (
+    <div
+      data-slot="collection-toolbar"
+      className={cn("flex flex-col gap-2", className)}
+      role="toolbar"
+      aria-label={ariaLabel}
+    >
+      <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center">
+        {context ? (
+          <div data-slot="collection-toolbar-context" className="min-w-0 shrink-0">
+            {context}
+          </div>
+        ) : null}
+        {search ? (
+          <div data-slot="collection-toolbar-search" className="min-w-0 flex-1">
+            {search}
+          </div>
+        ) : null}
+        {(controls || actions) ? (
+          <div className="flex min-w-0 flex-wrap items-center gap-1 sm:ml-auto sm:flex-nowrap">
+            {controls ? (
+              <div data-slot="collection-toolbar-controls" className="flex min-w-0 flex-wrap items-center gap-1">
+                {controls}
+              </div>
+            ) : null}
+            {actions ? (
+              <div data-slot="collection-toolbar-actions" className="flex shrink-0 items-center gap-1">
+                {actions}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+      {feedback ? (
+        <div data-slot="collection-toolbar-feedback" className="min-w-0">
+          {feedback}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/src/components/CompanySettingsSidebar.production.tsx
+++ b/ui/src/components/CompanySettingsSidebar.production.tsx
@@ -1,0 +1,214 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  ChevronLeft,
+  Clock3,
+  Cpu,
+  Download,
+  FlaskConical,
+  KeyRound,
+  MailPlus,
+  MonitorCog,
+  Puzzle,
+  Shield,
+  SlidersHorizontal,
+  Upload,
+  UserRoundPen,
+  Users,
+} from "lucide-react";
+import type { PluginRecord } from "@paperclipai/shared";
+import { sidebarBadgesApi } from "@/api/sidebarBadges";
+import { pluginsApi } from "@/api/plugins";
+import { ApiError } from "@/api/client";
+import { Link, NavLink } from "@/lib/router";
+import { INSTANCE_SETTINGS_PATH_PREFIX } from "@/lib/instance-settings";
+import { SIDEBAR_SCROLL_RESET_STATE } from "@/lib/navigation-scroll";
+import { queryKeys } from "@/lib/queryKeys";
+import { useCompany } from "@/context/CompanyContext";
+import { useSidebar } from "@/context/SidebarContext";
+import { useCloudInstance } from "@/hooks/useCloudInstance";
+import { useHiddenSettings } from "@/hooks/useHiddenSettings";
+import { usePluginSlots } from "@/plugins/slots";
+import { SidebarNavItem } from "./SidebarNavItem.production";
+
+/**
+ * Sandbox-provider-only plugins (e.g. E2B, exe.dev, Modal) have no per-plugin
+ * settings page, so a sidebar entry would lead nowhere useful. Filter them out
+ * here. Plugins that mix a sandbox provider with other contributions still
+ * appear.
+ */
+function isSandboxProviderOnly(plugin: PluginRecord): boolean {
+  const drivers = plugin.manifestJson.environmentDrivers ?? [];
+  if (drivers.length === 0) return false;
+  return drivers.every((d) => d.kind === "sandbox_provider");
+}
+
+export function CompanySettingsSidebar() {
+  const { selectedCompany, selectedCompanyId } = useCompany();
+  const { isMobile, setSidebarOpen } = useSidebar();
+  const { hidden: hiddenSettings } = useHiddenSettings();
+  const showPage = (pageKey: string) => !hiddenSettings.has(pageKey);
+  const showPlugins = showPage("instance.plugins");
+  // Import is floored server-side on cloud-managed instances (403 cloud_managed), so the
+  // nav entry is hidden rather than dead-ending. Export stays available.
+  const isCloud = Boolean(useCloudInstance());
+  const { slots: companySettingsPluginSlots } = usePluginSlots({
+    slotTypes: ["companySettingsPage"],
+    companyId: selectedCompanyId,
+    enabled: !!selectedCompanyId,
+  });
+  const { data: badges } = useQuery({
+    queryKey: selectedCompanyId
+      ? queryKeys.sidebarBadges(selectedCompanyId)
+      : ["sidebar-badges", "__disabled__"] as const,
+    queryFn: async () => {
+      try {
+        return await sidebarBadgesApi.get(selectedCompanyId!);
+      } catch (error) {
+        if (error instanceof ApiError && (error.status === 401 || error.status === 403)) {
+          return null;
+        }
+        throw error;
+      }
+    },
+    enabled: !!selectedCompanyId,
+    retry: false,
+    refetchInterval: 15_000,
+  });
+  const { data: plugins } = useQuery({
+    queryKey: queryKeys.plugins.all,
+    queryFn: () => pluginsApi.list(),
+    // The listing only feeds the per-plugin subtree below; skip it when the
+    // operator hides the Plugins surface.
+    enabled: showPlugins,
+  });
+  const sidebarPlugins = (plugins ?? []).filter((plugin) => !isSandboxProviderOnly(plugin));
+
+  return (
+    <aside className="w-full h-full min-h-0 border-r border-border bg-background flex flex-col">
+      <div className="flex flex-col gap-1 px-3 py-3 shrink-0">
+        <Link
+          to="/dashboard"
+          onClick={() => {
+            if (isMobile) setSidebarOpen(false);
+          }}
+          className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+        >
+          <ChevronLeft className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate">{selectedCompany?.name ?? "Company"}</span>
+        </Link>
+      </div>
+
+      <nav className="flex-1 min-h-0 overflow-y-auto scrollbar-auto-hide px-3 py-2">
+        <div className="flex flex-col gap-0.5">
+          <SidebarNavItem to="/company/settings" label="General" icon={SlidersHorizontal} end />
+          {showPage("instance.profile") && (
+            <SidebarNavItem
+              to={`${INSTANCE_SETTINGS_PATH_PREFIX}/profile`}
+              label="Profile"
+              icon={UserRoundPen}
+              end
+            />
+          )}
+          {showPage("company.members") && (
+            <SidebarNavItem
+              to="/company/settings/members"
+              label="Members"
+              icon={Users}
+              badge={badges?.joinRequests ?? 0}
+              end
+            />
+          )}
+          {companySettingsPluginSlots
+            .filter((slot) => slot.routePath)
+            .map((slot) => (
+              <SidebarNavItem
+                key={`${slot.pluginKey}:${slot.id}`}
+                to={`/company/settings/${slot.routePath}`}
+                label={slot.displayName}
+                icon={Puzzle}
+                end
+              />
+            ))}
+          {showPage("company.invites") && (
+            <SidebarNavItem to="/company/settings/invites" label="Invites" icon={MailPlus} end />
+          )}
+          {showPage("company.secrets") && (
+            <SidebarNavItem to="/company/settings/secrets" label="Secrets" icon={KeyRound} end />
+          )}
+          {showPage("instance.environments") && (
+            <SidebarNavItem
+              to={`${INSTANCE_SETTINGS_PATH_PREFIX}/environments`}
+              label="Environments"
+              icon={MonitorCog}
+              end
+            />
+          )}
+          {showPage("instance.access") && (
+            <SidebarNavItem
+              to={`${INSTANCE_SETTINGS_PATH_PREFIX}/access`}
+              label="Access"
+              icon={Shield}
+              end
+            />
+          )}
+          {showPage("instance.heartbeats") && (
+            <SidebarNavItem
+              to={`${INSTANCE_SETTINGS_PATH_PREFIX}/heartbeats`}
+              label="Heartbeats"
+              icon={Clock3}
+              end
+            />
+          )}
+          {showPage("company.export") && (
+            <SidebarNavItem to="/company/export" label="Export" icon={Download} />
+          )}
+          {!isCloud && showPage("company.import") && (
+            <SidebarNavItem to="/company/import" label="Import" icon={Upload} end />
+          )}
+          {showPage("instance.experimental") && (
+            <SidebarNavItem
+              to={`${INSTANCE_SETTINGS_PATH_PREFIX}/experimental`}
+              label="Experimental"
+              icon={FlaskConical}
+            />
+          )}
+          {showPlugins && (
+            <SidebarNavItem
+              to={`${INSTANCE_SETTINGS_PATH_PREFIX}/plugins`}
+              label="Plugins"
+              icon={Puzzle}
+            />
+          )}
+          {showPlugins && sidebarPlugins.length > 0 ? (
+            <div className="ml-4 mt-1 flex flex-col gap-0.5 border-l border-border/70 pl-3">
+              {sidebarPlugins.map((plugin) => (
+                <NavLink
+                  key={plugin.id}
+                  to={`${INSTANCE_SETTINGS_PATH_PREFIX}/plugins/${plugin.id}`}
+                  state={SIDEBAR_SCROLL_RESET_STATE}
+                  className={({ isActive }) =>
+                    [
+                      "rounded-md px-2 py-1.5 text-xs transition-colors",
+                      isActive
+                        ? "bg-accent text-foreground"
+                        : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                    ].join(" ")
+                  }
+                >
+                  {plugin.manifestJson.displayName ?? plugin.packageName}
+                </NavLink>
+              ))}
+            </div>
+          ) : null}
+          {showPage("instance.adapters") && (
+            <SidebarNavItem
+              to={`${INSTANCE_SETTINGS_PATH_PREFIX}/adapters`}
+              label="Adapters"
+              icon={Cpu}
+            />
+          )}
+        </div>
+      </nav>
+    </aside>
+  );
+}

--- a/ui/src/components/CompanySettingsSidebar.test.tsx
+++ b/ui/src/components/CompanySettingsSidebar.test.tsx
@@ -16,6 +16,7 @@ const mockPluginsApi = vi.hoisted(() => ({
 const mockUsePluginSlots = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/router", () => ({
+  useNavigate: () => vi.fn(),
   Link: ({
     children,
     to,
@@ -41,7 +42,7 @@ vi.mock("@/lib/router", () => ({
 vi.mock("@/context/CompanyContext", () => ({
   useCompany: () => ({
     selectedCompanyId: "company-1",
-    selectedCompany: { id: "company-1", name: "Paperclip" },
+    selectedCompany: { id: "company-1", issuePrefix: "PAP", name: "Paperclip" },
   }),
 }));
 
@@ -53,6 +54,7 @@ vi.mock("@/context/SidebarContext", () => ({
 }));
 
 vi.mock("./SidebarNavItem", () => ({
+  SidebarNavExpandedProvider: ({ children }: { children: React.ReactNode }) => children,
   SidebarNavItem: (props: {
     to: string;
     label: string;

--- a/ui/src/components/CompanySettingsSidebar.tsx
+++ b/ui/src/components/CompanySettingsSidebar.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
 import {
-  ChevronLeft,
   Cpu,
   Download,
   FlaskConical,
@@ -17,16 +16,16 @@ import type { PluginRecord } from "@paperclipai/shared";
 import { sidebarBadgesApi } from "@/api/sidebarBadges";
 import { pluginsApi } from "@/api/plugins";
 import { ApiError } from "@/api/client";
-import { Link, NavLink } from "@/lib/router";
+import { NavLink } from "@/lib/router";
 import { INSTANCE_SETTINGS_PATH_PREFIX } from "@/lib/instance-settings";
 import { SIDEBAR_SCROLL_RESET_STATE } from "@/lib/navigation-scroll";
 import { queryKeys } from "@/lib/queryKeys";
 import { useCompany } from "@/context/CompanyContext";
-import { useSidebar } from "@/context/SidebarContext";
 import { useCloudInstance } from "@/hooks/useCloudInstance";
 import { useHiddenSettings } from "@/hooks/useHiddenSettings";
 import { usePluginSlots } from "@/plugins/slots";
 import { SidebarNavItem } from "./SidebarNavItem";
+import { ContextualSidebarFrame } from "./ContextualSidebarFrame";
 
 /**
  * Sandbox-provider-only plugins (e.g. E2B, exe.dev, Modal) have no per-plugin
@@ -41,8 +40,7 @@ function isSandboxProviderOnly(plugin: PluginRecord): boolean {
 }
 
 export function CompanySettingsSidebar() {
-  const { selectedCompany, selectedCompanyId } = useCompany();
-  const { isMobile, setSidebarOpen } = useSidebar();
+  const { selectedCompanyId } = useCompany();
   const { hidden: hiddenSettings } = useHiddenSettings();
   const showPage = (pageKey: string) => !hiddenSettings.has(pageKey);
   const showPlugins = showPage("instance.plugins");
@@ -82,20 +80,7 @@ export function CompanySettingsSidebar() {
   const sidebarPlugins = (plugins ?? []).filter((plugin) => !isSandboxProviderOnly(plugin));
 
   return (
-    <aside className="w-full h-full min-h-0 border-r border-border bg-background flex flex-col">
-      <div className="flex flex-col gap-1 px-3 py-3 shrink-0">
-        <Link
-          to="/dashboard"
-          onClick={() => {
-            if (isMobile) setSidebarOpen(false);
-          }}
-          className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
-        >
-          <ChevronLeft className="h-3.5 w-3.5 shrink-0" />
-          <span className="truncate">{selectedCompany?.name ?? "Organization"}</span>
-        </Link>
-      </div>
-
+    <ContextualSidebarFrame surface="settings" title="Settings" icon={SlidersHorizontal}>
       <nav className="flex-1 min-h-0 overflow-y-auto scrollbar-auto-hide px-3 py-2">
         <div className="flex flex-col gap-0.5">
           <SidebarNavItem to="/company/settings" label="General" icon={SlidersHorizontal} end />
@@ -196,6 +181,6 @@ export function CompanySettingsSidebar() {
           )}
         </div>
       </nav>
-    </aside>
+    </ContextualSidebarFrame>
   );
 }

--- a/ui/src/components/ContextualSidebarFrame.test.tsx
+++ b/ui/src/components/ContextualSidebarFrame.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Settings } from "lucide-react";
+import { ContextualSidebarFrame } from "./ContextualSidebarFrame";
+import { rememberContextualSidebarOrigin } from "@/lib/shell-navigation";
+
+const mockNavigate = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/router", () => ({ useNavigate: () => mockNavigate }));
+vi.mock("@/context/CompanyContext", () => ({
+  useCompany: () => ({ selectedCompany: { name: "Paperclip", issuePrefix: "PAP" } }),
+}));
+vi.mock("@/context/SidebarContext", () => ({
+  useSidebar: () => ({ isMobile: false, setSidebarOpen: vi.fn(), collapsed: true, peeking: false }),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("ContextualSidebarFrame", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  function render() {
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <ContextualSidebarFrame surface="settings" title="Settings" icon={Settings}>
+          <nav>Settings links</nav>
+        </ContextualSidebarFrame>,
+      );
+    });
+    return root;
+  }
+
+  it("renders the contextual identity and uses a safe fallback", () => {
+    const root = render();
+    expect(container.textContent).toContain("Paperclip");
+    expect(container.textContent).toContain("Settings");
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('button[aria-label="Back from Settings"]')?.click();
+    });
+    expect(mockNavigate).toHaveBeenCalledWith("/dashboard");
+    act(() => root.unmount());
+  });
+
+  it("returns to the same-company route that opened the contextual surface", () => {
+    rememberContextualSidebarOrigin({
+      surface: "settings",
+      companyPrefix: "PAP",
+      previousPathname: "/PAP/issues/task-1",
+    });
+    const root = render();
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>('button[aria-label="Back from Settings"]')?.click();
+    });
+    expect(mockNavigate).toHaveBeenCalledWith("/PAP/issues/task-1");
+    act(() => root.unmount());
+  });
+
+  it("can omit contextual identity when the breadcrumb already provides it", () => {
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <ContextualSidebarFrame surface="skills" title="Skills" showHeader={false}>
+          <nav>Skill links</nav>
+        </ContextualSidebarFrame>,
+      );
+    });
+
+    expect(container.textContent).toBe("Skill links");
+    expect(container.querySelector('[aria-label="Back from Skills"]')).toBeNull();
+    act(() => root.unmount());
+  });
+});

--- a/ui/src/components/ContextualSidebarFrame.tsx
+++ b/ui/src/components/ContextualSidebarFrame.tsx
@@ -1,0 +1,70 @@
+import { ChevronLeft, type LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+import { useCompany } from "@/context/CompanyContext";
+import { useSidebar } from "@/context/SidebarContext";
+import { useNavigate } from "@/lib/router";
+import {
+  readContextualSidebarOrigin,
+  type ContextualSidebarSurface,
+} from "@/lib/shell-navigation";
+import { cn } from "@/lib/utils";
+import { SidebarNavExpandedProvider } from "./SidebarNavItem";
+
+export function ContextualSidebarFrame({
+  surface,
+  title,
+  icon: Icon,
+  fallbackTo = "/dashboard",
+  showHeader = true,
+  className,
+  children,
+}: {
+  surface: ContextualSidebarSurface;
+  title: string;
+  icon?: LucideIcon;
+  fallbackTo?: string;
+  showHeader?: boolean;
+  className?: string;
+  children: ReactNode;
+}) {
+  const navigate = useNavigate();
+  const { selectedCompany } = useCompany();
+  const { isMobile, setSidebarOpen } = useSidebar();
+
+  function goBack() {
+    navigate(readContextualSidebarOrigin({
+      surface,
+      companyPrefix: selectedCompany?.issuePrefix,
+      fallbackTo,
+    }));
+    if (isMobile) setSidebarOpen(false);
+  }
+
+  return (
+    <SidebarNavExpandedProvider>
+      <aside
+        data-contextual-sidebar={surface}
+        className={cn("flex h-full min-h-0 w-full flex-col bg-muted", className)}
+      >
+        {showHeader ? (
+          <div className="flex shrink-0 flex-col gap-1 px-3 py-3">
+            <button
+              type="button"
+              onClick={goBack}
+              className="flex items-center gap-1.5 rounded-md px-2 py-1 text-left text-xs text-muted-foreground transition-colors hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              aria-label={`Back from ${title}`}
+            >
+              <ChevronLeft className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+              <span className="truncate">{selectedCompany?.name ?? "Organization"}</span>
+            </button>
+            <div className="flex min-w-0 items-center gap-2 px-2 py-1">
+              {Icon ? <Icon className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" /> : null}
+              <span className="min-w-0 flex-1 truncate text-sm font-bold text-foreground">{title}</span>
+            </div>
+          </div>
+        ) : null}
+        {children}
+      </aside>
+    </SidebarNavExpandedProvider>
+  );
+}

--- a/ui/src/components/IssueRow.test.tsx
+++ b/ui/src/components/IssueRow.test.tsx
@@ -122,6 +122,159 @@ describe("IssueRow", () => {
     });
   });
 
+  it("uses stable canonical identifier and timestamp columns at the trailing edge", () => {
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <IssueRow
+          issue={createIssue({ identifier: "PAP-42", title: "Canonical task" })}
+          presentation="task"
+          metadata={<span>Live</span>}
+          actions={<button type="button">More</button>}
+          trailingMeta="Updated now"
+        />,
+      );
+    });
+
+    const row = container.querySelector('[data-slot="task-row"]');
+    const leading = row?.querySelector('[data-slot="task-row-leading"]');
+    const title = row?.querySelector('[data-slot="task-row-title"]');
+    const metadata = row?.querySelector('[data-slot="task-row-metadata"]');
+    const identifier = row?.querySelector('[data-slot="task-row-identifier"]');
+    const timestamp = row?.querySelector('[data-slot="task-row-timestamp"]');
+    const actions = row?.querySelector('[data-slot="task-row-actions"]');
+    const link = row?.querySelector('[data-inbox-issue-link]');
+
+    expect(leading?.querySelector("svg")).not.toBeNull();
+    expect(title?.textContent).toContain("Canonical task");
+    expect(metadata?.textContent).toBe("Live");
+    expect(identifier?.textContent).toBe("PAP-42");
+    expect(timestamp?.textContent).toBe("Updated now");
+    expect(actions?.textContent).toBe("More");
+    expect(identifier?.className).toContain("w-20");
+    expect(timestamp?.className).toContain("w-24");
+    if (!link || !metadata || !identifier || !timestamp || !actions) throw new Error("Expected canonical task row slots");
+    expect(link.contains(actions)).toBe(false);
+    expect(metadata.compareDocumentPosition(actions) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(actions.compareDocumentPosition(identifier) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(identifier.compareDocumentPosition(timestamp) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(timestamp.nextElementSibling).toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  it("keeps the canonical archive action within the shared task-row height", () => {
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(
+        <IssueRow
+          issue={createIssue()}
+          presentation="task"
+          onArchive={() => undefined}
+        />,
+      );
+    });
+
+    const archiveButton = container.querySelector<HTMLButtonElement>('button[aria-label="Archive"]');
+    expect(archiveButton?.className).toContain("h-5");
+    expect(archiveButton?.className).toContain("py-0");
+    expect(archiveButton?.className).not.toContain("py-1");
+
+    act(() => root.unmount());
+  });
+
+  it("preserves the legacy archive action density", () => {
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(<IssueRow issue={createIssue()} onArchive={() => undefined} />);
+    });
+
+    const archiveButton = container.querySelector<HTMLButtonElement>('button[aria-label="Archive"]');
+    expect(archiveButton?.className).toContain("py-1");
+    expect(archiveButton?.className).not.toContain("h-5");
+
+    act(() => root.unmount());
+  });
+
+  it("emphasizes unread canonical titles and overlays the accessible mark-read control", () => {
+    const root = createRoot(container);
+    const onMarkRead = vi.fn();
+    act(() => {
+      root.render(
+        <IssueRow
+          issue={createIssue()}
+          presentation="task"
+          unreadState="visible"
+          onMarkRead={onMarkRead}
+        />,
+      );
+    });
+
+    const row = container.querySelector('[data-slot="task-row"]');
+    const title = row?.querySelector('[data-slot="task-row-title"]');
+    const unreadSlot = row?.querySelector('[data-testid="issue-row-unread-slot"]');
+    const markReadButton = unreadSlot?.querySelector<HTMLButtonElement>('button[aria-label="Mark as read"]');
+    expect(row?.getAttribute("data-unread")).toBe("true");
+    expect(title?.className).toContain("font-semibold");
+    expect(unreadSlot).not.toBeNull();
+    expect(unreadSlot?.className).toContain("absolute");
+    expect(markReadButton).not.toBeNull();
+    expect(markReadButton?.closest("a")).toBeNull();
+
+    act(() => markReadButton?.click());
+    expect(onMarkRead).toHaveBeenCalledTimes(1);
+
+    act(() => root.unmount());
+  });
+
+  it("keeps canonical leading geometry independent of unread state", () => {
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <>
+          <IssueRow issue={createIssue({ id: "read" })} presentation="task" unreadState="hidden" />
+          <IssueRow issue={createIssue({ id: "plain" })} presentation="task" />
+        </>,
+      );
+    });
+
+    const rows = Array.from(container.querySelectorAll('[data-slot="task-row"]'));
+    const unreadSlot = rows[0]?.querySelector('[data-testid="issue-row-unread-slot"]');
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.className).toBe(rows[1]?.className);
+    expect(unreadSlot).not.toBeNull();
+    expect(unreadSlot?.className).toContain("absolute");
+    expect(unreadSlot?.querySelector('button[aria-label="Mark as read"]')).toBeNull();
+    expect(rows[1]?.querySelector('[data-testid="issue-row-unread-slot"]')).toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  it("preserves task-tree indentation slots in the canonical layout", () => {
+    const root = createRoot(container);
+    act(() => {
+      root.render(
+        <IssueRow
+          issue={createIssue()}
+          presentation="task"
+          treeGuides={2}
+          chevronInGuide
+          leadingControl={<button type="button">Expand</button>}
+        />,
+      );
+    });
+
+    expect(container.querySelectorAll('[data-slot="task-row-tree-guide"]')).toHaveLength(2);
+    expect(container.querySelector('[data-slot="task-row-leading"]')?.textContent).toContain("Expand");
+    for (const connector of container.querySelectorAll('[data-slot="task-row-tree-connector"]')) {
+      expect(connector.className).toContain("left-7");
+    }
+    act(() => root.unmount());
+  });
+
   it("keeps editable row controls keyboard-accessible and outside the navigation link", () => {
     const root = createRoot(container);
 
@@ -509,6 +662,19 @@ describe("IssueRow", () => {
     });
   });
 
+  it("never renders a horizontal divider in canonical task presentation", () => {
+    const root = createRoot(container);
+
+    act(() => {
+      root.render(<IssueRow issue={createIssue()} presentation="task" showDivider />);
+    });
+
+    const row = container.querySelector('[data-slot="task-row"]');
+    expect(row?.className).not.toContain("border-b");
+
+    act(() => root.unmount());
+  });
+
   it("keeps the hover wash on the row root while the overlay link stays a bare positioning layer", () => {
     const root = createRoot(container);
 
@@ -619,6 +785,34 @@ describe("IssueRow", () => {
       expect(label).toContain("retry missed 5m ago");
       expect(label).not.toContain("next try");
     });
+
+    it.each(["task", "legacy"] as const)(
+      "places the recovery chip immediately after the title in %s list rows",
+      (presentation) => {
+        const root = createRoot(container);
+        act(() => {
+          root.render(
+            <IssueRow
+              issue={recoveryIssue(at(-5 * 60_000))}
+              presentation={presentation}
+            />,
+          );
+        });
+
+        const titleCluster = container.querySelector('[data-slot="task-row-title-cluster"]');
+        const title = titleCluster?.querySelector('[data-slot="task-row-title"]');
+        const chip = titleCluster?.querySelector('[data-testid="issue-row-recovery-indicator"]');
+        expect(titleCluster).not.toBeNull();
+        expect(title).not.toBeNull();
+        expect(chip).not.toBeNull();
+        if (!title || !chip) throw new Error("Expected the title and recovery chip");
+        expect(title.compareDocumentPosition(chip) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+        act(() => {
+          root.unmount();
+        });
+      },
+    );
 
     it("stays calm when the overdue attempt is a verified live run", () => {
       const chip = renderChip(

--- a/ui/src/components/IssueRow.tsx
+++ b/ui/src/components/IssueRow.tsx
@@ -24,12 +24,25 @@ import { hasAssignedBacklogBlocker } from "../lib/issue-blockers";
 import { ExternalObjectStatusSummary } from "./ExternalObjectStatusSummary";
 import { Badge } from "@/components/ui/badge";
 
-type UnreadState = "hidden" | "visible" | "fading";
+export type IssueRowUnreadState = "hidden" | "visible" | "fading";
+export type IssueRowPresentation = "legacy" | "task";
 
-interface IssueRowProps {
+export interface IssueRowProps {
   issue: Issue;
   issueLinkState?: unknown;
   selected?: boolean;
+  /** Opt-in canonical collection layout. Legacy remains the default until each surface migrates. */
+  presentation?: IssueRowPresentation;
+  /** Interactive disclosure or selection control before the canonical status glyph. */
+  leadingControl?: ReactNode;
+  /** Optional status override; defaults to the task's shared StatusIcon. */
+  statusSlot?: ReactNode;
+  /** Stable metadata slot before the task's optional collection columns. */
+  metadata?: ReactNode;
+  /** Stable interactive action slot before the identifier and timestamp columns. */
+  actions?: ReactNode;
+  /** Controls the canonical trailing identifier without affecting legacy layouts. */
+  showIdentifier?: boolean;
   mobileLeading?: ReactNode;
   desktopMetaLeading?: ReactNode;
   desktopLeadingSpacer?: boolean;
@@ -47,7 +60,7 @@ interface IssueRowProps {
   checklistCurrentStep?: boolean;
   checklistDependencyChips?: ReactNode;
   checklistRowId?: string;
-  unreadState?: UnreadState | null;
+  unreadState?: IssueRowUnreadState | null;
   onMarkRead?: () => void;
   onArchive?: () => void;
   archiveDisabled?: boolean;
@@ -57,21 +70,22 @@ interface IssueRowProps {
   /** Ancestor levels; renders that many vertical tree-guide slots (desktop). */
   treeGuides?: number;
   /**
-   * This row has its own collapse chevron sitting in the innermost guide
-   * column (a nested parent). Breaks the guide line there so the chevron is
-   * not crossed out by it.
+   * This nested row has its own collapse chevron aligned with the innermost
+   * guide. Breaks the guide line there so the chevron is not crossed out.
    */
   chevronInGuide?: boolean;
-  /** Opt in to a bottom divider on this row (default off; used by views that intentionally keep separators). */
+  /** Legacy-only opt in to a bottom divider; canonical task rows stay divider-free. */
   showDivider?: boolean;
 }
 
 export function InboxArchiveButton({
   onArchive,
   disabled,
+  compact = false,
 }: {
   onArchive: () => void;
   disabled?: boolean;
+  compact?: boolean;
 }) {
   return (
     <button
@@ -89,7 +103,10 @@ export function InboxArchiveButton({
         onArchive();
       }}
       disabled={disabled}
-      className="inline-flex shrink-0 items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100 disabled:pointer-events-none disabled:opacity-30"
+      className={cn(
+        "inline-flex shrink-0 items-center gap-1.5 rounded-md px-2 text-xs font-medium text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-foreground group-hover:opacity-100 focus-visible:opacity-100 disabled:pointer-events-none disabled:opacity-30",
+        compact ? "h-5 py-0" : "py-1",
+      )}
       aria-label="Archive"
     >
       <Archive className="h-3.5 w-3.5" />
@@ -102,6 +119,12 @@ export function IssueRow({
   issue,
   issueLinkState,
   selected = false,
+  presentation = "legacy",
+  leadingControl,
+  statusSlot,
+  metadata,
+  actions,
+  showIdentifier = true,
   mobileLeading,
   desktopMetaLeading,
   desktopLeadingSpacer = false,
@@ -127,10 +150,9 @@ export function IssueRow({
 }: IssueRowProps) {
   const issuePathId = issue.identifier ?? issue.id;
   const identifier = issue.identifier ?? issue.id.slice(0, 8);
-  // A row participates in the unread system whenever `unreadState` is supplied
-  // (inbox rows). It then reserves a fixed leading dot slot on all rows — read
-  // and unread alike — so the mark-read dot sits in the far-left gutter without
-  // shifting content, matching the sibling non-issue inbox rows.
+  // A row participates in the unread system whenever `unreadState` is supplied.
+  // Canonical rows overlay this affordance in their shared gutter, while legacy
+  // inbox rows retain their reserved slot until that presentation is migrated.
   const showUnreadSlot = unreadState != null;
   const showUnreadDot = unreadState === "visible" || unreadState === "fading";
   const unreadDotButton = (
@@ -202,6 +224,134 @@ export function IssueRow({
     </Badge>
   ) : null;
 
+  if (presentation === "task") {
+    const isUnread = unreadState === "visible" || unreadState === "fading";
+    return (
+      <div
+        onMouseEnter={onMouseEnter}
+        data-slot="task-row"
+        data-unread={isUnread ? "true" : undefined}
+        className={cn(
+          "group relative flex min-w-0 items-start gap-2 rounded-lg py-2.5 pl-4 pr-2 text-sm no-underline text-inherit sm:items-center sm:py-2",
+          "[&_button]:relative [&_button]:z-10",
+          selected ? "bg-accent/50 hover:bg-accent/50" : "hover:bg-accent/50",
+          checklistCurrentStep && "bg-primary/5",
+          className,
+        )}
+      >
+        <Link
+          to={createIssueDetailPath(issuePathId)}
+          state={detailState}
+          disableIssueQuicklook
+          issuePrefetch={issue}
+          data-inbox-issue-link
+          id={checklistRowId}
+          aria-current={checklistCurrentStep ? "step" : undefined}
+          onClickCapture={() => rememberIssueDetailLocationState(issuePathId, detailState)}
+          className="absolute inset-0 rounded-lg no-underline text-inherit focus-visible:z-10 focus-visible:outline-none focus-visible:ring-(length:--rad-3) focus-visible:ring-ring"
+        >
+          <span className="sr-only">Open {identifier}: {issue.title}</span>
+        </Link>
+
+        {showUnreadSlot ? (
+          <span
+            data-testid="issue-row-unread-slot"
+            className="absolute left-0 top-3 inline-flex h-4 w-4 items-center justify-center sm:top-1/2 sm:-translate-y-1/2"
+          >
+            {showUnreadDot ? unreadDotButton : null}
+          </span>
+        ) : null}
+
+        <span data-slot="task-row-leading" className="flex shrink-0 items-center gap-1 pt-px sm:pt-0">
+          {treeGuides > 0
+            ? Array.from({ length: treeGuides }, (_, level) => {
+              const gapForChevron = chevronInGuide && level === treeGuides - 1;
+              return (
+                <span
+                  key={`task-guide-${level}`}
+                  data-slot="task-row-tree-guide"
+                  aria-hidden="true"
+                  className="relative hidden w-4 shrink-0 self-stretch sm:block"
+                >
+                  <span
+                    data-slot="task-row-tree-connector"
+                    className="absolute -inset-y-3 left-7 w-px bg-background"
+                  >
+                    {gapForChevron ? (
+                      <span className="absolute inset-0 flex flex-col">
+                        <span className="flex-1 bg-border" />
+                        <span className="h-3.5 shrink-0" />
+                        <span className="flex-1 bg-border" />
+                      </span>
+                    ) : (
+                      <span className="absolute inset-0 bg-border" />
+                    )}
+                  </span>
+                </span>
+              );
+            })
+            : null}
+          {leadingControl}
+          {statusSlot ?? (
+            <StatusIcon
+              status={issue.status}
+              blockerAttention={issue.blockerAttention}
+              size="md"
+              className={selectedStatusClass}
+            />
+          )}
+          {productivityReviewIndicator}
+          {parkedBlockerIndicator}
+        </span>
+
+        <span className="flex min-w-0 flex-1 flex-col gap-1 sm:flex-row sm:items-center sm:gap-2">
+          <span data-slot="task-row-title-cluster" className="flex min-w-0 flex-1 items-start gap-1.5 sm:items-center">
+            <span
+              data-slot="task-row-title"
+              className={cn(
+                "min-w-0 line-clamp-2 text-sm sm:truncate sm:line-clamp-none",
+                isUnread && "font-semibold",
+                titleClassName,
+              )}
+            >
+              {issue.title}{titleSuffix}
+            </span>
+            {recoveryIndicator}
+          </span>
+          {checklistDependencyChips ? (
+            <span className="flex flex-wrap gap-1">{checklistDependencyChips}</span>
+          ) : null}
+          {mobileMeta ? (
+            <span className="text-xs text-muted-foreground sm:hidden">{mobileMeta}</span>
+          ) : null}
+        </span>
+
+        <span
+          data-slot="task-row-trailing"
+          className="ml-auto hidden min-w-0 shrink-0 items-center gap-2 sm:flex"
+        >
+          {externalObjectSummary ? (
+            <ExternalObjectStatusSummary summary={externalObjectSummary} compact />
+          ) : null}
+          {metadata ? <span data-slot="task-row-metadata" className="min-w-0">{metadata}</span> : null}
+          {desktopTrailing}
+          {actions ? <span data-slot="task-row-actions" className="flex shrink-0 items-center gap-1">{actions}</span> : null}
+          {onArchive ? <InboxArchiveButton onArchive={onArchive} disabled={archiveDisabled} compact /> : null}
+          {showIdentifier ? (
+            <span data-slot="task-row-identifier" className="w-20 shrink-0 text-right font-mono text-xs text-muted-foreground">
+              {identifier}
+            </span>
+          ) : null}
+          {trailingMeta ? (
+            <span data-slot="task-row-timestamp" className="w-24 shrink-0 truncate text-right text-xs text-muted-foreground">
+              {trailingMeta}
+            </span>
+          ) : null}
+        </span>
+      </div>
+    );
+  }
+
   return (
     <div
       onMouseEnter={onMouseEnter}
@@ -243,11 +393,16 @@ export function IssueRow({
         {mobileLeading ?? <StatusIcon status={issue.status} blockerAttention={issue.blockerAttention} size="md" className={selectedStatusClass} />}
         {productivityReviewIndicator}
         {parkedBlockerIndicator}
-        {recoveryIndicator}
       </span>
       <span className="flex min-w-0 flex-1 flex-col gap-1 sm:contents">
-        <span className={cn("line-clamp-2 text-sm sm:order-2 sm:min-w-0 sm:flex-1 sm:truncate sm:line-clamp-none", titleClassName)}>
-          {issue.title}{titleSuffix}
+        <span data-slot="task-row-title-cluster" className="flex min-w-0 items-start gap-1.5 sm:order-2 sm:flex-1 sm:items-center">
+          <span
+            data-slot="task-row-title"
+            className={cn("min-w-0 line-clamp-2 text-sm sm:truncate sm:line-clamp-none", titleClassName)}
+          >
+            {issue.title}{titleSuffix}
+          </span>
+          {recoveryIndicator}
         </span>
         {checklistDependencyChips ? (
           <span className="flex flex-wrap gap-1 sm:order-3 sm:ml-(--sz-calc-13)">
@@ -317,7 +472,6 @@ export function IssueRow({
                 {identifier}
               </span>
               {parkedBlockerIndicator}
-              {recoveryIndicator}
             </>
           )}
           {mobileMeta ? (
@@ -377,7 +531,7 @@ function renderRecoveryChip(
       role="status"
       aria-label={detail ? `${label} — ${detail}` : label}
       className={cn(
-        "ml-1.5 gap-0.5 text-(length:--text-nano)",
+        "shrink-0 gap-0.5 text-(length:--text-nano)",
         tone.className,
         selected ? "!border-muted-foreground !text-muted-foreground" : null,
       )}

--- a/ui/src/components/KeyboardShortcutsCheatsheet.test.tsx
+++ b/ui/src/components/KeyboardShortcutsCheatsheet.test.tsx
@@ -18,24 +18,16 @@ describe("KeyboardShortcutsCheatsheet", () => {
     document.body.innerHTML = "";
   });
 
-  it("lists the re-pointed Cmd/Ctrl+B sidebar collapse shortcut as a chord", () => {
+  it("does not advertise the retired sidebar collapse shortcut", () => {
     const root = createRoot(container);
     flushSync(() => {
       root.render(<KeyboardShortcutsCheatsheetContent />);
     });
 
-    // The collapse/expand row exists with its label.
     const row = [...container.querySelectorAll("span")].find(
       (node) => node.textContent?.trim() === "Collapse or expand sidebar",
     )?.parentElement;
-    expect(row).toBeTruthy();
-
-    // Rendered as a "+" chord (B + a Cmd/Ctrl cap), not a "then" sequence.
-    const caps = [...(row?.querySelectorAll("kbd") ?? [])].map((kbd) => kbd.textContent);
-    expect(caps).toContain("B");
-    expect(caps.some((cap) => cap === "⌘" || cap === "Ctrl")).toBe(true);
-    expect(row?.textContent).toContain("+");
-    expect(row?.textContent).not.toContain("then");
+    expect(row).toBeUndefined();
 
     flushSync(() => {
       root.unmount();

--- a/ui/src/components/KeyboardShortcutsCheatsheet.tsx
+++ b/ui/src/components/KeyboardShortcutsCheatsheet.tsx
@@ -8,17 +8,6 @@ interface ShortcutEntry {
   combo?: boolean;
 }
 
-// Platform-appropriate label for the Cmd/Ctrl modifier so the cheatsheet shows
-// the same key the user actually presses (re-pointed in the collapsible sidebar
-// work — Cmd/Ctrl+B toggles the rail).
-function getPlatformLabel() {
-  if (typeof navigator === "undefined") return "";
-  const nav = navigator as Navigator & { userAgentData?: { platform?: string } };
-  return nav.userAgentData?.platform || navigator.userAgent || "";
-}
-
-const META_KEY = /Mac|iPhone|iPad|iPod/.test(getPlatformLabel()) ? "⌘" : "Ctrl";
-
 interface ShortcutSection {
   title: string;
   shortcuts: ShortcutEntry[];
@@ -66,7 +55,6 @@ const sections: ShortcutSection[] = [
       { keys: ["/"], label: "Search current page or quick search" },
       { keys: ["c"], label: "New task" },
       { keys: ["["], label: "Toggle sidebar" },
-      { keys: [META_KEY, "B"], label: "Collapse or expand sidebar", combo: true },
       { keys: ["]"], label: "Toggle panel" },
       { keys: ["?"], label: "Show keyboard shortcuts" },
     ],

--- a/ui/src/components/Layout.test.tsx
+++ b/ui/src/components/Layout.test.tsx
@@ -586,6 +586,9 @@ describe("Layout", () => {
     expect(container.textContent).toContain("Apps sidebar");
     expect(container.textContent).toContain("Main company nav");
     expect(mockSetForceCollapsed).toHaveBeenCalledWith(true);
+    const secondaryRail = container.querySelector("[data-secondary-sidebar]");
+    expect(secondaryRail?.classList.contains("w-60")).toBe(true);
+    expect(secondaryRail?.classList.contains("shrink-0")).toBe(true);
 
     await act(async () => {
       root.unmount();

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -643,7 +643,7 @@ export function Layout() {
         )}
 
         {!isMobile && hasSecondarySidebar ? (
-          <SecondarySidebar>{secondarySidebar}</SecondarySidebar>
+          <SecondarySidebar className="w-60 shrink-0">{secondarySidebar}</SecondarySidebar>
         ) : null}
 
         <div className={cn("flex min-w-0 flex-col", isMobile ? "w-full" : "h-full flex-1")}>

--- a/ui/src/components/RequestCollapsedSidebar.test.tsx
+++ b/ui/src/components/RequestCollapsedSidebar.test.tsx
@@ -9,8 +9,6 @@ import { RequestCollapsedSidebar } from "./RequestCollapsedSidebar";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
-const COLLAPSED_STORAGE_KEY = "paperclip.sidebar.collapsed";
-
 let capturedValue: ReturnType<typeof useSidebar> | null = null;
 
 function Capture() {
@@ -82,25 +80,24 @@ describe("RequestCollapsedSidebar", () => {
     localStorage.clear();
   });
 
-  it("requests collapsed while mounted when there is no user pin", async () => {
+  it("records the legacy route request without collapsing the global navigation", async () => {
     active = await render(true);
     expect(capturedValue?.routeRequestsCollapsed).toBe(true);
-    expect(capturedValue?.collapsed).toBe(true);
+    expect(capturedValue?.collapsed).toBe(false);
   });
 
-  it("lets an explicit user pin override the route request", async () => {
+  it("keeps the global navigation expanded when old pin APIs are called", async () => {
     active = await render(true);
-    expect(capturedValue?.collapsed).toBe(true);
+    expect(capturedValue?.collapsed).toBe(false);
 
-    // User explicitly pins expanded — must win over the route's request.
-    flushSync(() => capturedValue?.setCollapsed(false));
+    flushSync(() => capturedValue?.setCollapsed(true));
     expect(capturedValue?.routeRequestsCollapsed).toBe(true);
     expect(capturedValue?.collapsed).toBe(false);
   });
 
   it("clears the request on unmount, restoring the global default", async () => {
     active = await render(true);
-    expect(capturedValue?.collapsed).toBe(true);
+    expect(capturedValue?.collapsed).toBe(false);
 
     // Navigate away: the route (and its <RequestCollapsedSidebar/>) unmounts.
     flushSync(() => active!.root.render(<Harness onRoute={false} />));
@@ -109,15 +106,14 @@ describe("RequestCollapsedSidebar", () => {
     expect(capturedValue?.collapsed).toBe(false);
   });
 
-  it("keeps a user pin after navigating away (pin persists, request cleared)", async () => {
+  it("clears the request without persisting a retired collapsed pin", async () => {
     active = await render(true);
     flushSync(() => capturedValue?.setCollapsed(true));
-    expect(localStorage.getItem(COLLAPSED_STORAGE_KEY)).toBe("1");
+    expect(localStorage.getItem("paperclip.sidebar.collapsed")).toBeNull();
 
     flushSync(() => active!.root.render(<Harness onRoute={false} />));
     await flushReact();
-    // Route request gone, but the explicit collapsed pin still applies.
     expect(capturedValue?.routeRequestsCollapsed).toBe(false);
-    expect(capturedValue?.collapsed).toBe(true);
+    expect(capturedValue?.collapsed).toBe(false);
   });
 });

--- a/ui/src/components/RequestCollapsedSidebar.tsx
+++ b/ui/src/components/RequestCollapsedSidebar.tsx
@@ -2,14 +2,10 @@ import { useEffect } from "react";
 import { useSidebar } from "../context/SidebarContext";
 
 /**
- * Effect-only component (renders nothing). While mounted, it asks the app
- * sidebar to default to **collapsed** (still peek-able) — the generic
- * "this route brings its own sidebar, keep the app one out of the way" case.
- *
- * Precedence is enforced by {@link SidebarContext}: an explicit user pin
- * (collapsed *or* expanded) always wins over this route request. When the
- * component unmounts — e.g. navigating away from the route that rendered it —
- * the cleanup clears the request and the global default is restored.
+ * Back-compat effect for routes that previously requested the app sidebar's
+ * retired icon rail. The request remains observable to older integrations,
+ * but {@link SidebarContext} keeps the global navigation expanded. Cleanup
+ * still clears the request when the route unmounts.
  *
  * Drop it anywhere inside a route's element tree:
  *

--- a/ui/src/components/RoutineContextualSidebar.test.tsx
+++ b/ui/src/components/RoutineContextualSidebar.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  RoutineContextualSidebar,
+  resolveRoutineDetailDestination,
+  routineActivityAuditHref,
+  routineDetailHref,
+  routineRunsAuditHref,
+} from "./RoutineContextualSidebar";
+
+vi.mock("@/lib/router", () => ({
+  useParams: () => ({ routineId: "routine-route" }),
+}));
+
+vi.mock("@/api/routines", () => ({
+  routinesApi: { get: vi.fn() },
+}));
+
+vi.mock("./ContextualSidebarFrame", () => ({
+  ContextualSidebarFrame: ({
+    surface,
+    title,
+    fallbackTo,
+    showHeader,
+    className,
+    children,
+  }: {
+    surface: string;
+    title: string;
+    fallbackTo: string;
+    showHeader?: boolean;
+    className?: string;
+    children: ReactNode;
+  }) => (
+    <aside
+      className={className}
+      data-surface={surface}
+      data-title={title}
+      data-fallback={fallbackTo}
+      data-show-header={String(showHeader)}
+    >
+      {children}
+    </aside>
+  ),
+}));
+
+vi.mock("./SidebarNavItem", () => ({
+  SidebarNavItem: ({ to, label }: { to: string; label: string }) => <a href={to}>{label}</a>,
+}));
+
+describe("routine contextual navigation", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    flushSync(() => root.unmount());
+    container.remove();
+  });
+
+  it("builds stable detail and scoped Audit destinations", () => {
+    expect(routineDetailHref("routine-1")).toBe("/routines/routine-1/overview");
+    expect(routineDetailHref("routine-1", "triggers")).toBe("/routines/routine-1/triggers");
+    expect(routineRunsAuditHref("routine-1")).toBe(
+      "/activity/runs?entityType=routine&entityId=routine-1",
+    );
+    expect(routineActivityAuditHref("routine-1")).toBe(
+      "/activity?entityType=routine&entityId=routine-1",
+    );
+  });
+
+  it("defaults and redirects legacy operation routes without remembering a prior section", () => {
+    expect(resolveRoutineDetailDestination({ routineId: "routine-1" }))
+      .toBe("/routines/routine-1/overview");
+    expect(resolveRoutineDetailDestination({ routineId: "routine-1", section: "unknown" }))
+      .toBe("/routines/routine-1/overview");
+    expect(resolveRoutineDetailDestination({ routineId: "routine-1", section: "runs" }))
+      .toBe("/activity/runs?entityType=routine&entityId=routine-1");
+    expect(resolveRoutineDetailDestination({ routineId: "routine-1", legacyTab: "activity" }))
+      .toBe("/activity?entityType=routine&entityId=routine-1");
+  });
+
+  it("renders the routine contextual sidebar with configuration and Audit links", () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    flushSync(() => root.render(
+      <QueryClientProvider client={queryClient}>
+        <RoutineContextualSidebar routineId="routine-1" title="Weekly release review" />
+      </QueryClientProvider>,
+    ));
+
+    const frame = container.querySelector("aside");
+    expect(frame?.getAttribute("data-surface")).toBe("routine");
+    expect(frame?.getAttribute("data-title")).toBe("Weekly release review");
+    expect(frame?.getAttribute("data-fallback")).toBe("/routines");
+    expect(frame?.getAttribute("data-show-header")).toBe("false");
+    expect(frame?.classList).toContain("bg-background");
+    expect(frame?.classList).toContain("border-r");
+    expect(container.querySelector('a[href="/routines/routine-1/overview"]')?.textContent).toBe("Overview");
+    expect(container.querySelector('a[href="/routines/routine-1/triggers"]')?.textContent).toBe("Schedule");
+    expect(container.querySelector('a[href="/activity/runs?entityType=routine&entityId=routine-1"]'))
+      .not.toBeNull();
+    expect(container.querySelector('a[href="/activity?entityType=routine&entityId=routine-1"]'))
+      .not.toBeNull();
+    expect(container.textContent).not.toContain("History");
+  });
+});

--- a/ui/src/components/RoutineContextualSidebar.tsx
+++ b/ui/src/components/RoutineContextualSidebar.tsx
@@ -1,0 +1,140 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  Activity,
+  Braces,
+  CalendarClock,
+  KeyRound,
+  LayoutDashboard,
+  Play,
+  Repeat,
+  Send,
+  type LucideIcon,
+} from "lucide-react";
+import { routinesApi } from "@/api/routines";
+import { queryKeys } from "@/lib/queryKeys";
+import { useParams } from "@/lib/router";
+import {
+  auditSectionHref,
+  routineAuditHref,
+} from "@/pages/audit/audit-navigation";
+import { ContextualSidebarFrame } from "./ContextualSidebarFrame";
+import { SidebarNavItem } from "./SidebarNavItem";
+
+export const ROUTINE_DETAIL_VIEWS = [
+  "overview",
+  "triggers",
+  "variables",
+  "delivery",
+  "secrets",
+  "history",
+] as const;
+
+export type RoutineDetailView = (typeof ROUTINE_DETAIL_VIEWS)[number];
+
+export type RoutineContextualNavItem = {
+  view: Exclude<RoutineDetailView, "history">;
+  label: string;
+  icon: LucideIcon;
+};
+
+export const ROUTINE_CONTEXTUAL_NAV_ITEMS: readonly RoutineContextualNavItem[] = [
+  { view: "overview", label: "Overview", icon: LayoutDashboard },
+  { view: "triggers", label: "Schedule", icon: CalendarClock },
+  { view: "variables", label: "Variables", icon: Braces },
+  { view: "delivery", label: "Delivery", icon: Send },
+  { view: "secrets", label: "Secrets", icon: KeyRound },
+];
+
+export function isRoutineDetailView(value: string | null | undefined): value is RoutineDetailView {
+  return ROUTINE_DETAIL_VIEWS.includes(value as RoutineDetailView);
+}
+
+export function routineDetailHref(routineId: string, view: RoutineDetailView = "overview") {
+  return `/routines/${routineId}/${view}`;
+}
+
+export function routineRunsAuditHref(routineId: string) {
+  return auditSectionHref("runs", {
+    entityType: "routine",
+    entityId: routineId,
+  });
+}
+
+export function routineActivityAuditHref(routineId: string) {
+  return routineAuditHref(routineId);
+}
+
+/**
+ * Canonical landing/legacy resolver used by the page and available to the
+ * shell. Detail configuration stays local; immutable operational history
+ * lives in scoped Audit.
+ */
+export function resolveRoutineDetailDestination(input: {
+  routineId: string;
+  section?: string | null;
+  legacyTab?: string | null;
+}) {
+  const requested = input.legacyTab ?? input.section;
+  if (requested === "runs") return routineRunsAuditHref(input.routineId);
+  if (requested === "activity") return routineActivityAuditHref(input.routineId);
+  if (isRoutineDetailView(requested)) return routineDetailHref(input.routineId, requested);
+  return routineDetailHref(input.routineId, "overview");
+}
+
+export function RoutineContextualSidebar({
+  routineId: routineIdProp,
+  title,
+}: {
+  routineId?: string;
+  title?: string;
+} = {}) {
+  const params = useParams<{ routineId?: string }>();
+  const routineId = routineIdProp ?? params.routineId ?? "";
+  const { data: routine } = useQuery({
+    queryKey: queryKeys.routines.detail(routineId),
+    queryFn: () => routinesApi.get(routineId),
+    enabled: Boolean(routineId && !title),
+  });
+  const frameTitle = title ?? routine?.title ?? "Routine";
+
+  return (
+    <ContextualSidebarFrame
+      surface="routine"
+      title={frameTitle}
+      icon={Repeat}
+      fallbackTo="/routines"
+      showHeader={false}
+      className="border-r border-border bg-background"
+    >
+      <nav className="min-h-0 flex-1 overflow-y-auto px-3 py-2" aria-label="Routine navigation">
+        <div className="flex flex-col gap-0.5">
+          {ROUTINE_CONTEXTUAL_NAV_ITEMS.map((item) => (
+            <SidebarNavItem
+              key={item.view}
+              to={routineDetailHref(routineId, item.view)}
+              label={item.label}
+              icon={item.icon}
+              end
+            />
+          ))}
+        </div>
+
+        <p className="px-4 pb-1 pt-5 text-(length:--text-nano) font-mono font-medium uppercase tracking-widest text-muted-foreground/60">
+          Audit
+        </p>
+        <div className="flex flex-col gap-0.5">
+          <SidebarNavItem
+            to={routineRunsAuditHref(routineId)}
+            label="Runs"
+            icon={Play}
+          />
+          <SidebarNavItem
+            to={routineActivityAuditHref(routineId)}
+            label="Activity"
+            icon={Activity}
+          />
+        </div>
+      </nav>
+    </ContextualSidebarFrame>
+  );
+}

--- a/ui/src/components/RoutineOverview.test.tsx
+++ b/ui/src/components/RoutineOverview.test.tsx
@@ -1,0 +1,203 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+import type { RoutineDetail, RoutineRunSummary } from "@paperclipai/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RoutineDetailContext, type RoutineDetailContextValue } from "./routine-sections/context";
+import {
+  RoutineOverview,
+  routineRunIssue,
+  summarizeRoutineSchedule,
+} from "./RoutineOverview";
+
+const issueRowRender = vi.hoisted(() => vi.fn());
+
+vi.mock("@/components/IssueRow", () => ({
+  IssueRow: (props: { issue: { title: string }; presentation?: string }) => {
+    issueRowRender(props);
+    return <div data-slot="task-row">{props.issue.title}</div>;
+  },
+}));
+
+vi.mock("@/components/MarkdownBody", () => ({
+  MarkdownBody: ({ children }: { children: string }) => <div data-testid="markdown">{children}</div>,
+}));
+
+vi.mock("@/lib/router", () => ({
+  Link: ({ to, children, ...props }: { to: string; children: ReactNode }) => (
+    <a href={to} {...props}>{children}</a>
+  ),
+}));
+
+const triggeredAt = new Date("2026-08-31T16:00:00.000Z");
+const run: RoutineRunSummary = {
+  id: "run-1",
+  companyId: "company-1",
+  routineId: "routine-1",
+  triggerId: "trigger-1",
+  source: "schedule",
+  status: "succeeded",
+  triggeredAt,
+  idempotencyKey: null,
+  triggerPayload: null,
+  dispatchFingerprint: null,
+  linkedIssueId: "issue-1",
+  coalescedIntoRunId: null,
+  failureReason: null,
+  completedAt: triggeredAt,
+  createdAt: triggeredAt,
+  updatedAt: triggeredAt,
+  trigger: { id: "trigger-1", kind: "schedule", label: "weekday" },
+  linkedIssue: {
+    id: "issue-1",
+    identifier: "PAP-42",
+    title: "Prepare the release digest",
+    status: "done",
+    priority: "high",
+    updatedAt: triggeredAt,
+  },
+};
+
+const routine = {
+  id: "routine-1",
+  companyId: "company-1",
+  projectId: "project-1",
+  folderId: null,
+  goalId: null,
+  parentIssueId: null,
+  title: "Weekly release review",
+  description: "Summarize **release readiness** for the operator.",
+  assigneeAgentId: "agent-1",
+  priority: "medium",
+  status: "active",
+  concurrencyPolicy: "coalesce_if_active",
+  catchUpPolicy: "skip_missed",
+  activityGatePolicy: "always",
+  activityGateScope: "company",
+  variables: [],
+  env: { PRIVATE_TOKEN: { type: "secret_ref", secretId: "secret-1" } },
+  latestRevisionId: "revision-1",
+  latestRevisionNumber: 1,
+  createdByAgentId: null,
+  createdByUserId: null,
+  responsibleUserId: null,
+  updatedByAgentId: null,
+  updatedByUserId: null,
+  lastTriggeredAt: triggeredAt,
+  lastEnqueuedAt: triggeredAt,
+  createdAt: triggeredAt,
+  updatedAt: triggeredAt,
+  project: null,
+  assignee: { id: "agent-1", name: "Release Manager", role: "manager", title: null, urlKey: "release-manager" },
+  parentIssue: null,
+  triggers: [{
+    id: "trigger-1",
+    companyId: "company-1",
+    routineId: "routine-1",
+    kind: "schedule",
+    label: "weekday",
+    enabled: true,
+    cronExpression: "0 9 * * 1-5",
+    timezone: "America/Los_Angeles",
+    nextRunAt: new Date("2026-09-01T16:00:00.000Z"),
+    lastFiredAt: triggeredAt,
+    publicId: null,
+    secretId: null,
+    signingMode: null,
+    replayWindowSec: null,
+    lastRotatedAt: null,
+    lastResult: "succeeded",
+    createdByAgentId: null,
+    createdByUserId: null,
+    updatedByAgentId: null,
+    updatedByUserId: null,
+    createdAt: triggeredAt,
+    updatedAt: triggeredAt,
+  }],
+  recentRuns: [run],
+  activeIssue: null,
+} as RoutineDetail;
+
+function contextFixture(): RoutineDetailContextValue {
+  return {
+    routine,
+    routineId: routine.id,
+    companyId: routine.companyId,
+    routineRuns: [run],
+    currentAssignee: {
+      id: "agent-1",
+      name: "Release Manager",
+      urlKey: "release-manager",
+    },
+    hasLiveRun: false,
+  } as RoutineDetailContextValue;
+}
+
+describe("RoutineOverview", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    issueRowRender.mockClear();
+    vi.spyOn(Date, "now").mockReturnValue(new Date("2026-08-31T17:00:00.000Z").getTime());
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    flushSync(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("summarizes enabled schedules and their next run", () => {
+    expect(summarizeRoutineSchedule(routine.triggers)).toMatchObject({
+      label: "1 active schedule",
+      detail: "0 9 * * 1-5 · America/Los_Angeles",
+      nextRunAt: new Date("2026-09-01T16:00:00.000Z"),
+    });
+    expect(summarizeRoutineSchedule([{ ...routine.triggers[0]!, enabled: false }])).toEqual({
+      label: "No active schedule",
+      detail: "Manual runs only",
+      nextRunAt: null,
+    });
+  });
+
+  it("adapts compact run tasks to the canonical task presentation", () => {
+    const issue = routineRunIssue(run.linkedIssue!, run, "company-1", "project-1");
+    expect(issue).toMatchObject({
+      id: "issue-1",
+      companyId: "company-1",
+      projectId: "project-1",
+      status: "done",
+      priority: "high",
+      originKind: "routine_execution",
+      originId: "routine-1",
+      originRunId: "run-1",
+    });
+  });
+
+  it("shows operational facts, readable description, agent, and recent task rows without secrets", () => {
+    flushSync(() => root.render(
+      <RoutineDetailContext.Provider value={contextFixture()}>
+        <RoutineOverview />
+      </RoutineDetailContext.Provider>,
+    ));
+
+    expect(container.textContent).toContain("1 active schedule");
+    expect(container.textContent).toContain("Next run");
+    expect(container.textContent).toContain("Release Manager");
+    expect(container.textContent).toContain("Summarize **release readiness** for the operator.");
+    expect(container.textContent).toContain("Prepare the release digest");
+    expect(container.textContent).not.toContain("PRIVATE_TOKEN");
+    expect(container.textContent).not.toContain("secret-1");
+    expect(issueRowRender).toHaveBeenCalledWith(expect.objectContaining({ presentation: "task" }));
+    expect(container.querySelector('a[href="/activity/runs?entityType=routine&entityId=routine-1"]'))
+      .not.toBeNull();
+    expect(container.querySelector('a[href="/activity?entityType=routine&entityId=routine-1"]'))
+      .not.toBeNull();
+  });
+});

--- a/ui/src/components/RoutineOverview.tsx
+++ b/ui/src/components/RoutineOverview.tsx
@@ -1,0 +1,249 @@
+import type {
+  Issue,
+  IssuePriority,
+  IssueStatus,
+  RoutineRunSummary,
+  RoutineTrigger,
+} from "@paperclipai/shared";
+import { ISSUE_PRIORITIES, ISSUE_STATUSES } from "@paperclipai/shared";
+import { CalendarClock, Clock3, Play, Repeat, UserRound } from "lucide-react";
+import { IssueRow } from "@/components/IssueRow";
+import { MarkdownBody } from "@/components/MarkdownBody";
+import { StatusBadge } from "@/components/StatusBadge";
+import { Button } from "@/components/ui/button";
+import { createIssueDetailLocationState } from "@/lib/issueDetailBreadcrumb";
+import { Link } from "@/lib/router";
+import {
+  routineActivityAuditHref,
+  routineDetailHref,
+  routineRunsAuditHref,
+} from "./RoutineContextualSidebar";
+import { useRoutineDetail } from "./routine-sections/context";
+
+export type RoutineScheduleSummary = {
+  label: string;
+  detail: string;
+  nextRunAt: Date | null;
+};
+
+export function formatRoutineTimestamp(value: Date | string) {
+  return new Date(value).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+export function summarizeRoutineSchedule(triggers: RoutineTrigger[]): RoutineScheduleSummary {
+  const schedules = triggers.filter((trigger) => trigger.kind === "schedule" && trigger.enabled);
+  const nextRunAt = schedules
+    .map((trigger) => trigger.nextRunAt ? new Date(trigger.nextRunAt) : null)
+    .filter((value): value is Date => value !== null && Number.isFinite(value.getTime()))
+    .sort((left, right) => left.getTime() - right.getTime())[0] ?? null;
+
+  if (schedules.length === 0) {
+    return { label: "No active schedule", detail: "Manual runs only", nextRunAt: null };
+  }
+
+  const first = schedules[0]!;
+  return {
+    label: schedules.length === 1 ? "1 active schedule" : `${schedules.length} active schedules`,
+    detail: first.cronExpression
+      ? `${first.cronExpression}${first.timezone ? ` · ${first.timezone}` : ""}`
+      : first.label ?? "Scheduled trigger",
+    nextRunAt,
+  };
+}
+
+function normalizeIssueStatus(value: string): IssueStatus {
+  return ISSUE_STATUSES.includes(value as IssueStatus) ? value as IssueStatus : "todo";
+}
+
+function normalizeIssuePriority(value: string): IssuePriority {
+  return ISSUE_PRIORITIES.includes(value as IssuePriority) ? value as IssuePriority : "medium";
+}
+
+/** Display-only adapter for the canonical task row; run summaries intentionally carry compact task data. */
+export function routineRunIssue(
+  summary: NonNullable<RoutineRunSummary["linkedIssue"]>,
+  run: RoutineRunSummary,
+  companyId: string,
+  projectId: string | null,
+): Issue {
+  return {
+    ...summary,
+    companyId,
+    projectId,
+    projectWorkspaceId: null,
+    goalId: null,
+    parentId: null,
+    description: null,
+    status: normalizeIssueStatus(summary.status),
+    workMode: "standard",
+    priority: normalizeIssuePriority(summary.priority),
+    reviewPolicy: null,
+    assigneeAgentId: null,
+    assigneeUserId: null,
+    checkoutRunId: null,
+    executionRunId: null,
+    executionAgentNameKey: null,
+    executionLockedAt: null,
+    createdByAgentId: null,
+    createdByUserId: null,
+    responsibleUserId: null,
+    issueNumber: null,
+    originKind: "routine_execution",
+    originId: run.routineId,
+    originRunId: run.id,
+    requestDepth: 0,
+    billingCode: null,
+    assigneeAdapterOverrides: null,
+    executionWorkspaceId: null,
+    executionWorkspacePreference: null,
+    executionWorkspaceSettings: null,
+    startedAt: null,
+    completedAt: null,
+    cancelledAt: null,
+    hiddenAt: null,
+    createdAt: run.triggeredAt,
+  };
+}
+
+function OverviewFact({
+  icon: Icon,
+  label,
+  value,
+  detail,
+}: {
+  icon: typeof Clock3;
+  label: string;
+  value: React.ReactNode;
+  detail?: React.ReactNode;
+}) {
+  return (
+    <div className="flex min-w-0 flex-col gap-1 rounded-lg border border-border p-3">
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+        <span>{label}</span>
+      </div>
+      <div className="min-w-0 text-sm font-medium text-foreground">{value}</div>
+      {detail ? <div className="min-w-0 text-xs text-muted-foreground">{detail}</div> : null}
+    </div>
+  );
+}
+
+export function RoutineOverview() {
+  const { routine, routineRuns, currentAssignee, hasLiveRun } = useRoutineDetail();
+  const schedule = summarizeRoutineSchedule(routine.triggers);
+  const sortedRuns = [...(routineRuns ?? [])].sort(
+    (left, right) => new Date(right.triggeredAt).getTime() - new Date(left.triggeredAt).getTime(),
+  );
+  const lastRun = sortedRuns[0] ?? null;
+  const recentRuns = sortedRuns.slice(0, 5);
+  const detailOrigin = createIssueDetailLocationState(
+    routine.title,
+    routineDetailHref(routine.id),
+    "issues",
+  );
+  const automationState = routine.status === "archived"
+    ? "archived"
+    : !routine.assigneeAgentId
+      ? "draft"
+      : routine.status;
+
+  return (
+    <div className="flex flex-col gap-6" data-routine-overview-mode="read">
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <OverviewFact
+          icon={Repeat}
+          label="State"
+          value={<StatusBadge status={automationState} />}
+          detail={hasLiveRun ? "A run is active now" : "No active run"}
+        />
+        <OverviewFact
+          icon={CalendarClock}
+          label="Schedule"
+          value={schedule.label}
+          detail={<span className="font-mono">{schedule.detail}</span>}
+        />
+        <OverviewFact
+          icon={Clock3}
+          label="Next run"
+          value={schedule.nextRunAt ? formatRoutineTimestamp(schedule.nextRunAt) : "Not scheduled"}
+          detail={schedule.nextRunAt ? "Scheduled" : "Add or enable a schedule"}
+        />
+        <OverviewFact
+          icon={Play}
+          label="Last run"
+          value={lastRun ? <StatusBadge status={lastRun.status} /> : "No runs yet"}
+          detail={lastRun ? formatRoutineTimestamp(lastRun.triggeredAt) : "Run manually or wait for the schedule"}
+        />
+      </div>
+
+      <section className="flex flex-col gap-2" aria-labelledby="routine-agent-heading">
+        <h2 id="routine-agent-heading" className="text-sm font-semibold">Default agent</h2>
+        {currentAssignee ? (
+          <Link
+            to={`/agents/${currentAssignee.urlKey ?? currentAssignee.id}`}
+            className="flex w-fit items-center gap-2 rounded-md text-sm font-medium hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <UserRound className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+            {currentAssignee.name}
+          </Link>
+        ) : (
+          <p className="text-sm text-muted-foreground">No default agent. Automatic triggers remain paused.</p>
+        )}
+      </section>
+
+      <section className="flex flex-col gap-2" aria-labelledby="routine-description-heading">
+        <h2 id="routine-description-heading" className="text-sm font-semibold">Description</h2>
+        {routine.description?.trim() ? (
+          <MarkdownBody className="text-sm text-foreground" linkIssueReferences>
+            {routine.description}
+          </MarkdownBody>
+        ) : (
+          <p className="text-sm text-muted-foreground">No description yet.</p>
+        )}
+      </section>
+
+      <section className="flex flex-col gap-2" aria-labelledby="routine-recent-runs-heading">
+        <div className="flex items-center justify-between gap-3">
+          <h2 id="routine-recent-runs-heading" className="text-sm font-semibold">Recent runs</h2>
+          <Button variant="ghost" size="sm" asChild>
+            <Link to={routineRunsAuditHref(routine.id)}>View all runs</Link>
+          </Button>
+        </div>
+        {recentRuns.length === 0 ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            No runs yet. Run the routine now or wait for its schedule.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-0.5">
+            {recentRuns.map((run) => run.linkedIssue ? (
+              <IssueRow
+                key={run.id}
+                issue={routineRunIssue(run.linkedIssue, run, routine.companyId, routine.projectId)}
+                issueLinkState={detailOrigin}
+                presentation="task"
+                metadata={(
+                  <span className="flex items-center gap-2">
+                    <StatusBadge status={run.status} />
+                    <span className="font-mono text-xs text-muted-foreground">{formatRoutineTimestamp(run.triggeredAt)}</span>
+                  </span>
+                )}
+              />
+            ) : (
+              <div key={run.id} className="flex min-w-0 items-center gap-2 rounded-lg px-2 py-2 text-sm">
+                <StatusBadge status={run.status} />
+                <span className="min-w-0 flex-1 truncate">{run.trigger?.label ?? "Routine run"}</span>
+                <span className="shrink-0 font-mono text-xs text-muted-foreground">{formatRoutineTimestamp(run.triggeredAt)}</span>
+              </div>
+            ))}
+          </div>
+        )}
+        <Button variant="link" size="sm" className="w-fit px-0" asChild>
+          <Link to={routineActivityAuditHref(routine.id)}>View routine activity</Link>
+        </Button>
+      </section>
+    </div>
+  );
+}

--- a/ui/src/components/SecondarySidebar.production.tsx
+++ b/ui/src/components/SecondarySidebar.production.tsx
@@ -1,0 +1,39 @@
+import { type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import { SidebarNavExpandedProvider } from "./SidebarNavItem.production";
+
+/**
+ * Fixed-width contextual pane that sits between the collapsed app rail and the
+ * main content on takeover routes (company settings, plugin `routeSidebar`).
+ *
+ * The takeover model (PAP-10695) no longer *replaces* the app `<Sidebar/>`:
+ * the host collapses it to its 64px rail (still peek-able) and renders the
+ * contextual sidebar here, yielding `[ rail 64px ][ secondary ~240px ][ content ]`.
+ *
+ * It is a dumb container — fixed `w-60`, full-height, non-shrinking, with a
+ * right border and its own vertical scroll — so callers just drop the
+ * contextual nav (or a plugin slot mount) inside as `children`.
+ *
+ * Because the pane is always 240px wide it forces the full-label presentation
+ * on any `SidebarNavItem` inside it, so the contextual nav stays readable even
+ * while the app sidebar is collapsed to its rail (PAP-10700).
+ */
+export function SecondarySidebar({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div
+      data-secondary-sidebar=""
+      className={cn(
+        "h-full w-60 shrink-0 overflow-y-auto border-r border-border bg-background",
+        className,
+      )}
+    >
+      <SidebarNavExpandedProvider>{children}</SidebarNavExpandedProvider>
+    </div>
+  );
+}

--- a/ui/src/components/SecondarySidebar.tsx
+++ b/ui/src/components/SecondarySidebar.tsx
@@ -3,20 +3,9 @@ import { cn } from "@/lib/utils";
 import { SidebarNavExpandedProvider } from "./SidebarNavItem";
 
 /**
- * Fixed-width contextual pane that sits between the collapsed app rail and the
- * main content on takeover routes (company settings, plugin `routeSidebar`).
- *
- * The takeover model (PAP-10695) no longer *replaces* the app `<Sidebar/>`:
- * the host collapses it to its 64px rail (still peek-able) and renders the
- * contextual sidebar here, yielding `[ rail 64px ][ secondary ~240px ][ content ]`.
- *
- * It is a dumb container — fixed `w-60`, full-height, non-shrinking, with a
- * right border and its own vertical scroll — so callers just drop the
- * contextual nav (or a plugin slot mount) inside as `children`.
- *
- * Because the pane is always 240px wide it forces the full-label presentation
- * on any `SidebarNavItem` inside it, so the contextual nav stays readable even
- * while the app sidebar is collapsed to its rail (PAP-10700).
+ * Content adapter for a contextual sidebar. Depending on the route, Layout
+ * either places it inside the primary SidebarShell or mounts it as an adjacent
+ * secondary rail.
  */
 export function SecondarySidebar({
   children,
@@ -29,7 +18,7 @@ export function SecondarySidebar({
     <div
       data-secondary-sidebar=""
       className={cn(
-        "h-full w-60 shrink-0 overflow-y-auto border-r border-border bg-background",
+        "h-full w-full min-w-0 overflow-hidden",
         className,
       )}
     >

--- a/ui/src/components/Sidebar.production.tsx
+++ b/ui/src/components/Sidebar.production.tsx
@@ -1,0 +1,251 @@
+import {
+  Inbox,
+  ListChecks,
+  CircleDot,
+  Target,
+  LayoutDashboard,
+  DollarSign,
+  History,
+  Search,
+  SquarePen,
+  Network,
+  Boxes,
+  Repeat,
+  Layers,
+  GitBranch,
+  Package,
+  Settings,
+  FolderOpen,
+  AppWindow,
+  MessagesSquare,
+  GanttChartSquare,
+  LayoutGrid,
+} from "lucide-react";
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { SidebarSection } from "./SidebarSection";
+import { SidebarNavItem } from "./SidebarNavItem.production";
+import { SidebarAgents } from "./SidebarAgents.production";
+import { SidebarProjects } from "./SidebarProjects";
+import { SidebarStarredProjects } from "./SidebarStarredProjects.production";
+import { useDialogActions } from "../context/DialogContext";
+import { useCompany } from "../context/CompanyContext";
+import { useSidebar } from "../context/SidebarContext";
+import { attentionApi } from "../api/attention";
+import { heartbeatsApi } from "../api/heartbeats";
+import { instanceSettingsApi } from "../api/instanceSettings";
+import { queryKeys } from "../lib/queryKeys";
+import { attentionBadgeCount } from "../lib/attention";
+import { useInboxBadge } from "../hooks/useInboxBadge";
+import { usePublishSharedQueryData, useSharedPollingQuery } from "../hooks/useSharedPolling";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn, SIDEBAR_RAIL_HIDDEN_LABEL } from "../lib/utils";
+import { PluginSlotOutlet } from "@/plugins/slots";
+import { PluginLauncherOutlet } from "@/plugins/launchers";
+import { SidebarCompanyMenu } from "./SidebarCompanyMenu.production";
+
+export function Sidebar() {
+  const { openNewIssue } = useDialogActions();
+  // Every labeled section is collapsible (session-scoped, default open) —
+  // one policy across static nav groups and the data-driven sections.
+  const [workOpen, setWorkOpen] = useState(true);
+  const [companyOpen, setCompanyOpen] = useState(true);
+  const { selectedCompanyId, selectedCompany } = useCompany();
+  const { collapsed, peeking } = useSidebar();
+  const rail = collapsed && !peeking;
+  const inboxBadge = useInboxBadge(selectedCompanyId);
+  const { data: experimentalSettings } = useQuery({
+    queryKey: queryKeys.instance.experimentalSettings,
+    queryFn: () => instanceSettingsApi.getExperimental(),
+  });
+  const liveRunsQueryKey = queryKeys.liveRuns(selectedCompanyId!);
+  const sharedLiveRuns = useSharedPollingQuery({
+    companyId: selectedCompanyId,
+    resourceKey: "live-runs",
+    queryKey: liveRunsQueryKey,
+    enabled: !!selectedCompanyId,
+    // Event-sourced via LiveUpdatesProvider (GitHub issue 9627) + reconnect reconcile — no
+    // interval poll needed. Polling here also re-armed React Query's timer on
+    // every live-event cache write, a major source of steady-state churn.
+    refetchInterval: false,
+    leaderOnly: true,
+  });
+  const { data: liveRuns, dataUpdatedAt: liveRunsUpdatedAt } = useQuery({
+    queryKey: liveRunsQueryKey,
+    queryFn: () => heartbeatsApi.liveRunsForCompany(selectedCompanyId!),
+    enabled: sharedLiveRuns.enabled,
+    refetchInterval: sharedLiveRuns.refetchInterval,
+  });
+  usePublishSharedQueryData(sharedLiveRuns, liveRuns, liveRunsUpdatedAt);
+  const liveRunCount = liveRuns?.length ?? 0;
+  const showWorkspacesLink = experimentalSettings?.enableIsolatedWorkspaces === true;
+  const showApps = experimentalSettings?.enableApps === true;
+  const showPipelines = experimentalSettings?.enablePipelines === true;
+  const showStatusCards = experimentalSettings?.enableStatusCards === true;
+  const goalsLinkPending = experimentalSettings === undefined;
+  const showGoalsLink = experimentalSettings?.enableGoalsSidebarLink === true;
+  // Decisions (attention home) is an experimental surface (PAP-13481): the nav
+  // item is hidden entirely until the flag is enabled (same no-flash pattern as
+  // showWorkspacesLink — it defaults hidden, so no placeholder is needed).
+  const showDecisions = experimentalSettings?.enableDecisions === true;
+  const { data: attentionFeed } = useQuery({
+    queryKey: queryKeys.attention(selectedCompanyId!),
+    queryFn: () => attentionApi.list(selectedCompanyId!),
+    enabled: !!selectedCompanyId && showDecisions,
+    refetchInterval: 60_000,
+  });
+  const attentionCount = attentionBadgeCount(attentionFeed);
+  const showCases = experimentalSettings?.enableCases === true;
+  // Streamlined left navigation (top-level Projects link + starred children) is
+  // now the standard product sidebar (PAP-12472). The former experimental
+  // opt-out was retired; classic per-project collapsible mode is no longer
+  // user-selectable. Kept as a constant so the classic branch below stays as a
+  // documented reference until it is fully removed. Routes are unaffected.
+  const streamlined = true;
+  // Conference Room Chat flag (PAP-136/PAP-137): the Conference Room nav item
+  // is a new surface, hidden entirely while the flag is off (same no-flash
+  // pattern as showWorkspacesLink above).
+  const conferenceRoomChatEnabled = experimentalSettings?.enableConferenceRoomChat === true;
+
+  const pluginContext = {
+    companyId: selectedCompanyId,
+    companyPrefix: selectedCompany?.issuePrefix ?? null,
+  };
+
+  return (
+    <aside className="w-full h-full min-h-0 border-r border-border bg-background flex flex-col">
+      {/* Top bar: company name, aligned with top sections and borderless.
+          Search deliberately does NOT live here:
+          the header's spare width goes to the workspace/organization name,
+          which is the user's orientation anchor and truncates otherwise.
+          Search is the first nav item below instead. */}
+      <div className="flex items-center gap-1 px-3 h-12 shrink-0">
+        <SidebarCompanyMenu />
+      </div>
+
+      <nav className="flex-1 min-h-0 overflow-y-auto scrollbar-auto-hide flex flex-col gap-4 pointer-coarse:gap-3 px-3 py-2">
+        <div className="flex flex-col gap-0.5">
+          {/* New Task button aligned with nav items */}
+          {(() => {
+            const newTaskButton = (
+              <button
+                onClick={() => openNewIssue()}
+                data-slot="icon-button"
+                aria-label={rail ? "New Task" : undefined}
+                className="flex items-center gap-2.5 mx-2 rounded-lg px-2 py-1.5 pointer-coarse:py-1 text-(length:--text-compact) font-medium text-foreground/80 hover:bg-accent/50 hover:text-foreground transition-colors"
+              >
+                <SquarePen className="h-4 w-4 shrink-0" />
+                <span className={rail ? SIDEBAR_RAIL_HIDDEN_LABEL : "truncate"}>New Task</span>
+              </button>
+            );
+            return rail ? (
+              <Tooltip>
+                <TooltipTrigger asChild>{newTaskButton}</TooltipTrigger>
+                <TooltipContent side="right">New Task</TooltipContent>
+              </Tooltip>
+            ) : (
+              newTaskButton
+            );
+          })()}
+          {/* Search moved out of the header so the workspace name keeps the
+              width; a nav row also keeps search reachable from the
+              collapsed rail, where the old header icon was dropped entirely.
+              Cmd/Ctrl+K remains the keyboard path (command palette). */}
+          <SidebarNavItem to="/search" label="Search" icon={Search} />
+          <SidebarNavItem to="/dashboard" label="Dashboard" icon={LayoutDashboard} liveCount={liveRunCount} />
+          <SidebarNavItem
+            to="/inbox"
+            label="Inbox"
+            icon={Inbox}
+            badge={inboxBadge.inbox}
+            badgeLabel="unread"
+            badgeTone={inboxBadge.failedRuns > 0 ? "danger" : "default"}
+            alert={inboxBadge.failedRuns > 0}
+          />
+          {showDecisions ? (
+            <SidebarNavItem
+              to="/decisions"
+              label="Decisions"
+              icon={ListChecks}
+              badge={attentionCount}
+              badgeLabel="decisions"
+            />
+          ) : null}
+          {showStatusCards ? (
+            <SidebarNavItem to="/status" label="Status" icon={LayoutGrid} textBadge="beta" />
+          ) : null}
+          {conferenceRoomChatEnabled ? (
+            <SidebarNavItem to="/board-chat" label="Conference Room" icon={MessagesSquare} />
+          ) : null}
+        </div>
+
+        <SidebarSection label="Work" collapsible={{ open: workOpen, onOpenChange: setWorkOpen }}>
+          <SidebarNavItem to="/issues" label="Tasks" icon={CircleDot} />
+          {showCases ? (
+            <SidebarNavItem to="/cases" label="Cases" icon={Layers} textBadge="beta" />
+          ) : null}
+          <SidebarNavItem to="/routines" label="Routines" icon={Repeat} />
+          {showPipelines ? (
+            <SidebarNavItem to="/pipelines" label="Pipelines" icon={GitBranch} />
+          ) : null}
+          {showGoalsLink ? (
+            <SidebarNavItem to="/goals" label="Goals" icon={Target} />
+          ) : goalsLinkPending ? (
+            <div
+              data-testid="sidebar-goals-placeholder"
+              className="h-8 pointer-coarse:h-7"
+              aria-hidden="true"
+            />
+          ) : null}
+          <SidebarNavItem to="/artifacts" label="Artifacts" icon={Package} />
+          <SidebarNavItem to="/skills" label="Skills" icon={Boxes} />
+          {showWorkspacesLink ? (
+            <SidebarNavItem to="/workspaces" label="Workspaces" icon={GitBranch} />
+          ) : null}
+          {streamlined ? (
+            <>
+              <SidebarNavItem to="/projects" label="Projects" icon={FolderOpen} />
+              <SidebarStarredProjects />
+            </>
+          ) : null}
+          <PluginSlotOutlet
+            slotTypes={["sidebar"]}
+            context={pluginContext}
+            className="flex flex-col gap-0.5"
+            itemClassName="text-(length:--text-compact) font-medium"
+            missingBehavior="placeholder"
+          />
+          <PluginLauncherOutlet
+            placementZones={["sidebar"]}
+            context={pluginContext}
+            className="flex flex-col gap-0.5"
+            itemClassName="text-(length:--text-compact) font-medium"
+          />
+        </SidebarSection>
+
+        {/* Classic mode restores the per-project collapsible below Work. */}
+        {streamlined ? null : <SidebarProjects />}
+
+        <SidebarAgents streamlined={streamlined} />
+
+        <SidebarSection label="Company" collapsible={{ open: companyOpen, onOpenChange: setCompanyOpen }}>
+          <SidebarNavItem to="/org" label="Org" icon={Network} />
+          {showApps ? <SidebarNavItem to="/apps" label="Apps" icon={AppWindow} /> : null}
+          <SidebarNavItem to="/timeline" label="Timeline" icon={GanttChartSquare} />
+          <SidebarNavItem to="/costs" label="Costs" icon={DollarSign} />
+          {/* One entry — /audit merged into the rich Activity feed (PAP-16302). */}
+          <SidebarNavItem to="/activity" label="Activity" icon={History} />
+          <SidebarNavItem to="/company/settings" label="Settings" icon={Settings} />
+        </SidebarSection>
+
+        <PluginSlotOutlet
+          slotTypes={["sidebarPanel"]}
+          context={pluginContext}
+          className="flex flex-col gap-3"
+          itemClassName="rounded-lg border border-border p-3"
+          missingBehavior="placeholder"
+        />
+      </nav>
+    </aside>
+  );
+}

--- a/ui/src/components/Sidebar.test.tsx
+++ b/ui/src/components/Sidebar.test.tsx
@@ -100,16 +100,22 @@ vi.mock("./SidebarCompanyMenu", () => ({
 
 vi.mock("./SidebarAgents", () => ({
   SidebarAgents: ({ streamlined }: { streamlined?: boolean }) => (
-    <div data-testid="sidebar-agents" data-streamlined={String(streamlined)} />
+    <div data-testid="sidebar-agents" data-streamlined={String(streamlined)}>
+      Active agents
+    </div>
   ),
 }));
 
 vi.mock("./SidebarProjects", () => ({
-  SidebarProjects: () => <div data-testid="sidebar-projects">Projects collapsible</div>,
+  SidebarProjects: () => <div data-testid="sidebar-projects">Classic projects</div>,
 }));
 
 vi.mock("./SidebarStarredProjects", () => ({
   SidebarStarredProjects: () => <div data-testid="sidebar-starred-projects" />,
+}));
+
+vi.mock("./SidebarRecentTasks", () => ({
+  SidebarRecentTasks: () => <div data-testid="sidebar-recent-tasks">Recent Tasks</div>,
 }));
 
 async function flushReact() {
@@ -150,6 +156,7 @@ describe("Sidebar", () => {
     mockAttentionApi.list.mockResolvedValue({ items: [] });
     mockSidebar.isMobile = false;
     mockSidebar.collapsed = false;
+    mockSidebar.collapseLocked = false;
     mockSidebar.peeking = false;
   });
 
@@ -157,6 +164,21 @@ describe("Sidebar", () => {
     container.remove();
     document.body.innerHTML = "";
     vi.clearAllMocks();
+  });
+
+  it("keeps the default sidebar edge borderless", async () => {
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({ enableIsolatedWorkspaces: false });
+    const root = await renderSidebar();
+
+    const sidebar = container.querySelector("aside");
+    expect(sidebar?.classList).not.toContain("border-r");
+    expect(sidebar?.classList).not.toContain("border-border");
+    expect(sidebar?.classList).toContain("bg-border/50");
+    expect(sidebar?.classList).toContain("dark:bg-muted");
+
+    flushSync(() => {
+      root.unmount();
+    });
   });
 
   it("shows Search as a nav item instead of a header icon", async () => {
@@ -201,7 +223,7 @@ describe("Sidebar", () => {
     });
   });
 
-  it("streamlined (flag ON): keeps Task wording, top-level Projects link, no per-project collapsible", async () => {
+  it("uses the simplified work navigation with one Agents destination", async () => {
     mockInstanceSettingsApi.getExperimental.mockResolvedValue({
       enableIsolatedWorkspaces: false,
       enableStreamlinedLeftNavigation: true,
@@ -217,34 +239,35 @@ describe("Sidebar", () => {
 
     const projectsLink = [...container.querySelectorAll("nav a")].find((a) => a.textContent?.trim() === "Projects");
     expect(projectsLink?.getAttribute("href")).toBe("/projects");
-
-    expect(container.querySelector('[data-testid="sidebar-projects"]')).toBeNull();
-    expect(
-      container.querySelector('[data-testid="sidebar-agents"]')?.getAttribute("data-streamlined"),
-    ).toBe("true");
+    const agentLinks = [...container.querySelectorAll('a[href="/agents"]')];
+    expect(agentLinks).toHaveLength(1);
+    expect([...container.querySelectorAll('a[href="/activity"]')]).toHaveLength(1);
+    expect(navLabels).toContain("Audit");
+    expect(navLabels).not.toContain("Settings");
+    expect(navLabels).not.toContain("Activity");
+    expect(navLabels).not.toContain("Costs");
+    expect(container.querySelector('[data-testid="sidebar-recent-tasks"]')).not.toBeNull();
 
     flushSync(() => {
       root.unmount();
     });
   });
 
-  it("defaults to streamlined navigation while experimental settings are loading", async () => {
+  it("keeps the simplified navigation while experimental settings are loading", async () => {
     mockInstanceSettingsApi.getExperimental.mockImplementation(() => new Promise(() => {}));
     const root = await renderSidebar();
 
     const navLabels = [...container.querySelectorAll("nav a")].map((a) => a.textContent?.trim());
     expect(navLabels).toContain("Projects");
-    expect(container.querySelector('[data-testid="sidebar-projects"]')).toBeNull();
-    expect(
-      container.querySelector('[data-testid="sidebar-agents"]')?.getAttribute("data-streamlined"),
-    ).toBe("true");
+    expect(navLabels).toContain("Agents");
+    expect(container.textContent).not.toContain("Organization");
 
     flushSync(() => {
       root.unmount();
     });
   });
 
-  it("streamlined is now standard: a stale enableStreamlinedLeftNavigation=false opt-out is ignored", async () => {
+  it("ignores the retired streamlined navigation opt-out", async () => {
     // PAP-12472 retired the experimental opt-out; the streamlined sidebar is the
     // only path, so an old `false` setting no longer restores classic mode.
     mockInstanceSettingsApi.getExperimental.mockResolvedValue({
@@ -257,11 +280,44 @@ describe("Sidebar", () => {
     expect(navLabels).toContain("Tasks");
     // Top-level Projects link + starred children stay, per-project collapsible gone.
     expect(navLabels).toContain("Projects");
-    expect(container.querySelector('[data-testid="sidebar-projects"]')).toBeNull();
     expect(container.querySelector('[data-testid="sidebar-starred-projects"]')).not.toBeNull();
-    expect(
-      container.querySelector('[data-testid="sidebar-agents"]')?.getAttribute("data-streamlined"),
-    ).toBe("true");
+    expect(navLabels).toContain("Agents");
+
+    flushSync(() => {
+      root.unmount();
+    });
+  });
+
+  it("restores legacy agent and organization navigation when Streamlined UI is off", async () => {
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({
+      enableStreamlinedUi: false,
+      enableApps: true,
+    });
+    const root = await renderSidebar();
+
+    const labels = [...container.querySelectorAll("nav a")].map((anchor) => anchor.textContent?.trim());
+    expect(container.querySelector('[data-testid="sidebar-recent-tasks"]')).toBeNull();
+    expect(container.querySelector('[data-testid="sidebar-projects"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="sidebar-agents"]')?.getAttribute("data-streamlined")).toBe("undefined");
+    expect(container.textContent).toContain("Organization");
+    expect(labels).toEqual(expect.arrayContaining(["Org", "Apps", "Timeline", "Costs", "Activity", "Settings"]));
+    expect(labels).not.toContain("Audit");
+    expect(labels).not.toContain("Projects");
+    expect(container.querySelector('a[href="/agents"]')).toBeNull();
+    expect(container.querySelector("aside")?.classList).toContain("border-r");
+
+    flushSync(() => {
+      root.unmount();
+    });
+  });
+
+  it("locks the legacy collapse control while a secondary sidebar forces the rail", async () => {
+    mockSidebar.collapseLocked = true;
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({ enableStreamlinedUi: false });
+    const root = await renderSidebar();
+
+    expect(container.querySelector('button[aria-label="Collapse sidebar"]')).toBeNull();
+    expect(container.querySelector('button[aria-label="Expand sidebar"]')).toBeNull();
 
     flushSync(() => {
       root.unmount();
@@ -336,25 +392,25 @@ describe("Sidebar", () => {
     });
   });
 
-  it("shows Skills directly below Artifacts in Work", async () => {
-    mockInstanceSettingsApi.getExperimental.mockResolvedValue({ enableIsolatedWorkspaces: false });
+  it("groups and orders the streamlined Work and Org navigation", async () => {
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({
+      enableIsolatedWorkspaces: false,
+      enableApps: true,
+    });
     const root = await renderSidebar();
-
-    const artifactsLink = [...container.querySelectorAll("a")].find(
-      (anchor) => anchor.textContent === "Artifacts",
-    );
-    expect(artifactsLink?.getAttribute("href")).toBe("/artifacts");
-
-    const navText = container.querySelector("nav")?.textContent ?? "";
-    expect(navText).toContain("Artifacts");
-    expect(navText).toContain("Skills");
-    expect(navText.indexOf("Artifacts")).toBeLessThan(navText.indexOf("Skills"));
 
     const sections = [...container.querySelectorAll("nav > div")];
     const workSection = sections.find((section) => section.textContent?.startsWith("Work"));
-    const companySection = sections.find((section) => section.textContent?.startsWith("Organization"));
-    expect(workSection?.textContent).toContain("Skills");
-    expect(companySection?.textContent).not.toContain("Skills");
+    const orgSection = sections.find((section) => section.textContent?.startsWith("Org"));
+    const labels = (section: Element | undefined) => [...(section?.querySelectorAll("a") ?? [])]
+      .map((anchor) => anchor.textContent?.trim());
+
+    expect(labels(workSection)).toEqual(["Tasks", "Projects", "Routines", "Artifacts"]);
+    expect(labels(orgSection)).toEqual(["Agents", "Skills", "Apps", "Audit"]);
+    expect(sections.indexOf(workSection!)).toBeLessThan(sections.indexOf(orgSection!));
+    expect(
+      workSection?.querySelector('a[href="/issues"] svg')?.classList.contains("lucide-circle-check"),
+    ).toBe(true);
 
     flushSync(() => {
       root.unmount();
@@ -398,25 +454,22 @@ describe("Sidebar", () => {
     expect(link?.getAttribute("href")).toBe("/goals");
 
     const navText = container.querySelector("nav")?.textContent ?? "";
-    expect(navText.indexOf("Goals")).toBeLessThan(navText.indexOf("Artifacts"));
+    expect(navText.indexOf("Artifacts")).toBeLessThan(navText.indexOf("Goals"));
 
     flushSync(() => {
       root.unmount();
     });
   });
 
-  it("places Timeline in the Company section", async () => {
+  it("keeps Timeline out of the global navigation", async () => {
     mockInstanceSettingsApi.getExperimental.mockResolvedValue({ enableIsolatedWorkspaces: false });
     const root = await renderSidebar();
 
     const sections = [...container.querySelectorAll("nav > div")];
     const workSection = sections.find((section) => section.textContent?.startsWith("Work"));
-    const companySection = sections.find((section) => section.textContent?.startsWith("Organization"));
+    expect(workSection?.textContent).toContain("Projects");
     expect(workSection?.textContent).not.toContain("Timeline");
-    expect(companySection?.textContent).toContain("Timeline");
-
-    const timelineLink = [...container.querySelectorAll("a")].find((anchor) => anchor.textContent === "Timeline");
-    expect(timelineLink?.getAttribute("href")).toBe("/timeline");
+    expect(container.querySelector('a[href="/timeline"]')).toBeNull();
 
     flushSync(() => {
       root.unmount();
@@ -479,7 +532,7 @@ describe("Sidebar", () => {
     });
   });
 
-  it("always shows Apps at the bottom of the Work section", async () => {
+  it("always shows Apps in the Org section", async () => {
     mockInstanceSettingsApi.getExperimental.mockResolvedValue({ enableApps: false });
     const root = await renderSidebar();
 
@@ -487,10 +540,10 @@ describe("Sidebar", () => {
     const link = links.find((anchor) => anchor.textContent === "Apps");
     expect(link?.getAttribute("href")).toBe("/apps");
     expect(links.findIndex((anchor) => anchor.textContent === "Apps")).toBeGreaterThan(
-      links.findIndex((anchor) => anchor.textContent === "Projects"),
+      links.findIndex((anchor) => anchor.textContent === "Skills"),
     );
     expect(links.findIndex((anchor) => anchor.textContent === "Apps")).toBeLessThan(
-      links.findIndex((anchor) => anchor.textContent === "Org"),
+      links.findIndex((anchor) => anchor.textContent === "Audit"),
     );
 
     flushSync(() => {
@@ -536,80 +589,14 @@ describe("Sidebar", () => {
     });
   });
 
-  it("header toggle collapses an expanded sidebar (aria-expanded reflects state)", async () => {
+  it("does not render a global navigation collapse affordance", async () => {
     mockInstanceSettingsApi.getExperimental.mockResolvedValue({ enableIsolatedWorkspaces: false });
-    const root = await renderSidebar();
-
-    const toggle = container.querySelector<HTMLButtonElement>('button[aria-label="Collapse sidebar"]');
-    expect(toggle).not.toBeNull();
-    expect(toggle?.getAttribute("aria-expanded")).toBe("true");
-
-    flushSync(() => {
-      toggle?.click();
-    });
-    expect(mockSidebar.toggleCollapsed).toHaveBeenCalledTimes(1);
-
-    flushSync(() => {
-      root.unmount();
-    });
-  });
-
-  it("hides the expand/collapse toggle while a secondary sidebar locks the rail", async () => {
-    // A secondary sidebar forces the rail; the user must not be able to expand
-    // the primary while it is shown (PAP-10694).
-    mockInstanceSettingsApi.getExperimental.mockResolvedValue({ enableIsolatedWorkspaces: false });
-    mockSidebar.collapseLocked = true;
     const root = await renderSidebar();
 
     expect(container.querySelector('button[aria-label="Collapse sidebar"]')).toBeNull();
     expect(container.querySelector('button[aria-label="Expand sidebar"]')).toBeNull();
-
-    mockSidebar.collapseLocked = false;
-    flushSync(() => {
-      root.unmount();
-    });
-  });
-
-  it("keeps the collapsed rail top bar to just the company logo (no clipped toggle)", async () => {
-    // In the narrow rail the collapse toggle doesn't fit beside the logo and
-    // would overflow/clip, shoving the logo out of the icon column (PAP-10676), so
-    // it is dropped in the rail. Expansion stays reachable via hover-peek + Pin
-    // and Cmd/Ctrl+B. The toggle returns as soon as the panel is expanded or
-    // peeking (covered by the other top-bar tests).
-    mockSidebar.collapsed = true;
-    mockInstanceSettingsApi.getExperimental.mockResolvedValue({ enableIsolatedWorkspaces: false });
-    const root = await renderSidebar();
-
-    expect(container.querySelector('button[aria-label="Expand sidebar"]')).toBeNull();
-    // The company menu (company switcher / logo) is still present in the rail.
+    expect(container.querySelector('button[aria-label="Keep sidebar expanded"]')).toBeNull();
     expect(container.textContent).toContain("Company menu");
-    // Search survives the rail as an icon-only nav item — the old
-    // header icon was dropped entirely here, leaving the rail with no visible
-    // search affordance.
-    const railSearchLink = [...container.querySelectorAll("nav a")]
-      .find((anchor) => anchor.getAttribute("href") === "/search");
-    expect(railSearchLink).toBeTruthy();
-
-    flushSync(() => {
-      root.unmount();
-    });
-  });
-
-  it("peek header shows a pin that promotes the peek to pinned-expanded", async () => {
-    mockSidebar.collapsed = true;
-    mockSidebar.peeking = true;
-    mockInstanceSettingsApi.getExperimental.mockResolvedValue({ enableIsolatedWorkspaces: false });
-    const root = await renderSidebar();
-
-    // The collapse toggle is replaced by the pin while peeking.
-    expect(container.querySelector('button[aria-label="Expand sidebar"]')).toBeNull();
-    const pin = container.querySelector<HTMLButtonElement>('button[aria-label="Keep sidebar expanded"]');
-    expect(pin).not.toBeNull();
-
-    flushSync(() => {
-      pin?.click();
-    });
-    expect(mockSidebar.setCollapsed).toHaveBeenCalledWith(false);
 
     flushSync(() => {
       root.unmount();

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import {
   Inbox,
   ListChecks,
-  CircleDot,
+  CircleCheck,
   Target,
   LayoutDashboard,
   DollarSign,
@@ -16,13 +16,11 @@ import {
   Package,
   Settings,
   FolderOpen,
-  PanelLeftClose,
-  PanelLeftOpen,
-  Pin,
   AppWindow,
   MessagesSquare,
   GanttChartSquare,
   LayoutGrid,
+  Users,
 } from "lucide-react";
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
@@ -31,6 +29,7 @@ import { SidebarNavItem } from "./SidebarNavItem";
 import { SidebarAgents } from "./SidebarAgents";
 import { SidebarProjects } from "./SidebarProjects";
 import { SidebarStarredProjects } from "./SidebarStarredProjects";
+import { SidebarRecentTasks } from "./SidebarRecentTasks";
 import { useDialogActions } from "../context/DialogContext";
 import { useCompany } from "../context/CompanyContext";
 import { useSidebar } from "../context/SidebarContext";
@@ -40,8 +39,8 @@ import { instanceSettingsApi } from "../api/instanceSettings";
 import { queryKeys } from "../lib/queryKeys";
 import { attentionBadgeCount } from "../lib/attention";
 import { useInboxBadge } from "../hooks/useInboxBadge";
+import { useStreamlinedUiEnabled } from "../hooks/useStreamlinedUiEnabled";
 import { usePublishSharedQueryData, useSharedPollingQuery } from "../hooks/useSharedPolling";
-import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn, SIDEBAR_RAIL_HIDDEN_LABEL } from "../lib/utils";
 import { PluginSlotOutlet } from "@/plugins/slots";
@@ -53,9 +52,10 @@ export function Sidebar() {
   // Every labeled section is collapsible (session-scoped, default open) —
   // one policy across static nav groups and the data-driven sections.
   const [workOpen, setWorkOpen] = useState(true);
-  const [companyOpen, setCompanyOpen] = useState(true);
+  const [organizationOpen, setOrganizationOpen] = useState(true);
   const { selectedCompanyId, selectedCompany } = useCompany();
-  const { isMobile, collapsed, collapseLocked, peeking, toggleCollapsed, setCollapsed } = useSidebar();
+  const { collapsed, peeking } = useSidebar();
+  const { enabled: streamlinedUiEnabled } = useStreamlinedUiEnabled();
   const rail = collapsed && !peeking;
   const inboxBadge = useInboxBadge(selectedCompanyId);
   const { data: experimentalSettings } = useQuery({
@@ -82,6 +82,9 @@ export function Sidebar() {
   });
   usePublishSharedQueryData(sharedLiveRuns, liveRuns, liveRunsUpdatedAt);
   const liveRunCount = liveRuns?.length ?? 0;
+  const liveIssueIds = new Set(
+    (liveRuns ?? []).flatMap((run) => run.issueId ? [run.issueId] : []),
+  );
   const showWorkspacesLink = experimentalSettings?.enableIsolatedWorkspaces === true;
   const showPipelines = experimentalSettings?.enablePipelines === true;
   const showStatusCards = experimentalSettings?.enableStatusCards === true;
@@ -99,12 +102,6 @@ export function Sidebar() {
   });
   const attentionCount = attentionBadgeCount(attentionFeed);
   const showCases = experimentalSettings?.enableCases === true;
-  // Streamlined left navigation (top-level Projects link + starred children) is
-  // now the standard product sidebar (PAP-12472). The former experimental
-  // opt-out was retired; classic per-project collapsible mode is no longer
-  // user-selectable. Kept as a constant so the classic branch below stays as a
-  // documented reference until it is fully removed. Routes are unaffected.
-  const streamlined = true;
   // Conference Room Chat flag (PAP-136/PAP-137): the Conference Room nav item
   // is a new surface, hidden entirely while the flag is off (same no-flash
   // pattern as showWorkspacesLink above).
@@ -116,55 +113,21 @@ export function Sidebar() {
   };
 
   return (
-    <aside className="w-full h-full min-h-0 border-r border-border bg-background flex flex-col">
-      {/* Top bar: Company name (bold) + collapse control — aligned with top
-          sections (no visible border). Search deliberately does NOT live here:
+    <aside
+      className={cn(
+        "w-full h-full min-h-0 flex flex-col",
+        streamlinedUiEnabled
+          ? "bg-border/50 dark:bg-muted"
+          : "border-r border-border bg-background",
+      )}
+    >
+      {/* Top bar: company name, aligned with top sections and borderless.
+          Search deliberately does NOT live here:
           the header's spare width goes to the workspace/organization name,
           which is the user's orientation anchor and truncates otherwise.
           Search is the first nav item below instead. */}
-      <div className="flex items-center gap-1 px-3 h-12 shrink-0">
+      <div className="flex h-(--sz-60px) shrink-0 items-center gap-1 px-3">
         <SidebarCompanyMenu />
-        {/* In the collapsed rail the toggle doesn't fit beside the logo —
-            keeping it would overflow the 64px rail and squeeze the logo out of
-            alignment with the icon column below it. It returns as
-            soon as the panel is expanded (pinned) or peeking. Expansion in the
-            rail is still reachable via hover-peek + Pin and Cmd/Ctrl+B. */}
-        {!rail ? (
-          <>
-            {/* Desktop-only collapse/expand affordance. While peeking (hover flyout
-                over the collapsed rail) it becomes a Pin that promotes the peek to a
-                pinned-expanded sidebar; otherwise it toggles the pinned rail. Mobile
-                uses the off-canvas drawer, so this control is hidden there. It is
-                also hidden while a secondary sidebar forces the rail (collapseLocked):
-                the user cannot expand the primary while a secondary sidebar is shown. */}
-            {!isMobile && !collapseLocked ? (
-              peeking ? (
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  className="text-muted-foreground shrink-0"
-                  aria-label="Keep sidebar expanded"
-                  title="Keep sidebar expanded"
-                  onClick={() => setCollapsed(false)}
-                >
-                  <Pin className="h-4 w-4" />
-                </Button>
-              ) : (
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  className="text-muted-foreground shrink-0"
-                  aria-expanded={!collapsed}
-                  aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-                  title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-                  onClick={() => toggleCollapsed()}
-                >
-                  {collapsed ? <PanelLeftOpen className="h-4 w-4" /> : <PanelLeftClose className="h-4 w-4" />}
-                </Button>
-              )
-            ) : null}
-          </>
-        ) : null}
       </div>
 
       <nav className="flex-1 min-h-0 overflow-y-auto scrollbar-auto-hide flex flex-col gap-4 pointer-coarse:gap-3 px-3 py-2">
@@ -176,7 +139,10 @@ export function Sidebar() {
                 onClick={() => openNewIssue()}
                 data-slot="icon-button"
                 aria-label={rail ? "New Task" : undefined}
-                className="flex items-center gap-2.5 mx-2 rounded-lg px-2 py-1.5 pointer-coarse:py-1 text-(length:--text-compact) font-medium text-foreground/80 hover:bg-accent/50 hover:text-foreground transition-colors"
+                className={cn(
+                  "flex items-center gap-2.5 mx-2 rounded-lg px-2 py-1.5 pointer-coarse:py-1 text-(length:--text-compact) font-medium text-foreground/80 hover:text-foreground transition-colors",
+                  streamlinedUiEnabled ? "hover:bg-background" : "hover:bg-accent/50",
+                )}
               >
                 <SquarePen className="h-4 w-4 shrink-0" />
                 <span className={rail ? SIDEBAR_RAIL_HIDDEN_LABEL : "truncate"}>New Task</span>
@@ -224,11 +190,18 @@ export function Sidebar() {
         </div>
 
         <SidebarSection label="Work" collapsible={{ open: workOpen, onOpenChange: setWorkOpen }}>
-          <SidebarNavItem to="/issues" label="Tasks" icon={CircleDot} />
+          <SidebarNavItem to="/issues" label="Tasks" icon={CircleCheck} />
+          {streamlinedUiEnabled ? (
+            <>
+              <SidebarNavItem to="/projects" label="Projects" icon={FolderOpen} />
+              <SidebarStarredProjects />
+            </>
+          ) : null}
+          <SidebarNavItem to="/routines" label="Routines" icon={Repeat} />
+          <SidebarNavItem to="/artifacts" label="Artifacts" icon={Package} />
           {showCases ? (
             <SidebarNavItem to="/cases" label="Cases" icon={Layers} textBadge="beta" />
           ) : null}
-          <SidebarNavItem to="/routines" label="Routines" icon={Repeat} />
           {showPipelines ? (
             <SidebarNavItem to="/pipelines" label="Pipelines" icon={GitBranch} />
           ) : null}
@@ -241,16 +214,8 @@ export function Sidebar() {
               aria-hidden="true"
             />
           ) : null}
-          <SidebarNavItem to="/artifacts" label="Artifacts" icon={Package} />
-          <SidebarNavItem to="/skills" label="Skills" icon={Boxes} />
           {showWorkspacesLink ? (
             <SidebarNavItem to="/workspaces" label="Workspaces" icon={GitBranch} />
-          ) : null}
-          {streamlined ? (
-            <>
-              <SidebarNavItem to="/projects" label="Projects" icon={FolderOpen} />
-              <SidebarStarredProjects />
-            </>
           ) : null}
           <PluginSlotOutlet
             slotTypes={["sidebar"]}
@@ -265,22 +230,39 @@ export function Sidebar() {
             className="flex flex-col gap-0.5"
             itemClassName="text-(length:--text-compact) font-medium"
           />
-          <SidebarNavItem to="/apps" label="Apps" icon={AppWindow} />
         </SidebarSection>
 
-        {/* Classic mode restores the per-project collapsible below Work. */}
-        {streamlined ? null : <SidebarProjects />}
+        {streamlinedUiEnabled ? (
+          <SidebarSection
+            label="Org"
+            collapsible={{ open: organizationOpen, onOpenChange: setOrganizationOpen }}
+          >
+            <SidebarNavItem to="/agents" label="Agents" icon={Users} />
+            <SidebarNavItem to="/skills" label="Skills" icon={Boxes} />
+            <SidebarNavItem to="/apps" label="Apps" icon={AppWindow} />
+            <SidebarNavItem to="/activity" label="Audit" icon={History} />
+          </SidebarSection>
+        ) : null}
 
-        <SidebarAgents streamlined={streamlined} />
-
-        <SidebarSection label="Organization" collapsible={{ open: companyOpen, onOpenChange: setCompanyOpen }}>
-          <SidebarNavItem to="/org" label="Org" icon={Network} />
-          <SidebarNavItem to="/timeline" label="Timeline" icon={GanttChartSquare} />
-          <SidebarNavItem to="/costs" label="Costs" icon={DollarSign} />
-          {/* One entry — /audit merged into the rich Activity feed (PAP-16302). */}
-          <SidebarNavItem to="/activity" label="Activity" icon={History} />
-          <SidebarNavItem to="/company/settings" label="Settings" icon={Settings} />
-        </SidebarSection>
+        {streamlinedUiEnabled ? (
+          <SidebarRecentTasks companyId={selectedCompanyId} liveIssueIds={liveIssueIds} />
+        ) : (
+          <>
+            <SidebarProjects />
+            <SidebarAgents />
+            <SidebarSection
+              label="Organization"
+              collapsible={{ open: organizationOpen, onOpenChange: setOrganizationOpen }}
+            >
+              <SidebarNavItem to="/org" label="Org" icon={Network} />
+              <SidebarNavItem to="/apps" label="Apps" icon={AppWindow} />
+              <SidebarNavItem to="/timeline" label="Timeline" icon={GanttChartSquare} />
+              <SidebarNavItem to="/costs" label="Costs" icon={DollarSign} />
+              <SidebarNavItem to="/activity" label="Activity" icon={History} />
+              <SidebarNavItem to="/company/settings" label="Settings" icon={Settings} />
+            </SidebarSection>
+          </>
+        )}
 
         <PluginSlotOutlet
           slotTypes={["sidebarPanel"]}

--- a/ui/src/components/SidebarAccountMenu.production.tsx
+++ b/ui/src/components/SidebarAccountMenu.production.tsx
@@ -1,0 +1,286 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  BookOpen,
+  LogOut,
+  Megaphone,
+  type LucideIcon,
+  UserRound,
+  UserRoundPen,
+} from "lucide-react";
+import type { DeploymentMode, ServerGitInfo } from "@paperclipai/shared";
+import { Link } from "@/lib/router";
+import { authApi } from "@/api/auth";
+import { queryKeys } from "@/lib/queryKeys";
+import { useSignOut } from "@/hooks/useSignOut";
+import { useSidebar } from "../context/SidebarContext";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { cn, SIDEBAR_RAIL_HIDDEN_LABEL } from "../lib/utils";
+import { ThemeToggle } from "./ThemeToggle";
+import { SidebarServerInfo } from "./SidebarServerInfo";
+import { Badge } from "@/components/ui/badge";
+
+const PROFILE_SETTINGS_PATH = "/company/settings/instance/profile";
+const DOCS_URL = "https://docs.paperclip.ing/";
+const FEEDBACK_URL = "https://paperclip.ing/feedback";
+const SOURCE_REPOSITORY_URL = "https://github.com/paperclipai/paperclip";
+const SOURCE_VERSION_RE = /\+\d+\.git\.([0-9a-f]{7,40})(?:\.dirty)?$/i;
+
+interface SidebarAccountMenuProps {
+  deploymentMode?: DeploymentMode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  serverGit?: ServerGitInfo;
+  version?: string | null;
+}
+
+interface MenuActionProps {
+  label: string;
+  description: string;
+  icon: LucideIcon;
+  onClick?: () => void;
+  href?: string;
+  external?: boolean;
+}
+
+function deriveInitials(name: string) {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length >= 2) {
+    return `${parts[0]?.[0] ?? ""}${parts[parts.length - 1]?.[0] ?? ""}`.toUpperCase();
+  }
+  return name.slice(0, 2).toUpperCase();
+}
+
+function deriveUserSlug(name: string | null | undefined, email: string | null | undefined, id: string | null | undefined) {
+  const candidates = [name, email?.split("@")[0], email, id];
+  for (const candidate of candidates) {
+    const slug = candidate
+      ?.trim()
+      .toLowerCase()
+      .replace(/['"]/g, "")
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+    if (slug) return slug;
+  }
+  return "me";
+}
+
+function sourceVersionSha(version: string): string | null {
+  const sourceVersion = version.match(SOURCE_VERSION_RE);
+  return sourceVersion?.[1] ?? null;
+}
+
+function MenuAction({ label, description, icon: Icon, onClick, href, external = false }: MenuActionProps) {
+  const className =
+    "flex w-full items-start gap-3 rounded-xl px-3 py-3 text-left transition-colors hover:bg-accent/60";
+
+  const content = (
+    <>
+      <span className="mt-0.5 rounded-lg border border-border bg-background/70 p-2 text-muted-foreground">
+        <Icon className="size-4" />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-sm font-medium text-foreground">{label}</span>
+        <span className="block text-xs text-muted-foreground">{description}</span>
+      </span>
+    </>
+  );
+
+  if (href) {
+    if (external) {
+      return (
+        <a href={href} target="_blank" rel="noreferrer" className={className} onClick={onClick}>
+          {content}
+        </a>
+      );
+    }
+
+    return (
+      <Link to={href} className={className} onClick={onClick}>
+        {content}
+      </Link>
+    );
+  }
+
+  return (
+    <button type="button" className={className} onClick={onClick}>
+      {content}
+    </button>
+  );
+}
+
+export function SidebarAccountMenu({
+  deploymentMode,
+  open: controlledOpen,
+  onOpenChange,
+  serverGit,
+  version,
+}: SidebarAccountMenuProps) {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const { isMobile, setSidebarOpen, collapsed, peeking } = useSidebar();
+  const rail = collapsed && !peeking;
+  const open = controlledOpen ?? internalOpen;
+  const setOpen = onOpenChange ?? setInternalOpen;
+  const { data: session } = useQuery({
+    queryKey: queryKeys.auth.session,
+    queryFn: () => authApi.getSession(),
+    retry: false,
+  });
+
+  const signOutMutation = useSignOut({ onSignedOut: closeNavigationChrome });
+
+  const displayName = session?.user.name?.trim() || "Board";
+  const secondaryLabel =
+    session?.user.email?.trim() || (deploymentMode === "authenticated" ? "Signed in" : "Local workspace board");
+  const accountBadge = deploymentMode === "authenticated" ? "Account" : "Local";
+  const initials = deriveInitials(displayName);
+  const profileHref = `/u/${deriveUserSlug(session?.user.name, session?.user.email, session?.user.id)}`;
+  const sourceSha = version ? sourceVersionSha(version) : null;
+  const sourceFullSha =
+    sourceSha && serverGit?.available && serverGit.fullSha.toLowerCase().startsWith(sourceSha.toLowerCase())
+      ? serverGit.fullSha
+      : sourceSha;
+  const sourceBranch = sourceSha && serverGit?.available ? serverGit.branchName : null;
+
+  function closeNavigationChrome() {
+    setOpen(false);
+    if (isMobile) setSidebarOpen(false);
+  }
+
+  function handleSignOut() {
+    signOutMutation.mutate();
+  }
+
+  return (
+    <div className="border-t border-r border-border bg-background px-3 py-2">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className="flex w-full items-center gap-2.5 px-3 py-2 text-left text-(length:--text-compact) font-medium text-foreground/80 transition-colors hover:bg-accent/50 hover:text-foreground"
+            aria-label="Open account menu"
+          >
+            <Avatar size="sm">
+              {session?.user.image ? <AvatarImage src={session.user.image} alt={displayName} /> : null}
+              <AvatarFallback>{initials}</AvatarFallback>
+            </Avatar>
+            <span className={cn("min-w-0 flex-1 truncate", rail && SIDEBAR_RAIL_HIDDEN_LABEL)}>{displayName}</span>
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          side="top"
+          align="start"
+          sideOffset={10}
+          className="w-(--sz-277px) max-w-(--sz-calc-24) overflow-hidden rounded-t-2xl rounded-b-none border-border p-0 shadow-2xl"
+        >
+          <div className="h-24 bg-(image:--gradient-extract-25)" />
+          <div className="-mt-8 px-4 pb-4">
+            <div className="flex items-start gap-3">
+              <div className="rounded-2xl border-4 border-popover bg-popover p-0.5 shadow-sm">
+                <Avatar size="lg">
+                  {session?.user.image ? <AvatarImage src={session.user.image} alt={displayName} /> : null}
+                  <AvatarFallback>{initials}</AvatarFallback>
+                </Avatar>
+              </div>
+              <div className="min-w-0 flex-1 pt-1">
+                <div className="flex items-center gap-2">
+                  <h2 className="truncate text-base font-semibold text-foreground">{displayName}</h2>
+                  <Badge variant="ghost" className="bg-accent text-(length:--text-nano) font-semibold uppercase tracking-wide text-muted-foreground">
+                    {accountBadge}
+                  </Badge>
+                </div>
+                <p className="truncate text-sm text-muted-foreground">{secondaryLabel}</p>
+                {sourceSha && sourceFullSha ? (
+                  <div className="mt-1 text-xs text-muted-foreground">
+                    {sourceBranch ? (
+                      <a
+                        href={`${SOURCE_REPOSITORY_URL}/tree/${encodeURIComponent(sourceBranch)}`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="block truncate transition-colors hover:text-foreground"
+                      >
+                        {sourceBranch}
+                      </a>
+                    ) : null}
+                    <p>
+                      Paperclip{" "}
+                      <a
+                        href={`${SOURCE_REPOSITORY_URL}/commit/${sourceFullSha}`}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="transition-colors hover:text-foreground"
+                      >
+                        {sourceSha.slice(0, 7)}
+                      </a>
+                    </p>
+                  </div>
+                ) : version ? (
+                  <p className="mt-1 text-xs text-muted-foreground">Paperclip v{version}</p>
+                ) : null}
+              </div>
+            </div>
+
+            <div className="mt-4 space-y-1">
+              <MenuAction
+                label="View profile"
+                description="Open your activity, task, and usage ledger."
+                icon={UserRound}
+                href={profileHref}
+                onClick={closeNavigationChrome}
+              />
+              <MenuAction
+                label="Edit profile"
+                description="Update your display name and avatar."
+                icon={UserRoundPen}
+                href={PROFILE_SETTINGS_PATH}
+                onClick={closeNavigationChrome}
+              />
+              <MenuAction
+                label="Documentation"
+                description="Open Paperclip docs in a new tab."
+                icon={BookOpen}
+                href={DOCS_URL}
+                external
+                onClick={() => setOpen(false)}
+              />
+              <MenuAction
+                label="Feedback"
+                description="Share feedback or report an issue."
+                icon={Megaphone}
+                href={FEEDBACK_URL}
+                external
+                onClick={() => setOpen(false)}
+              />
+              <ThemeToggle variant="menu-action" onAfterToggle={() => setOpen(false)} />
+              {deploymentMode === "authenticated" ? (
+                <button
+                  type="button"
+                  className={cn(
+                    "flex w-full items-start gap-3 rounded-xl px-3 py-3 text-left transition-colors hover:bg-destructive/10",
+                    signOutMutation.isPending && "cursor-not-allowed opacity-60",
+                  )}
+                  onClick={handleSignOut}
+                  disabled={signOutMutation.isPending}
+                >
+                  <span className="mt-0.5 rounded-lg border border-border bg-background/70 p-2 text-muted-foreground">
+                    <LogOut className="size-4" />
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block text-sm font-medium text-foreground">
+                      {signOutMutation.isPending ? "Signing out..." : "Sign out"}
+                    </span>
+                    <span className="block text-xs text-muted-foreground">
+                      End this browser session.
+                    </span>
+                  </span>
+                </button>
+              ) : null}
+              <SidebarServerInfo />
+            </div>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}

--- a/ui/src/components/SidebarAccountMenu.test.tsx
+++ b/ui/src/components/SidebarAccountMenu.test.tsx
@@ -100,6 +100,29 @@ describe("SidebarAccountMenu", () => {
     vi.clearAllMocks();
   });
 
+  it("shares the nav background without separator borders", async () => {
+    const root = createRoot(container);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <SidebarAccountMenu deploymentMode="local_trusted" />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    const accountSurface = container.firstElementChild;
+    expect(accountSurface?.className).toContain("bg-border/50");
+    expect(accountSurface?.className).toContain("dark:bg-muted");
+    expect(accountSurface?.className).not.toContain("border-t");
+    expect(accountSurface?.className).not.toContain("border-r");
+    expect(accountSurface?.className).not.toContain("border-border");
+
+    await act(async () => root.unmount());
+  });
+
   it("keeps authenticated self-hosted sign-out on the local auth flow", async () => {
     const root = createRoot(container);
     const queryClient = new QueryClient({
@@ -135,6 +158,7 @@ describe("SidebarAccountMenu", () => {
     await flushReact();
 
     expect(document.body.textContent).toContain("Edit profile");
+    expect(document.body.textContent).toContain("Settings");
     expect(document.body.textContent).not.toContain("Instance settings");
     expect(document.body.textContent).toContain("Documentation");
     expect(document.body.textContent).toContain("Feedback");
@@ -157,6 +181,7 @@ describe("SidebarAccountMenu", () => {
     expect(document.body.querySelector('[data-slot="popover-content"]')?.className)
       .toContain("w-(--sz-277px)");
     expect(document.body.querySelector('a[href="/company/settings/instance/profile"]')).not.toBeNull();
+    expect(document.body.querySelector('a[href="/company/settings"]')).not.toBeNull();
 
     const signOutButton = Array.from(document.body.querySelectorAll("button")).find(
       (button) => button.textContent?.includes("Sign out"),

--- a/ui/src/components/SidebarAccountMenu.tsx
+++ b/ui/src/components/SidebarAccountMenu.tsx
@@ -4,6 +4,7 @@ import {
   BookOpen,
   LogOut,
   Megaphone,
+  Settings,
   type LucideIcon,
   UserRound,
   UserRoundPen,
@@ -33,6 +34,8 @@ interface SidebarAccountMenuProps {
   onOpenChange?: (open: boolean) => void;
   serverGit?: ServerGitInfo;
   version?: string | null;
+  /** Contextual navigation occupies a full sidebar even if the saved global nav mode is collapsed. */
+  forceExpanded?: boolean;
 }
 
 interface MenuActionProps {
@@ -116,10 +119,11 @@ export function SidebarAccountMenu({
   onOpenChange,
   serverGit,
   version,
+  forceExpanded = false,
 }: SidebarAccountMenuProps) {
   const [internalOpen, setInternalOpen] = useState(false);
   const { isMobile, setSidebarOpen, collapsed, peeking } = useSidebar();
-  const rail = collapsed && !peeking;
+  const rail = collapsed && !peeking && !forceExpanded;
   const open = controlledOpen ?? internalOpen;
   const setOpen = onOpenChange ?? setInternalOpen;
   const { data: session } = useQuery({
@@ -153,7 +157,7 @@ export function SidebarAccountMenu({
   }
 
   return (
-    <div className="border-t border-r border-border bg-background px-3 py-2">
+    <div className="bg-border/50 px-3 py-2 dark:bg-muted">
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <button
@@ -222,6 +226,13 @@ export function SidebarAccountMenu({
             </div>
 
             <div className="mt-4 space-y-1">
+              <MenuAction
+                label="Settings"
+                description="Manage company and instance settings."
+                icon={Settings}
+                href="/company/settings"
+                onClick={closeNavigationChrome}
+              />
               <MenuAction
                 label="View profile"
                 description="Open your activity, task, and usage ledger."

--- a/ui/src/components/SidebarAgents.production.tsx
+++ b/ui/src/components/SidebarAgents.production.tsx
@@ -1,0 +1,683 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Link, useLocation } from "@/lib/router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  MoreHorizontal,
+  Loader2,
+  LogOut,
+  PauseCircle,
+  Pencil,
+  PlayCircle,
+  Plus,
+  Star,
+  Users,
+  AlertTriangle,
+} from "lucide-react";
+import { useCompany } from "../context/CompanyContext";
+import { useDialogActions } from "../context/DialogContext";
+import { useSidebar } from "../context/SidebarContext";
+import { useToastActions } from "../context/ToastContext";
+import { agentsApi } from "../api/agents";
+import { builtInAgentsApi, type BuiltInAgentStatus } from "../api/builtInAgents";
+import { BuiltInLifecycleChip } from "./BuiltInAgentBadges";
+import { authApi } from "../api/auth";
+import { heartbeatsApi } from "../api/heartbeats";
+import { instanceSettingsApi } from "../api/instanceSettings";
+import { SIDEBAR_SCROLL_RESET_STATE } from "../lib/navigation-scroll";
+import { queryKeys } from "../lib/queryKeys";
+import { cn, agentRouteRef, agentUrl, SIDEBAR_RAIL_HIDDEN_LABEL } from "../lib/utils";
+import { useAgentOrder } from "../hooks/useAgentOrder";
+import {
+  isStarred,
+  resourceMembershipState,
+  starredResourceIds,
+  useResourceMembershipMutation,
+  useResourceMemberships,
+} from "../hooks/useResourceMemberships";
+import { usePublishSharedQueryData, useSharedPollingQuery } from "../hooks/useSharedPolling";
+import {
+  AGENT_SORT_MODE_UPDATED_EVENT,
+  getAgentSortModeStorageKey,
+  readAgentSortMode,
+  type AgentSortModeUpdatedDetail,
+  type AgentSidebarSortMode,
+  writeAgentSortMode,
+} from "../lib/agent-order";
+import { AgentIcon } from "./AgentIconPicker";
+import { BudgetSidebarMarker } from "./BudgetSidebarMarker";
+import { SidebarNavItem } from "./SidebarNavItem.production";
+import { SidebarSection, type SidebarSectionRadioChoice } from "./SidebarSection";
+import { StarToggle } from "./StarToggle";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import type { Agent } from "@paperclipai/shared";
+
+/**
+ * When no agent is running, the sidebar falls back to showing at most this many
+ * recently-active agents plus a "See all agents" link (IA Phase 5).
+ */
+const RECENT_AGENT_LIMIT = 3;
+const LIVE_AGENT_LINGER_MS = 120_000;
+
+const AGENT_SORT_CHOICES: SidebarSectionRadioChoice[] = [
+  { value: "top", label: "Top" },
+  { value: "alphabetical", label: "Alphabetical" },
+  { value: "recent", label: "Recent" },
+];
+
+function agentTimestamp(agent: Agent, field: "lastHeartbeatAt" | "updatedAt" | "createdAt"): number {
+  const raw = agent[field];
+  if (!raw) return 0;
+  const time = new Date(raw).getTime();
+  return Number.isFinite(time) ? time : 0;
+}
+
+function sortAgents(agents: Agent[], sortMode: AgentSidebarSortMode): Agent[] {
+  if (sortMode === "top") return agents;
+  const sorted = [...agents];
+  if (sortMode === "alphabetical") {
+    sorted.sort((left, right) => left.name.localeCompare(right.name, undefined, { sensitivity: "base" }));
+    return sorted;
+  }
+  sorted.sort((left, right) => {
+    const heartbeatDiff = agentTimestamp(right, "lastHeartbeatAt") - agentTimestamp(left, "lastHeartbeatAt");
+    if (heartbeatDiff !== 0) return heartbeatDiff;
+
+    const updatedDiff = agentTimestamp(right, "updatedAt") - agentTimestamp(left, "updatedAt");
+    if (updatedDiff !== 0) return updatedDiff;
+
+    const createdDiff = agentTimestamp(right, "createdAt") - agentTimestamp(left, "createdAt");
+    return createdDiff !== 0
+      ? createdDiff
+      : left.name.localeCompare(right.name, undefined, { sensitivity: "base" });
+  });
+  return sorted;
+}
+
+// Sidebar star reveals with the agent row's own group, not the shared group.
+const AGENT_STAR_ROW_REVEAL =
+  "opacity-0 transition-opacity group-hover/agent:opacity-100 group-focus-within/agent:opacity-100";
+
+function SidebarAgentItem({
+  activeAgentId,
+  activeTab,
+  agent,
+  disabled,
+  isMobile,
+  leaving,
+  onLeaveAgent,
+  onPauseResume,
+  rail,
+  runCount,
+  setSidebarOpen,
+  builtInStatus,
+  starred = false,
+  onToggleStar,
+  starPending = false,
+}: {
+  activeAgentId: string | null;
+  activeTab: string | null;
+  agent: Agent;
+  disabled: boolean;
+  isMobile: boolean;
+  leaving: boolean;
+  onLeaveAgent: (agent: Agent) => void;
+  onPauseResume: (agent: Agent, action: "pause" | "resume") => void;
+  rail: boolean;
+  runCount: number;
+  setSidebarOpen: (open: boolean) => void;
+  builtInStatus?: BuiltInAgentStatus;
+  starred?: boolean;
+  onToggleStar?: (agent: Agent, starred: boolean) => void;
+  starPending?: boolean;
+}) {
+  const routeRef = agentRouteRef(agent);
+  const href = activeTab ? `${agentUrl(agent)}/${activeTab}` : agentUrl(agent);
+  const editHref = `${agentUrl(agent)}/configuration`;
+  const isActive = activeAgentId === routeRef;
+  const isPaused = agent.status === "paused";
+  const isBudgetPaused = isPaused && agent.pauseReason === "budget";
+  const hasInvalidOrgChain = agent.orgChainHealth?.status === "invalid_org_chain";
+  const pauseResumeLabel = isPaused ? "Resume agent" : "Pause agent";
+  const pauseResumeDisabled = disabled || agent.status === "pending_approval" || isBudgetPaused || (isPaused && hasInvalidOrgChain);
+  const pauseResumeDisabledLabel = disabled
+    ? "Updating..."
+    : isBudgetPaused
+      ? "Budget paused"
+      : isPaused && hasInvalidOrgChain
+        ? "Invalid org chain"
+      : pauseResumeLabel;
+  const showBuiltInLifecycle = builtInStatus === "needs_setup" || builtInStatus === "pending_approval";
+  const trailingLabel = [
+    showBuiltInLifecycle ? `Built-in agent ${builtInStatus.replace(/_/g, " ")}` : null,
+    hasInvalidOrgChain ? "Invalid reporting chain" : null,
+  ].filter(Boolean).join(", ") || undefined;
+
+  // C11 (DECISION-SHEET.md): the row itself is a SidebarNavItem, so agent rows
+  // share the nav-row chrome (type, active state, rail tooltip, live dot).
+  const navItem = (
+    <SidebarNavItem
+      to={href}
+      label={agent.name}
+      iconNode={<AgentIcon icon={agent.icon} className="shrink-0 h-4 w-4" />}
+      active={isActive}
+      liveCount={runCount}
+      labelClassName={showBuiltInLifecycle ? "min-w-(--sz-4_5rem) flex-initial" : undefined}
+      className={cn(
+        "min-w-0 flex-1",
+        // Reserve room for the hover ⋯ menu; starred rows widen it for the
+        // inline unstar star.
+        starred && !isMobile ? "pr-14" : "pr-8",
+      )}
+      trailing={
+        showBuiltInLifecycle || hasInvalidOrgChain ? (
+          <span className="ml-1 flex shrink-0 items-center gap-1">
+            {showBuiltInLifecycle ? <BuiltInLifecycleChip status={builtInStatus} compact /> : null}
+            {hasInvalidOrgChain ? (
+              <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-amber-500" aria-label="Invalid reporting chain" />
+            ) : null}
+          </span>
+        ) : undefined
+      }
+      trailingLabel={trailingLabel}
+      liveAccessory={
+        agent.pauseReason === "budget" ? <BudgetSidebarMarker title="Agent paused by budget" /> : undefined
+      }
+    />
+  );
+
+  // Rail: the star/menu overlays are hidden, so render the nav item bare (it
+  // supplies its own rail tooltip) and let it fill the column like every other
+  // rail row.
+  if (rail) return navItem;
+
+  return (
+    <div className="group/agent relative flex items-center">
+      {navItem}
+
+      {starred && !isMobile && onToggleStar ? (
+        // Desktop: quiet inline unstar, left of the ⋯ menu, revealed on hover/focus.
+        <span className="absolute right-10 top-1/2 -translate-y-1/2">
+          <StarToggle
+            size="row"
+            quiet
+            starred
+            pending={starPending}
+            resourceName={agent.name}
+            onToggle={() => onToggleStar(agent, false)}
+            revealClassName={AGENT_STAR_ROW_REVEAL}
+          />
+        </span>
+      ) : null}
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            className={cn(
+              "absolute right-3 top-1/2 h-6 w-6 -translate-y-1/2 transition-opacity data-[state=open]:pointer-events-auto data-[state=open]:opacity-100",
+              isMobile
+                ? "opacity-100"
+                : "pointer-events-none opacity-0 group-hover/agent:pointer-events-auto group-hover/agent:opacity-100 group-focus-within/agent:pointer-events-auto group-focus-within/agent:opacity-100",
+            )}
+            aria-label={`Open actions for ${agent.name}`}
+          >
+            <MoreHorizontal className="h-3.5 w-3.5" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-48">
+          {onToggleStar ? (
+            <>
+              <DropdownMenuItem
+                onClick={() => {
+                  if (starPending) return;
+                  onToggleStar(agent, !starred);
+                }}
+                disabled={starPending}
+              >
+                {starPending ? (
+                  <Loader2 className="size-4 motion-safe:animate-spin" />
+                ) : (
+                  <Star className={cn("size-4", starred && "fill-amber-500 text-amber-500")} />
+                )}
+                <span>{starred ? "Remove from starred" : "Star agent"}</span>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+            </>
+          ) : null}
+          <DropdownMenuItem asChild>
+            <Link
+              to={editHref}
+              onClick={() => {
+                if (isMobile) setSidebarOpen(false);
+              }}
+            >
+              <Pencil className="size-4" />
+              <span>Edit agent</span>
+            </Link>
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onClick={() => {
+              if (pauseResumeDisabled) return;
+              onPauseResume(agent, isPaused ? "resume" : "pause");
+            }}
+            disabled={pauseResumeDisabled}
+            title={isBudgetPaused ? "Agent was paused by budget limits" : undefined}
+          >
+            {isPaused ? <PlayCircle className="size-4" /> : <PauseCircle className="size-4" />}
+            <span>{pauseResumeDisabledLabel}</span>
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onClick={() => {
+              if (leaving) return;
+              onLeaveAgent(agent);
+            }}
+            disabled={leaving}
+          >
+            {leaving ? <Loader2 className="size-4 motion-safe:animate-spin" /> : <LogOut className="size-4" />}
+            <span>{leaving ? "Leaving..." : "Leave agent"}</span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
+export function SidebarAgents({ streamlined = false }: { streamlined?: boolean } = {}) {
+  const [open, setOpen] = useState(true);
+  const [pendingAgentIds, setPendingAgentIds] = useState<Set<string>>(() => new Set());
+  const [liveLingerVersion, setLiveLingerVersion] = useState(0);
+  const lastSeenLiveAtRef = useRef<Map<string, number>>(new Map());
+  const queryClient = useQueryClient();
+  const { selectedCompanyId } = useCompany();
+  const { openNewAgent } = useDialogActions();
+  const { isMobile, setSidebarOpen, collapsed, peeking } = useSidebar();
+  const rail = collapsed && !peeking;
+  const { pushToast } = useToastActions();
+  const location = useLocation();
+
+  const { data: agents } = useQuery({
+    queryKey: queryKeys.agents.list(selectedCompanyId!),
+    queryFn: () => agentsApi.list(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+  });
+  const { data: experimentalSettings } = useQuery({
+    queryKey: queryKeys.instance.experimentalSettings,
+    queryFn: () => instanceSettingsApi.getExperimental(),
+    enabled: !!selectedCompanyId,
+  });
+  const builtInAgentsEnabled = experimentalSettings?.enableBuiltInAgents === true;
+  const { data: builtInAgents } = useQuery({
+    queryKey: queryKeys.builtInAgents.list(selectedCompanyId!),
+    queryFn: () => builtInAgentsApi.list(selectedCompanyId!),
+    enabled: !!selectedCompanyId && builtInAgentsEnabled,
+  });
+  const builtInStatusByAgentId = useMemo(() => {
+    const map = new Map<string, BuiltInAgentStatus>();
+    if (!builtInAgentsEnabled) return map;
+    for (const entry of builtInAgents ?? []) {
+      if (entry.agentId) map.set(entry.agentId, entry.status);
+    }
+    return map;
+  }, [builtInAgents, builtInAgentsEnabled]);
+  const { data: session } = useQuery({
+    queryKey: queryKeys.auth.session,
+    queryFn: () => authApi.getSession(),
+  });
+  const membershipsQuery = useResourceMemberships(selectedCompanyId);
+  const membershipMutation = useResourceMembershipMutation(selectedCompanyId);
+
+  const liveRunsQueryKey = queryKeys.liveRuns(selectedCompanyId!);
+  const sharedLiveRuns = useSharedPollingQuery({
+    companyId: selectedCompanyId,
+    resourceKey: "live-runs",
+    queryKey: liveRunsQueryKey,
+    enabled: !!selectedCompanyId,
+    // Event-sourced via LiveUpdatesProvider (issue 9627); no interval poll needed.
+    refetchInterval: false,
+    leaderOnly: true,
+  });
+  const { data: liveRuns, dataUpdatedAt: liveRunsUpdatedAt } = useQuery({
+    queryKey: liveRunsQueryKey,
+    queryFn: () => heartbeatsApi.liveRunsForCompany(selectedCompanyId!),
+    enabled: sharedLiveRuns.enabled,
+    refetchInterval: sharedLiveRuns.refetchInterval,
+  });
+  usePublishSharedQueryData(sharedLiveRuns, liveRuns, liveRunsUpdatedAt);
+
+  const liveCountByAgent = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const run of liveRuns ?? []) {
+      counts.set(run.agentId, (counts.get(run.agentId) ?? 0) + 1);
+    }
+    return counts;
+  }, [liveRuns]);
+  const liveAgentIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const [agentId, count] of liveCountByAgent) {
+      if (count > 0) ids.add(agentId);
+    }
+    return ids;
+  }, [liveCountByAgent]);
+
+  const visibleAgents = useMemo(() => {
+    const filtered = (agents ?? []).filter(
+      (a: Agent) =>
+        a.status !== "terminated" &&
+        (
+          !membershipsQuery.isSuccess ||
+          resourceMembershipState(membershipsQuery.data, "agent", a.id) !== "left"
+        )
+    );
+    return filtered;
+  }, [agents, membershipsQuery.data, membershipsQuery.isSuccess]);
+  const currentUserId = session?.user?.id ?? session?.session?.userId ?? null;
+  const sortModeStorageKey = useMemo(() => {
+    if (!selectedCompanyId) return null;
+    return getAgentSortModeStorageKey(selectedCompanyId, currentUserId);
+  }, [currentUserId, selectedCompanyId]);
+  const [sortMode, setSortMode] = useState<AgentSidebarSortMode>(() => {
+    if (!sortModeStorageKey) return "top";
+    return readAgentSortMode(sortModeStorageKey);
+  });
+  const { orderedAgents } = useAgentOrder({
+    agents: visibleAgents,
+    companyId: selectedCompanyId,
+    userId: currentUserId,
+  });
+  const sortedAgents = useMemo(
+    () => sortAgents(orderedAgents, sortMode),
+    [orderedAgents, sortMode],
+  );
+  const sortedAgentIdSet = useMemo(
+    () => new Set(sortedAgents.map((agent: Agent) => agent.id)),
+    [sortedAgents],
+  );
+
+  useEffect(() => {
+    const now = Date.now();
+    for (const agentId of liveAgentIds) {
+      lastSeenLiveAtRef.current.set(agentId, now);
+    }
+    for (const agentId of lastSeenLiveAtRef.current.keys()) {
+      if (!sortedAgentIdSet.has(agentId)) {
+        lastSeenLiveAtRef.current.delete(agentId);
+      }
+    }
+  }, [liveAgentIds, sortedAgentIdSet]);
+
+  // IA Phase 5 (streamlined): if any agent has a live run, show only those
+  // active agents. Agents that just stopped running linger briefly so clustered
+  // run boundaries do not make rows pop out and the section does not immediately
+  // swap to the recent fallback during short all-idle gaps. Otherwise fall back
+  // to up to RECENT_AGENT_LIMIT agents. Either way a "See all agents" link is
+  // shown so the full list is always reachable.
+  // Classic mode (PAP-89, flag OFF) restores the show-all behavior.
+  const runningAgents = useMemo(() => {
+    const nowForLiveLinger = Date.now();
+    const lastSeenLiveAtByAgent = lastSeenLiveAtRef.current;
+    return sortedAgents.filter((agent: Agent) => {
+      if ((liveCountByAgent.get(agent.id) ?? 0) > 0) return true;
+      const lastSeenLiveAt = lastSeenLiveAtByAgent.get(agent.id);
+      return lastSeenLiveAt !== undefined && nowForLiveLinger - lastSeenLiveAt <= LIVE_AGENT_LINGER_MS;
+    });
+  }, [liveCountByAgent, liveLingerVersion, sortedAgents]);
+  const hasActiveAgents = runningAgents.length > 0;
+  const displayedAgents = !streamlined
+    ? sortedAgents
+    : hasActiveAgents
+      ? runningAgents
+      : sortedAgents.slice(0, RECENT_AGENT_LIMIT);
+  // Always expose "See all agents" whenever the displayed list is a subset of all
+  // agents, so users never lose the entry point to the full list. In classic mode
+  // every agent is already shown, so the link is unnecessary.
+  const showSeeAllLink = streamlined && sortedAgents.length > 0;
+
+  const agentMatch = location.pathname.match(/^\/(?:[^/]+\/)?agents\/([^/]+)(?:\/([^/]+))?/);
+  const activeAgentId = agentMatch?.[1] ?? null;
+  const activeTab = agentMatch?.[2] ?? null;
+
+  useEffect(() => {
+    if (!sortModeStorageKey) {
+      setSortMode("top");
+      return;
+    }
+    setSortMode(readAgentSortMode(sortModeStorageKey));
+  }, [sortModeStorageKey]);
+
+  useEffect(() => {
+    if (!sortModeStorageKey) return;
+
+    const onStorage = (event: StorageEvent) => {
+      if (event.key !== sortModeStorageKey) return;
+      setSortMode(readAgentSortMode(sortModeStorageKey));
+    };
+    const onCustomEvent = (event: Event) => {
+      const detail = (event as CustomEvent<AgentSortModeUpdatedDetail>).detail;
+      if (!detail || detail.storageKey !== sortModeStorageKey) return;
+      setSortMode(detail.sortMode);
+    };
+
+    window.addEventListener("storage", onStorage);
+    window.addEventListener(AGENT_SORT_MODE_UPDATED_EVENT, onCustomEvent);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener(AGENT_SORT_MODE_UPDATED_EVENT, onCustomEvent);
+    };
+  }, [sortModeStorageKey]);
+
+  useEffect(() => {
+    if (!streamlined) return;
+
+    const now = Date.now();
+    let nextExpiryAt: number | null = null;
+    for (const agent of sortedAgents) {
+      if ((liveCountByAgent.get(agent.id) ?? 0) > 0) continue;
+      const lastSeenLiveAt = lastSeenLiveAtRef.current.get(agent.id);
+      if (lastSeenLiveAt === undefined) continue;
+      const expiresAt = lastSeenLiveAt + LIVE_AGENT_LINGER_MS;
+      if (expiresAt < now) continue;
+      nextExpiryAt = nextExpiryAt === null ? expiresAt : Math.min(nextExpiryAt, expiresAt);
+    }
+    if (nextExpiryAt === null) return;
+
+    const timeoutId = window.setTimeout(() => {
+      setLiveLingerVersion((version) => version + 1);
+    }, Math.max(0, nextExpiryAt - now + 1));
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [streamlined, sortedAgents, liveCountByAgent, liveLingerVersion]);
+
+  const persistSortMode = useCallback(
+    (value: string) => {
+      const nextSortMode: AgentSidebarSortMode =
+        value === "alphabetical" || value === "recent" ? value : "top";
+      setSortMode(nextSortMode);
+      if (sortModeStorageKey) {
+        writeAgentSortMode(sortModeStorageKey, nextSortMode);
+      }
+    },
+    [sortModeStorageKey],
+  );
+
+  const pauseResumeAgent = useMutation({
+    mutationFn: ({ agent, action }: { agent: Agent; action: "pause" | "resume" }) =>
+      action === "pause"
+        ? agentsApi.pause(agent.id, selectedCompanyId ?? undefined)
+        : agentsApi.resume(agent.id, selectedCompanyId ?? undefined),
+    onMutate: ({ agent }) => {
+      setPendingAgentIds((current) => {
+        const next = new Set(current);
+        next.add(agent.id);
+        return next;
+      });
+    },
+    onSuccess: async (_agent, { agent, action }) => {
+      if (selectedCompanyId) {
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: queryKeys.agents.list(selectedCompanyId) }),
+          queryClient.invalidateQueries({ queryKey: queryKeys.liveRuns(selectedCompanyId) }),
+          queryClient.invalidateQueries({ queryKey: queryKeys.dashboard(selectedCompanyId) }),
+        ]);
+      }
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agent.id) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agentRouteRef(agent)) }),
+      ]);
+      pushToast({
+        title: action === "pause" ? "Agent paused" : "Agent resumed",
+        body: agent.name,
+        tone: "success",
+      });
+    },
+    onError: (error, { agent, action }) => {
+      pushToast({
+        title: action === "pause" ? "Could not pause agent" : "Could not resume agent",
+        body: error instanceof Error ? error.message : agent.name,
+        tone: "error",
+      });
+    },
+    onSettled: (_data, _error, { agent }) => {
+      setPendingAgentIds((current) => {
+        const next = new Set(current);
+        next.delete(agent.id);
+        return next;
+      });
+    },
+  });
+
+  const leaveAgent = useCallback(
+    (agent: Agent) => membershipMutation.mutate({
+      resourceType: "agent",
+      resourceId: agent.id,
+      resourceName: agent.name,
+      state: "left",
+    }),
+    [membershipMutation],
+  );
+  const agentLeaving = useCallback(
+    (agent: Agent) =>
+      membershipMutation.isPending &&
+      membershipMutation.variables?.resourceType === "agent" &&
+      membershipMutation.variables.resourceId === agent.id,
+    [membershipMutation.isPending, membershipMutation.variables],
+  );
+
+  const toggleStarAgent = useCallback(
+    (agent: Agent, starred: boolean) => membershipMutation.mutate({
+      resourceType: "agent",
+      resourceId: agent.id,
+      resourceName: agent.name,
+      starred,
+    }),
+    [membershipMutation],
+  );
+  const agentStarPending = useCallback(
+    (agent: Agent) =>
+      membershipMutation.isPending &&
+      membershipMutation.variables?.resourceType === "agent" &&
+      membershipMutation.variables.resourceId === agent.id &&
+      membershipMutation.variables.starred !== undefined,
+    [membershipMutation.isPending, membershipMutation.variables],
+  );
+
+  // Starred agents pin to the top of the section (name order), and are deduped
+  // out of the active/recent subset so no agent appears twice.
+  const starredAgentIdSet = useMemo(
+    () => new Set(starredResourceIds(membershipsQuery.data, "agent")),
+    [membershipsQuery.data],
+  );
+  const starredAgents = useMemo(
+    () => sortAgents(visibleAgents.filter((agent: Agent) => starredAgentIdSet.has(agent.id)), "alphabetical"),
+    [visibleAgents, starredAgentIdSet],
+  );
+  const dedupedDisplayedAgents = useMemo(
+    () => displayedAgents.filter((agent: Agent) => !starredAgentIdSet.has(agent.id)),
+    [displayedAgents, starredAgentIdSet],
+  );
+
+  const renderAgentRow = (agent: Agent, isStarredRow: boolean) => (
+    <SidebarAgentItem
+      key={agent.id}
+      activeAgentId={activeAgentId}
+      activeTab={activeTab}
+      agent={agent}
+      disabled={pendingAgentIds.has(agent.id)}
+      isMobile={isMobile}
+      leaving={agentLeaving(agent)}
+      onLeaveAgent={leaveAgent}
+      onPauseResume={(targetAgent, action) => pauseResumeAgent.mutate({ agent: targetAgent, action })}
+      rail={rail}
+      runCount={liveCountByAgent.get(agent.id) ?? 0}
+      setSidebarOpen={setSidebarOpen}
+      builtInStatus={builtInStatusByAgentId.get(agent.id)}
+      starred={isStarredRow || isStarred(membershipsQuery.data, "agent", agent.id)}
+      onToggleStar={toggleStarAgent}
+      starPending={agentStarPending(agent)}
+    />
+  );
+
+  return (
+    <SidebarSection
+      label="Agents"
+      collapsible={{ open, onOpenChange: setOpen }}
+      headerAction={{
+        ariaLabel: "New agent",
+        icon: Plus,
+        onClick: openNewAgent,
+      }}
+      menu={{
+        ariaLabel: "Agents section actions",
+        actions: [
+          { type: "item", label: "Browse agents", icon: Users, href: "/agents/all" },
+          { type: "separator" },
+        ],
+        radioLabel: "Agent sort",
+        radioChoices: AGENT_SORT_CHOICES,
+        radioValue: sortMode,
+        onRadioValueChange: persistSortMode,
+      }}
+    >
+      {starredAgents.map((agent: Agent) => renderAgentRow(agent, true))}
+      {dedupedDisplayedAgents.map((agent: Agent) => renderAgentRow(agent, false))}
+      {showSeeAllLink && (() => {
+        // Deliberately NOT a SidebarNavItem: this is a quiet muted affordance
+        // (plain Link) that must not adopt nav-row active-route highlighting.
+        const seeAllLink = (
+          <Link
+            to="/agents/all"
+            state={SIDEBAR_SCROLL_RESET_STATE}
+            aria-label={rail ? "See all agents" : undefined}
+            onClick={() => {
+              if (isMobile) setSidebarOpen(false);
+            }}
+            className="flex items-center gap-2.5 mx-2 rounded-lg px-2 py-1.5 pointer-coarse:py-1 text-(length:--text-compact) font-medium text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+          >
+            <Users className="shrink-0 h-4 w-4" />
+            <span className={rail ? SIDEBAR_RAIL_HIDDEN_LABEL : undefined}>See all agents</span>
+          </Link>
+        );
+        return rail ? (
+          <Tooltip>
+            <TooltipTrigger asChild>{seeAllLink}</TooltipTrigger>
+            <TooltipContent side="right">See all agents</TooltipContent>
+          </Tooltip>
+        ) : (
+          seeAllLink
+        );
+      })()}
+    </SidebarSection>
+  );
+}

--- a/ui/src/components/SidebarAgents.tsx
+++ b/ui/src/components/SidebarAgents.tsx
@@ -663,7 +663,7 @@ export function SidebarAgents({ streamlined = false }: { streamlined?: boolean }
             onClick={() => {
               if (isMobile) setSidebarOpen(false);
             }}
-            className="flex items-center gap-2.5 mx-2 rounded-lg px-2 py-1.5 pointer-coarse:py-1 text-(length:--text-compact) font-medium text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+            className="flex items-center gap-2.5 mx-2 rounded-lg px-2 py-1.5 pointer-coarse:py-1 text-(length:--text-compact) font-medium text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
           >
             <Users className="shrink-0 h-4 w-4" />
             <span className={rail ? SIDEBAR_RAIL_HIDDEN_LABEL : undefined}>See all agents</span>

--- a/ui/src/components/SidebarCompanyMenu.production.tsx
+++ b/ui/src/components/SidebarCompanyMenu.production.tsx
@@ -1,0 +1,513 @@
+import { useCallback, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Check,
+  ChevronsUpDown,
+  GripVertical,
+  LogOut,
+  Plus,
+  RefreshCw,
+  UserPlus,
+} from "lucide-react";
+import {
+  DndContext,
+  MouseSensor,
+  TouchSensor,
+  closestCenter,
+  type DragEndEvent,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { SortableContext, arrayMove, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import type { Company } from "@paperclipai/shared";
+import { Link, useLocation, useNavigate } from "@/lib/router";
+import { authApi } from "@/api/auth";
+import { cloudApi, type CloudStackSummary } from "@/api/cloud";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useCompany } from "@/context/CompanyContext";
+import { useDialogActions } from "@/context/DialogContext";
+import { useCloudInstance } from "@/hooks/useCloudInstance";
+import { useCompanyOrder } from "@/hooks/useCompanyOrder";
+import { useSignOut } from "@/hooks/useSignOut";
+import { navigateTopLevel } from "@/lib/browserNavigation";
+import { cloudStackCreateUrl, cloudStackEnterUrl } from "@/lib/cloudLinks";
+import { queryKeys } from "@/lib/queryKeys";
+import { cn, SIDEBAR_RAIL_HIDDEN_LABEL } from "@/lib/utils";
+import { useSidebar } from "../context/SidebarContext";
+import { CompanyPatternIcon } from "./CompanyPatternIcon";
+
+interface SidebarCompanyMenuProps {
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+const WORKSPACE_ICON_CLASS = "size-5 shrink-0 rounded-md text-(length:--text-micro)";
+const WORKSPACE_BADGE_CLASS =
+  "shrink-0 rounded bg-muted px-1.5 py-0.5 font-mono text-(length:--text-nano) text-muted-foreground";
+
+function WorkspaceIcon({ company }: { company: Company }) {
+  return (
+    <CompanyPatternIcon
+      companyName={company.name}
+      logoUrl={company.logoUrl}
+      className={WORKSPACE_ICON_CLASS}
+    />
+  );
+}
+
+/**
+ * Cloud stacks have no hot-linkable icon URL in the portfolio payload, so v1
+ * renders the same deterministic monogram treatment cloud's own portfolio page
+ * uses — seeded by the display name, never fetched.
+ */
+function StackIcon({ displayName }: { displayName: string }) {
+  return <CompanyPatternIcon companyName={displayName} className={WORKSPACE_ICON_CLASS} />;
+}
+
+/**
+ * The switcher trigger on a Cloud instance. A Cloud tenant holds exactly one
+ * company and the harness pushes the stack's uploaded workspace icon into
+ * that company's branding, so the company logo is the stack logo here.
+ * The stack rows keep the monogram treatment above.
+ */
+function CurrentStackIcon({
+  displayName,
+  company,
+}: {
+  displayName: string;
+  company: Company | null;
+}) {
+  return (
+    <CompanyPatternIcon
+      companyName={displayName}
+      logoUrl={company?.logoUrl}
+      className={WORKSPACE_ICON_CLASS}
+    />
+  );
+}
+
+function CloudStackItem({
+  stack,
+  isSelected,
+  onSelect,
+}: {
+  stack: CloudStackSummary;
+  isSelected: boolean;
+  onSelect: (stack: CloudStackSummary) => void;
+}) {
+  return (
+    <DropdownMenuItem
+      onSelect={() => onSelect(stack)}
+      className={cn("min-w-0 gap-2 py-2", isSelected && "bg-accent text-accent-foreground")}
+    >
+      <StackIcon displayName={stack.displayName} />
+      <span className="min-w-0 flex-1 truncate" title={stack.displayName}>
+        {stack.displayName}
+      </span>
+      {/* Company badges are 3-4 character issue prefixes, but stack slugs are
+          user-chosen and can be long enough to truncate the name to a single
+          letter — the name is the primary identifier, so the badge yields. */}
+      <span className={cn(WORKSPACE_BADGE_CLASS, "max-w-24 truncate")} title={stack.stackSlug}>
+        {stack.stackSlug}
+      </span>
+      {isSelected ? <Check className="size-4 shrink-0 text-muted-foreground" /> : null}
+    </DropdownMenuItem>
+  );
+}
+
+function SortableCompanyItem({
+  company,
+  isEditing,
+  isSelected,
+  onSelect,
+}: {
+  company: Company;
+  isEditing: boolean;
+  isSelected: boolean;
+  onSelect: (company: Company) => void;
+}) {
+  const {
+    attributes,
+    listeners,
+    setActivatorNodeRef,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: company.id, disabled: !isEditing });
+
+  return (
+    <DropdownMenuItem
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        zIndex: isDragging ? 10 : undefined,
+      }}
+      onSelect={(event) => {
+        if (isEditing) {
+          event.preventDefault();
+          return;
+        }
+        onSelect(company);
+      }}
+      className={cn(
+        "min-w-0 gap-2 py-2",
+        isEditing && "cursor-grab",
+        isDragging && "opacity-80",
+        isSelected && "bg-accent text-accent-foreground",
+      )}
+    >
+      <WorkspaceIcon company={company} />
+      <span className="min-w-0 flex-1 truncate">{company.name}</span>
+      {isEditing ? (
+        <button
+          type="button"
+          ref={setActivatorNodeRef}
+          aria-label={`Reorder ${company.name}`}
+          className="inline-flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-(length:--rad-2) focus-visible:ring-ring"
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+          }}
+          {...attributes}
+          {...listeners}
+        >
+          <GripVertical className="size-4" aria-hidden="true" />
+        </button>
+      ) : (
+        <>
+          <span className={WORKSPACE_BADGE_CLASS}>{company.issuePrefix}</span>
+          {isSelected ? <Check className="size-4 text-muted-foreground" /> : null}
+        </>
+      )}
+    </DropdownMenuItem>
+  );
+}
+
+export function SidebarCompanyMenu({ open: controlledOpen, onOpenChange }: SidebarCompanyMenuProps = {}) {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const [isEditingOrder, setIsEditingOrder] = useState(false);
+  const { companies, selectedCompany, setSelectedCompanyId, companyListUnavailable, retryCompanies } =
+    useCompany();
+  const { openOnboarding } = useDialogActions();
+  const { isMobile, setSidebarOpen, collapsed, peeking } = useSidebar();
+  const rail = collapsed && !peeking;
+  const location = useLocation();
+  const navigate = useNavigate();
+  const open = controlledOpen ?? internalOpen;
+  const setOpen = onOpenChange ?? setInternalOpen;
+  const sensors = useSensors(
+    useSensor(MouseSensor, {
+      activationConstraint: { distance: 8 },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 180, tolerance: 6 },
+    }),
+  );
+  const sidebarCompanies = useMemo(
+    () => companies.filter((company) => company.status !== "archived"),
+    [companies],
+  );
+  const { data: session } = useQuery({
+    queryKey: queryKeys.auth.session,
+    queryFn: () => authApi.getSession(),
+    retry: false,
+  });
+  const currentUserId = session?.user?.id ?? session?.session?.userId ?? null;
+  const { orderedCompanies, persistOrder } = useCompanyOrder({
+    companies: sidebarCompanies,
+    userId: currentUserId,
+  });
+
+  // In Paperclip Cloud the switcher lists the signed-in user's stacks
+  // (organizations) instead of the instance's companies: a cloud instance holds
+  // exactly one company, and switching means leaving this tenant host entirely.
+  const cloud = useCloudInstance();
+  const isCloud = Boolean(cloud);
+  const cloudBaseUrl = cloud?.cloudBaseUrl ?? null;
+  const stacksQuery = useQuery({
+    queryKey: queryKeys.cloud.stacks,
+    queryFn: () => cloudApi.listStacks(),
+    enabled: isCloud,
+    staleTime: 30_000,
+    retry: false,
+  });
+  const stacks = stacksQuery.data?.stacks ?? [];
+  const currentStack = isCloud
+    ? stacks.find((stack) => stack.isCurrent)
+      ?? stacks.find((stack) => Boolean(cloud?.stackSlug) && stack.stackSlug === cloud?.stackSlug)
+      ?? null
+    : null;
+  const createStackUrl = isCloud ? cloudStackCreateUrl(cloudBaseUrl) : null;
+  const switcherNoun = isCloud ? "organization" : "company";
+  // The one name the chrome shows for "where am I": the stack in cloud, the
+  // company when self-hosted.
+  const currentName = isCloud
+    ? currentStack?.displayName ?? cloud?.stackDisplayName ?? cloud?.stackSlug ?? null
+    : selectedCompany?.name ?? null;
+
+  const signOutMutation = useSignOut({ onSignedOut: closeNavigationChrome });
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen) setIsEditingOrder(false);
+    setOpen(nextOpen);
+  }
+
+  function closeNavigationChrome() {
+    setOpen(false);
+    setIsEditingOrder(false);
+    if (isMobile) setSidebarOpen(false);
+  }
+
+  function selectCompany(company: Company) {
+    const pathPrefix = location.pathname.split("/")[1]?.toUpperCase();
+    const isCompanyRoute = sidebarCompanies.some((sidebarCompany) => (
+      sidebarCompany.issuePrefix.toUpperCase() === pathPrefix
+    ));
+    const shouldLeaveCurrentRoute = company.id !== selectedCompany?.id
+      && (location.pathname.startsWith("/instance/") || isCompanyRoute);
+
+    setSelectedCompanyId(company.id);
+    setOpen(false);
+    if (isMobile) setSidebarOpen(false);
+    if (shouldLeaveCurrentRoute) {
+      navigate(`/${company.issuePrefix}/dashboard`);
+    }
+  }
+
+  /**
+   * Switching stacks is a full top-level navigation, not client routing: the
+   * cloud entry-code handoff authenticates the user for the target stack and
+   * wakes it if it is asleep before landing on its own tenant host.
+   */
+  function selectStack(stack: CloudStackSummary) {
+    setOpen(false);
+    if (isMobile) setSidebarOpen(false);
+    if (stack.stackSlug === currentStack?.stackSlug) return;
+    const target = cloudStackEnterUrl(cloudBaseUrl, stack.stackSlug);
+    if (!target) return;
+    navigateTopLevel(target);
+  }
+
+  function addCompany() {
+    setOpen(false);
+    if (isMobile) setSidebarOpen(false);
+    // Cloud creates organizations in the cloud app; the in-app company wizard
+    // is unreachable there (POST /companies is a 403 floor on managed stacks).
+    if (isCloud) {
+      if (createStackUrl) navigateTopLevel(createStackUrl);
+      return;
+    }
+    // Skip the front-door "how would you like to get started?" choice and land
+    // directly on "Name your organization" — this entry point is unambiguously
+    // "create a new company" (PAP-431).
+    openOnboarding({ initialStep: 1 });
+  }
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+
+      const ids = orderedCompanies.map((company) => company.id);
+      const oldIndex = ids.indexOf(active.id as string);
+      const newIndex = ids.indexOf(over.id as string);
+      if (oldIndex === -1 || newIndex === -1) return;
+
+      persistOrder(arrayMove(ids, oldIndex, newIndex));
+    },
+    [orderedCompanies, persistOrder],
+  );
+
+  return (
+    <DropdownMenu open={open} onOpenChange={handleOpenChange}>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          // The nav icon column sits at nav px-3 + item mx-2 + item px-2.
+          // Match that inset with wrapper px-3 + trigger px-4. Override the
+          // Button's direct-SVG padding too so the expanded chevron cannot pull
+          // the avatar four pixels left of the nav icons.
+          // `min-w-0` on every link of the flex chain (button → label row → label)
+          // is what lets the name truncate: a flex item's default `min-width:auto`
+          // floors it at its content width, so without it a long name widens the
+          // trigger past the sidebar and pushes the chevron out of bounds. Company
+          // names were short in practice; cloud stack names are user-chosen.
+          className="h-9 min-w-0 flex-1 justify-start gap-2 px-4 text-left hover:bg-accent/50 hover:text-foreground has-[>svg]:px-4 dark:hover:bg-accent/50"
+          aria-label={
+            currentName
+              ? `Open ${currentName} ${switcherNoun} switcher`
+              : `Open ${switcherNoun} switcher`
+          }
+        >
+          <span className="flex min-w-0 flex-1 items-center gap-2">
+            {isCloud
+              ? currentName ? <CurrentStackIcon displayName={currentName} company={selectedCompany} /> : null
+              : selectedCompany ? <WorkspaceIcon company={selectedCompany} /> : null}
+            {/* The header has room for ~110px of name beside the collapse
+                control (~142px on mobile, which hides it) — search moved to
+                the nav to buy that width. A name that still
+                truncates stays hover-recoverable via title. */}
+            <span
+              className={cn(
+                "min-w-0 truncate text-sm font-bold text-foreground",
+                rail && SIDEBAR_RAIL_HIDDEN_LABEL,
+              )}
+              title={currentName ?? undefined}
+            >
+              {currentName ?? (isCloud ? "Select organization" : "Select company")}
+            </span>
+          </span>
+          {!rail && <ChevronsUpDown className="size-3.5 shrink-0 text-muted-foreground" />}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" sideOffset={8} className="w-64 p-1">
+        <div className="flex items-center justify-between gap-2 px-2 py-1.5">
+          <DropdownMenuLabel className="p-0 text-(length:--text-micro) font-semibold uppercase text-muted-foreground">
+            {isCloud ? "Switch organization" : "Switch company"}
+          </DropdownMenuLabel>
+          {/* Stack order is owned by cloud's own portfolio in v1, so the
+              drag-to-reorder affordance stays self-hosted-only. */}
+          {isCloud ? null : (
+            <button
+              type="button"
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                setIsEditingOrder((current) => !current);
+              }}
+              className="rounded px-1.5 py-0.5 text-(length:--text-micro) font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            >
+              {isEditingOrder ? "Done" : "Edit"}
+            </button>
+          )}
+        </div>
+        <div className="max-h-96 overflow-y-auto">
+          {isCloud ? (
+            <>
+              {stacks.map((stack) => (
+                <CloudStackItem
+                  key={stack.stackSlug}
+                  stack={stack}
+                  isSelected={stack.stackSlug === currentStack?.stackSlug}
+                  onSelect={selectStack}
+                />
+              ))}
+              {stacks.length === 0 ? (
+                <DropdownMenuItem disabled>
+                  {stacksQuery.isLoading
+                    ? "Loading organizations..."
+                    : stacksQuery.isError
+                      ? "Could not load organizations"
+                      : "No organizations"}
+                </DropdownMenuItem>
+              ) : null}
+            </>
+          ) : (
+            <>
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+              >
+                <SortableContext
+                  items={orderedCompanies.map((company) => company.id)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  {orderedCompanies.map((company) => (
+                    <SortableCompanyItem
+                      key={company.id}
+                      company={company}
+                      isEditing={isEditingOrder}
+                      isSelected={company.id === selectedCompany?.id}
+                      onSelect={selectCompany}
+                    />
+                  ))}
+                </SortableContext>
+              </DndContext>
+              {orderedCompanies.length === 0 ? (
+                // "No companies" is a claim about the account. After a failed
+                // list request it is one we cannot make, and this menu is the
+                // only place the customer can act on it — say what happened and
+                // offer the way back.
+                companyListUnavailable ? (
+                  <>
+                    <DropdownMenuItem disabled>Couldn&apos;t load companies</DropdownMenuItem>
+                    <DropdownMenuItem
+                      onSelect={(event) => {
+                        // Keep the menu open so the result of the retry is visible.
+                        event.preventDefault();
+                        void retryCompanies();
+                      }}
+                    >
+                      <RefreshCw className="h-4 w-4 mr-2" />
+                      Try again
+                    </DropdownMenuItem>
+                  </>
+                ) : (
+                  <DropdownMenuItem disabled>No companies</DropdownMenuItem>
+                )
+              ) : null}
+            </>
+          )}
+        </div>
+        <DropdownMenuSeparator />
+        {/* A cloud instance without a configured cloud origin has nowhere to
+            send the user, so the row (and its separator) drop out entirely. */}
+        {isCloud && !createStackUrl ? null : (
+          <>
+            <DropdownMenuItem
+              onClick={addCompany}
+              className="gap-2 py-2 text-muted-foreground"
+              disabled={isEditingOrder}
+            >
+              <Plus className="size-4" />
+              <span>Create new organization...</span>
+            </DropdownMenuItem>
+            <DropdownMenuSeparator />
+          </>
+        )}
+        <DropdownMenuItem asChild disabled={isEditingOrder}>
+          <Link
+            to="/company/settings/invites"
+            onClick={(event) => {
+              if (isEditingOrder) {
+                event.preventDefault();
+                return;
+              }
+              closeNavigationChrome();
+            }}
+          >
+            <UserPlus className="size-4" />
+            <span className="truncate">
+              {currentName ? `Invite people to ${currentName}` : "Invite people"}
+            </span>
+          </Link>
+        </DropdownMenuItem>
+        {session?.session ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              variant="destructive"
+              onClick={() => signOutMutation.mutate()}
+              disabled={isEditingOrder || signOutMutation.isPending}
+            >
+              <LogOut className="size-4" />
+              <span>{signOutMutation.isPending ? "Signing out..." : "Sign out"}</span>
+            </DropdownMenuItem>
+          </>
+        ) : null}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/ui/src/components/SidebarCompanyMenu.test.tsx
+++ b/ui/src/components/SidebarCompanyMenu.test.tsx
@@ -293,6 +293,11 @@ describe("SidebarCompanyMenu", () => {
 
     const trigger = container.querySelector('button[aria-label="Open Acme Labs organization switcher"]');
     expect(trigger).not.toBeNull();
+    expect(trigger?.classList).toContain("px-4");
+    expect(trigger?.classList).toContain("has-[>svg]:px-4");
+    expect(trigger?.classList).toContain("hover:bg-background");
+    expect(trigger?.classList).toContain("hover:text-foreground");
+    expect(trigger?.classList).toContain("dark:hover:bg-background");
     act(() => {
       trigger?.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0 }));
       trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));

--- a/ui/src/components/SidebarCompanyMenu.tsx
+++ b/ui/src/components/SidebarCompanyMenu.tsx
@@ -343,17 +343,16 @@ export function SidebarCompanyMenu({ open: controlledOpen, onOpenChange }: Sideb
       <DropdownMenuTrigger asChild>
         <Button
           variant="ghost"
-          // `px-3` (not px-2) so the logo's left edge lines up with the nav icon
-          // column (nav px-3 + item px-3) and, crucially, stays put between states:
-          // the Button's default size adds `has-[>svg]:px-3`, so with the chevron
-          // svg present (expanded) it was already 12px but without it (rail) it fell
-          // back to 8px — a 4px horizontal jump on collapse (PAP-10676).
+          // The nav icon column sits at nav px-3 + item mx-2 + item px-2.
+          // Match that inset with wrapper px-3 + trigger px-4. Override the
+          // Button's direct-SVG padding too so the expanded chevron cannot pull
+          // the avatar four pixels left of the nav icons.
           // `min-w-0` on every link of the flex chain (button → label row → label)
           // is what lets the name truncate: a flex item's default `min-width:auto`
           // floors it at its content width, so without it a long name widens the
           // trigger past the sidebar and pushes the chevron out of bounds. Company
           // names were short in practice; cloud stack names are user-chosen.
-          className="h-9 min-w-0 flex-1 justify-start gap-2 px-3 text-left"
+          className="h-9 min-w-0 flex-1 justify-start gap-2 px-4 text-left hover:bg-background hover:text-foreground has-[>svg]:px-4 dark:hover:bg-background"
           aria-label={
             currentName
               ? `Open ${currentName} ${switcherNoun} switcher`

--- a/ui/src/components/SidebarNavItem.production.tsx
+++ b/ui/src/components/SidebarNavItem.production.tsx
@@ -1,0 +1,226 @@
+import { createContext, useContext, type ReactNode } from "react";
+import { NavLink } from "@/lib/router";
+import { SIDEBAR_SCROLL_RESET_STATE } from "../lib/navigation-scroll";
+import { cn, SIDEBAR_RAIL_HIDDEN_LABEL } from "../lib/utils";
+import { useSidebar } from "../context/SidebarContext";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import type { LucideIcon } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+
+/**
+ * Forces the full-label (non-rail) presentation for any `SidebarNavItem`
+ * rendered beneath it, regardless of the global `useSidebar().collapsed` state.
+ *
+ * Takeover routes (PAP-10695) collapse the app `<Sidebar/>` to its 64px rail
+ * and render the contextual nav in a fixed 240px `SecondarySidebar`. That pane
+ * is always wide enough for labels, but its `SidebarNavItem` children still
+ * read the *global* `collapsed=true` and would otherwise render icon-only —
+ * leaving the settings nav unreadable (PAP-10700). Wrapping the pane in this
+ * provider decouples its items from the global rail collapse.
+ */
+const SidebarNavExpandedContext = createContext(false);
+
+export function SidebarNavExpandedProvider({ children }: { children: ReactNode }) {
+  return (
+    <SidebarNavExpandedContext.Provider value={true}>
+      {children}
+    </SidebarNavExpandedContext.Provider>
+  );
+}
+
+export function useSidebarNavExpanded() {
+  return useContext(SidebarNavExpandedContext);
+}
+
+interface SidebarNavItemProps {
+  to: string;
+  label: string;
+  icon?: LucideIcon;
+  /**
+   * Pre-rendered icon element for rows whose icon isn't a plain Lucide
+   * component (e.g. the agent rows' `AgentIcon`). Takes precedence over `icon`;
+   * the caller owns its sizing/color classes.
+   */
+  iconNode?: ReactNode;
+  end?: boolean;
+  className?: string;
+  labelClassName?: string;
+  badge?: number;
+  badgeTone?: "default" | "danger" | "warning";
+  /**
+   * Accessible noun for the numeric badge when collapsed to the rail, where the
+   * count is rendered as a dot (e.g. `badgeLabel="unread"` → "Inbox, 28 unread").
+   */
+  badgeLabel?: string;
+  textBadge?: string;
+  textBadgeTone?: "default" | "amber";
+  alert?: boolean;
+  liveCount?: number;
+  /**
+   * Overrides NavLink's own route matching for rows whose active state is
+   * computed externally (agent rows match `/agents/:ref` across tab suffixes).
+   */
+  active?: boolean;
+  /** Rendered after the label, before the right-aligned status cluster. */
+  trailing?: ReactNode;
+  /** Accessible text for `trailing` status content, surfaced in the collapsed rail (where `trailing` is hidden). */
+  trailingLabel?: string;
+  /** Rendered inside the right-aligned status cluster, before the live dot. */
+  liveAccessory?: ReactNode;
+}
+
+export function SidebarNavItem({
+  to,
+  label,
+  icon: Icon,
+  iconNode,
+  end,
+  className,
+  labelClassName,
+  badge,
+  badgeTone = "default",
+  badgeLabel,
+  textBadge,
+  textBadgeTone = "default",
+  alert = false,
+  liveCount,
+  active,
+  trailing,
+  trailingLabel,
+  liveAccessory,
+}: SidebarNavItemProps) {
+  const { isMobile, setSidebarOpen, collapsed, peeking } = useSidebar();
+  // A fixed-width contextual pane (SecondarySidebar) forces full labels even
+  // when the global app sidebar is collapsed to its rail (PAP-10700).
+  const forceExpanded = useSidebarNavExpanded();
+  // The icon-only rail presentation only applies when pinned collapsed and not
+  // peeking; a peek/expanded panel — or an expanded contextual pane — restores
+  // the full label + badge.
+  const rail = collapsed && !peeking && !forceExpanded;
+
+  const hasBadge = badge != null && badge > 0;
+  const hasLive = liveCount != null && liveCount > 0;
+
+  // Accessible text equivalent for the collapsed dot indicator. The visible
+  // label is `sr-only` in the rail, so the count must be surfaced here.
+  const railStatusText = hasLive
+    ? `${liveCount} live`
+    : hasBadge
+      ? `${badge}${badgeLabel ? ` ${badgeLabel}` : ""}`
+      : alert
+        ? "attention needed"
+        : undefined;
+  const railAriaLabel = !rail || (!railStatusText && !trailingLabel)
+    ? undefined
+    : `${label}${railStatusText ? `, ${railStatusText}` : ""}${trailingLabel ? `, ${trailingLabel}` : ""}`;
+
+  const link = (
+    <NavLink
+      to={to}
+      state={SIDEBAR_SCROLL_RESET_STATE}
+      end={end}
+      aria-label={railAriaLabel}
+      onClick={() => { if (isMobile) setSidebarOpen(false); }}
+      className={({ isActive }) =>
+        cn(
+          // One rhythm and one inset pill highlight: mx-2 floats the row off
+          // the sidebar edges, rounded-lg matches the card anchor, px-2 gives
+          // the icon breathing room inside the pill. Rows with hover menus
+          // (agents/projects) reserve extra right padding via className.
+          "flex items-center gap-2.5 mx-2 rounded-lg px-2 py-1.5 pointer-coarse:py-1 text-(length:--text-compact) font-medium transition-colors",
+          (active ?? isActive)
+            ? "bg-accent text-foreground"
+            : "text-foreground/80 hover:bg-accent/50 hover:text-foreground",
+          className,
+        )
+      }
+    >
+      <span className="relative shrink-0">
+        {iconNode ?? (Icon ? <Icon className="h-4 w-4" /> : null)}
+        {alert && (
+          <span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-red-500 shadow-(--shadow-extract-12)" aria-hidden="true" />
+        )}
+        {/* Collapsed rail: numeric badge / live count collapse to a dot on the
+            icon. The icon markup is untouched so it stays pixel-aligned. */}
+        {rail && !alert && hasLive && (
+          <span className="absolute -right-0.5 -top-0.5 flex h-2 w-2" aria-hidden="true">
+            <span className="animate-pulse absolute inline-flex h-full w-full rounded-full bg-blue-600 dark:bg-blue-400 opacity-75" />
+            <span className="relative inline-flex h-2 w-2 rounded-full bg-blue-600 dark:bg-blue-400 shadow-(--shadow-extract-12)" />
+          </span>
+        )}
+        {rail && !alert && !hasLive && hasBadge && (
+          <span
+            className={cn(
+              "absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full shadow-(--shadow-extract-12)",
+              badgeTone === "danger"
+                ? "bg-red-600"
+                : badgeTone === "warning"
+                  ? "bg-amber-500"
+                  : "bg-primary",
+            )}
+            aria-hidden="true"
+          />
+        )}
+      </span>
+      <span className={rail ? SIDEBAR_RAIL_HIDDEN_LABEL : cn("min-w-0 flex-1 truncate", labelClassName)}>{label}</span>
+      {!rail && trailing}
+      {!rail && textBadge && (
+        <Badge variant="ghost"
+          className={cn(
+            "ml-auto px-1.5 text-(length:--text-nano) leading-none",
+            textBadgeTone === "amber"
+              ? "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400"
+              : "bg-muted text-muted-foreground",
+          )}
+        >
+          {textBadge}
+        </Badge>
+      )}
+      {!rail && (hasLive || liveAccessory) && (
+        <span className="ml-auto flex items-center gap-1.5">
+          {liveAccessory}
+          {hasLive && (
+            <>
+              <span className="relative flex h-2 w-2">
+                <span className="animate-pulse absolute inline-flex h-full w-full rounded-full bg-blue-600 dark:bg-blue-400 opacity-75" />
+                <span className="relative inline-flex rounded-full h-2 w-2 bg-blue-600 dark:bg-blue-400" />
+              </span>
+              <span className="text-(length:--text-micro) font-medium text-blue-600 dark:text-blue-400">{liveCount} live</span>
+            </>
+          )}
+        </span>
+      )}
+      {!rail && hasBadge && (
+        <Badge variant="ghost"
+          className={cn(
+            "ml-auto px-1.5 leading-none",
+            badgeTone === "danger"
+              ? "bg-red-600/90 text-red-50"
+              : badgeTone === "warning"
+                ? "bg-amber-500/90 text-amber-50"
+                : "bg-primary text-primary-foreground",
+          )}
+        >
+          {badge}
+        </Badge>
+      )}
+    </NavLink>
+  );
+
+  if (!rail) return link;
+
+  // The tooltip wraps a plain block element rather than the NavLink directly:
+  // Radix `asChild` (Slot) drops React Router's *function* className, which would
+  // strip `flex` off the <a> and render it as a block — the in-flow label would
+  // then stack under the icon and the row would grow. Anchoring the tooltip to a
+  // wrapper keeps the <a> rendering normally (flex), so the row stays 1:1 with
+  // the expanded state and the icon never moves (PAP-10676).
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div>{link}</div>
+      </TooltipTrigger>
+      <TooltipContent side="right">{label}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/ui/src/components/SidebarNavItem.test.tsx
+++ b/ui/src/components/SidebarNavItem.test.tsx
@@ -82,6 +82,36 @@ describe("SidebarNavItem", () => {
     expect(link().getAttribute("aria-label")).toBeNull();
   });
 
+  it("outlines icon alert badges with the streamlined sidebar surface", () => {
+    render(<SidebarNavItem to="/inbox" label="Inbox" icon={Inbox} alert />);
+
+    const alertBadge = container.querySelector('[data-slot="sidebar-icon-alert-badge"]');
+    expect(alertBadge).not.toBeNull();
+    expect(classTokens(alertBadge)).toContain("shadow-(--shadow-sidebar-icon-badge)");
+    expect(classTokens(alertBadge)).not.toContain("shadow-(--shadow-extract-12)");
+  });
+
+  it("omits the icon slot when an item has no icon", () => {
+    render(<SidebarNavItem to="/issues/one" label="Recent task" />);
+
+    expect(link().querySelector('[data-slot="sidebar-nav-icon"]')).toBeNull();
+    expect(link().firstElementChild?.textContent).toBe("Recent task");
+  });
+
+  it("uses the Paper nav surface for the active item", () => {
+    render(<SidebarNavItem to="/issues" label="Tasks" icon={Inbox} active />);
+
+    expect(classTokens(link())).toContain("bg-background");
+    expect(classTokens(link())).not.toContain("bg-accent");
+  });
+
+  it("uses the active nav surface for hover", () => {
+    render(<SidebarNavItem to="/issues" label="Tasks" icon={Inbox} />);
+
+    expect(classTokens(link())).toContain("hover:bg-background");
+    expect(classTokens(link())).not.toContain("hover:bg-accent/50");
+  });
+
   it("clips the label (kept in flow for 1:1 row height) and collapses the badge to a dot in the rail", () => {
     sidebarState.collapsed = true;
     render(<SidebarNavItem to="/inbox" label="Inbox" icon={Inbox} badge={28} badgeLabel="unread" />);
@@ -135,9 +165,9 @@ describe("SidebarNavItem", () => {
   });
 
   it("forces the full label inside an expanded contextual pane even when globally collapsed", () => {
-    // The takeover model collapses the global sidebar (collapsed=true) while the
-    // 240px SecondarySidebar still needs readable labels (PAP-10700). The
-    // provider must override the global rail collapse.
+    // The takeover preserves the user's saved global collapse preference while
+    // replacing its contents. The provider keeps the contextual navigation
+    // readable without changing that preference.
     sidebarState.collapsed = true;
     render(
       <SidebarNavExpandedProvider>

--- a/ui/src/components/SidebarNavItem.tsx
+++ b/ui/src/components/SidebarNavItem.tsx
@@ -11,12 +11,10 @@ import { Badge } from "@/components/ui/badge";
  * Forces the full-label (non-rail) presentation for any `SidebarNavItem`
  * rendered beneath it, regardless of the global `useSidebar().collapsed` state.
  *
- * Takeover routes (PAP-10695) collapse the app `<Sidebar/>` to its 64px rail
- * and render the contextual nav in a fixed 240px `SecondarySidebar`. That pane
- * is always wide enough for labels, but its `SidebarNavItem` children still
- * read the *global* `collapsed=true` and would otherwise render icon-only —
- * leaving the settings nav unreadable (PAP-10700). Wrapping the pane in this
- * provider decouples its items from the global rail collapse.
+ * Contextual takeover routes replace the global navigation inside the same
+ * sidebar shell. The user's saved global collapse preference can still be
+ * `collapsed=true`, so this provider keeps contextual navigation readable
+ * without mutating that preference.
  */
 const SidebarNavExpandedContext = createContext(false);
 
@@ -90,16 +88,17 @@ export function SidebarNavItem({
   liveAccessory,
 }: SidebarNavItemProps) {
   const { isMobile, setSidebarOpen, collapsed, peeking } = useSidebar();
-  // A fixed-width contextual pane (SecondarySidebar) forces full labels even
-  // when the global app sidebar is collapsed to its rail (PAP-10700).
+  // A contextual takeover forces full labels even when the saved global app
+  // sidebar preference is collapsed.
   const forceExpanded = useSidebarNavExpanded();
   // The icon-only rail presentation only applies when pinned collapsed and not
-  // peeking; a peek/expanded panel — or an expanded contextual pane — restores
+  // peeking; a peek/expanded panel — or a contextual takeover — restores
   // the full label + badge.
   const rail = collapsed && !peeking && !forceExpanded;
 
   const hasBadge = badge != null && badge > 0;
   const hasLive = liveCount != null && liveCount > 0;
+  const showIconSlot = Boolean(iconNode || Icon || alert || (rail && (hasLive || hasBadge)));
 
   // Accessible text equivalent for the collapsed dot indicator. The visible
   // label is `sr-only` in the rail, so the count must be surfaced here.
@@ -129,39 +128,45 @@ export function SidebarNavItem({
           // (agents/projects) reserve extra right padding via className.
           "flex items-center gap-2.5 mx-2 rounded-lg px-2 py-1.5 pointer-coarse:py-1 text-(length:--text-compact) font-medium transition-colors",
           (active ?? isActive)
-            ? "bg-accent text-foreground"
-            : "text-foreground/80 hover:bg-accent/50 hover:text-foreground",
+            ? "bg-background text-foreground"
+            : "text-foreground/80 hover:bg-background hover:text-foreground",
           className,
         )
       }
     >
-      <span className="relative shrink-0">
-        {iconNode ?? (Icon ? <Icon className="h-4 w-4" /> : null)}
-        {alert && (
-          <span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-red-500 shadow-(--shadow-extract-12)" aria-hidden="true" />
-        )}
-        {/* Collapsed rail: numeric badge / live count collapse to a dot on the
-            icon. The icon markup is untouched so it stays pixel-aligned. */}
-        {rail && !alert && hasLive && (
-          <span className="absolute -right-0.5 -top-0.5 flex h-2 w-2" aria-hidden="true">
-            <span className="animate-pulse absolute inline-flex h-full w-full rounded-full bg-blue-600 dark:bg-blue-400 opacity-75" />
-            <span className="relative inline-flex h-2 w-2 rounded-full bg-blue-600 dark:bg-blue-400 shadow-(--shadow-extract-12)" />
-          </span>
-        )}
-        {rail && !alert && !hasLive && hasBadge && (
-          <span
-            className={cn(
-              "absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full shadow-(--shadow-extract-12)",
-              badgeTone === "danger"
-                ? "bg-red-600"
-                : badgeTone === "warning"
-                  ? "bg-amber-500"
-                  : "bg-primary",
-            )}
-            aria-hidden="true"
-          />
-        )}
-      </span>
+      {showIconSlot ? (
+        <span data-slot="sidebar-nav-icon" className="relative shrink-0">
+          {iconNode ?? (Icon ? <Icon className="h-4 w-4" /> : null)}
+          {alert && (
+            <span
+              data-slot="sidebar-icon-alert-badge"
+              className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-red-500 shadow-(--shadow-sidebar-icon-badge)"
+              aria-hidden="true"
+            />
+          )}
+          {/* Collapsed rail: numeric badge / live count collapse to a dot on the
+              icon. The icon markup is untouched so it stays pixel-aligned. */}
+          {rail && !alert && hasLive && (
+            <span className="absolute -right-0.5 -top-0.5 flex h-2 w-2" aria-hidden="true">
+              <span className="animate-pulse absolute inline-flex h-full w-full rounded-full bg-blue-600 dark:bg-blue-400 opacity-75" />
+              <span className="relative inline-flex h-2 w-2 rounded-full bg-blue-600 dark:bg-blue-400 shadow-(--shadow-sidebar-icon-badge)" />
+            </span>
+          )}
+          {rail && !alert && !hasLive && hasBadge && (
+            <span
+              className={cn(
+                "absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full shadow-(--shadow-sidebar-icon-badge)",
+                badgeTone === "danger"
+                  ? "bg-red-600"
+                  : badgeTone === "warning"
+                    ? "bg-amber-500"
+                    : "bg-primary",
+              )}
+              aria-hidden="true"
+            />
+          )}
+        </span>
+      ) : null}
       <span className={rail ? SIDEBAR_RAIL_HIDDEN_LABEL : cn("min-w-0 flex-1 truncate", labelClassName)}>{label}</span>
       {!rail && trailing}
       {!rail && textBadge && (

--- a/ui/src/components/SidebarProjects.tsx
+++ b/ui/src/components/SidebarProjects.tsx
@@ -140,8 +140,8 @@ function ProjectItem({
       className={cn(
         "flex min-w-0 flex-1 items-center gap-2.5 mx-2 rounded-lg px-2 py-1.5 pr-8 pointer-coarse:py-1 text-(length:--text-compact) font-medium transition-colors",
         activeProjectRef === routeRef || activeProjectRef === project.id
-          ? "bg-accent text-foreground"
-          : "text-foreground/80 hover:bg-accent/50 hover:text-foreground",
+          ? "bg-background text-foreground"
+          : "text-foreground/80 hover:bg-background hover:text-foreground",
       )}
     >
       <ProjectTile color={project.color ?? null} icon={project.icon ?? null} size="xs" />

--- a/ui/src/components/SidebarRecentTasks.test.tsx
+++ b/ui/src/components/SidebarRecentTasks.test.tsx
@@ -1,0 +1,188 @@
+// @vitest-environment jsdom
+
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { SidebarRecentTasks } from "./SidebarRecentTasks";
+import {
+  getRecentTasksStorageKey,
+  readRecentTasks,
+  recordRecentTask,
+} from "@/lib/recent-tasks";
+
+const mockAuthApi = vi.hoisted(() => ({ getSession: vi.fn() }));
+const mockIssuesApi = vi.hoisted(() => ({ get: vi.fn() }));
+
+vi.mock("@/api/auth", () => ({ authApi: mockAuthApi }));
+vi.mock("@/api/issues", () => ({ issuesApi: mockIssuesApi }));
+vi.mock("@/lib/router", () => ({
+  NavLink: ({ children, to, className, ...props }: {
+    children: ReactNode;
+    to: string;
+    className?: string | ((state: { isActive: boolean }) => string);
+  }) => (
+    <a
+      href={to}
+      className={typeof className === "function" ? className({ isActive: false }) : className}
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+}));
+vi.mock("@/context/SidebarContext", () => ({
+  useSidebar: () => ({
+    collapsed: false,
+    peeking: false,
+    isMobile: false,
+    setSidebarOpen: vi.fn(),
+  }),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("SidebarRecentTasks", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    window.localStorage.clear();
+    mockIssuesApi.get.mockReset();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mockAuthApi.getSession.mockResolvedValue({
+      session: { id: "session-1", userId: "user-1" },
+      user: { id: "user-1", name: "Board", email: "board@example.test", image: null },
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function render() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <TooltipProvider>
+            <SidebarRecentTasks companyId="company-1" liveIssueIds={new Set(["issue-1"])} />
+          </TooltipProvider>
+        </QueryClientProvider>,
+      );
+    });
+    await act(async () => {
+      for (let index = 0; index < 5; index += 1) {
+        await Promise.resolve();
+        await new Promise((resolve) => window.setTimeout(resolve, 0));
+      }
+    });
+    return queryClient;
+  }
+
+  it("renders a compact empty state", async () => {
+    await render();
+    expect(container.textContent).toContain("Recent Tasks");
+    expect(container.textContent).toContain("Open or create a task");
+  });
+
+  it("renders refreshed task text and live state without shifting for a status icon", async () => {
+    recordRecentTask({
+      id: "issue-1",
+      companyId: "company-1",
+      title: "Initial title",
+      identifier: "PAP-1",
+      status: "todo",
+      updatedAt: new Date(1),
+    }, "user-1");
+    mockIssuesApi.get.mockResolvedValue({
+      id: "issue-1",
+      companyId: "company-1",
+      title: "Refreshed title",
+      identifier: "PAP-1",
+      status: "in_progress",
+      hiddenAt: null,
+      updatedAt: new Date(2),
+    });
+
+    const queryClient = await render();
+    await act(async () => {
+      for (let index = 0; index < 5; index += 1) {
+        await Promise.resolve();
+        await new Promise((resolve) => window.setTimeout(resolve, 0));
+      }
+    });
+
+    const link = container.querySelector('a[href="/issues/issue-1"]');
+    expect(mockIssuesApi.get).toHaveBeenCalledWith("issue-1");
+    expect(queryClient.getQueryData(["issues", "detail", "issue-1"])).toMatchObject({
+      title: "Refreshed title",
+    });
+    expect(link?.textContent).toContain("Refreshed title");
+    expect(link?.textContent).toContain("1 live");
+    expect(link?.querySelector('[aria-label="In Progress"]')).toBeNull();
+    expect(link?.querySelector('[data-slot="recent-task-icon-spacer"]')).toBeNull();
+    expect(link?.querySelector('[data-slot="sidebar-nav-icon"]')).toBeNull();
+    expect(link?.firstElementChild?.textContent).toBe("Refreshed title");
+  });
+
+  it("synchronizes recent tasks written by another tab", async () => {
+    mockIssuesApi.get.mockImplementation(() => new Promise(() => {}));
+    await render();
+    const storageKey = getRecentTasksStorageKey("company-1", "user-1");
+    const entries = [{
+      id: "issue-2",
+      companyId: "company-1",
+      title: "Cross-tab task",
+      identifier: "PAP-2",
+      status: "todo" as const,
+      recordedAt: 2,
+    }];
+
+    await act(async () => {
+      window.localStorage.setItem(storageKey, JSON.stringify(entries));
+      window.dispatchEvent(new StorageEvent("storage", { key: storageKey }));
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('a[href="/issues/issue-2"]')?.textContent).toContain("Cross-tab task");
+  });
+
+  it("prunes tasks that become hidden", async () => {
+    recordRecentTask({
+      id: "issue-hidden",
+      companyId: "company-1",
+      title: "Hidden task",
+      identifier: "PAP-3",
+      status: "todo",
+      updatedAt: new Date(3),
+    }, "user-1");
+    mockIssuesApi.get.mockResolvedValue({
+      id: "issue-hidden",
+      companyId: "company-1",
+      title: "Hidden task",
+      identifier: "PAP-3",
+      status: "todo",
+      hiddenAt: new Date(),
+      updatedAt: new Date(4),
+    });
+
+    await render();
+    await act(async () => {
+      await Promise.resolve();
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+    });
+
+    expect(container.querySelector('a[href="/issues/issue-hidden"]')).toBeNull();
+    expect(readRecentTasks(
+      getRecentTasksStorageKey("company-1", "user-1"),
+      "company-1",
+    )).toEqual([]);
+  });
+});

--- a/ui/src/components/SidebarRecentTasks.tsx
+++ b/ui/src/components/SidebarRecentTasks.tsx
@@ -1,0 +1,69 @@
+import { useQuery } from "@tanstack/react-query";
+import { authApi } from "@/api/auth";
+import { queryKeys } from "@/lib/queryKeys";
+import { useRecentTasks } from "@/hooks/useRecentTasks";
+import { useSidebar } from "@/context/SidebarContext";
+import { SidebarSection } from "./SidebarSection";
+import { SidebarNavItem } from "./SidebarNavItem";
+
+export function SidebarRecentTasks({
+  companyId,
+  liveIssueIds,
+}: {
+  companyId: string | null | undefined;
+  liveIssueIds: ReadonlySet<string>;
+}) {
+  const { collapsed, peeking } = useSidebar();
+  const rail = collapsed && !peeking;
+  const { data: session, isPending } = useQuery({
+    queryKey: queryKeys.auth.session,
+    queryFn: () => authApi.getSession(),
+    retry: false,
+  });
+
+  if (!companyId || isPending) return null;
+
+  const userId = session?.user?.id ?? session?.session?.userId ?? null;
+  return (
+    <RecentTasksList
+      key={`${companyId}:${userId ?? "__local_board__"}`}
+      companyId={companyId}
+      userId={userId}
+      liveIssueIds={liveIssueIds}
+      rail={rail}
+    />
+  );
+}
+
+function RecentTasksList({
+  companyId,
+  userId,
+  liveIssueIds,
+  rail,
+}: {
+  companyId: string;
+  userId: string | null;
+  liveIssueIds: ReadonlySet<string>;
+  rail: boolean;
+}) {
+  const { entries } = useRecentTasks({ companyId, userId });
+
+  if (rail && entries.length === 0) return null;
+
+  return (
+    <SidebarSection label="Recent Tasks">
+      {entries.length === 0 ? (
+        <p className="mx-3 px-2 py-1 text-(length:--text-micro) leading-snug text-muted-foreground/70">
+          Open or create a task to keep it close at hand.
+        </p>
+      ) : entries.map((entry) => (
+        <SidebarNavItem
+          key={entry.id}
+          to={`/issues/${entry.id}`}
+          label={entry.title}
+          liveCount={liveIssueIds.has(entry.id) ? 1 : undefined}
+        />
+      ))}
+    </SidebarSection>
+  );
+}

--- a/ui/src/components/SidebarShell.production.tsx
+++ b/ui/src/components/SidebarShell.production.tsx
@@ -1,0 +1,244 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FocusEventHandler,
+  type KeyboardEvent,
+  type MouseEventHandler,
+  type PointerEvent,
+  type ReactNode,
+} from "react";
+import { cn } from "@/lib/utils";
+
+const DEFAULT_SIDEBAR_WIDTH = 240;
+const MIN_SIDEBAR_WIDTH = 208;
+const MAX_SIDEBAR_WIDTH = 420;
+const SIDEBAR_WIDTH_STEP = 16;
+
+// Collapsed icon rail. Width is chosen so the icon is *centered* in the rail,
+// which keeps the active/hover highlight symmetric around it (PAP-10676):
+// the icon's left edge sits at nav px-3 (12) + item px-3 (12) = 24px, so a
+// matching 24px trailing margin (12 item px-3 + 12 nav px-3) yields
+// 24 + 16 (icon) + 24 = 64. The icon's left edge is unchanged from the expanded
+// layout, so icons stay pixel-identical across states.
+export const SIDEBAR_RAIL_WIDTH = 64;
+
+function clampSidebarWidth(width: number) {
+  return Math.min(MAX_SIDEBAR_WIDTH, Math.max(MIN_SIDEBAR_WIDTH, width));
+}
+
+function readStoredSidebarWidth(storageKey: string) {
+  if (typeof window === "undefined") return DEFAULT_SIDEBAR_WIDTH;
+
+  try {
+    const stored = window.localStorage.getItem(storageKey);
+    if (!stored) return DEFAULT_SIDEBAR_WIDTH;
+    const parsed = Number.parseInt(stored, 10);
+    if (!Number.isFinite(parsed)) return DEFAULT_SIDEBAR_WIDTH;
+    return clampSidebarWidth(parsed);
+  } catch {
+    return DEFAULT_SIDEBAR_WIDTH;
+  }
+}
+
+function writeStoredSidebarWidth(storageKey: string, width: number) {
+  if (typeof window === "undefined") return;
+
+  try {
+    window.localStorage.setItem(storageKey, String(clampSidebarWidth(width)));
+  } catch {
+    // Storage can be unavailable in private contexts; resizing should still work.
+  }
+}
+
+type SidebarShellProps = {
+  children: ReactNode;
+  /** Whether the sidebar occupies space at all (mobile back-compat / hidden). */
+  open: boolean;
+  /** Pinned collapsed (rail) mode. Desktop-only; the caller gates this. */
+  collapsed?: boolean;
+  /** Ephemeral hover/focus peek. Only meaningful while collapsed. */
+  peeking?: boolean;
+  resizable?: boolean;
+  storageKey?: string;
+  className?: string;
+  /** Forwarded to the overlay panel so Layout can wire peek triggers. */
+  onPanelMouseEnter?: MouseEventHandler<HTMLDivElement>;
+  onPanelMouseLeave?: MouseEventHandler<HTMLDivElement>;
+  onPanelFocusCapture?: FocusEventHandler<HTMLDivElement>;
+  onPanelBlurCapture?: FocusEventHandler<HTMLDivElement>;
+};
+
+/**
+ * Layout shell for the desktop sidebar. Owns the persisted expanded width and
+ * renders two layers:
+ *  - an in-flow spacer that reserves `reservedWidth` (rail when collapsed,
+ *    expanded width otherwise) so content to the right only reflows on pin, and
+ *  - an absolutely-positioned panel of `panelWidth` (rail at rest, expanded
+ *    while peeking) that overlays content — with shadow/raised z-index — when it
+ *    is wider than the reserved spacer.
+ *
+ * The icon-alignment guarantee comes for free: collapsing is a pure width
+ * change with `overflow-hidden` clipping the labels; item padding/icon markup
+ * are never touched, so the left-aligned icon stays pixel-identical.
+ *
+ * Opening/closing is intentionally instant (no width transition): the pin toggle
+ * and peek snap between rail and expanded widths so the content never appears to
+ * slide. Resizing the drag handle is likewise direct.
+ */
+export function SidebarShell({
+  children,
+  open,
+  collapsed = false,
+  peeking = false,
+  resizable = false,
+  storageKey = "paperclip.sidebar.width",
+  className,
+  onPanelMouseEnter,
+  onPanelMouseLeave,
+  onPanelFocusCapture,
+  onPanelBlurCapture,
+}: SidebarShellProps) {
+  const [width, setWidth] = useState(() => readStoredSidebarWidth(storageKey));
+  const [isResizing, setIsResizing] = useState(false);
+  const widthRef = useRef(width);
+  const dragState = useRef<{ startX: number; startWidth: number } | null>(null);
+
+  useEffect(() => {
+    const storedWidth = readStoredSidebarWidth(storageKey);
+    widthRef.current = storedWidth;
+    setWidth(storedWidth);
+  }, [storageKey]);
+
+  // Unified width function (plan §5): one code path for every pinned state.
+  const expandedWidth = open ? width : 0;
+  const reservedWidth = !open ? 0 : collapsed ? SIDEBAR_RAIL_WIDTH : expandedWidth;
+  const panelWidth = !open ? 0 : collapsed && !peeking ? SIDEBAR_RAIL_WIDTH : expandedWidth;
+  const isOverlay = panelWidth > reservedWidth;
+
+  // The drag handle can only resize the expanded width, so it is disabled while
+  // collapsed (the rail width is a fixed constant, not user-resizable).
+  const canResize = resizable && open && !collapsed;
+
+  const reservedStyle = useMemo(
+    () => ({ width: `${reservedWidth}px` }),
+    [reservedWidth],
+  );
+  const panelStyle = useMemo(
+    () => ({ width: `${panelWidth}px` }),
+    [panelWidth],
+  );
+
+  const commitWidth = useCallback(
+    (nextWidth: number) => {
+      const clamped = clampSidebarWidth(nextWidth);
+      widthRef.current = clamped;
+      setWidth(clamped);
+      writeStoredSidebarWidth(storageKey, clamped);
+    },
+    [storageKey],
+  );
+
+  const handlePointerDown = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      if (!canResize) return;
+
+      event.preventDefault();
+      event.currentTarget.setPointerCapture(event.pointerId);
+      dragState.current = { startX: event.clientX, startWidth: widthRef.current };
+      setIsResizing(true);
+    },
+    [canResize],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      if (!dragState.current) return;
+
+      const nextWidth = dragState.current.startWidth + event.clientX - dragState.current.startX;
+      const clamped = clampSidebarWidth(nextWidth);
+      widthRef.current = clamped;
+      setWidth(clamped);
+    },
+    [],
+  );
+
+  const endResize = useCallback(() => {
+    if (!dragState.current) return;
+
+    dragState.current = null;
+    setIsResizing(false);
+    writeStoredSidebarWidth(storageKey, widthRef.current);
+  }, [storageKey]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (!canResize) return;
+
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        commitWidth(width - SIDEBAR_WIDTH_STEP);
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        commitWidth(width + SIDEBAR_WIDTH_STEP);
+      } else if (event.key === "Home") {
+        event.preventDefault();
+        commitWidth(MIN_SIDEBAR_WIDTH);
+      } else if (event.key === "End") {
+        event.preventDefault();
+        commitWidth(MAX_SIDEBAR_WIDTH);
+      }
+    },
+    [canResize, commitWidth, width],
+  );
+
+  return (
+    <div className={cn("relative h-full shrink-0", className)} style={reservedStyle}>
+      <div
+        className={cn(
+          "absolute inset-y-0 left-0 flex flex-col overflow-hidden",
+          // Open/close is instant (PAP-10676): no width transition so the rail and
+          // expanded states snap without any sliding motion.
+          // Overlay styling only while the panel is wider than its reserved
+          // spacer (i.e. peeking) so it floats above content without reflow.
+          isOverlay
+            ? "z-30 border-r border-border bg-background shadow-lg"
+            : "z-0",
+        )}
+        style={panelStyle}
+        data-sidebar-overlay={isOverlay ? "" : undefined}
+        onMouseEnter={onPanelMouseEnter}
+        onMouseLeave={onPanelMouseLeave}
+        onFocusCapture={onPanelFocusCapture}
+        onBlurCapture={onPanelBlurCapture}
+      >
+        {children}
+        {canResize ? (
+          <div
+            role="separator"
+            aria-label="Resize sidebar"
+            aria-orientation="vertical"
+            aria-valuemin={MIN_SIDEBAR_WIDTH}
+            aria-valuemax={MAX_SIDEBAR_WIDTH}
+            aria-valuenow={width}
+            tabIndex={0}
+            className={cn(
+              "absolute inset-y-0 right-0 z-20 w-3 cursor-col-resize touch-none outline-none",
+              "before:absolute before:inset-y-0 before:left-1/2 before:w-px before:-translate-x-1/2 before:bg-transparent before:transition-colors",
+              "hover:before:bg-border focus-visible:before:bg-ring",
+              isResizing && "before:bg-ring",
+            )}
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={endResize}
+            onPointerCancel={endResize}
+            onLostPointerCapture={endResize}
+            onKeyDown={handleKeyDown}
+          />
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/SidebarShell.test.tsx
+++ b/ui/src/components/SidebarShell.test.tsx
@@ -88,6 +88,27 @@ describe("SidebarShell", () => {
     expect(window.localStorage.getItem("test.sidebar.width")).toBe("320");
   });
 
+  it("matches the properties panel resize-grip hover treatment", () => {
+    act(() => {
+      root.render(
+        <SidebarShell open resizable storageKey="test.sidebar.width">
+          <div>Sidebar</div>
+        </SidebarShell>,
+      );
+    });
+
+    const separator = handle();
+    const indicator = separator?.firstElementChild as HTMLDivElement | null;
+
+    expect(separator?.parentElement).toBe(spacer());
+    expect(separator?.className).toContain("group");
+    expect(separator?.style.right).toBe("-4px");
+    expect(separator?.style.width).toBe("8px");
+    expect(indicator?.className).toContain("w-0.5");
+    expect(indicator?.className).toContain("group-hover:bg-ring");
+    expect(indicator?.className).toContain("group-focus-visible:bg-ring");
+  });
+
   it("supports keyboard resizing and clamps to the configured bounds", () => {
     act(() => {
       root.render(

--- a/ui/src/components/SidebarShell.tsx
+++ b/ui/src/components/SidebarShell.tsx
@@ -215,30 +215,36 @@ export function SidebarShell({
         onBlurCapture={onPanelBlurCapture}
       >
         {children}
-        {canResize ? (
-          <div
-            role="separator"
-            aria-label="Resize sidebar"
-            aria-orientation="vertical"
-            aria-valuemin={MIN_SIDEBAR_WIDTH}
-            aria-valuemax={MAX_SIDEBAR_WIDTH}
-            aria-valuenow={width}
-            tabIndex={0}
-            className={cn(
-              "absolute inset-y-0 right-0 z-20 w-3 cursor-col-resize touch-none outline-none",
-              "before:absolute before:inset-y-0 before:left-1/2 before:w-px before:-translate-x-1/2 before:bg-transparent before:transition-colors",
-              "hover:before:bg-border focus-visible:before:bg-ring",
-              isResizing && "before:bg-ring",
-            )}
-            onPointerDown={handlePointerDown}
-            onPointerMove={handlePointerMove}
-            onPointerUp={endResize}
-            onPointerCancel={endResize}
-            onLostPointerCapture={endResize}
-            onKeyDown={handleKeyDown}
-          />
-        ) : null}
       </div>
+      {canResize ? (
+        <div
+          role="separator"
+          aria-label="Resize sidebar"
+          aria-orientation="vertical"
+          aria-valuemin={MIN_SIDEBAR_WIDTH}
+          aria-valuemax={MAX_SIDEBAR_WIDTH}
+          aria-valuenow={width}
+          tabIndex={0}
+          data-dragging={isResizing ? "" : undefined}
+          className="group absolute inset-y-0 z-20 cursor-col-resize touch-none outline-none"
+          style={{ right: -4, width: 8 }}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={endResize}
+          onPointerCancel={endResize}
+          onLostPointerCapture={endResize}
+          onKeyDown={handleKeyDown}
+        >
+          <div
+            className={cn(
+              "mx-auto h-full w-0.5 transition-colors",
+              isResizing
+                ? "bg-ring"
+                : "bg-transparent group-hover:bg-ring group-focus-visible:bg-ring",
+            )}
+          />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/ui/src/components/SidebarStarredProjects.production.tsx
+++ b/ui/src/components/SidebarStarredProjects.production.tsx
@@ -1,0 +1,218 @@
+import { useCallback, useMemo } from "react";
+import { NavLink, useLocation } from "@/lib/router";
+import { useQuery } from "@tanstack/react-query";
+import { Loader2, LogOut, MoreHorizontal, Star } from "lucide-react";
+import { useCompany } from "../context/CompanyContext";
+import { useSidebar } from "../context/SidebarContext";
+import { projectsApi } from "../api/projects";
+import { SIDEBAR_SCROLL_RESET_STATE } from "../lib/navigation-scroll";
+import { queryKeys } from "../lib/queryKeys";
+import { cn, projectRouteRef, SIDEBAR_RAIL_HIDDEN_LABEL } from "../lib/utils";
+import {
+  isStarred,
+  starredResourceIds,
+  useResourceMembershipMutation,
+  useResourceMemberships,
+} from "../hooks/useResourceMemberships";
+import { BudgetSidebarMarker } from "./BudgetSidebarMarker";
+import { ProjectTile } from "./ProjectTile";
+import { StarToggle } from "./StarToggle";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import type { Project } from "@paperclipai/shared";
+
+// Sidebar star reveals with the row's own group, not the shared unnamed group.
+const STAR_ROW_REVEAL =
+  "opacity-0 transition-opacity group-hover/starred-project:opacity-100 group-focus-within/starred-project:opacity-100";
+
+/**
+ * Compact starred-project children rendered directly below the top-level
+ * `Projects` nav row in the streamlined sidebar. Starring/unstarring itself
+ * happens from browse/detail surfaces; here we only ever *remove* a star
+ * (plus the existing leave affordance). Archived projects are filtered out
+ * server-side, so a stale star never resurrects a hidden project.
+ */
+export function SidebarStarredProjects() {
+  const { selectedCompanyId } = useCompany();
+  const { isMobile, setSidebarOpen, collapsed, peeking } = useSidebar();
+  const rail = collapsed && !peeking;
+  const location = useLocation();
+
+  const { data: projects } = useQuery({
+    queryKey: queryKeys.projects.list(selectedCompanyId!),
+    queryFn: () => projectsApi.list(selectedCompanyId!),
+    enabled: !!selectedCompanyId,
+  });
+  const membershipsQuery = useResourceMemberships(selectedCompanyId);
+  const membershipMutation = useResourceMembershipMutation(selectedCompanyId);
+
+  const projectMatch = location.pathname.match(/^\/(?:[^/]+\/)?projects\/([^/]+)/);
+  const activeProjectRef = projectMatch?.[1] ?? null;
+
+  const starredProjects = useMemo(() => {
+    if (!membershipsQuery.isSuccess) return [];
+    const starredIds = new Set(starredResourceIds(membershipsQuery.data, "project"));
+    if (starredIds.size === 0) return [];
+    const byId = new Map((projects ?? []).map((project: Project) => [project.id, project]));
+    return Array.from(starredIds)
+      .map((id) => byId.get(id))
+      .filter((project): project is Project => !!project)
+      .sort((left, right) =>
+        left.name.localeCompare(right.name, undefined, { sensitivity: "base" }),
+      );
+  }, [membershipsQuery.data, membershipsQuery.isSuccess, projects]);
+
+  const unstar = useCallback(
+    (project: Project) => membershipMutation.mutate({
+      resourceType: "project",
+      resourceId: project.id,
+      resourceName: project.name,
+      starred: false,
+    }),
+    [membershipMutation],
+  );
+  const leave = useCallback(
+    (project: Project) => membershipMutation.mutate({
+      resourceType: "project",
+      resourceId: project.id,
+      resourceName: project.name,
+      state: "left",
+    }),
+    [membershipMutation],
+  );
+  const pendingFor = useCallback(
+    (project: Project) =>
+      membershipMutation.isPending &&
+      membershipMutation.variables?.resourceType === "project" &&
+      membershipMutation.variables.resourceId === project.id,
+    [membershipMutation.isPending, membershipMutation.variables],
+  );
+
+  // Don't render anything until memberships load — no skeleton flash in the nav.
+  if (!membershipsQuery.isSuccess) return null;
+
+  // Empty starred groups should not add a placeholder row or extra sidebar spacing.
+  if (starredProjects.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col gap-0.5" aria-label="Starred projects">
+      {starredProjects.map((project) => {
+        const routeRef = projectRouteRef(project);
+        const isActive = activeProjectRef === routeRef || activeProjectRef === project.id;
+        const pending = pendingFor(project);
+        const unstarPending = pending && membershipMutation.variables?.starred === false;
+        const leavePending = pending && membershipMutation.variables?.state === "left";
+        const starred = isStarred(membershipsQuery.data, "project", project.id);
+
+        const link = (
+          <NavLink
+            to={`/projects/${routeRef}/issues`}
+            state={SIDEBAR_SCROLL_RESET_STATE}
+            onClick={() => {
+              if (isMobile) setSidebarOpen(false);
+            }}
+            className={cn(
+              "flex min-w-0 flex-1 items-center gap-2.5 mx-2 rounded-lg px-2 py-1.5 pointer-coarse:py-1 pr-8 text-(length:--text-compact) font-medium transition-colors",
+              !rail && "pl-6",
+              isActive
+                ? "bg-accent text-foreground"
+                : "text-foreground/80 hover:bg-accent/50 hover:text-foreground",
+            )}
+          >
+            <ProjectTile color={project.color ?? null} icon={project.icon ?? null} size="xs" />
+            <span className={rail ? SIDEBAR_RAIL_HIDDEN_LABEL : "flex-1 truncate"}>{project.name}</span>
+            {!rail && project.pauseReason === "budget" ? (
+              <BudgetSidebarMarker title="Project paused by budget" />
+            ) : null}
+          </NavLink>
+        );
+
+        return (
+          <div key={project.id} className="group/starred-project relative flex items-center">
+            {rail ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="min-w-0 flex-1">{link}</div>
+                </TooltipTrigger>
+                <TooltipContent side="right">{project.name}</TooltipContent>
+              </Tooltip>
+            ) : (
+              link
+            )}
+
+            {!rail && !isMobile ? (
+              // Desktop: quiet inline unstar revealed on hover/focus.
+              <span className="absolute right-3 top-1/2 -translate-y-1/2">
+                <StarToggle
+                  size="row"
+                  quiet
+                  starred={starred}
+                  pending={unstarPending}
+                  resourceName={project.name}
+                  onToggle={() => unstar(project)}
+                  revealClassName={STAR_ROW_REVEAL}
+                />
+              </span>
+            ) : null}
+
+            {!rail && isMobile ? (
+              // Touch: explicit ⋯ menu (no hover). Star action + separated Leave.
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    className="absolute right-3 top-1/2 h-6 w-6 -translate-y-1/2 opacity-100"
+                    aria-label={`Open actions for ${project.name}`}
+                  >
+                    <MoreHorizontal className="h-3.5 w-3.5" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-48">
+                  <DropdownMenuItem
+                    onClick={() => {
+                      if (pending) return;
+                      unstar(project);
+                    }}
+                    disabled={pending}
+                  >
+                    {unstarPending ? (
+                      <Loader2 className="size-4 motion-safe:animate-spin" />
+                    ) : (
+                      <Star className="size-4 fill-amber-500 text-amber-500" />
+                    )}
+                    <span>Remove from starred</span>
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onClick={() => {
+                      if (pending) return;
+                      leave(project);
+                    }}
+                    disabled={pending}
+                  >
+                    {leavePending ? (
+                      <Loader2 className="size-4 motion-safe:animate-spin" />
+                    ) : (
+                      <LogOut className="size-4" />
+                    )}
+                    <span>Leave project</span>
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/ui/src/components/SidebarStarredProjects.tsx
+++ b/ui/src/components/SidebarStarredProjects.tsx
@@ -124,8 +124,8 @@ export function SidebarStarredProjects() {
               "flex min-w-0 flex-1 items-center gap-2.5 mx-2 rounded-lg px-2 py-1.5 pointer-coarse:py-1 pr-8 text-(length:--text-compact) font-medium transition-colors",
               !rail && "pl-6",
               isActive
-                ? "bg-accent text-foreground"
-                : "text-foreground/80 hover:bg-accent/50 hover:text-foreground",
+                ? "bg-background text-foreground"
+                : "text-foreground/80 hover:bg-background hover:text-foreground",
             )}
           >
             <ProjectTile color={project.color ?? null} icon={project.icon ?? null} size="xs" />

--- a/ui/src/components/SkillsContextualSidebar.test.tsx
+++ b/ui/src/components/SkillsContextualSidebar.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SkillsContextualSidebar } from "./SkillsContextualSidebar";
+import { contextualSidebarStyles } from "./contextual-sidebar-styles";
+
+const sidebarNavItemMock = vi.hoisted(() => vi.fn());
+const mockLocation = vi.hoisted(() => ({ pathname: "/PAP/skills", search: "" }));
+
+vi.mock("@/lib/router", () => ({
+  useLocation: () => mockLocation,
+  useNavigate: () => vi.fn(),
+}));
+vi.mock("@/context/CompanyContext", () => ({
+  useCompany: () => ({ selectedCompany: { name: "Paperclip", issuePrefix: "PAP" } }),
+}));
+vi.mock("@/context/SidebarContext", () => ({
+  useSidebar: () => ({ isMobile: false, setSidebarOpen: vi.fn() }),
+}));
+vi.mock("./SidebarNavItem", () => ({
+  SidebarNavExpandedProvider: ({ children }: { children: React.ReactNode }) => children,
+  SidebarNavItem: (props: { to: string; label: string; active?: boolean }) => {
+    sidebarNavItemMock(props);
+    return <a href={props.to} aria-current={props.active ? "page" : undefined}>{props.label}</a>;
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("SkillsContextualSidebar", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    mockLocation.pathname = "/PAP/skills";
+    mockLocation.search = "";
+  });
+
+  afterEach(() => {
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  function render() {
+    const root = createRoot(container);
+    act(() => root.render(<SkillsContextualSidebar />));
+    return root;
+  }
+
+  it("keeps Installed, Discover, and authored My Skills visible together", () => {
+    const root = render();
+
+    expect(container.textContent).toContain("Installed");
+    expect(container.textContent).toContain("Discover");
+    expect(container.textContent).toContain("My Skills");
+    expect(container.textContent).toContain("Skills you create, edit, and test.");
+    expect(container.textContent).not.toContain("Paperclip");
+    expect(container.querySelector('[aria-label="Back from Skills"]')).toBeNull();
+    expect(container.querySelector('[aria-current="page"]')?.textContent).toBe("Installed");
+
+    act(() => root.unmount());
+  });
+
+  it("uses the shared contextual-navigation spacing and type contract", () => {
+    const root = render();
+
+    expect(container.querySelector('[data-slot="contextual-sidebar-nav"]')?.className).toBe(
+      contextualSidebarStyles.nav,
+    );
+    expect(container.querySelector('[data-slot="contextual-sidebar-section"]')?.className).toBe(
+      contextualSidebarStyles.section,
+    );
+    expect(container.querySelector('[data-slot="contextual-sidebar-section-label"]')?.className).toBe(
+      contextualSidebarStyles.sectionLabel,
+    );
+    expect(container.querySelector('[data-slot="contextual-sidebar-section-description"]')?.className).toBe(
+      contextualSidebarStyles.sectionDescription,
+    );
+    expect(
+      Array.from(container.querySelectorAll('[data-slot="contextual-sidebar-group"]')).every(
+        (group) => group.className === contextualSidebarStyles.group,
+      ),
+    ).toBe(true);
+
+    act(() => root.unmount());
+  });
+
+  it("activates Discover for old catalog links without changing the navigation", () => {
+    mockLocation.search = "?tab=bundled";
+    const root = render();
+
+    expect(container.querySelector('[aria-current="page"]')?.textContent).toBe("Discover");
+    expect(sidebarNavItemMock.mock.calls.map(([props]) => props.to)).toEqual([
+      "/skills",
+      "/skills?tab=discover",
+      "/skills/studio",
+    ]);
+
+    act(() => root.unmount());
+  });
+
+  it("activates My Skills throughout Studio", () => {
+    mockLocation.pathname = "/PAP/skills/studio/skill-1";
+    mockLocation.search = "?tab=files";
+    const root = render();
+
+    expect(container.querySelector('[aria-current="page"]')?.textContent).toBe("My Skills");
+
+    act(() => root.unmount());
+  });
+});

--- a/ui/src/components/SkillsContextualSidebar.tsx
+++ b/ui/src/components/SkillsContextualSidebar.tsx
@@ -1,0 +1,79 @@
+import { Compass, Library, PencilRuler } from "lucide-react";
+import { useLocation } from "@/lib/router";
+import {
+  resolveSkillsNavigationView,
+  SKILLS_NAVIGATION_HREFS,
+} from "@/pages/skills/skills-navigation";
+import { ContextualSidebarFrame } from "./ContextualSidebarFrame";
+import { SidebarNavItem } from "./SidebarNavItem";
+import { contextualSidebarStyles } from "./contextual-sidebar-styles";
+
+export {
+  resolveSkillsDiscoveryView,
+  resolveSkillsNavigationView,
+  SKILLS_NAVIGATION_HREFS,
+  withSkillsDiscoveryView,
+  type SkillsNavigationView,
+} from "@/pages/skills/skills-navigation";
+
+export function SkillsContextualSidebar() {
+  const location = useLocation();
+  const activeView = resolveSkillsNavigationView(location.pathname, location.search);
+
+  return (
+    <ContextualSidebarFrame
+      surface="skills"
+      title="Skills"
+      icon={Library}
+      fallbackTo="/dashboard"
+      showHeader={false}
+      className="border-r border-border bg-background"
+    >
+      <nav
+        aria-label="Skills"
+        data-slot="contextual-sidebar-nav"
+        className={contextualSidebarStyles.nav}
+      >
+        <div data-slot="contextual-sidebar-group" className={contextualSidebarStyles.group}>
+          <SidebarNavItem
+            to={SKILLS_NAVIGATION_HREFS.installed}
+            label="Installed"
+            icon={Library}
+            active={activeView === "installed"}
+            end
+          />
+          <SidebarNavItem
+            to={SKILLS_NAVIGATION_HREFS.discover}
+            label="Discover"
+            icon={Compass}
+            active={activeView === "discover"}
+            end
+          />
+        </div>
+
+        <div data-slot="contextual-sidebar-section" className={contextualSidebarStyles.section}>
+          <div
+            data-slot="contextual-sidebar-section-label"
+            className={contextualSidebarStyles.sectionLabel}
+          >
+            Author
+          </div>
+          <p
+            data-slot="contextual-sidebar-section-description"
+            className={contextualSidebarStyles.sectionDescription}
+          >
+            Skills you create, edit, and test.
+          </p>
+          <div data-slot="contextual-sidebar-group" className={contextualSidebarStyles.group}>
+            <SidebarNavItem
+              to={SKILLS_NAVIGATION_HREFS.authored}
+              label="My Skills"
+              icon={PencilRuler}
+              active={activeView === "authored"}
+            />
+          </div>
+        </div>
+      </nav>
+    </ContextualSidebarFrame>
+  );
+}

--- a/ui/src/components/contextual-sidebar-styles.ts
+++ b/ui/src/components/contextual-sidebar-styles.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared visual contract for the Skills and Apps contextual navigation rails.
+ *
+ * Keep these surfaces on the same token-backed spacing and typography so their
+ * navigation hierarchy cannot drift as either area evolves.
+ */
+export const contextualSidebarStyles = {
+  nav: "flex min-h-0 flex-1 flex-col overflow-y-auto scrollbar-auto-hide px-3 py-2",
+  group: "flex flex-col gap-0.5",
+  section: "mt-4 border-t border-border pt-3",
+  sectionLabel:
+    "px-2 pb-1 text-(length:--text-micro) font-semibold uppercase tracking-wide text-muted-foreground",
+  sectionDescription:
+    "px-4 pb-1.5 text-(length:--text-micro) leading-snug text-muted-foreground/70",
+} as const;

--- a/ui/src/components/onboarding/PillGuy.tsx
+++ b/ui/src/components/onboarding/PillGuy.tsx
@@ -34,8 +34,8 @@ function DormantPill() {
     <svg viewBox="0 0 100 93" fill="none" aria-hidden className="size-full">
       <path d={BODY_PATH} fill={`url(#${DORMANT_GRADIENT_ID})`} />
       {/* Closed eyes: the same rounded rects as the open pair, flattened. */}
-      <rect x="75.9199" y="66.3047" width="9" height="4" rx="2" fill="#060606" />
-      <rect x="28.9199" y="66.3047" width="9" height="4" rx="2" fill="#060606" />
+      <rect x="75.9199" y="66.3047" width="9" height="4" rx="2" fill="var(--pill-guy-eye)" />
+      <rect x="28.9199" y="66.3047" width="9" height="4" rx="2" fill="var(--pill-guy-eye)" />
       <defs>
         <linearGradient
           id={DORMANT_GRADIENT_ID}
@@ -45,8 +45,8 @@ function DormantPill() {
           y2="107.486"
           gradientUnits="userSpaceOnUse"
         >
-          <stop stopColor="#626262" />
-          <stop offset="1" stopColor="#101010" />
+          <stop stopColor="var(--pill-guy-dormant-top)" />
+          <stop offset="1" stopColor="var(--pill-guy-dormant-bottom)" />
         </linearGradient>
       </defs>
     </svg>
@@ -57,9 +57,9 @@ function AlivePill() {
   return (
     <svg viewBox="0 0 100 93" fill="none" aria-hidden className="size-full">
       <path d={BODY_PATH} fill={`url(#${ALIVE_GRADIENT_ID})`} />
-      <rect x="76.1406" y="63.1328" width="8.87072" height="10.3492" rx="4.43536" fill="#060606" />
-      <rect x="28.8301" y="63.1328" width="8.87072" height="10.3492" rx="4.43536" fill="#060606" />
-      <path d={TUFT_PATH} fill="#2D200D" />
+      <rect x="76.1406" y="63.1328" width="8.87072" height="10.3492" rx="4.43536" fill="var(--pill-guy-eye)" />
+      <rect x="28.8301" y="63.1328" width="8.87072" height="10.3492" rx="4.43536" fill="var(--pill-guy-eye)" />
+      <path d={TUFT_PATH} fill="var(--pill-guy-tuft)" />
       <defs>
         <linearGradient
           id={ALIVE_GRADIENT_ID}
@@ -69,8 +69,8 @@ function AlivePill() {
           y2="107.486"
           gradientUnits="userSpaceOnUse"
         >
-          <stop stopColor="#3028AA" />
-          <stop offset="1" stopColor="#FF0000" />
+          <stop stopColor="var(--pill-guy-alive-top)" />
+          <stop offset="1" stopColor="var(--pill-guy-alive-bottom)" />
         </linearGradient>
       </defs>
     </svg>

--- a/ui/src/components/routine-sections/editable-sections.production.tsx
+++ b/ui/src/components/routine-sections/editable-sections.production.tsx
@@ -4,6 +4,7 @@ import {
   Braces,
   Clock3,
   Edit3,
+  KeyRound,
   Play,
   Plus,
   X,
@@ -84,8 +85,8 @@ const activityGatePolicyOptions = [
 const activityGateScopeOptions = [
   {
     value: "company",
-    title: "Organization-wide",
-    description: "Any activity across the organization counts as a reason to run.",
+    title: "Company-wide",
+    description: "Any activity across the company counts as a reason to run.",
   },
   {
     value: "project",
@@ -143,6 +144,7 @@ export function OverviewSection({
       .sort((a, b) => a.getTime() - b.getTime())[0];
     return upcoming ? upcoming.toLocaleString() : null;
   }, [routine.triggers]);
+  const boundSecrets = editDraft.env ? Object.keys(editDraft.env).length : 0;
   const lastRun = (routineRuns ?? [])[0] ?? null;
   const recentActivity = (activity ?? []).slice(0, 5);
 
@@ -318,7 +320,7 @@ export function OverviewSection({
       </div>
 
       {/* Summary cards */}
-      <div className="grid gap-3 sm:grid-cols-2">
+      <div className="grid gap-3 sm:grid-cols-3">
         <SummaryCard
           icon={Clock3}
           label="Triggers"
@@ -326,6 +328,14 @@ export function OverviewSection({
           hint={nextFire ? `Next fire ${nextFire}` : "No schedule"}
           to={() => navigateToSection("triggers")}
           ariaLabel={`${activeTriggers} triggers. Open triggers.`}
+        />
+        <SummaryCard
+          icon={KeyRound}
+          label="Secrets"
+          value={boundSecrets === 0 ? "None" : `${boundSecrets} bound`}
+          hint="Manage bound secrets"
+          to={() => navigateToSection("secrets")}
+          ariaLabel={`${boundSecrets} secrets bound. Open secrets.`}
         />
         <SummaryCard
           icon={Play}

--- a/ui/src/context/BreadcrumbContext.tsx
+++ b/ui/src/context/BreadcrumbContext.tsx
@@ -23,8 +23,15 @@ interface BreadcrumbContextValue {
   setBreadcrumbs: (crumbs: Breadcrumb[]) => void;
   breadcrumbToolbar: ReactNode | null;
   setBreadcrumbToolbar: (node: ReactNode | null) => void;
+  breadcrumbPanelControl: BreadcrumbPanelControl | null;
+  setBreadcrumbPanelControl: (control: BreadcrumbPanelControl | null) => void;
   mobileToolbar: ReactNode | null;
   setMobileToolbar: (node: ReactNode | null) => void;
+}
+
+export interface BreadcrumbPanelControl {
+  open: boolean;
+  onToggle: () => void;
 }
 
 interface BreadcrumbProviderProps {
@@ -62,6 +69,8 @@ export function buildDocumentTitle(breadcrumbs: Breadcrumb[], companyName?: stri
 export function BreadcrumbProvider({ children, companyName }: BreadcrumbProviderProps) {
   const [breadcrumbs, setBreadcrumbsState] = useState<Breadcrumb[]>([]);
   const [breadcrumbToolbar, setBreadcrumbToolbarState] = useState<ReactNode | null>(null);
+  const [breadcrumbPanelControl, setBreadcrumbPanelControlState] =
+    useState<BreadcrumbPanelControl | null>(null);
   const [mobileToolbar, setMobileToolbarState] = useState<ReactNode | null>(null);
 
   const setBreadcrumbs = useCallback((crumbs: Breadcrumb[]) => {
@@ -76,6 +85,10 @@ export function BreadcrumbProvider({ children, companyName }: BreadcrumbProvider
     setBreadcrumbToolbarState(node);
   }, []);
 
+  const setBreadcrumbPanelControl = useCallback((control: BreadcrumbPanelControl | null) => {
+    setBreadcrumbPanelControlState(control);
+  }, []);
+
   useEffect(() => {
     document.title = buildDocumentTitle(breadcrumbs, companyName);
   }, [breadcrumbs, companyName]);
@@ -87,6 +100,8 @@ export function BreadcrumbProvider({ children, companyName }: BreadcrumbProvider
         setBreadcrumbs,
         breadcrumbToolbar,
         setBreadcrumbToolbar,
+        breadcrumbPanelControl,
+        setBreadcrumbPanelControl,
         mobileToolbar,
         setMobileToolbar,
       }}

--- a/ui/src/context/SidebarContext.test.tsx
+++ b/ui/src/context/SidebarContext.test.tsx
@@ -8,30 +8,15 @@ import { SidebarProvider, useSidebar } from "./SidebarContext";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
-const COLLAPSED_STORAGE_KEY = "paperclip.sidebar.collapsed";
-
-// Mutable media state driving the matchMedia mock.
-const mediaState = { mobile: false, hoverFine: true };
-
-function act(callback: () => void) {
-  flushSync(callback);
-}
-
-function setViewport({ mobile, hoverFine }: { mobile?: boolean; hoverFine?: boolean }) {
-  if (typeof mobile === "boolean") mediaState.mobile = mobile;
-  if (typeof hoverFine === "boolean") mediaState.hoverFine = hoverFine;
-  Object.defineProperty(window, "innerWidth", {
-    configurable: true,
-    writable: true,
-    value: mediaState.mobile ? 500 : 1280,
-  });
-}
-
 let capturedValue: ReturnType<typeof useSidebar> | null = null;
 
 function Capture() {
   capturedValue = useSidebar();
   return null;
+}
+
+function act(callback: () => void) {
+  flushSync(callback);
 }
 
 function renderProvider(): { root: Root; host: HTMLDivElement } {
@@ -53,25 +38,26 @@ describe("SidebarContext", () => {
 
   beforeEach(() => {
     localStorage.clear();
+    localStorage.setItem("paperclip.sidebar.collapsed", "1");
     capturedValue = null;
-    setViewport({ mobile: false, hoverFine: true });
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      writable: true,
+      value: 1280,
+    });
     Object.defineProperty(window, "matchMedia", {
       configurable: true,
       writable: true,
-      value: vi.fn().mockImplementation((query: string) => {
-        const isHoverQuery = query.includes("(hover: hover)");
-        const matches = isHoverQuery ? mediaState.hoverFine : mediaState.mobile;
-        return {
-          matches,
-          media: query,
-          onchange: null,
-          addEventListener: vi.fn(),
-          removeEventListener: vi.fn(),
-          addListener: vi.fn(),
-          removeListener: vi.fn(),
-          dispatchEvent: vi.fn(),
-        };
-      }),
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
     });
   });
 
@@ -84,219 +70,42 @@ describe("SidebarContext", () => {
     localStorage.clear();
   });
 
-  describe("precedence: user pin > route request > default", () => {
-    it("defaults to expanded (collapsed=false) with no pin and no route request", () => {
-      active = renderProvider();
-      expect(capturedValue?.collapsed).toBe(false);
-    });
+  it("keeps the global navigation expanded even when legacy collapsed state exists", () => {
+    active = renderProvider();
 
-    it("uses the route request when there is no user pin", () => {
-      active = renderProvider();
-      act(() => capturedValue?.setRouteRequestsCollapsed(true));
-      expect(capturedValue?.collapsed).toBe(true);
-    });
-
-    it("lets an explicit user pin override the route request", () => {
-      active = renderProvider();
-      act(() => capturedValue?.setRouteRequestsCollapsed(true));
-      expect(capturedValue?.collapsed).toBe(true);
-
-      // User pins expanded — this must win over the route's collapse request.
-      act(() => capturedValue?.setCollapsed(false));
-      expect(capturedValue?.collapsed).toBe(false);
-
-      // And pinning collapsed wins too.
-      act(() => capturedValue?.setCollapsed(true));
-      expect(capturedValue?.collapsed).toBe(true);
-    });
-
-    it("toggleCollapsed flips the effective mode and records a pin", () => {
-      active = renderProvider();
-      expect(capturedValue?.collapsed).toBe(false);
-
-      act(() => capturedValue?.toggleCollapsed());
-      expect(capturedValue?.collapsed).toBe(true);
-      expect(localStorage.getItem(COLLAPSED_STORAGE_KEY)).toBe("1");
-
-      act(() => capturedValue?.toggleCollapsed());
-      expect(capturedValue?.collapsed).toBe(false);
-      expect(localStorage.getItem(COLLAPSED_STORAGE_KEY)).toBe("0");
-    });
-
-    it("toggleCollapsed pins expanded when only a route request is active", () => {
-      active = renderProvider();
-      act(() => capturedValue?.setRouteRequestsCollapsed(true));
-      expect(capturedValue?.collapsed).toBe(true);
-
-      // Effective is collapsed (via route); toggling should flip to expanded.
-      act(() => capturedValue?.toggleCollapsed());
-      expect(capturedValue?.collapsed).toBe(false);
-      expect(localStorage.getItem(COLLAPSED_STORAGE_KEY)).toBe("0");
-    });
+    expect(capturedValue?.collapsed).toBe(false);
+    expect(capturedValue?.collapseLocked).toBe(false);
+    expect(capturedValue?.peeking).toBe(false);
   });
 
-  describe("forced collapse (secondary sidebar): overrides the pin, preserves preference", () => {
-    it("forces collapsed even when the user pinned expanded, without mutating the pin", () => {
-      active = renderProvider();
-      // User prefers expanded site-wide.
-      act(() => capturedValue?.setCollapsed(false));
-      expect(capturedValue?.collapsed).toBe(false);
-      expect(localStorage.getItem(COLLAPSED_STORAGE_KEY)).toBe("0");
+  it("keeps the legacy collapse API inert", () => {
+    active = renderProvider();
 
-      // Entering a secondary-sidebar route forces the rail and locks it.
-      act(() => capturedValue?.setForceCollapsed(true));
-      expect(capturedValue?.collapsed).toBe(true);
-      expect(capturedValue?.collapseLocked).toBe(true);
-      // The persisted preference is untouched.
-      expect(localStorage.getItem(COLLAPSED_STORAGE_KEY)).toBe("0");
-    });
+    act(() => capturedValue?.setCollapsed(true));
+    act(() => capturedValue?.toggleCollapsed());
+    act(() => capturedValue?.setForceCollapsed(true));
+    act(() => capturedValue?.setPeeking(true));
 
-    it("restores the user's preference when the force is cleared (leaving the route)", () => {
-      active = renderProvider();
-      act(() => capturedValue?.setCollapsed(false));
-      act(() => capturedValue?.setForceCollapsed(true));
-      expect(capturedValue?.collapsed).toBe(true);
-
-      // Navigating away clears the force; the expanded preference returns.
-      act(() => capturedValue?.setForceCollapsed(false));
-      expect(capturedValue?.collapsed).toBe(false);
-      expect(capturedValue?.collapseLocked).toBe(false);
-    });
-
-    it("locks the toggle while forced: toggleCollapsed is a no-op and never writes the pin", () => {
-      active = renderProvider();
-      act(() => capturedValue?.setCollapsed(false));
-      act(() => capturedValue?.setForceCollapsed(true));
-
-      act(() => capturedValue?.toggleCollapsed());
-      expect(capturedValue?.collapsed).toBe(true); // still forced
-      expect(localStorage.getItem(COLLAPSED_STORAGE_KEY)).toBe("0"); // pin unchanged
-    });
-
-    it("never forces or locks on mobile", () => {
-      setViewport({ mobile: true });
-      active = renderProvider();
-      act(() => capturedValue?.setForceCollapsed(true));
-      expect(capturedValue?.collapsed).toBe(false);
-      expect(capturedValue?.collapseLocked).toBe(false);
-    });
+    expect(capturedValue?.collapsed).toBe(false);
+    expect(capturedValue?.collapseLocked).toBe(false);
+    expect(capturedValue?.peeking).toBe(false);
   });
 
-  describe("persistence round-trip", () => {
-    it("writes '1'/'0' to localStorage on setCollapsed", () => {
-      active = renderProvider();
-      act(() => capturedValue?.setCollapsed(true));
-      expect(localStorage.getItem(COLLAPSED_STORAGE_KEY)).toBe("1");
-      act(() => capturedValue?.setCollapsed(false));
-      expect(localStorage.getItem(COLLAPSED_STORAGE_KEY)).toBe("0");
-    });
+  it("tracks route requests for compatibility without collapsing the navigation", () => {
+    active = renderProvider();
 
-    it("reads the persisted pin synchronously on first paint (no flash)", () => {
-      localStorage.setItem(COLLAPSED_STORAGE_KEY, "1");
-      active = renderProvider();
-      // Collapsed is already true on the very first captured render.
-      expect(capturedValue?.collapsed).toBe(true);
-    });
+    act(() => capturedValue?.setRouteRequestsCollapsed(true));
 
-    it("treats a missing/garbage value as unpinned", () => {
-      localStorage.setItem(COLLAPSED_STORAGE_KEY, "yes");
-      active = renderProvider();
-      expect(capturedValue?.collapsed).toBe(false);
-      // Unpinned, so a route request still applies.
-      act(() => capturedValue?.setRouteRequestsCollapsed(true));
-      expect(capturedValue?.collapsed).toBe(true);
-    });
+    expect(capturedValue?.routeRequestsCollapsed).toBe(true);
+    expect(capturedValue?.collapsed).toBe(false);
   });
 
-  describe("mobile gating", () => {
-    it("never reports collapsed on mobile even with a collapsed pin", () => {
-      localStorage.setItem(COLLAPSED_STORAGE_KEY, "1");
-      setViewport({ mobile: true });
-      active = renderProvider();
-      expect(capturedValue?.isMobile).toBe(true);
-      expect(capturedValue?.collapsed).toBe(false);
-    });
+  it("retains sidebarOpen and toggleSidebar for the mobile drawer", () => {
+    active = renderProvider();
+    const initial = capturedValue?.sidebarOpen;
 
-    it("never reports peeking on mobile", () => {
-      localStorage.setItem(COLLAPSED_STORAGE_KEY, "1");
-      setViewport({ mobile: true });
-      active = renderProvider();
-      act(() => capturedValue?.setPeeking(true));
-      expect(capturedValue?.peeking).toBe(false);
-    });
-  });
+    act(() => capturedValue?.toggleSidebar());
 
-  describe("peek gating", () => {
-    it("peeks when collapsed on a hover-capable pointer", () => {
-      localStorage.setItem(COLLAPSED_STORAGE_KEY, "1");
-      setViewport({ mobile: false, hoverFine: true });
-      active = renderProvider();
-      expect(capturedValue?.collapsed).toBe(true);
-      act(() => capturedValue?.setPeeking(true));
-      expect(capturedValue?.peeking).toBe(true);
-    });
-
-    it("does not peek when expanded", () => {
-      setViewport({ mobile: false, hoverFine: true });
-      active = renderProvider();
-      expect(capturedValue?.collapsed).toBe(false);
-      act(() => capturedValue?.setPeeking(true));
-      expect(capturedValue?.peeking).toBe(false);
-    });
-
-    it("does not peek on a coarse/non-hover pointer", () => {
-      localStorage.setItem(COLLAPSED_STORAGE_KEY, "1");
-      setViewport({ mobile: false, hoverFine: false });
-      active = renderProvider();
-      expect(capturedValue?.collapsed).toBe(true);
-      act(() => capturedValue?.setPeeking(true));
-      expect(capturedValue?.peeking).toBe(false);
-    });
-
-    // iPadOS Safari keeps the hover/pointer media query false even with a
-    // trackpad attached (PAP-10725); a real cursor still emits "mouse" pointer
-    // events, which must unlock peek at runtime.
-    it("peeks once a mouse-type pointer event is seen (iPad + trackpad)", () => {
-      localStorage.setItem(COLLAPSED_STORAGE_KEY, "1");
-      setViewport({ mobile: false, hoverFine: false });
-      active = renderProvider();
-      expect(capturedValue?.collapsed).toBe(true);
-
-      // No cursor seen yet → peek stays gated despite the media query.
-      act(() => capturedValue?.setPeeking(true));
-      expect(capturedValue?.peeking).toBe(false);
-
-      // A trackpad/mouse moves: a "mouse" pointer event unlocks peek.
-      act(() => {
-        const e = new Event("pointermove");
-        (e as unknown as { pointerType: string }).pointerType = "mouse";
-        window.dispatchEvent(e);
-      });
-      expect(capturedValue?.peeking).toBe(true);
-    });
-
-    it("ignores touch pointer events (touch-only stays gated)", () => {
-      localStorage.setItem(COLLAPSED_STORAGE_KEY, "1");
-      setViewport({ mobile: false, hoverFine: false });
-      active = renderProvider();
-
-      act(() => capturedValue?.setPeeking(true));
-      act(() => {
-        const e = new Event("pointerover");
-        (e as unknown as { pointerType: string }).pointerType = "touch";
-        window.dispatchEvent(e);
-      });
-      expect(capturedValue?.peeking).toBe(false);
-    });
-  });
-
-  describe("back-compat", () => {
-    it("retains sidebarOpen/toggleSidebar for the drawer", () => {
-      active = renderProvider();
-      const initial = capturedValue?.sidebarOpen;
-      expect(typeof initial).toBe("boolean");
-      act(() => capturedValue?.toggleSidebar());
-      expect(capturedValue?.sidebarOpen).toBe(!initial);
-    });
+    expect(capturedValue?.sidebarOpen).toBe(!initial);
   });
 });

--- a/ui/src/context/SidebarContext.tsx
+++ b/ui/src/context/SidebarContext.tsx
@@ -14,27 +14,20 @@ interface SidebarContextValue {
   setSidebarOpen: (open: boolean) => void;
   toggleSidebar: () => void;
   isMobile: boolean;
-  // Pinned desktop mode: expanded | collapsed. Desktop-only.
+  // Back-compat collapse API. The global navigation is permanently expanded;
+  // these values remain for callers that have not removed old requests.
   collapsed: boolean;
   setCollapsed: (next: boolean) => void;
   toggleCollapsed: () => void;
-  // True while a secondary sidebar forces the rail: the collapse is locked, so
-  // the expand/toggle affordance must be hidden/inert. Desktop-only.
+  // Retained compatibility value; always false now that the rail is retired.
   collapseLocked: boolean;
-  // Ephemeral peek (hover flyout). Only meaningful on desktop, collapsed,
-  // hover-capable pointer. Never persisted.
+  // Retained compatibility value; the retired rail can no longer peek.
   peeking: boolean;
   setPeeking: (next: boolean) => void;
-  // Hard, ephemeral collapse forced by an active secondary sidebar (settings,
-  // plugin `routeSidebar`, …). HIGHER precedence than the user pin — the rule
-  // is "a secondary sidebar always collapses the primary" — but it never
-  // mutates the persisted pin, so leaving the route restores the preference.
-  // Wired by Layout (PAP-10694).
+  // Legacy requests remain observable without affecting the global nav.
   forceCollapsed: boolean;
   setForceCollapsed: (next: boolean) => void;
-  // Route-requested collapse: a route may *default* the app sidebar to
-  // collapsed. LOWER precedence than an explicit user pin. Wired by routes via
-  // RequestCollapsedSidebar.
+  // Route-requested collapse retained for integration compatibility.
   routeRequestsCollapsed: boolean;
   setRouteRequestsCollapsed: (next: boolean) => void;
 }
@@ -42,62 +35,13 @@ interface SidebarContextValue {
 const SidebarContext = createContext<SidebarContextValue | null>(null);
 
 const MOBILE_BREAKPOINT = 768;
-const COLLAPSED_STORAGE_KEY = "paperclip.sidebar.collapsed";
-const PEEK_POINTER_QUERY = "(hover: hover) and (pointer: fine)";
-
-// Tri-state read of the persisted user pin:
-//   true  → pinned collapsed ("1")
-//   false → pinned expanded ("0")
-//   null  → no pin (fall through to route request, then global default)
-// Read synchronously in the state initializer so first paint matches the
-// persisted mode (mirrors the `paperclip.sidebar.width` pattern in
-// ResizableSidebarPane and avoids an expand→collapse flash).
-function readStoredCollapsed(): boolean | null {
-  if (typeof window === "undefined") return null;
-
-  try {
-    const stored = window.localStorage.getItem(COLLAPSED_STORAGE_KEY);
-    if (stored === "1") return true;
-    if (stored === "0") return false;
-    return null;
-  } catch {
-    return null;
-  }
-}
-
-function writeStoredCollapsed(value: boolean) {
-  if (typeof window === "undefined") return;
-
-  try {
-    window.localStorage.setItem(COLLAPSED_STORAGE_KEY, value ? "1" : "0");
-  } catch {
-    // Storage can be unavailable in private contexts; pinning should still
-    // work for the current session.
-  }
-}
-
-function readPointerCanPeek(): boolean {
-  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
-    return false;
-  }
-
-  try {
-    return window.matchMedia(PEEK_POINTER_QUERY).matches;
-  } catch {
-    return false;
-  }
-}
 
 export function SidebarProvider({ children }: { children: ReactNode }) {
   const [isMobile, setIsMobile] = useState(() => window.innerWidth < MOBILE_BREAKPOINT);
   const [sidebarOpen, setSidebarOpen] = useState(() => window.innerWidth >= MOBILE_BREAKPOINT);
 
-  // `null` = unpinned; an explicit user pin takes precedence over route request.
-  const [userCollapsed, setUserCollapsed] = useState<boolean | null>(() => readStoredCollapsed());
   const [routeRequestsCollapsed, setRouteRequestsCollapsed] = useState(false);
   const [forceCollapsed, setForceCollapsed] = useState(false);
-  const [rawPeeking, setRawPeeking] = useState(false);
-  const [pointerCanPeek, setPointerCanPeek] = useState(() => readPointerCanPeek());
 
   useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
@@ -109,67 +53,14 @@ export function SidebarProvider({ children }: { children: ReactNode }) {
     return () => mql.removeEventListener("change", onChange);
   }, []);
 
-  useEffect(() => {
-    if (typeof window.matchMedia !== "function") return;
-    const mql = window.matchMedia(PEEK_POINTER_QUERY);
-    // Latch on only — see the runtime detection below for why this never flips
-    // back to false.
-    const onChange = (e: MediaQueryListEvent) => {
-      if (e.matches) setPointerCanPeek(true);
-    };
-    mql.addEventListener("change", onChange);
-    return () => mql.removeEventListener("change", onChange);
-  }, []);
-
-  // iPadOS Safari does not flip the `(hover: hover) and (pointer: fine)` media
-  // query when a trackpad/mouse is attached, so the query above stays false even
-  // though a real cursor is driving the UI — and hover-peek never triggers
-  // (PAP-10725). Detect a fine pointer at runtime instead: a genuine
-  // mouse/trackpad emits pointer events with `pointerType: "mouse"`, whereas
-  // touch reports "touch" and the Pencil reports "pen", so this never enables on
-  // touch-only input. Treat peek capability as a one-way latch — once a cursor
-  // has been seen we keep peek available for the session.
-  useEffect(() => {
-    if (pointerCanPeek || typeof window.PointerEvent !== "function") return;
-    const onPointer = (e: PointerEvent) => {
-      if (e.pointerType === "mouse") setPointerCanPeek(true);
-    };
-    window.addEventListener("pointerover", onPointer, { passive: true });
-    window.addEventListener("pointermove", onPointer, { passive: true });
-    return () => {
-      window.removeEventListener("pointerover", onPointer);
-      window.removeEventListener("pointermove", onPointer);
-    };
-  }, [pointerCanPeek]);
-
-  // Precedence (highest wins): forced (active secondary sidebar) > explicit user
-  // pin > route request > default expanded. The force is ephemeral and never
-  // touches the persisted pin, so dropping it restores the user's preference.
-  const pinnedOrRequested = userCollapsed !== null ? userCollapsed : routeRequestsCollapsed;
-  const desktopCollapsed = forceCollapsed || pinnedOrRequested;
-  // Collapsed/peek are desktop-only; mobile always uses the drawer. The user
-  // pin is preserved across the breakpoint and reapplies on the desktop side.
-  const collapsed = isMobile ? false : desktopCollapsed;
-  // While forced, the pin is locked: the expand/toggle affordance is inert.
-  const collapseLocked = !isMobile && forceCollapsed;
-  // Peek only applies when collapsed on a hover-capable pointer.
-  const peeking = rawPeeking && collapsed && pointerCanPeek;
-
-  const setCollapsed = useCallback((next: boolean) => {
-    setUserCollapsed(next);
-    writeStoredCollapsed(next);
-  }, []);
-
-  const toggleCollapsed = useCallback(() => {
-    // While a secondary sidebar forces the rail, the toggle is locked: it must
-    // neither expand the rail nor mutate the persisted preference.
-    if (forceCollapsed) return;
-    setCollapsed(!pinnedOrRequested);
-  }, [forceCollapsed, pinnedOrRequested, setCollapsed]);
-
-  const setPeeking = useCallback((next: boolean) => {
-    setRawPeeking(next);
-  }, []);
+  // The icon rail has been retired. Keep the old API inert so routes and
+  // plugins compiled against it cannot collapse the global navigation.
+  const collapsed = false;
+  const collapseLocked = false;
+  const peeking = false;
+  const setCollapsed = useCallback((_next: boolean) => {}, []);
+  const toggleCollapsed = useCallback(() => {}, []);
+  const setPeeking = useCallback((_next: boolean) => {}, []);
 
   const toggleSidebar = useCallback(() => setSidebarOpen((v) => !v), []);
 

--- a/ui/src/hooks/useRecentTasks.ts
+++ b/ui/src/hooks/useRecentTasks.ts
@@ -1,0 +1,112 @@
+import { useEffect, useMemo, useState } from "react";
+import { useQueries } from "@tanstack/react-query";
+import type { Issue } from "@paperclipai/shared";
+import { ApiError } from "@/api/client";
+import { issuesApi } from "@/api/issues";
+import { queryKeys } from "@/lib/queryKeys";
+import {
+  RECENT_TASKS_UPDATED_EVENT,
+  getRecentTasksStorageKey,
+  pruneRecentTasks,
+  readRecentTasks,
+  updateRecentTaskSnapshots,
+  type RecentTaskEntry,
+} from "@/lib/recent-tasks";
+
+type RecentTasksUpdatedDetail = {
+  storageKey: string;
+  entries: RecentTaskEntry[];
+};
+
+export function useRecentTasks({
+  companyId,
+  userId,
+}: {
+  companyId: string | null | undefined;
+  userId: string | null | undefined;
+}) {
+  const storageKey = useMemo(
+    () => companyId ? getRecentTasksStorageKey(companyId, userId) : null,
+    [companyId, userId],
+  );
+  const [entries, setEntries] = useState<RecentTaskEntry[]>(() => (
+    storageKey && companyId ? readRecentTasks(storageKey, companyId) : []
+  ));
+
+  useEffect(() => {
+    setEntries(storageKey && companyId ? readRecentTasks(storageKey, companyId) : []);
+  }, [companyId, storageKey]);
+
+  useEffect(() => {
+    if (!storageKey || !companyId) return;
+
+    const sync = () => setEntries(readRecentTasks(storageKey, companyId));
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === storageKey) sync();
+    };
+    const onRecentTasksUpdated = (event: Event) => {
+      const detail = (event as CustomEvent<RecentTasksUpdatedDetail>).detail;
+      if (detail?.storageKey === storageKey) setEntries(detail.entries);
+    };
+
+    window.addEventListener("storage", onStorage);
+    window.addEventListener(RECENT_TASKS_UPDATED_EVENT, onRecentTasksUpdated);
+    return () => {
+      window.removeEventListener("storage", onStorage);
+      window.removeEventListener(RECENT_TASKS_UPDATED_EVENT, onRecentTasksUpdated);
+    };
+  }, [companyId, storageKey]);
+
+  const detailQueries = useQueries({
+    queries: entries.map((entry) => ({
+      queryKey: queryKeys.issues.detail(entry.id),
+      queryFn: () => issuesApi.get(entry.id),
+      retry: false,
+      staleTime: 30_000,
+    })),
+  });
+
+  const refreshedEntries = entries.map((entry, index) => {
+    const issue = detailQueries[index]?.data;
+    if (!issue || issue.companyId !== companyId || issue.hiddenAt) return entry;
+    return {
+      ...entry,
+      title: issue.title,
+      identifier: issue.identifier,
+      status: issue.status,
+    };
+  });
+  const queryRevision = detailQueries
+    .map((query) => `${query.dataUpdatedAt}:${query.errorUpdatedAt}:${query.status}`)
+    .join("|");
+
+  useEffect(() => {
+    if (!storageKey || !companyId || detailQueries.length === 0) return;
+
+    const resolvedIssues: Issue[] = [];
+    const removeIds = new Set<string>();
+    detailQueries.forEach((query, index) => {
+      const entry = entries[index];
+      if (!entry) return;
+      if (query.data) {
+        if (query.data.companyId !== companyId || query.data.hiddenAt) {
+          removeIds.add(entry.id);
+        } else {
+          resolvedIssues.push(query.data);
+        }
+      } else if (query.error instanceof ApiError && [403, 404].includes(query.error.status)) {
+        removeIds.add(entry.id);
+      }
+    });
+
+    updateRecentTaskSnapshots(storageKey, companyId, resolvedIssues);
+    pruneRecentTasks(storageKey, companyId, removeIds);
+    // queryRevision is the stable notification boundary for the useQueries result array.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [companyId, entries, queryRevision, storageKey]);
+
+  return {
+    entries: refreshedEntries,
+    storageKey,
+  };
+}

--- a/ui/src/hooks/useStreamlinedUiEnabled.test.tsx
+++ b/ui/src/hooks/useStreamlinedUiEnabled.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createRoot, type Root } from "react-dom/client";
+import { flushSync } from "react-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resolveStreamlinedUiEnabled,
+  useStreamlinedUiEnabled,
+} from "./useStreamlinedUiEnabled";
+
+const mockInstanceSettingsApi = vi.hoisted(() => ({
+  getExperimental: vi.fn(),
+}));
+
+vi.mock("@/api/instanceSettings", () => ({
+  instanceSettingsApi: mockInstanceSettingsApi,
+}));
+
+function Probe() {
+  const state = useStreamlinedUiEnabled();
+  return <output>{`${state.enabled}:${state.loaded}`}</output>;
+}
+
+async function flushReact() {
+  for (let index = 0; index < 5; index += 1) {
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  }
+  flushSync(() => {});
+}
+
+describe("useStreamlinedUiEnabled", () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    host = document.createElement("div");
+    document.body.appendChild(host);
+    root = createRoot(host);
+  });
+
+  afterEach(() => {
+    flushSync(() => root.unmount());
+    host.remove();
+    vi.clearAllMocks();
+  });
+
+  it("fails open for missing settings and loading state", () => {
+    expect(resolveStreamlinedUiEnabled(undefined)).toBe(true);
+    expect(resolveStreamlinedUiEnabled(null)).toBe(true);
+
+    mockInstanceSettingsApi.getExperimental.mockImplementation(() => new Promise(() => {}));
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    flushSync(() => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Probe />
+        </QueryClientProvider>,
+      );
+    });
+
+    expect(host.textContent).toBe("true:false");
+  });
+
+  it("uses the legacy shell only for an explicit false value", async () => {
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({ enableStreamlinedUi: false });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    flushSync(() => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Probe />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    expect(host.textContent).toBe("false:true");
+    expect(resolveStreamlinedUiEnabled({ enableStreamlinedUi: true })).toBe(true);
+    expect(resolveStreamlinedUiEnabled({ enableStreamlinedUi: false })).toBe(false);
+  });
+});

--- a/ui/src/hooks/useStreamlinedUiEnabled.ts
+++ b/ui/src/hooks/useStreamlinedUiEnabled.ts
@@ -1,0 +1,44 @@
+import { useContext } from "react";
+import { QueryClient, QueryClientContext, useQuery } from "@tanstack/react-query";
+import type { InstanceExperimentalSettings } from "@paperclipai/shared";
+import { instanceSettingsApi } from "@/api/instanceSettings";
+import { queryKeys } from "@/lib/queryKeys";
+
+export function resolveStreamlinedUiEnabled(
+  settings:
+    | Pick<InstanceExperimentalSettings, "enableStreamlinedUi">
+    | null
+    | undefined,
+): boolean {
+  return settings?.enableStreamlinedUi !== false;
+}
+
+let detachedClient: QueryClient | null = null;
+function getDetachedClient(): QueryClient {
+  detachedClient ??= new QueryClient();
+  return detachedClient;
+}
+
+/**
+ * The streamlined shell is the default experience. Missing legacy values,
+ * loading states, and read failures all fail open so the app never flashes or
+ * falls back to the legacy shell unless an instance explicitly opts out.
+ */
+export function useStreamlinedUiEnabled(): { enabled: boolean; loaded: boolean } {
+  const contextClient = useContext(QueryClientContext);
+  const query = useQuery(
+    {
+      queryKey: queryKeys.instance.experimentalSettings,
+      queryFn: () => instanceSettingsApi.getExperimental(),
+      enabled: contextClient != null,
+    },
+    contextClient ?? getDetachedClient(),
+  );
+
+  if (!contextClient) return { enabled: true, loaded: true };
+
+  return {
+    enabled: resolveStreamlinedUiEnabled(query.data),
+    loaded: query.isFetched,
+  };
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -154,6 +154,16 @@
   --agent-10a: #f2d95f;
   --agent-10b: #4fbcba;
 
+  /* Onboarding mascot artwork (brand-fixed, theme-independent). Keeping the
+     SVG palette in the token layer preserves the source asset while allowing
+     components to remain token-only. */
+  --pill-guy-eye: #060606;
+  --pill-guy-dormant-top: #626262;
+  --pill-guy-dormant-bottom: #101010;
+  --pill-guy-tuft: #2d200d;
+  --pill-guy-alive-top: #3028aa;
+  --pill-guy-alive-bottom: #ff0000;
+
   /* Status colors — one base hue per status, consumed by the agent / task
      status chips and the task status icons. Mode-independent: the `.status-chip`,
      `.status-fill` and inline icon helpers derive the light vs dark
@@ -266,18 +276,25 @@
 
   /* Portable side-panel geometry and hierarchy. These stay centralized so
      task, project, agent, and future hosts render the same Codex-like chrome. */
-  --side-panel-header-height: var(--sz-48px);
+  --side-panel-header-height: var(--sz-60px);
   --side-panel-tab-height: var(--sz-30px);
+  --side-panel-streamlined-tab-min-width: var(--sz-72px);
+  --side-panel-streamlined-tab-max-width: var(--sz-160px);
+  --side-panel-tab-edge-fade-width: var(--sz-32px);
   --side-panel-tab-label-max-width: var(--sz-100px);
   --side-panel-tab-label-expanded-max-width: calc(var(--side-panel-tab-label-max-width) + var(--sz-18px));
-  --side-panel-tab-label-fade-width: var(--sz-18px);
+  --side-panel-tab-label-fade-width: var(--sz-32px);
   --side-panel-tab-radius: var(--radius-xl);
   --side-panel-control-radius: var(--radius-xl);
   --side-panel-launcher-width: var(--sz-320px);
   --side-panel-bg: var(--background);
   --side-panel-fg: var(--foreground);
+  --streamlined-task-detail-bg: var(--background);
   --side-panel-tab-active-bg: color-mix(in oklab, var(--accent) 88%, var(--background));
   --side-panel-tab-hover-bg: color-mix(in oklab, var(--accent) 58%, transparent);
+  --radius-task-composer: 16px;
+  --shadow-task-composer: 0 2px 8px -2px color-mix(in oklab, var(--foreground) 7%, transparent),
+    0 12px 32px -8px color-mix(in oklab, var(--foreground) 12%, transparent);
 
   /* Composer mode-chip hues (v5–v7 decisions): agent + plan reuse the task
      status hues; ask is the v5 blue. Consumed as `--sc` seeds through the
@@ -302,6 +319,7 @@
   /* Redesigned chat-shell column cap (phase 2c): one token caps the page
      wrapper, thread body, and pinned composer so they widen in lockstep. */
   --tc-shell-max-w: 60rem;
+  --sz-66px: 66px;
 
   /* Active-turn status island and its checklist overlay. */
   --sz-turn-status-island: min(100%, 42rem);
@@ -316,10 +334,11 @@
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
+  --background: oklch(0.205 0 0);
   --foreground: oklch(0.985 0 0);
-  --side-panel-bg: rgb(10 10 10);
+  --side-panel-bg: var(--background);
   --side-panel-fg: oklch(0.985 0 0);
+  --streamlined-task-detail-bg: var(--background);
   --card: oklch(0.205 0 0);
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.205 0 0);
@@ -373,6 +392,11 @@
   --status-task-icon-in_review: #9474f0;  /* deeper than violet-400, reads purple */
   --status-task-icon-done: #34d06f;
   --status-task-icon-cancelled: #9a958a;
+}
+
+.streamlined-task-detail-surface {
+  --side-panel-bg: var(--streamlined-task-detail-bg);
+  background-color: var(--streamlined-task-detail-bg);
 }
 
 ::highlight(paperclip-doc-annotation-open) {
@@ -562,6 +586,61 @@
 #main-content:has([data-task-chat-shell]) {
   scrollbar-gutter: auto;
 }
+
+/* Paper task-detail properties rhythm: values share the 12px label scale and
+   each section gets a full 24px breathing interval before the next heading. */
+.task-detail-properties [data-property-section="true"] {
+  padding-bottom: calc(var(--spacing) * 6);
+}
+
+.task-detail-properties [data-property-value="true"],
+.task-detail-properties [data-property-value="true"] .text-sm {
+  font-size: var(--text-xs);
+  line-height: var(--text-xs--line-height);
+}
+
+/* The generic line-tab variant deliberately keeps active tabs transparent.
+   The task-detail sidebar uses a filled active tab instead; the pane slot ID
+   gives this contextual treatment enough specificity without affecting other
+   line-tab surfaces. */
+#properties-pane-header-slot .task-detail-pane-tab[data-state="active"] {
+  background-color: var(--muted);
+}
+
+/* Codex-style pane tabs soften clipped labels into the tab surface. The mask
+   stays on the label itself so short names remain visually untouched. */
+.task-detail-pane-tab-label {
+  -webkit-mask-image: linear-gradient(
+    to right,
+    var(--foreground) 0,
+    var(--foreground) calc(100% - calc(var(--spacing) * 4)),
+    transparent 100%
+  );
+  mask-image: linear-gradient(
+    to right,
+    var(--foreground) 0,
+    var(--foreground) calc(100% - calc(var(--spacing) * 4)),
+    transparent 100%
+  );
+}
+
+/* Keep continuation tabs readable as they pass beneath the fixed add control.
+   The mask is enabled only while content remains beyond the right edge. */
+.side-panel-tabs-scroll[data-scroll-end-fade="true"] {
+  -webkit-mask-image: linear-gradient(
+    to right,
+    var(--foreground) 0,
+    var(--foreground) calc(100% - var(--side-panel-tab-edge-fade-width)),
+    transparent 100%
+  );
+  mask-image: linear-gradient(
+    to right,
+    var(--foreground) 0,
+    var(--foreground) calc(100% - var(--side-panel-tab-edge-fade-width)),
+    transparent 100%
+  );
+}
+
 /* Light mode scrollbar on hover */
 .scrollbar-auto-hide:hover {
   scrollbar-color: oklch(0.7 0 0) transparent;
@@ -795,7 +874,14 @@
   transition-duration: var(--motion-side-panel-tab);
   transition-timing-function: var(--motion-ease-standard);
 }
-.side-panel-tab-label-fade {
+.side-panel-tab-close-motion {
+  transition-property: color, background-color, border-color, box-shadow, transform;
+  transition-duration: var(--motion-side-panel-tab);
+  transition-timing-function: var(--motion-ease-standard);
+}
+.side-panel-tab-label-fade,
+.side-panel-tab-label-close-fade[data-truncated="true"],
+[data-appearance="streamlined-task"]:is(:hover, :focus-within) .side-panel-tab-label-close-fade {
   -webkit-mask-image: linear-gradient(to right, black calc(100% - var(--side-panel-tab-label-fade-width)), transparent);
   mask-image: linear-gradient(to right, black calc(100% - var(--side-panel-tab-label-fade-width)), transparent);
   -webkit-mask-repeat: no-repeat;
@@ -816,7 +902,8 @@
   .tc-turn-metrics,
   .tc-line-scroll-inner,
   .tc-pane-glide,
-  .side-panel-tab-motion { transition: none; }
+  .side-panel-tab-motion,
+  .side-panel-tab-close-motion { transition: none; }
   /* The pill keyframes carry the X-centering; with animation:none restore it. */
   .tc-scroll-pill-in,
   .tc-scroll-pill-out { transform: translate(-50%, 0); }
@@ -2396,7 +2483,8 @@ span.paperclip-mention-chip[data-mention-kind="external-object"] {
   --shadow-extract-9: 0 18px 42px rgba(15,23,42,0.06); /* Extracted from ui/src/components/IssueThreadInteractionCard.tsx (shadow-[0_18px_42px_rgba(15,23,42,0.06)]). */
   --shadow-extract-10: 0 1px 0 1px var(--border); /* Extracted from ui/src/components/KeyboardShortcutsCheatsheet.tsx; corrected for full-color semantic tokens. */
   --shadow-extract-11: 0 18px 50px rgba(37,99,235,0.08); /* LiveRunWidget.tsx glow. Gallery feedback r2: liveness glow recolored cyan->status blue (value edit, site unchanged; originally extracted as rgba(6,182,212,0.08)). */
-  --shadow-extract-12: 0 0 0 2px var(--background); /* Extracted from ui/src/components/SidebarNavItem.tsx; corrected for full-color semantic tokens. */
+  --shadow-extract-12: 0 0 0 2px var(--background); /* Production sidebar icon-badge outline. */
+  --shadow-sidebar-icon-badge: 0 0 0 2px var(--muted); /* Streamlined sidebar icon-badge outline; matches the sidebar surface. */
   --shadow-extract-13: 0 0 0 3px rgba(245,158,11,0.18); /* Extracted from ui/src/components/environment-variables-editor/index.tsx (shadow-[0_0_0_3px_rgba(245,158,11,0.18)]). */
   --shadow-extract-14: 0 0 12px rgba(37,99,235,0.08); /* AgentDetail.tsx live-card glow. Gallery feedback r2: liveness glow recolored cyan->status blue (value edit, site unchanged; originally extracted as rgba(6,182,212,0.08)). */
   --shadow-extract-18: 0 18px 44px -28px rgba(0,0,0,0.45); /* Extracted from ui/src/pages/ProfileSettings.tsx (shadow-[0_18px_44px_-28px_rgba(0,0,0,0.45)]). */

--- a/ui/src/lib/queryKeys.test.ts
+++ b/ui/src/lib/queryKeys.test.ts
@@ -19,3 +19,17 @@ describe("project query keys", () => {
     expect(queryKeys.projects.all("company-1")).toEqual(["projects", "company-1"]);
   });
 });
+
+describe("audit query keys", () => {
+  it("separates entity-scoped activity from the unscoped feed", () => {
+    const unscoped = queryKeys.audit.agentActions("company-1", { actorScope: "all" });
+    const routine = queryKeys.audit.agentActions("company-1", {
+      actorScope: "all",
+      entityType: "routine",
+      entityId: "routine-1",
+    });
+
+    expect(routine).not.toEqual(unscoped);
+    expect(routine).toContain("routine-1");
+  });
+});

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -96,6 +96,8 @@ export const queryKeys = {
       ] as const,
   },
   audit: {
+    runs: (companyId: string, agentId?: string | null) =>
+      ["audit", companyId, "runs", agentId ?? "__all"] as const,
     agentActions: (
       companyId: string,
       filters: {
@@ -104,6 +106,7 @@ export const queryKeys = {
         responsibleUserId?: string | null;
         runId?: string | null;
         entityType?: string | null;
+        entityId?: string | null;
         action?: string | null;
         from?: string | null;
         to?: string | null;
@@ -119,6 +122,7 @@ export const queryKeys = {
         filters.responsibleUserId ?? "__all",
         filters.runId ?? "__all",
         filters.entityType ?? "__all",
+        filters.entityId ?? "__all",
         filters.action ?? "__all",
         filters.actorType ?? "__all",
         filters.from ?? "",

--- a/ui/src/lib/recent-tasks.test.ts
+++ b/ui/src/lib/recent-tasks.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  RECENT_TASKS_LIMIT,
+  RECENT_TASKS_UPDATED_EVENT,
+  getRecentTasksStorageKey,
+  pruneRecentTasks,
+  readRecentTasks,
+  recordRecentTask,
+  updateRecentTaskSnapshots,
+} from "./recent-tasks";
+
+const issue = (id: string, companyId = "company-1") => ({
+  id,
+  companyId,
+  title: `Task ${id}`,
+  identifier: `PAP-${id}`,
+  status: "todo" as const,
+  updatedAt: new Date(0),
+});
+
+describe("recent task persistence", () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it("is account and company scoped", () => {
+    expect(getRecentTasksStorageKey("company-1", "user-1")).not.toBe(
+      getRecentTasksStorageKey("company-1", "user-2"),
+    );
+    expect(getRecentTasksStorageKey("company-1", "user-1")).not.toBe(
+      getRecentTasksStorageKey("company-2", "user-1"),
+    );
+  });
+
+  it("deduplicates, only promotes newer activity, and stays bounded", () => {
+    for (let index = 0; index < RECENT_TASKS_LIMIT + 2; index += 1) {
+      recordRecentTask(issue(String(index)), "user-1", index);
+    }
+    recordRecentTask(issue("4"), "user-1", 4);
+
+    let entries = readRecentTasks(getRecentTasksStorageKey("company-1", "user-1"), "company-1");
+    expect(entries[0]?.id).toBe("6");
+
+    recordRecentTask(issue("4"), "user-1", 99);
+
+    entries = readRecentTasks(getRecentTasksStorageKey("company-1", "user-1"), "company-1");
+    expect(entries).toHaveLength(RECENT_TASKS_LIMIT);
+    expect(entries[0]?.id).toBe("4");
+    expect(entries.filter((entry) => entry.id === "4")).toHaveLength(1);
+  });
+
+  it("publishes same-tab updates", () => {
+    const listener = vi.fn();
+    window.addEventListener(RECENT_TASKS_UPDATED_EVENT, listener);
+    recordRecentTask(issue("1"), "user-1");
+    expect(listener).toHaveBeenCalledOnce();
+    listener.mockClear();
+    recordRecentTask(issue("1"), "user-1");
+    expect(listener).not.toHaveBeenCalled();
+    window.removeEventListener(RECENT_TASKS_UPDATED_EVENT, listener);
+  });
+
+  it("prunes unavailable tasks and refreshes stored snapshots", () => {
+    recordRecentTask(issue("1"), "user-1", 1);
+    recordRecentTask(issue("2"), "user-1", 2);
+    const storageKey = getRecentTasksStorageKey("company-1", "user-1");
+
+    updateRecentTaskSnapshots(storageKey, "company-1", [{
+      ...issue("2"),
+      title: "Updated task",
+      status: "in_progress",
+      updatedAt: new Date(3),
+    }]);
+    pruneRecentTasks(storageKey, "company-1", new Set(["1"]));
+
+    expect(readRecentTasks(storageKey, "company-1")).toEqual([
+      expect.objectContaining({
+        id: "2",
+        title: "Updated task",
+        status: "in_progress",
+        recordedAt: 3,
+      }),
+    ]);
+  });
+
+  it("ignores malformed and cross-company entries", () => {
+    const storageKey = getRecentTasksStorageKey("company-1", "user-1");
+    window.localStorage.setItem(storageKey, JSON.stringify([
+      issue("other", "company-2"),
+      { nonsense: true },
+    ]));
+    expect(readRecentTasks(storageKey, "company-1")).toEqual([]);
+  });
+});

--- a/ui/src/lib/recent-tasks.ts
+++ b/ui/src/lib/recent-tasks.ts
@@ -1,0 +1,155 @@
+import type { Issue, IssueStatus } from "@paperclipai/shared";
+
+export const RECENT_TASKS_LIMIT = 5;
+export const RECENT_TASKS_UPDATED_EVENT = "paperclip:recent-tasks-updated";
+
+export interface RecentTaskEntry {
+  id: string;
+  companyId: string;
+  title: string;
+  identifier: string | null;
+  status: IssueStatus;
+  recordedAt: number;
+}
+
+interface RecentTasksUpdatedDetail {
+  storageKey: string;
+  entries: RecentTaskEntry[];
+}
+
+export function getRecentTasksStorageKey(companyId: string, userId: string | null | undefined) {
+  return `paperclip.recentTasks:${companyId}:${userId ?? "__local_board__"}`;
+}
+
+function isRecentTaskEntry(value: unknown, companyId: string): value is RecentTaskEntry {
+  if (!value || typeof value !== "object") return false;
+  const entry = value as Partial<RecentTaskEntry>;
+  return entry.companyId === companyId
+    && typeof entry.id === "string"
+    && entry.id.length > 0
+    && typeof entry.title === "string"
+    && (entry.identifier === null || typeof entry.identifier === "string")
+    && typeof entry.status === "string"
+    && typeof entry.recordedAt === "number"
+    && Number.isFinite(entry.recordedAt);
+}
+
+export function readRecentTasks(storageKey: string, companyId: string): RecentTaskEntry[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const parsed = JSON.parse(window.localStorage.getItem(storageKey) ?? "[]") as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return normalizeRecentTasks(
+      parsed.filter((entry): entry is RecentTaskEntry => isRecentTaskEntry(entry, companyId)),
+    );
+  } catch {
+    return [];
+  }
+}
+
+function normalizeRecentTasks(entries: RecentTaskEntry[]) {
+  const seen = new Set<string>();
+  return [...entries]
+    .sort((left, right) => right.recordedAt - left.recordedAt)
+    .filter((entry) => {
+      if (seen.has(entry.id)) return false;
+      seen.add(entry.id);
+      return true;
+    })
+    .slice(0, RECENT_TASKS_LIMIT);
+}
+
+function publishRecentTasks(storageKey: string, entries: RecentTaskEntry[]) {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent<RecentTasksUpdatedDetail>(RECENT_TASKS_UPDATED_EVENT, {
+    detail: { storageKey, entries },
+  }));
+}
+
+export function writeRecentTasks(storageKey: string, entries: RecentTaskEntry[]) {
+  if (typeof window === "undefined") return;
+  const bounded = normalizeRecentTasks(entries);
+  try {
+    window.localStorage.setItem(storageKey, JSON.stringify(bounded));
+  } catch {
+    // The in-tab event still keeps mounted navigation current for this session.
+  }
+  publishRecentTasks(storageKey, bounded);
+}
+
+export function recordRecentTask(
+  issue: Pick<Issue, "id" | "companyId" | "title" | "identifier" | "status" | "updatedAt">,
+  userId: string | null | undefined,
+  recordedAt = new Date(issue.updatedAt).getTime(),
+) {
+  const storageKey = getRecentTasksStorageKey(issue.companyId, userId);
+  const current = readRecentTasks(storageKey, issue.companyId);
+  const existing = current.find((candidate) => candidate.id === issue.id);
+  const activityAt = Number.isFinite(recordedAt)
+    ? recordedAt
+    : existing?.recordedAt ?? Date.now();
+  const entry: RecentTaskEntry = {
+    id: issue.id,
+    companyId: issue.companyId,
+    title: issue.title,
+    identifier: issue.identifier,
+    status: issue.status,
+    recordedAt: activityAt,
+  };
+  if (
+    existing
+    && existing.title === entry.title
+    && existing.identifier === entry.identifier
+    && existing.status === entry.status
+    && existing.recordedAt === entry.recordedAt
+  ) return;
+
+  writeRecentTasks(
+    storageKey,
+    existing
+      ? current.map((candidate) => candidate.id === issue.id ? entry : candidate)
+      : [entry, ...current],
+  );
+}
+
+export function pruneRecentTasks(
+  storageKey: string,
+  companyId: string,
+  removeIds: ReadonlySet<string>,
+) {
+  if (removeIds.size === 0) return;
+  const current = readRecentTasks(storageKey, companyId);
+  const next = current.filter((entry) => !removeIds.has(entry.id));
+  if (next.length !== current.length) writeRecentTasks(storageKey, next);
+}
+
+export function updateRecentTaskSnapshots(
+  storageKey: string,
+  companyId: string,
+  issues: ReadonlyArray<Pick<Issue, "id" | "companyId" | "title" | "identifier" | "status" | "updatedAt">>,
+) {
+  const issueById = new Map(issues.map((issue) => [issue.id, issue]));
+  const current = readRecentTasks(storageKey, companyId);
+  let changed = false;
+  const next = current.map((entry) => {
+    const issue = issueById.get(entry.id);
+    if (!issue || issue.companyId !== companyId) return entry;
+    const activityAt = new Date(issue.updatedAt).getTime();
+    const nextRecordedAt = Number.isFinite(activityAt) ? activityAt : entry.recordedAt;
+    if (
+      issue.title === entry.title
+      && issue.identifier === entry.identifier
+      && issue.status === entry.status
+      && nextRecordedAt === entry.recordedAt
+    ) return entry;
+    changed = true;
+    return {
+      ...entry,
+      title: issue.title,
+      identifier: issue.identifier,
+      status: issue.status,
+      recordedAt: nextRecordedAt,
+    };
+  });
+  if (changed) writeRecentTasks(storageKey, next);
+}

--- a/ui/src/lib/shell-navigation.test.ts
+++ b/ui/src/lib/shell-navigation.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  classifyShellRoute,
+  getCompanyPathSegments,
+  readContextualSidebarOrigin,
+  rememberContextualSidebarOrigin,
+} from "./shell-navigation";
+
+describe("shell navigation", () => {
+  beforeEach(() => window.sessionStorage.clear());
+
+  it("classifies task detail independently from list routes", () => {
+    expect(classifyShellRoute("/PAP/issues", "PAP").isTaskDetail).toBe(false);
+    expect(classifyShellRoute("/PAP/issues/task-1", "PAP").isTaskDetail).toBe(true);
+  });
+
+  it("classifies the built-in contextual surfaces", () => {
+    expect(classifyShellRoute("/PAP/company/settings/secrets", "PAP").builtInContextualSurface).toBe("settings");
+    expect(classifyShellRoute("/PAP/company/export", "PAP").builtInContextualSurface).toBe("settings");
+    expect(classifyShellRoute("/PAP/apps/connections", "PAP").builtInContextualSurface).toBe("apps");
+    expect(classifyShellRoute("/PAP/tools/runtime", "PAP").builtInContextualSurface).toBe("apps");
+    expect(classifyShellRoute("/PAP/agents/agent-1/instructions", "PAP").builtInContextualSurface).toBe("agent");
+    expect(classifyShellRoute("/PAP/agents/agent-1/runs/run-1", "PAP").builtInContextualSurface).toBe("agent");
+    expect(classifyShellRoute("/PAP/routines/routine-1/overview", "PAP").builtInContextualSurface).toBe("routine");
+    expect(classifyShellRoute("/PAP/skills", "PAP").builtInContextualSurface).toBe("skills");
+    expect(classifyShellRoute("/PAP/skills/studio/skill-1", "PAP").builtInContextualSurface).toBe("skills");
+  });
+
+  it("keeps Agent and Routine collection routes in the global shell", () => {
+    for (const pathname of [
+      "/PAP/agents",
+      "/PAP/agents/all",
+      "/PAP/agents/active",
+      "/PAP/agents/paused",
+      "/PAP/agents/error",
+      "/PAP/agents/builtin",
+      "/PAP/agents/new",
+      "/PAP/routines",
+    ]) {
+      expect(classifyShellRoute(pathname, "PAP").builtInContextualSurface).toBeNull();
+    }
+  });
+
+  it("rejects a different company prefix", () => {
+    expect(getCompanyPathSegments("/OTHER/issues/task-1", "PAP")).toEqual([]);
+  });
+
+  it("remembers only safe same-company origins", () => {
+    rememberContextualSidebarOrigin({
+      surface: "settings",
+      companyPrefix: "PAP",
+      previousPathname: "/PAP/issues/task-1",
+    });
+    expect(readContextualSidebarOrigin({
+      surface: "settings",
+      companyPrefix: "PAP",
+      fallbackTo: "/dashboard",
+    })).toBe("/PAP/issues/task-1");
+
+    rememberContextualSidebarOrigin({
+      surface: "settings",
+      companyPrefix: "PAP",
+      previousPathname: "/OTHER/dashboard",
+    });
+    expect(readContextualSidebarOrigin({
+      surface: "settings",
+      companyPrefix: "PAP",
+      fallbackTo: "/dashboard",
+    })).toBe("/PAP/issues/task-1");
+  });
+
+  it("falls back when storage contains an unsafe path", () => {
+    window.sessionStorage.setItem(
+      "paperclip.contextualSidebar.origin:PAP:settings",
+      "/OTHER/company/settings",
+    );
+    expect(readContextualSidebarOrigin({
+      surface: "settings",
+      companyPrefix: "PAP",
+      fallbackTo: "/dashboard",
+    })).toBe("/dashboard");
+  });
+});

--- a/ui/src/lib/shell-navigation.ts
+++ b/ui/src/lib/shell-navigation.ts
@@ -1,0 +1,106 @@
+export type ContextualSidebarSurface =
+  | "settings"
+  | "apps"
+  | "agent"
+  | "routine"
+  | "skills"
+  | `plugin:${string}`;
+
+export interface ShellRouteClassification {
+  companySegments: string[];
+  isTaskDetail: boolean;
+  builtInContextualSurface: Exclude<ContextualSidebarSurface, `plugin:${string}`> | null;
+}
+
+const CONTEXTUAL_ORIGIN_KEY_PREFIX = "paperclip.contextualSidebar.origin";
+
+export function getCompanyPathSegments(pathname: string, companyPrefix: string | undefined): string[] {
+  if (!companyPrefix) return [];
+  const segments = pathname.split("/").filter(Boolean);
+  if (segments.length < 2) return [];
+  if (segments[0]?.toUpperCase() !== companyPrefix.toUpperCase()) return [];
+  return segments.slice(1);
+}
+
+export function classifyShellRoute(
+  pathname: string,
+  companyPrefix: string | undefined,
+): ShellRouteClassification {
+  const companySegments = getCompanyPathSegments(pathname, companyPrefix);
+  const root = companySegments[0]?.toLowerCase();
+  const isCompanySettings = root === "company" && ["settings", "export", "import"].includes(
+    companySegments[1]?.toLowerCase() ?? "",
+  );
+  const agentSegment = companySegments[1]?.toLowerCase();
+  const isAgentDetail = root === "agents"
+    && Boolean(agentSegment)
+    && agentSegment !== "new"
+    && !["all", "active", "paused", "error", "builtin"].includes(agentSegment ?? "");
+  const isRoutineDetail = root === "routines" && companySegments.length >= 2;
+  const isSkillsSurface = root === "skills";
+
+  return {
+    companySegments,
+    isTaskDetail: root === "issues" && companySegments.length >= 2,
+    builtInContextualSurface: isCompanySettings
+      ? "settings"
+      : root === "apps" || root === "tools"
+        ? "apps"
+        : isAgentDetail
+          ? "agent"
+          : isRoutineDetail
+            ? "routine"
+            : isSkillsSurface
+              ? "skills"
+        : null,
+  };
+}
+
+function contextualOriginStorageKey(surface: ContextualSidebarSurface, companyPrefix: string) {
+  return `${CONTEXTUAL_ORIGIN_KEY_PREFIX}:${companyPrefix.toUpperCase()}:${surface}`;
+}
+
+function isCompanyPath(pathname: string, companyPrefix: string) {
+  const first = pathname.split("/").filter(Boolean)[0];
+  return first?.toUpperCase() === companyPrefix.toUpperCase();
+}
+
+export function rememberContextualSidebarOrigin({
+  surface,
+  companyPrefix,
+  previousPathname,
+}: {
+  surface: ContextualSidebarSurface;
+  companyPrefix: string;
+  previousPathname: string;
+}) {
+  if (typeof window === "undefined" || !isCompanyPath(previousPathname, companyPrefix)) return;
+
+  try {
+    window.sessionStorage.setItem(
+      contextualOriginStorageKey(surface, companyPrefix),
+      previousPathname,
+    );
+  } catch {
+    // Navigation still has a deterministic fallback when storage is unavailable.
+  }
+}
+
+export function readContextualSidebarOrigin({
+  surface,
+  companyPrefix,
+  fallbackTo,
+}: {
+  surface: ContextualSidebarSurface;
+  companyPrefix: string | null | undefined;
+  fallbackTo: string;
+}) {
+  if (typeof window === "undefined" || !companyPrefix) return fallbackTo;
+
+  try {
+    const stored = window.sessionStorage.getItem(contextualOriginStorageKey(surface, companyPrefix));
+    return stored && isCompanyPath(stored, companyPrefix) ? stored : fallbackTo;
+  } catch {
+    return fallbackTo;
+  }
+}

--- a/ui/src/pages/AgentDetail.instructions.test.tsx
+++ b/ui/src/pages/AgentDetail.instructions.test.tsx
@@ -348,6 +348,7 @@ describe("PromptsTab instruction editor", () => {
       { "AGENTS.md": makeDetail(summary, "# Current") },
       { onDirtyChange },
     );
+    await selectInstructionMode("Edit");
 
     const editorProps = await waitFor(() => {
       const latest = markdownEditorRenderMock.mock.calls.at(-1)?.[0] as
@@ -382,6 +383,7 @@ describe("PromptsTab instruction editor", () => {
         onCancelActionChange: (next) => { cancelAction = next; },
       },
     );
+    await selectInstructionMode("Edit");
 
     const editor = await waitFor(() => {
       const candidate = container.querySelector<HTMLTextAreaElement>('[data-testid="markdown-editor"]');

--- a/ui/src/pages/AgentDetail.instructions.test.tsx
+++ b/ui/src/pages/AgentDetail.instructions.test.tsx
@@ -78,6 +78,10 @@ vi.mock("../components/MarkdownEditor", () => ({
   },
 }));
 
+vi.mock("../components/MarkdownBody", () => ({
+  MarkdownBody: ({ children }: { children: string }) => <div data-testid="markdown-body">{children}</div>,
+}));
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -279,6 +283,13 @@ describe("PromptsTab instruction editor", () => {
     await flushReact();
   }
 
+  async function selectInstructionMode(mode: "Read" | "Edit" | "Raw") {
+    await act(async () => {
+      buttonByText(container, mode.toLowerCase()).click();
+    });
+    await flushReact();
+  }
+
   it("uses server markdown metadata for extensionless files and saves MarkdownEditor drafts", async () => {
     const summary = makeSummary("AGENTS", "AGENTS", {
       language: "markdown",
@@ -288,6 +299,13 @@ describe("PromptsTab instruction editor", () => {
       makeBundle("AGENTS", [summary]),
       { AGENTS: makeDetail(summary, "# Current") },
     );
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="markdown-body"]')?.textContent).toBe("# Current");
+    });
+    await selectInstructionMode("Raw");
+    expect(container.querySelector('[data-testid="instructions-raw-source"]')?.textContent?.trim()).toBe("# Current");
+    await selectInstructionMode("Edit");
 
     const editor = await waitFor(() => {
       const candidate = container.querySelector<HTMLTextAreaElement>('[data-testid="markdown-editor"]');
@@ -401,6 +419,7 @@ describe("PromptsTab instruction editor", () => {
       { "settings.json": makeDetail(summary, "{\n  \"ok\": true\n}") },
     );
 
+    await selectInstructionMode("Edit");
     await waitFor(() => {
       expect(container.querySelector<HTMLTextAreaElement>('textarea[placeholder="File contents"]')).not.toBeNull();
     });
@@ -417,6 +436,7 @@ describe("PromptsTab instruction editor", () => {
       buttonByText(container, "Create").click();
     });
 
+    await selectInstructionMode("Edit");
     await waitFor(() => {
       expect(container.querySelector('[data-testid="markdown-editor"]')).not.toBeNull();
     });
@@ -433,6 +453,7 @@ describe("PromptsTab instruction editor", () => {
       { "FALLBACK.md": makeDetail(summary, "# Fallback", { markdown: undefined }) },
     );
 
+    await selectInstructionMode("Edit");
     await waitFor(() => {
       expect(container.querySelector("[data-testid=\"markdown-editor\"]")).not.toBeNull();
       expect(markdownEditorRenderMock).toHaveBeenLastCalledWith(expect.objectContaining({
@@ -451,6 +472,7 @@ describe("PromptsTab instruction editor", () => {
       { "NOTES.md": makeDetail(summary, "raw instructions") },
     );
 
+    await selectInstructionMode("Edit");
     await waitFor(() => {
       expect(container.querySelector('[data-testid="markdown-editor"]')).toBeNull();
       expect(container.querySelector<HTMLTextAreaElement>('textarea[placeholder="File contents"]')?.value).toBe("raw instructions");

--- a/ui/src/pages/AgentDetail.production.tsx
+++ b/ui/src/pages/AgentDetail.production.tsx
@@ -9,9 +9,12 @@ import {
 } from "../api/agents";
 import { builtInAgentsApi, type BuiltInManagedResourceKind } from "../api/builtInAgents";
 import { companySkillsApi } from "../api/companySkills";
+import { budgetsApi } from "../api/budgets";
 import { heartbeatsApi } from "../api/heartbeats";
 import { instanceSettingsApi } from "../api/instanceSettings";
 import { ApiError } from "../api/client";
+import { ChartCard, RunActivityChart, PriorityChart, IssueStatusChart, SuccessRateChart } from "../components/ActivityCharts";
+import { SHOW_TASK_PRIORITY_UI } from "../lib/ui-flags";
 import { activityApi } from "../api/activity";
 import { accessApi } from "../api/access";
 import { issuesApi } from "../api/issues";
@@ -25,10 +28,10 @@ import { queryKeys } from "../lib/queryKeys";
 import { copyTextToClipboard } from "../lib/clipboard";
 import { AgentSkillsTab } from "./agent-skills/AgentSkillsTab";
 import { AgentConfigForm } from "../components/AgentConfigForm";
+import { PageTabBar } from "../components/PageTabBar";
 import { adapterLabels, roleLabels, help } from "../components/agent-config-primitives";
 import { ToggleSwitch } from "@/components/ui/toggle-switch";
 import { useAdapterCapabilities } from "@/adapters/use-adapter-capabilities";
-import { useStreamlinedUiEnabled } from "../hooks/useStreamlinedUiEnabled";
 import { redactCommandText as redactCommandSecretText } from "@paperclipai/adapter-utils";
 import { MarkdownEditor } from "../components/MarkdownEditor";
 import { assetsApi } from "../api/assets";
@@ -37,16 +40,18 @@ import { getUIAdapter, buildTranscript, onAdapterChange } from "../adapters";
 import { StatusBadge } from "../components/StatusBadge";
 import { MarkdownBody } from "../components/MarkdownBody";
 import { CopyText } from "../components/CopyText";
-import { IssueRow } from "../components/IssueRow";
+import { EntityRow } from "../components/EntityRow";
 import { StatusGlyph } from "../components/StatusGlyph";
 import { MembershipAction } from "../components/MembershipAction";
 import { StarToggle } from "../components/StarToggle";
 import { Identity } from "../components/Identity";
+import { AuditFeed } from "./audit/AuditFeed.production";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { AgentActionButtons } from "../components/AgentActionButtons";
 import { InlineBanner } from "../components/InlineBanner";
 import { BuiltInBundlePanel } from "../components/BuiltInBundlePanel";
 import { ConfigureBuiltInAgentModal } from "../components/ConfigureBuiltInAgentModal";
+import { BudgetPolicyCard } from "../components/BudgetPolicyCard";
 import { TrustPresetSection } from "../components/TrustPresetSection";
 import { FileTree, buildFileTree } from "../components/FileTree";
 import { ScrollToBottom } from "../components/ScrollToBottom";
@@ -54,14 +59,12 @@ import { SourceResolvedFoldCallout } from "../components/SourceResolvedFoldCallo
 import { SourceResolvedFoldBadge } from "../components/SourceResolvedFoldBadge";
 import { readSourceResolvedWatchdogFold } from "../lib/source-resolved-watchdog-fold";
 import { buildSameOriginWebSocketUrl } from "../lib/websocket-url";
-import { formatDate, relativeTime, formatTokens, visibleRunCostUsd } from "../lib/utils";
+import { formatCents, formatDate, relativeTime, formatTokens, visibleRunCostUsd } from "../lib/utils";
 import { cn } from "../lib/utils";
 import { describeRunRetryState } from "../lib/runRetryState";
 import { Button } from "@/components/ui/button";
-import { Tabs } from "@/components/ui/tabs";
-import { PageTabBar } from "../components/PageTabBar";
-import { AuditFeed } from "./audit/AuditFeed";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs } from "@/components/ui/tabs";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   CheckCircle2,
@@ -99,10 +102,10 @@ import {
   isUuidLike,
   type Agent,
   type AgentDetail as AgentDetailRecord,
+  type BudgetPolicySummary,
   type HeartbeatRun,
   type HeartbeatRunEvent,
   type AgentRuntimeState,
-  type Issue,
   type LiveEvent,
   type WorkspaceOperation,
   isResponsibleUserDenialCode,
@@ -110,12 +113,6 @@ import {
 } from "@paperclipai/shared";
 import { ResponsibleUserDenialNotice } from "../components/ResponsibleUserDenialNotice";
 import { RunWorkspaceRecoverySurface } from "../components/RunWorkspaceRecoverySurface";
-import { RunnerInspector } from "../components/RunnerInspector";
-import { HoneycombRunLink } from "../components/HoneycombRunLink";
-import {
-  ProviderTraceStatusBadge,
-  runRequestedProviderTrace,
-} from "../components/ProviderTraceStatusBadge";
 import { buildPermissionsForTrustPreset, getTrustPreset } from "../lib/trust-policy-ui";
 import { redactHomePathUserSegments, redactHomePathUserSegmentsInValue } from "@paperclipai/adapter-utils";
 import { agentRouteRef } from "../lib/utils";
@@ -126,14 +123,6 @@ import {
   useResourceMemberships,
 } from "../hooks/useResourceMemberships";
 import { Badge } from "@/components/ui/badge";
-import {
-  AGENT_DETAIL_NAVIGATION,
-  agentDetailHref,
-  agentLegacyAuditSection,
-  agentScopedAuditHref,
-  parseAgentDetailView,
-  type AgentDetailView,
-} from "./agent-detail-navigation";
 
 const runStatusIcons: Record<string, { icon: typeof CheckCircle2; color: string }> = {
   succeeded: { icon: CheckCircle2, color: "text-green-600 dark:text-green-400" },
@@ -286,10 +275,9 @@ function scrollToContainerBottom(container: ScrollContainer, behavior: ScrollBeh
   container.scrollTo({ top: container.scrollHeight, behavior });
 }
 
-/** @deprecated Use AGENT_DETAIL_NAVIGATION for contextual navigation. */
-export const AGENT_DETAIL_TABS = AGENT_DETAIL_NAVIGATION.flatMap((section) => section.items);
+type AgentDetailView = "dashboard" | "instructions" | "configuration" | "secrets" | "skills" | "tools" | "runs" | "audit" | "budget";
 
-const LEGACY_AGENT_DETAIL_TABS = [
+export const AGENT_DETAIL_TABS: ReadonlyArray<{ value: AgentDetailView; label: string }> = [
   { value: "dashboard", label: "Dashboard" },
   { value: "instructions", label: "Instructions" },
   { value: "skills", label: "Skills" },
@@ -299,7 +287,7 @@ const LEGACY_AGENT_DETAIL_TABS = [
   { value: "runs", label: "Runs" },
   { value: "audit", label: "Audit" },
   { value: "budget", label: "Budget" },
-] as const;
+];
 
 export const DISCARD_AGENT_CONFIG_CHANGES_MESSAGE = "Discard unsaved agent configuration changes?";
 
@@ -335,7 +323,17 @@ export function restoreAgentConfigHistoryEntry(
   return true;
 }
 
-export { agentDetailHref, agentScopedAuditHref, parseAgentDetailView };
+export function parseAgentDetailView(value: string | null): AgentDetailView {
+  if (value === "instructions" || value === "prompts") return "instructions";
+  if (value === "configure" || value === "configuration") return "configuration";
+  if (value === "secrets") return "secrets";
+  if (value === "skills") return "skills";
+  if (value === "tools") return "tools";
+  if (value === "budget") return "budget";
+  if (value === "audit") return "audit";
+  if (value === "runs") return value;
+  return "dashboard";
+}
 
 function usageNumber(usage: Record<string, unknown> | null, ...keys: string[]) {
   if (!usage) return 0;
@@ -760,27 +758,12 @@ export function AgentDetail() {
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
-  const { enabled: streamlinedUiEnabled } = useStreamlinedUiEnabled();
   const [actionError, setActionError] = useState<string | null>(null);
   const [dismissedLeftAgentIds, setDismissedLeftAgentIds] = useState<Set<string>>(() => new Set());
-  const activeView: AgentDetailView = urlRunId ? "run-detail" : parseAgentDetailView(urlTab ?? null);
-  const legacyAuditSection = !urlRunId ? agentLegacyAuditSection(urlTab ?? null) : null;
-  const legacyView = urlRunId
-    ? "runs"
-    : legacyAuditSection === "runs"
-      ? "runs"
-      : legacyAuditSection === "activity"
-        ? "audit"
-        : legacyAuditSection === "costs" || legacyAuditSection === "budgets"
-          ? "budget"
-          : activeView === "overview"
-            ? "dashboard"
-            : activeView === "runtime"
-              ? "configuration"
-              : activeView;
-  const needsOverviewData = activeView === "overview";
-  const needsRunData = activeView === "run-detail";
-  const shouldLoadHeartbeats = needsOverviewData || needsRunData;
+  const activeView = urlRunId ? "runs" as AgentDetailView : parseAgentDetailView(urlTab ?? null);
+  const needsDashboardData = activeView === "dashboard";
+  const needsRunData = activeView === "runs" || Boolean(urlRunId);
+  const shouldLoadHeartbeats = needsDashboardData || needsRunData;
   const [configDirty, setConfigDirty] = useState(false);
   const [configSaving, setConfigSaving] = useState(false);
   const saveConfigActionRef = useRef<(() => void) | null>(null);
@@ -799,6 +782,7 @@ export function AgentDetail() {
   const prepareAgentNavigation = useCallback(() => {
     return confirmAgentConfigNavigation(configDirty);
   }, [configDirty]);
+
   const { data: agent, isLoading, error } = useQuery<AgentDetailRecord>({
     queryKey: [...queryKeys.agents.detail(routeAgentRef), lookupCompanyId ?? null],
     queryFn: () => agentsApi.get(routeAgentRef, lookupCompanyId),
@@ -806,20 +790,8 @@ export function AgentDetail() {
   });
   const resolvedCompanyId = agent?.companyId ?? selectedCompanyId;
   const canonicalAgentRef = agent ? agentRouteRef(agent) : routeAgentRef;
-  const handleLegacyTabChange = useCallback((next: string) => {
-    if (!prepareAgentNavigation()) return;
-    navigate(`/agents/${canonicalAgentRef || routeAgentRef}/${next}`);
-  }, [canonicalAgentRef, navigate, prepareAgentNavigation, routeAgentRef]);
   const agentLookupRef = agent?.id ?? routeAgentRef;
   const resolvedAgentId = agent?.id ?? null;
-  const { data: boardAccess } = useQuery({
-    queryKey: queryKeys.access.currentBoardAccess,
-    queryFn: () => accessApi.getCurrentBoardAccess(),
-    retry: false,
-  });
-  const canUseProviderTrace =
-    boardAccess?.source === "local_implicit" ||
-    boardAccess?.isInstanceAdmin === true;
   const membershipsQuery = useResourceMemberships(resolvedCompanyId);
   const membershipMutation = useResourceMembershipMutation(resolvedCompanyId);
   const agentMembershipState = resolvedAgentId
@@ -903,7 +875,7 @@ export function AgentDetail() {
   const { data: runtimeState } = useQuery({
     queryKey: queryKeys.agents.runtimeState(resolvedAgentId ?? routeAgentRef),
     queryFn: () => agentsApi.runtimeState(resolvedAgentId!, resolvedCompanyId ?? undefined),
-    enabled: Boolean(resolvedAgentId) && needsOverviewData,
+    enabled: Boolean(resolvedAgentId) && needsDashboardData,
   });
 
   const { data: heartbeats } = useQuery({
@@ -915,37 +887,58 @@ export function AgentDetail() {
   const { data: allIssues } = useQuery({
     queryKey: [...queryKeys.issues.list(resolvedCompanyId!), "participant-agent", resolvedAgentId ?? "__none__"],
     queryFn: () => issuesApi.list(resolvedCompanyId!, { participantAgentId: resolvedAgentId! }),
-    enabled: !!resolvedCompanyId && !!resolvedAgentId && needsOverviewData,
+    enabled: !!resolvedCompanyId && !!resolvedAgentId && needsDashboardData,
   });
 
   const { data: allAgents } = useQuery({
     queryKey: queryKeys.agents.list(resolvedCompanyId!),
     queryFn: () => agentsApi.list(resolvedCompanyId!),
-    enabled: !!resolvedCompanyId && needsOverviewData,
+    enabled: !!resolvedCompanyId && needsDashboardData,
   });
 
-  const { data: skillSnapshot } = useQuery({
-    queryKey: queryKeys.agents.skills(resolvedAgentId ?? "__none__"),
-    queryFn: () => agentsApi.skills(resolvedAgentId!, resolvedCompanyId ?? undefined),
-    enabled: Boolean(resolvedCompanyId && resolvedAgentId && needsOverviewData),
+  const { data: budgetOverview } = useQuery({
+    queryKey: queryKeys.budgets.overview(resolvedCompanyId ?? "__none__"),
+    queryFn: () => budgetsApi.overview(resolvedCompanyId!),
+    enabled: !!resolvedCompanyId,
+    refetchInterval: 30_000,
+    staleTime: 5_000,
   });
 
-  const { data: overviewCompanySkills } = useQuery({
-    queryKey: queryKeys.companySkills.list(resolvedCompanyId ?? "__none__"),
-    queryFn: () => companySkillsApi.list(resolvedCompanyId!),
-    enabled: Boolean(resolvedCompanyId && needsOverviewData),
-  });
-
-  const assignedIssues = useMemo(
-    () => [...(allIssues ?? [])].sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()),
-    [allIssues],
-  );
+  const assignedIssues = (allIssues ?? [])
+    .sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
   const reportsToAgent = (allAgents ?? []).find((a) => a.id === agent?.reportsTo);
   const directReports = (allAgents ?? []).filter((a) => a.reportsTo === agent?.id && a.status !== "terminated");
-  const overviewSkillNames = useMemo(() => {
-    const namesByKey = new Map((overviewCompanySkills ?? []).map((skill) => [skill.key, skill.name]));
-    return (skillSnapshot?.desiredSkills ?? []).map((key) => namesByKey.get(key) ?? key);
-  }, [overviewCompanySkills, skillSnapshot?.desiredSkills]);
+  const agentBudgetSummary = useMemo(() => {
+    const matched = budgetOverview?.policies.find(
+      (policy) => policy.scopeType === "agent" && policy.scopeId === (agent?.id ?? routeAgentRef),
+    );
+    if (matched) return matched;
+    const budgetMonthlyCents = agent?.budgetMonthlyCents ?? 0;
+    const spentMonthlyCents = agent?.spentMonthlyCents ?? 0;
+    return {
+      policyId: "",
+      companyId: resolvedCompanyId ?? "",
+      scopeType: "agent",
+      scopeId: agent?.id ?? routeAgentRef,
+      scopeName: agent?.name ?? "Agent",
+      metric: "billed_cents",
+      windowKind: "calendar_month_utc",
+      amount: budgetMonthlyCents,
+      observedAmount: spentMonthlyCents,
+      remainingAmount: Math.max(0, budgetMonthlyCents - spentMonthlyCents),
+      utilizationPercent:
+        budgetMonthlyCents > 0 ? Number(((spentMonthlyCents / budgetMonthlyCents) * 100).toFixed(2)) : 0,
+      warnPercent: 80,
+      hardStopEnabled: true,
+      notifyEnabled: true,
+      isActive: budgetMonthlyCents > 0,
+      status: budgetMonthlyCents > 0 && spentMonthlyCents >= budgetMonthlyCents ? "hard_stop" : "ok",
+      paused: agent?.status === "paused",
+      pauseReason: agent?.pauseReason ?? null,
+      windowStart: new Date(),
+      windowEnd: new Date(),
+    } satisfies BudgetPolicySummary;
+  }, [agent, budgetOverview?.policies, resolvedCompanyId, routeAgentRef]);
   const mobileLiveRun = useMemo(
     () => (heartbeats ?? []).find((r) => r.status === "running" || r.status === "queued") ?? null,
     [heartbeats],
@@ -959,19 +952,29 @@ export function AgentDetail() {
       }
       return;
     }
-    if (!streamlinedUiEnabled) {
-      if (routeAgentRef !== canonicalAgentRef) {
-        navigate(`/agents/${canonicalAgentRef}/${urlTab ?? "dashboard"}`, { replace: true });
-      }
-      return;
-    }
-    if (legacyAuditSection) return;
-    const canonicalTab = activeView === "run-detail" ? "overview" : activeView;
+    const canonicalTab =
+      activeView === "instructions"
+        ? "instructions"
+        : activeView === "configuration"
+          ? "configuration"
+          : activeView === "secrets"
+            ? "secrets"
+            : activeView === "skills"
+              ? "skills"
+              : activeView === "tools"
+                ? "tools"
+                : activeView === "runs"
+                  ? "runs"
+                  : activeView === "audit"
+                    ? "audit"
+                    : activeView === "budget"
+                      ? "budget"
+                      : "dashboard";
     if (routeAgentRef !== canonicalAgentRef || urlTab !== canonicalTab) {
-      navigate(agentDetailHref(canonicalAgentRef, canonicalTab), { replace: true });
+      navigate(`/agents/${canonicalAgentRef}/${canonicalTab}`, { replace: true });
       return;
     }
-  }, [agent, routeAgentRef, canonicalAgentRef, urlRunId, urlTab, activeView, legacyAuditSection, navigate, streamlinedUiEnabled]);
+  }, [agent, routeAgentRef, canonicalAgentRef, urlRunId, urlTab, activeView, navigate]);
 
   useEffect(() => {
     if (!agent?.companyId || agent.companyId === selectedCompanyId) return;
@@ -1003,6 +1006,24 @@ export function AgentDetail() {
     },
     onError: (err) => {
       setActionError(err instanceof Error ? err.message : "Action failed");
+    },
+  });
+
+  const budgetMutation = useMutation({
+    mutationFn: (amount: number) =>
+      budgetsApi.upsertPolicy(resolvedCompanyId!, {
+        scopeType: "agent",
+        scopeId: agent?.id ?? routeAgentRef,
+        amount,
+        windowKind: "calendar_month_utc",
+      }),
+    onSuccess: () => {
+      if (!resolvedCompanyId) return;
+      queryClient.invalidateQueries({ queryKey: queryKeys.budgets.overview(resolvedCompanyId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(routeAgentRef) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agentLookupRef) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.agents.list(resolvedCompanyId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.dashboard(resolvedCompanyId) });
     },
   });
 
@@ -1038,18 +1059,29 @@ export function AgentDetail() {
       { label: "Agents", href: "/agents" },
     ];
     const agentName = agent?.name ?? routeAgentRef ?? "Agent";
-    if (activeView === "overview" && !urlRunId) {
+    if (activeView === "dashboard" && !urlRunId) {
       crumbs.push({ label: agentName });
     } else {
-      crumbs.push({ label: agentName, href: agentDetailHref(canonicalAgentRef) });
+      crumbs.push({ label: agentName, href: `/agents/${canonicalAgentRef}/dashboard` });
       if (urlRunId) {
-        crumbs.push({ label: "Runs", href: agent?.id ? agentScopedAuditHref(agent.id, "runs") : undefined });
+        crumbs.push({ label: "Runs", href: `/agents/${canonicalAgentRef}/runs` });
         crumbs.push({ label: `Run ${urlRunId.slice(0, 8)}` });
+      } else if (activeView === "instructions") {
+        crumbs.push({ label: "Instructions" });
+      } else if (activeView === "configuration") {
+        crumbs.push({ label: "Configuration" });
+      } else if (activeView === "secrets") {
+        crumbs.push({ label: "Secrets" });
+      // } else if (activeView === "skills") { // TODO: bring back later
+      //   crumbs.push({ label: "Skills" });
+      } else if (activeView === "tools") {
+        crumbs.push({ label: "Tools" });
+      } else if (activeView === "runs") {
+        crumbs.push({ label: "Runs" });
+      } else if (activeView === "budget") {
+        crumbs.push({ label: "Budget" });
       } else {
-        const item = AGENT_DETAIL_NAVIGATION
-          .flatMap((section) => section.items)
-          .find((candidate) => candidate.value === activeView);
-        crumbs.push({ label: item?.label ?? "Overview" });
+        crumbs.push({ label: "Dashboard" });
       }
     }
     setBreadcrumbs(crumbs);
@@ -1149,17 +1181,14 @@ export function AgentDetail() {
   if (isLoading) return <PageSkeleton variant="detail" />;
   if (error) return <p className="text-sm text-destructive">{error.message}</p>;
   if (!agent) return null;
-  if (streamlinedUiEnabled && !urlRunId && legacyAuditSection) {
-    return <Navigate to={agentScopedAuditHref(agent.id, legacyAuditSection)} replace />;
-  }
   if (!urlRunId && !urlTab) {
-    return <Navigate to={streamlinedUiEnabled ? agentDetailHref(canonicalAgentRef) : `/agents/${canonicalAgentRef}/dashboard`} replace />;
+    return <Navigate to={`/agents/${canonicalAgentRef}/dashboard`} replace />;
   }
   const isPendingApproval = agent.status === "pending_approval";
   const hasInvalidOrgChain = agent.orgChainHealth?.status === "invalid_org_chain";
   const pausedEscalationWarning = !hasInvalidOrgChain ? agent.orgChainHealth?.escalationWarning ?? null : null;
   const showConfigActionBar = (
-    activeView === "runtime" || activeView === "instructions" || activeView === "secrets"
+    activeView === "configuration" || activeView === "instructions" || activeView === "secrets"
   ) && (configDirty || configSaving);
   const showLeftAgentNotice = agentMembershipState === "left" && !dismissedLeftAgentIds.has(agent.id);
   const agentMembershipPending =
@@ -1169,6 +1198,11 @@ export function AgentDetail() {
   const agentStarred = isStarred(membershipsQuery.data, "agent", agent.id);
   const agentStarPending = agentMembershipPending && membershipMutation.variables?.starred !== undefined;
   const agentJoinLeavePending = agentMembershipPending && membershipMutation.variables?.starred === undefined;
+
+  function handleAgentTabChange(value: string) {
+    if (value === activeView || !prepareAgentNavigation()) return;
+    navigate(`/agents/${canonicalAgentRef}/${value}`);
+  }
 
   return (
     <div className={cn("space-y-6", isMobile && showConfigActionBar && "pb-24")}>
@@ -1248,7 +1282,7 @@ export function AgentDetail() {
             </button>
           </AgentIconPicker>
           <div className="min-w-0">
-            <div className="flex flex-wrap items-center justify-end gap-2">
+            <div className="flex items-center gap-2">
               <h2 className="text-2xl font-bold truncate">{agent.name}</h2>
             </div>
             <p className="text-sm text-muted-foreground truncate">
@@ -1275,7 +1309,6 @@ export function AgentDetail() {
             companyId={resolvedCompanyId}
             assignLabel="Assign Task"
             runLabel="Run Heartbeat"
-            canRunWithProviderTrace={canUseProviderTrace}
             actionsDisabled={agentAction.isPending}
             workActionsDisabled={hasInvalidOrgChain}
             workActionsDisabledReason="Repair this agent's reporting chain before assigning tasks or starting runs"
@@ -1363,15 +1396,18 @@ export function AgentDetail() {
         />
       )}
 
-      {!streamlinedUiEnabled && !urlRunId ? (
-        <Tabs value={legacyView} onValueChange={handleLegacyTabChange}>
+      {!urlRunId && (
+        <Tabs
+          value={activeView}
+          onValueChange={handleAgentTabChange}
+        >
           <PageTabBar
-            items={LEGACY_AGENT_DETAIL_TABS}
-            value={legacyView}
-            onValueChange={handleLegacyTabChange}
+            items={AGENT_DETAIL_TABS}
+            value={activeView}
+            onValueChange={handleAgentTabChange}
           />
         </Tabs>
-      ) : null}
+      )}
 
       {actionError && <p className="text-sm text-destructive">{actionError}</p>}
       {isPendingApproval && (
@@ -1439,15 +1475,13 @@ export function AgentDetail() {
       )}
 
       {/* View content */}
-      {activeView === "overview" && (streamlinedUiEnabled || !legacyAuditSection) && (
+      {activeView === "dashboard" && (
         <AgentOverview
           agent={agent}
           runs={heartbeats ?? []}
           assignedIssues={assignedIssues}
           runtimeState={runtimeState}
-          reportsToAgent={reportsToAgent}
-          directReportCount={directReports.length}
-          skillNames={overviewSkillNames}
+          agentId={agent.id}
           agentRouteId={canonicalAgentRef}
         />
       )}
@@ -1463,22 +1497,17 @@ export function AgentDetail() {
         />
       )}
 
-      {activeView === "runtime" && (
-        <div className="max-w-3xl">
-          <ConfigurationTab
-            agent={agent}
-            companyId={resolvedCompanyId ?? undefined}
-            onDirtyChange={setConfigDirty}
-            onSaveActionChange={setSaveConfigAction}
-            onCancelActionChange={setCancelConfigAction}
-            onSavingChange={setConfigSaving}
-            updatePermissions={updatePermissions}
-            canConfigureProviderTrace={canUseProviderTrace}
-            content="runtime"
-            hidePromptTemplate
-            hideInstructionsFile
-          />
-        </div>
+      {activeView === "configuration" && (
+        <AgentConfigurePage
+          agent={agent}
+          agentId={agent.id}
+          companyId={resolvedCompanyId ?? undefined}
+          onDirtyChange={setConfigDirty}
+          onSaveActionChange={setSaveConfigAction}
+          onCancelActionChange={setCancelConfigAction}
+          onSavingChange={setConfigSaving}
+          updatePermissions={updatePermissions}
+        />
       )}
 
       {activeView === "secrets" && (
@@ -1507,32 +1536,7 @@ export function AgentDetail() {
         <AgentToolsTab agent={agent} companyId={resolvedCompanyId} />
       )}
 
-      {activeView === "permissions" && (
-        <div className="max-w-3xl">
-          <ConfigurationTab
-            agent={agent}
-            companyId={resolvedCompanyId ?? undefined}
-            onDirtyChange={setConfigDirty}
-            onSaveActionChange={setSaveConfigAction}
-            onCancelActionChange={setCancelConfigAction}
-            onSavingChange={setConfigSaving}
-            updatePermissions={updatePermissions}
-            content="permissions"
-          />
-        </div>
-      )}
-
-      {activeView === "api-keys" && (
-        <div className="max-w-3xl">
-          <KeysTab agentId={agent.id} companyId={resolvedCompanyId ?? undefined} />
-        </div>
-      )}
-
-      {activeView === "revisions" && (
-        <AgentRevisionsTab agent={agent} companyId={resolvedCompanyId ?? undefined} />
-      )}
-
-      {activeView === "run-detail" && (
+      {activeView === "runs" && (
         <RunsTab
           runs={heartbeats ?? []}
           companyId={resolvedCompanyId!}
@@ -1544,31 +1548,18 @@ export function AgentDetail() {
         />
       )}
 
-      {!streamlinedUiEnabled && legacyAuditSection === "runs" && (
-        <RunsTab
-          runs={heartbeats ?? []}
-          companyId={resolvedCompanyId!}
-          agentId={agent.id}
-          agentRouteId={canonicalAgentRef}
-          selectedRunId={null}
-          adapterType={agent.adapterType}
-          adapterConfig={agent.adapterConfig}
-        />
-      )}
-
-      {!streamlinedUiEnabled && legacyAuditSection === "activity" && resolvedCompanyId ? (
-        <AuditFeed companyId={resolvedCompanyId} lockedAgentId={agent.id} />
+      {activeView === "audit" && resolvedCompanyId ? (
+        <AuditFeed companyId={resolvedCompanyId} lockedAgentId={agent.id} hideHeader />
       ) : null}
 
-      {!streamlinedUiEnabled && (legacyAuditSection === "costs" || legacyAuditSection === "budgets") ? (
-        <div className="space-y-3">
-          <h3 className="text-lg font-semibold">Agent budget</h3>
-          <p className="text-sm text-muted-foreground">
-            Review this agent&apos;s budget policy and spend in the organization costs view.
-          </p>
-          <Button variant="outline" asChild>
-            <Link to="/costs">Open costs and budgets</Link>
-          </Button>
+      {activeView === "budget" && resolvedCompanyId ? (
+        <div className="max-w-3xl">
+          <BudgetPolicyCard
+            summary={agentBudgetSummary}
+            isSaving={budgetMutation.isPending}
+            onSave={(amount) => budgetMutation.mutate(amount)}
+            variant="plain"
+          />
         </div>
       ) : null}
     </div>
@@ -1765,25 +1756,21 @@ function LatestRunCard({
   );
 }
 
-/* ---- Agent Overview ---- */
+/* ---- Agent Overview (main single-page view) ---- */
 
-export function AgentOverview({
+function AgentOverview({
   agent,
   runs,
   assignedIssues,
   runtimeState,
-  reportsToAgent,
-  directReportCount,
-  skillNames,
+  agentId,
   agentRouteId,
 }: {
   agent: AgentDetailRecord;
   runs: HeartbeatRun[];
-  assignedIssues: Issue[];
+  assignedIssues: { id: string; title: string; status: string; priority: string; identifier?: string | null; createdAt: Date }[];
   runtimeState?: AgentRuntimeState;
-  reportsToAgent?: Agent;
-  directReportCount: number;
-  skillNames: string[];
+  agentId: string;
   agentRouteId: string;
 }) {
   const issuesById = useMemo(() => {
@@ -1791,81 +1778,37 @@ export function AgentOverview({
     for (const issue of assignedIssues) map.set(issue.id, issue);
     return map;
   }, [assignedIssues]);
-  const configuredModel = asNonEmptyString(agent.adapterConfig?.model)
-    ?? asNonEmptyString(agent.adapterConfig?.modelName)
-    ?? asNonEmptyString(agent.runtimeConfig?.model)
-    ?? "Adapter default";
-  const lastRun = runs[0] ?? null;
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-8">
+      {/* Latest Run */}
       <LatestRunCard runs={runs} agentId={agentRouteId} issuesById={issuesById} />
 
-      <div className="grid gap-4 md:grid-cols-2">
-        <section className="rounded-lg border border-border p-4" aria-labelledby="agent-identity-heading">
-          <div className="mb-4 flex items-center justify-between gap-3">
-            <h3 id="agent-identity-heading" className="text-sm font-medium">Identity</h3>
-            <StatusBadge status={agent.status} />
-          </div>
-          <div className="space-y-3">
-            <SummaryRow label="Role"><span className="text-sm">{roleLabels[agent.role] ?? agent.role}</span></SummaryRow>
-            <SummaryRow label="Title"><span className="text-sm">{agent.title ?? "Not set"}</span></SummaryRow>
-            <SummaryRow label="Reports to">
-              {reportsToAgent ? (
-                <Link className="text-sm hover:underline" to={agentDetailHref(agentRouteRef(reportsToAgent))}>
-                  {reportsToAgent.name}
-                </Link>
-              ) : <span className="text-sm">Board</span>}
-            </SummaryRow>
-            <SummaryRow label="Direct reports"><span className="text-sm tabular-nums">{directReportCount}</span></SummaryRow>
-          </div>
-        </section>
-
-        <section className="rounded-lg border border-border p-4" aria-labelledby="agent-runtime-heading">
-          <div className="mb-4 flex items-center justify-between gap-3">
-            <h3 id="agent-runtime-heading" className="text-sm font-medium">Harness / Runtime</h3>
-            <Link className="text-xs text-muted-foreground hover:text-foreground" to={agentDetailHref(agentRouteId, "runtime")}>Configure</Link>
-          </div>
-          <div className="space-y-3">
-            <SummaryRow label="Adapter"><span className="text-sm">{adapterLabels[agent.adapterType] ?? agent.adapterType}</span></SummaryRow>
-            <SummaryRow label="Model"><span className="max-w-64 truncate text-sm font-mono">{configuredModel}</span></SummaryRow>
-            <SummaryRow label="Session"><span className="max-w-64 truncate text-sm font-mono">{runtimeState?.sessionDisplayId ?? runtimeState?.sessionId ?? "No session"}</span></SummaryRow>
-            <SummaryRow label="Last run">
-              <span className="text-sm">{lastRun ? `${lastRun.status} · ${relativeTime(lastRun.createdAt)}` : "No runs"}</span>
-            </SummaryRow>
-          </div>
-        </section>
-
-        <section className="rounded-lg border border-border p-4" aria-labelledby="agent-capabilities-heading">
-          <h3 id="agent-capabilities-heading" className="mb-3 text-sm font-medium">Capabilities</h3>
-          {agent.capabilities?.trim() ? (
-            <MarkdownBody className="text-sm [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">{agent.capabilities}</MarkdownBody>
-          ) : (
-            <p className="text-sm text-muted-foreground">No capability summary has been added.</p>
-          )}
-        </section>
-
-        <section className="rounded-lg border border-border p-4" aria-labelledby="agent-skills-heading">
-          <div className="mb-3 flex items-center justify-between gap-3">
-            <h3 id="agent-skills-heading" className="text-sm font-medium">Skills</h3>
-            <Link className="text-xs text-muted-foreground hover:text-foreground" to={agentDetailHref(agentRouteId, "skills")}>Manage</Link>
-          </div>
-          {skillNames.length > 0 ? (
-            <div className="flex flex-wrap gap-2">
-              {skillNames.slice(0, 8).map((skill) => <Badge key={skill} variant="secondary">{skill}</Badge>)}
-              {skillNames.length > 8 ? <Badge variant="outline">+{skillNames.length - 8} more</Badge> : null}
-            </div>
-          ) : (
-            <p className="text-sm text-muted-foreground">No skills enabled.</p>
-          )}
-        </section>
+      {/* Charts */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <ChartCard title="Run Activity" subtitle="Last 14 days">
+          <RunActivityChart runs={runs} />
+        </ChartCard>
+        {/* PAP-411: "Tasks by Priority" chart hidden behind SHOW_TASK_PRIORITY_UI. */}
+        {SHOW_TASK_PRIORITY_UI && (
+          <ChartCard title="Tasks by Priority" subtitle="Last 14 days">
+            <PriorityChart issues={assignedIssues} />
+          </ChartCard>
+        )}
+        <ChartCard title="Tasks by Status" subtitle="Last 14 days">
+          <IssueStatusChart issues={assignedIssues} />
+        </ChartCard>
+        <ChartCard title="Success Rate" subtitle="Last 14 days">
+          <SuccessRateChart runs={runs} />
+        </ChartCard>
       </div>
 
-      <section className="space-y-3" aria-labelledby="agent-recent-tasks-heading">
+      {/* Recent Issues */}
+      <div className="space-y-3">
         <div className="flex items-center justify-between">
-          <h3 id="agent-recent-tasks-heading" className="text-sm font-medium">Recent Tasks</h3>
+          <h3 className="text-sm font-medium">Recent Tasks</h3>
           <Link
-            to={`/issues?participantAgentId=${agent.id}`}
+            to={`/issues?participantAgentId=${agentId}`}
             className="text-xs text-muted-foreground hover:text-foreground transition-colors"
           >
             See All &rarr;
@@ -1874,39 +1817,108 @@ export function AgentOverview({
         {assignedIssues.length === 0 ? (
           <p className="text-sm text-muted-foreground">No recent tasks.</p>
         ) : (
-          <div className="overflow-hidden rounded-lg border border-border">
-            {assignedIssues.slice(0, 6).map((issue) => (
-              <IssueRow
+          <div className="border border-border rounded-lg">
+            {assignedIssues.slice(0, 10).map((issue) => (
+              <EntityRow
                 key={issue.id}
-                issue={issue}
-                presentation="task"
-                metadata={<span className="text-xs text-muted-foreground">{relativeTime(issue.updatedAt)}</span>}
-                showDivider
+                identifier={issue.identifier ?? issue.id.slice(0, 8)}
+                title={issue.title}
+                to={`/issues/${issue.identifier ?? issue.id}`}
+                trailing={<StatusBadge status={issue.status} />}
               />
             ))}
-            {assignedIssues.length > 6 && (
-              <div className="border-t border-border px-3 py-2 text-center text-xs text-muted-foreground">
-                +{assignedIssues.length - 6} more tasks
+            {assignedIssues.length > 10 && (
+              <div className="px-3 py-2 text-xs text-muted-foreground text-center border-t border-border">
+                +{assignedIssues.length - 10} more tasks
               </div>
             )}
           </div>
         )}
-      </section>
+      </div>
 
-      <section className="space-y-3" aria-labelledby="agent-audit-links-heading">
-        <h3 id="agent-audit-links-heading" className="text-sm font-medium">Audit</h3>
-        <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
-          {(["activity", "runs", "costs", "budgets"] as const).map((section) => (
-            <Link
-              key={section}
-              to={agentScopedAuditHref(agent.id, section)}
-              className="rounded-lg border border-border px-3 py-2 text-sm font-medium capitalize hover:bg-accent"
-            >
-              {section}
-            </Link>
-          ))}
+      {/* Costs */}
+      <div className="space-y-3">
+        <h3 className="text-sm font-medium">Costs</h3>
+        <CostsSection runtimeState={runtimeState} runs={runs} />
+      </div>
+    </div>
+  );
+}
+
+/* ---- Costs Section (inline) ---- */
+
+function CostsSection({
+  runtimeState,
+  runs,
+}: {
+  runtimeState?: AgentRuntimeState;
+  runs: HeartbeatRun[];
+}) {
+  const runsWithCost = runs
+    .filter((r) => {
+      const metrics = runMetrics(r);
+      return metrics.cost > 0 || metrics.input > 0 || metrics.output > 0 || metrics.cached > 0;
+    })
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+
+  return (
+    <div className="space-y-4">
+      {runtimeState && (
+        <div className="border border-border rounded-lg p-4">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 tabular-nums">
+            <div>
+              <span className="text-xs text-muted-foreground block">Input tokens</span>
+              <span className="text-lg font-semibold">{formatTokens(runtimeState.totalInputTokens)}</span>
+            </div>
+            <div>
+              <span className="text-xs text-muted-foreground block">Output tokens</span>
+              <span className="text-lg font-semibold">{formatTokens(runtimeState.totalOutputTokens)}</span>
+            </div>
+            <div>
+              <span className="text-xs text-muted-foreground block">Cached tokens</span>
+              <span className="text-lg font-semibold">{formatTokens(runtimeState.totalCachedInputTokens)}</span>
+            </div>
+            <div>
+              <span className="text-xs text-muted-foreground block">Total cost</span>
+              <span className="text-lg font-semibold">{formatCents(runtimeState.totalCostCents)}</span>
+            </div>
+          </div>
         </div>
-      </section>
+      )}
+      {runsWithCost.length > 0 && (
+        <div className="border border-border rounded-lg overflow-hidden">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b border-border bg-accent/20">
+                <th scope="col" className="text-left px-3 py-2 font-medium text-muted-foreground">Date</th>
+                <th scope="col" className="text-left px-3 py-2 font-medium text-muted-foreground">Run</th>
+                <th scope="col" className="text-right px-3 py-2 font-medium text-muted-foreground">Input</th>
+                <th scope="col" className="text-right px-3 py-2 font-medium text-muted-foreground">Output</th>
+                <th scope="col" className="text-right px-3 py-2 font-medium text-muted-foreground">Cost</th>
+              </tr>
+            </thead>
+            <tbody>
+              {runsWithCost.slice(0, 10).map((run) => {
+                const metrics = runMetrics(run);
+                return (
+                  <tr key={run.id} className="border-b border-border last:border-b-0">
+                    <td className="px-3 py-2">{formatDate(run.createdAt)}</td>
+                    <td className="px-3 py-2 font-mono">{run.id.slice(0, 8)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums">{formatTokens(metrics.input)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums">{formatTokens(metrics.output)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums">
+                      {metrics.cost > 0
+                        ? `$${metrics.cost.toFixed(4)}`
+                        : "-"
+                      }
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }
@@ -1936,15 +1948,29 @@ export function syncAgentRouteAfterRename(
   return true;
 }
 
-function AgentRevisionsTab({
+function AgentConfigurePage({
   agent,
+  agentId,
   companyId,
+  onDirtyChange,
+  onSaveActionChange,
+  onCancelActionChange,
+  onSavingChange,
+  updatePermissions,
 }: {
   agent: AgentDetailRecord;
+  agentId: string;
   companyId?: string;
+  onDirtyChange: (dirty: boolean) => void;
+  onSaveActionChange: (save: (() => void) | null) => void;
+  onCancelActionChange: (cancel: (() => void) | null) => void;
+  onSavingChange: (saving: boolean) => void;
+  updatePermissions: { mutate: (permissions: AgentPermissionUpdate) => void; isPending: boolean };
 }) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const { tab: urlTab } = useParams<{ tab?: string }>();
+  const [revisionsOpen, setRevisionsOpen] = useState(false);
 
   const { data: configRevisions } = useQuery({
     queryKey: queryKeys.agents.configRevisions(agent.id),
@@ -1956,48 +1982,80 @@ function AgentRevisionsTab({
     onSuccess: (updated) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agent.id) });
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.configRevisions(agent.id) });
-      if (!syncAgentRouteAfterRename(queryClient, navigate, agent, updated, "revisions")) {
+      if (!syncAgentRouteAfterRename(queryClient, navigate, agent, updated, urlTab ?? "configuration")) {
         queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agent.urlKey) });
       }
     },
   });
 
   return (
-    <div className="max-w-3xl space-y-3">
-      <div className="flex items-baseline justify-between gap-3">
-        <h3 className="text-sm font-medium">Configuration Revisions</h3>
-        <span className="text-xs text-muted-foreground">{configRevisions?.length ?? 0} total</span>
+    <div className="max-w-3xl space-y-6">
+      <ConfigurationTab
+        agent={agent}
+        onDirtyChange={onDirtyChange}
+        onSaveActionChange={onSaveActionChange}
+        onCancelActionChange={onCancelActionChange}
+        onSavingChange={onSavingChange}
+        updatePermissions={updatePermissions}
+        companyId={companyId}
+        hidePromptTemplate
+        hideInstructionsFile
+      />
+      <div>
+        <h3 className="text-sm font-medium mb-3">API Keys</h3>
+        <KeysTab agentId={agentId} companyId={companyId} />
       </div>
-      {(configRevisions ?? []).length === 0 ? (
-        <p className="text-sm text-muted-foreground">No configuration revisions yet.</p>
-      ) : (
-        <div className="space-y-2">
-          {(configRevisions ?? []).map((revision) => (
-            <div key={revision.id} className="space-y-2 rounded-md border border-border p-3">
-              <div className="flex items-center justify-between gap-3">
-                <div className="text-xs text-muted-foreground">
-                  <span className="font-mono">{revision.id.slice(0, 8)}</span>
-                  <span className="mx-1">·</span>
-                  <span>{formatDate(revision.createdAt)}</span>
-                  <span className="mx-1">·</span>
-                  <span>{revision.source}</span>
-                </div>
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={() => rollbackConfig.mutate(revision.id)}
-                  disabled={rollbackConfig.isPending}
-                >
-                  Restore
-                </Button>
+
+      {/* Configuration Revisions — collapsible at the bottom */}
+      <div>
+        <button
+          className="flex items-center gap-2 text-sm font-medium hover:text-foreground transition-colors"
+          onClick={() => setRevisionsOpen((v) => !v)}
+        >
+          {revisionsOpen
+            ? <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+            : <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+          }
+          Configuration Revisions
+          <span className="text-xs font-normal text-muted-foreground">{configRevisions?.length ?? 0}</span>
+        </button>
+        {revisionsOpen && (
+          <div className="mt-3">
+            {(configRevisions ?? []).length === 0 ? (
+              <p className="text-sm text-muted-foreground">No configuration revisions yet.</p>
+            ) : (
+              <div className="space-y-2">
+                {(configRevisions ?? []).slice(0, 10).map((revision) => (
+                  <div key={revision.id} className="border border-border/70 rounded-md p-3 space-y-2">
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="text-xs text-muted-foreground">
+                        <span className="font-mono">{revision.id.slice(0, 8)}</span>
+                        <span className="mx-1">·</span>
+                        <span>{formatDate(revision.createdAt)}</span>
+                        <span className="mx-1">·</span>
+                        <span>{revision.source}</span>
+                      </div>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-7 px-2.5 text-xs"
+                        onClick={() => rollbackConfig.mutate(revision.id)}
+                        disabled={rollbackConfig.isPending}
+                      >
+                        Restore
+                      </Button>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Changed:{" "}
+                      {revision.changedKeys.length > 0 ? revision.changedKeys.join(", ") : "no tracked changes"}
+                    </p>
+                  </div>
+                ))}
               </div>
-              <p className="text-xs text-muted-foreground">
-                Changed: {revision.changedKeys.length > 0 ? revision.changedKeys.join(", ") : "no tracked changes"}
-              </p>
-            </div>
-          ))}
-        </div>
-      )}
+            )}
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -2014,8 +2072,7 @@ function ConfigurationTab({
   updatePermissions,
   hidePromptTemplate,
   hideInstructionsFile,
-  content = "runtime",
-  canConfigureProviderTrace = false,
+  content = "configuration",
 }: {
   agent: AgentDetailRecord;
   companyId?: string;
@@ -2026,8 +2083,7 @@ function ConfigurationTab({
   updatePermissions: { mutate: (permissions: AgentPermissionUpdate) => void; isPending: boolean };
   hidePromptTemplate?: boolean;
   hideInstructionsFile?: boolean;
-  content?: "runtime" | "permissions" | "secrets";
-  canConfigureProviderTrace?: boolean;
+  content?: "configuration" | "secrets";
 }) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
@@ -2042,7 +2098,7 @@ function ConfigurationTab({
         ? queryKeys.agents.adapterModels(companyId, agent.adapterType)
         : ["agents", "none", "adapter-models", agent.adapterType],
     queryFn: () => agentsApi.adapterModels(companyId!, agent.adapterType),
-    enabled: Boolean(companyId) && content === "runtime",
+    enabled: Boolean(companyId) && content === "configuration",
   });
 
   const lowTrustSelected = getTrustPreset(agent.permissions) === "low_trust_review";
@@ -2050,7 +2106,7 @@ function ConfigurationTab({
   const { data: boundaryProjects, isLoading: boundaryProjectsLoading } = useQuery({
     queryKey: companyId ? queryKeys.projects.list(companyId) : ["projects", "__low-trust-disabled"],
     queryFn: () => projectsApi.list(companyId!),
-    enabled: Boolean(companyId && lowTrustSelected) && content === "permissions",
+    enabled: Boolean(companyId && lowTrustSelected) && content === "configuration",
   });
 
   const { data: boundaryIssues, isLoading: boundaryIssuesLoading } = useQuery({
@@ -2058,7 +2114,7 @@ function ConfigurationTab({
       ? [...queryKeys.issues.list(companyId), "low-trust-boundary-candidates"]
       : ["issues", "__low-trust-disabled"],
     queryFn: () => issuesApi.list(companyId!, { limit: 100, sortField: "updated", sortDir: "desc" }),
-    enabled: Boolean(companyId && lowTrustSelected) && content === "permissions",
+    enabled: Boolean(companyId && lowTrustSelected) && content === "configuration",
   });
 
   const updateAgent = useMutation({
@@ -2093,18 +2149,11 @@ function ConfigurationTab({
     }
     lastAgentRef.current = agent;
   }, [agent, awaitingRefreshAfterSave]);
-  const isConfigSaving = content !== "permissions" && (updateAgent.isPending || awaitingRefreshAfterSave);
+  const isConfigSaving = updateAgent.isPending || awaitingRefreshAfterSave;
 
   useEffect(() => {
     onSavingChange(isConfigSaving);
   }, [onSavingChange, isConfigSaving]);
-
-  useEffect(() => {
-    if (content !== "permissions") return;
-    onDirtyChange(false);
-    onSaveActionChange(null);
-    onCancelActionChange(null);
-  }, [content, onCancelActionChange, onDirtyChange, onSaveActionChange]);
 
   const canCreateAgents = Boolean(agent.permissions?.canCreateAgents);
   const canCreateSkills = agent.permissions?.canCreateSkills !== false;
@@ -2117,14 +2166,14 @@ function ConfigurationTab({
       : taskAssignSource === "agent_creator"
         ? "Enabled automatically while this agent can create new agents."
         : taskAssignSource === "explicit_grant"
-          ? "Enabled via explicit organization permission grant."
+          ? "Enabled via explicit company permission grant."
           : taskAssignSource === "simple_default"
-            ? "Enabled by simple organization-wide task assignment defaults."
+            ? "Enabled by simple company-wide task assignment defaults."
             : "Disabled unless explicitly granted.";
 
   return (
     <div className="space-y-6">
-      {content !== "permissions" ? <AgentConfigForm
+      <AgentConfigForm
         mode="edit"
         agent={agent}
         onSave={(patch) => updateAgent.mutateAsync(patch)}
@@ -2136,17 +2185,16 @@ function ConfigurationTab({
         hideInlineSave
         hidePromptTemplate={hidePromptTemplate}
         hideInstructionsFile={hideInstructionsFile}
-        content={content === "runtime" ? "configuration" : "secrets"}
+        content={content}
         sectionLayout="cards"
-        canConfigureProviderTrace={canConfigureProviderTrace}
-      /> : null}
-      {content === "runtime" ? (
+      />
+      {content === "configuration" ? (
         <p className="text-xs text-muted-foreground">
           Saved adapter config affects the next run. Active runs keep the config they started with, and config changes may start a fresh adapter session.
         </p>
       ) : null}
 
-      {content === "permissions" ? <TrustPresetSection
+      {content === "configuration" ? <TrustPresetSection
         permissions={agent.permissions}
         disabled={updatePermissions.isPending}
         companyId={companyId}
@@ -2169,7 +2217,7 @@ function ConfigurationTab({
         }
       /> : null}
 
-      {content === "permissions" ? <div>
+      {content === "configuration" ? <div>
         <h3 className="text-sm font-medium mb-3">Permissions</h3>
         <div className="border border-border rounded-lg p-4 space-y-4">
           <div className="flex items-center justify-between gap-4 text-sm">
@@ -2195,7 +2243,7 @@ function ConfigurationTab({
             <div className="space-y-1">
               <div>Can create/import skills</div>
               <p className="text-xs text-muted-foreground">
-                Lets this agent install, import, create, and scan organization skills without creating agents.
+                Lets this agent install, import, create, and scan company skills without creating agents.
               </p>
             </div>
             <ToggleSwitch
@@ -2255,8 +2303,7 @@ export function PromptsTab({
   const queryClient = useQueryClient();
   const { selectedCompanyId } = useCompany();
   const { isMobile } = useSidebar();
-  const [selectedFile, setSelectedFileState] = useState<string>("AGENTS.md");
-  const [instructionMode, setInstructionMode] = useState<"read" | "edit" | "raw">("read");
+  const [selectedFile, setSelectedFile] = useState<string>("AGENTS.md");
   const [showFilePanel, setShowFilePanel] = useState(false);
   const [draft, setDraft] = useState<string | null>(null);
   const [bundleDraft, setBundleDraft] = useState<{
@@ -2278,22 +2325,9 @@ export function PromptsTab({
     entryFile: string;
     selectedFile: string;
   } | null>(null);
-  // MDXEditor can normalize markdown and emit onChange while it mounts. Only
-  // treat editor output as a draft after a real interaction so merely opening
-  // an instructions file cannot mark the agent dirty.
-  const editorInteractedRef = useRef(false);
-  const markEditorInteracted = useCallback(() => {
-    editorInteractedRef.current = true;
-  }, []);
-  const setSelectedFile = useCallback((filePath: string) => {
-    editorInteractedRef.current = false;
-    setSelectedFileState(filePath);
-  }, []);
 
   useEffect(() => {
-    editorInteractedRef.current = false;
     setSelectedFile("AGENTS.md");
-    setInstructionMode("read");
     setShowFilePanel(false);
     setDraft(null);
     setBundleDraft(null);
@@ -2359,10 +2393,7 @@ export function PromptsTab({
       entryFile?: string;
       clearLegacyPromptTemplate?: boolean;
     }) => agentsApi.updateInstructionsBundle(agent.id, data, companyId),
-    onMutate: () => {
-      editorInteractedRef.current = false;
-      setAwaitingRefresh(true);
-    },
+    onMutate: () => setAwaitingRefresh(true),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.instructionsBundle(agent.id) });
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.detail(agent.id) });
@@ -2374,10 +2405,7 @@ export function PromptsTab({
   const saveFile = useMutation({
     mutationFn: (data: { path: string; content: string; clearLegacyPromptTemplate?: boolean }) =>
       agentsApi.saveInstructionsFile(agent.id, data, companyId),
-    onMutate: () => {
-      editorInteractedRef.current = false;
-      setAwaitingRefresh(true);
-    },
+    onMutate: () => setAwaitingRefresh(true),
     onSuccess: (_, variables) => {
       setPendingFiles((prev) => prev.filter((f) => f !== variables.path));
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.instructionsBundle(agent.id) });
@@ -2390,10 +2418,7 @@ export function PromptsTab({
 
   const deleteFile = useMutation({
     mutationFn: (relativePath: string) => agentsApi.deleteInstructionsFile(agent.id, relativePath, companyId),
-    onMutate: () => {
-      editorInteractedRef.current = false;
-      setAwaitingRefresh(true);
-    },
+    onMutate: () => setAwaitingRefresh(true),
     onSuccess: (_, relativePath) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.agents.instructionsBundle(agent.id) });
       queryClient.removeQueries({ queryKey: queryKeys.agents.instructionsFile(agent.id, relativePath) });
@@ -2405,7 +2430,7 @@ export function PromptsTab({
 
   const uploadMarkdownImage = useMutation({
     mutationFn: async ({ file, namespace }: { file: File; namespace: string }) => {
-      if (!selectedCompanyId) throw new Error("Select an organization to upload images");
+      if (!selectedCompanyId) throw new Error("Select a company to upload images");
       return assetsApi.uploadImage(selectedCompanyId, file, namespace);
     },
   });
@@ -2519,13 +2544,6 @@ export function PromptsTab({
 
   useEffect(() => { onSavingChange(isSaving); }, [onSavingChange, isSaving]);
   useEffect(() => { onDirtyChange(isDirty); }, [onDirtyChange, isDirty]);
-
-  useEffect(() => () => {
-    onSaveActionChange(null);
-    onCancelActionChange(null);
-    onDirtyChange(false);
-    onSavingChange(false);
-  }, [onCancelActionChange, onDirtyChange, onSaveActionChange, onSavingChange]);
 
   useEffect(() => {
     onSaveActionChange(isDirty ? () => {
@@ -2884,7 +2902,6 @@ export function PromptsTab({
             })}
             onSelectFile={(filePath) => {
               setSelectedFile(filePath);
-              setInstructionMode("read");
               if (!fileOptions.includes(filePath)) setDraft("");
               if (isMobile) setShowFilePanel(false);
             }}
@@ -2951,21 +2968,6 @@ export function PromptsTab({
               </div>
             </div>
             <div className="flex items-center gap-2">
-              <div className="flex items-center rounded-md border border-border p-0.5" role="group" aria-label="Instruction file view">
-                {(["read", "edit", "raw"] as const).map((mode) => (
-                  <Button
-                    key={mode}
-                    type="button"
-                    size="sm"
-                    variant={instructionMode === mode ? "secondary" : "ghost"}
-                    className="capitalize"
-                    aria-pressed={instructionMode === mode}
-                    onClick={() => setInstructionMode(mode)}
-                  >
-                    {mode}
-                  </Button>
-                ))}
-              </div>
               {!fileLoading && (
                 <CopyText
                   text={displayValue}
@@ -3002,56 +3004,22 @@ export function PromptsTab({
 
           {selectedFileExists && fileLoading && !selectedFileDetail ? (
             <PromptEditorSkeleton />
-          ) : instructionMode === "read" ? (
-            <div className="min-h-(--sz-420px) rounded-md border border-border bg-background p-4">
-              {displayValue.trim() ? (
-                useMarkdownEditor ? (
-                  <MarkdownBody className="max-w-none text-sm leading-7 [&>*:first-child]:mt-0 [&>*:last-child]:mb-0">
-                    {displayValue}
-                  </MarkdownBody>
-                ) : (
-                  <pre className="whitespace-pre-wrap break-words font-sans text-sm leading-7">{displayValue}</pre>
-                )
-              ) : (
-                <p className="text-sm text-muted-foreground">This instruction file is empty.</p>
-              )}
-            </div>
-          ) : instructionMode === "raw" ? (
-            <pre
-              data-testid="instructions-raw-source"
-              className="min-h-(--sz-420px) overflow-x-auto whitespace-pre-wrap break-words rounded-md border border-border bg-muted p-4 font-mono text-sm leading-7"
-            >
-              {displayValue}
-            </pre>
           ) : useMarkdownEditor ? (
-            <div
-              onBeforeInputCapture={markEditorInteracted}
-              onDropCapture={markEditorInteracted}
-              onInput={markEditorInteracted}
-              onKeyDownCapture={markEditorInteracted}
-              onPasteCapture={markEditorInteracted}
-              onPointerDownCapture={markEditorInteracted}
-            >
-              <MarkdownEditor
-                key={selectedOrEntryFile}
-                value={displayValue}
-                onChange={(value) => {
-                  if (!editorInteractedRef.current) return;
-                  setDraft(value ?? "");
-                }}
-                placeholder="# Agent instructions"
-                className="min-w-0 overflow-hidden"
-                contentClassName="min-h-(--sz-420px) max-w-full break-words text-sm leading-7"
-                imageUploadHandler={async (file) => {
-                  const namespace = `agents/${agent.id}/instructions/${selectedOrEntryFile.replaceAll("/", "-")}`;
-                  const asset = await uploadMarkdownImage.mutateAsync({ file, namespace });
-                  return asset.contentPath;
-                }}
-              />
-            </div>
+            <MarkdownEditor
+              key={selectedOrEntryFile}
+              value={displayValue}
+              onChange={(value) => setDraft(value ?? "")}
+              placeholder="# Agent instructions"
+              className="min-w-0 overflow-hidden"
+              contentClassName="min-h-(--sz-420px) max-w-full break-words text-sm leading-7"
+              imageUploadHandler={async (file) => {
+                const namespace = `agents/${agent.id}/instructions/${selectedOrEntryFile.replaceAll("/", "-")}`;
+                const asset = await uploadMarkdownImage.mutateAsync({ file, namespace });
+                return asset.contentPath;
+              }}
+            />
           ) : (
             <textarea
-              aria-label="Instruction file editor"
               value={displayValue}
               onChange={(event) => setDraft(event.target.value)}
               className="min-h-(--sz-420px) w-full min-w-0 rounded-md border border-border bg-transparent px-3 py-2 font-mono text-sm outline-none"
@@ -3268,29 +3236,6 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
     ),
   });
   const run = hydratedRun ?? initialRun;
-  const { data: boardAccess } = useQuery({
-    queryKey: queryKeys.access.currentBoardAccess,
-    queryFn: () => accessApi.getCurrentBoardAccess(),
-    retry: false,
-  });
-  const canUseProviderTrace =
-    boardAccess?.source === "local_implicit" ||
-    boardAccess?.isInstanceAdmin === true;
-  const { data: experimentalSettings } = useQuery({
-    queryKey: queryKeys.instance.experimentalSettings,
-    queryFn: () => instanceSettingsApi.getExperimental(),
-  });
-  const paperclipDeveloperMode =
-    experimentalSettings?.enablePaperclipDeveloperMode === true;
-  const { data: providerTraceRows } = useQuery({
-    queryKey: queryKeys.providerTraceMetadata(run.companyId, [run.id]),
-    queryFn: () => heartbeatsApi.providerTraceMetadata(run.companyId, [run.id]),
-    enabled: canUseProviderTrace,
-    retry: false,
-    refetchInterval:
-      run.status === "running" || run.status === "queued" ? 3000 : false,
-  });
-  const providerTraceMetadata = providerTraceRows?.[0] ?? null;
   const metrics = runMetrics(run);
   const { data: userDirectory } = useQuery({
     queryKey: queryKeys.access.companyUserDirectory(run.companyId),
@@ -3307,7 +3252,6 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
   }, [run.responsibleUserId, userDirectory]);
   const responsibleDenialCode = isResponsibleUserDenialCode(run.errorCode) ? run.errorCode : null;
   const [sessionOpen, setSessionOpen] = useState(false);
-  const [inspectorOpen, setInspectorOpen] = useState(false);
   const [claudeLoginResult, setClaudeLoginResult] = useState<ClaudeLoginResult | null>(null);
 
   useEffect(() => {
@@ -3388,27 +3332,6 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
     },
   });
 
-  const rerunWithTrace = useMutation({
-    mutationFn: async () => {
-      const result = await agentsApi.wakeup(run.agentId, {
-        source: "on_demand",
-        triggerDetail: "manual",
-        reason: "rerun_with_provider_trace",
-        payload: retryPayload,
-        debug: { providerTrace: "raw" },
-      }, run.companyId);
-      if (!("id" in result)) {
-        throw new Error(result.message ?? "Trace re-run was skipped.");
-      }
-      return result;
-    },
-    onSuccess: (newRun) => {
-      setInspectorOpen(false);
-      queryClient.invalidateQueries({ queryKey: queryKeys.heartbeats(run.companyId, run.agentId) });
-      navigate(`/agents/${agentRouteId}/runs/${newRun.id}`);
-    },
-  });
-
   const { data: touchedIssues } = useQuery({
     queryKey: queryKeys.runIssues(run.id),
     queryFn: () => activityApi.issuesForRun(run.id),
@@ -3479,13 +3402,8 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
         <div className="flex flex-col sm:flex-row">
           {/* Left column: status + timing */}
           <div className="flex-1 p-4 space-y-3">
-            <div className="flex items-center gap-2 flex-wrap">
+            <div className="flex items-center gap-2">
               <StatusBadge status={run.status} />
-              <ProviderTraceStatusBadge
-                trace={providerTraceMetadata}
-                requested={runRequestedProviderTrace(run.contextSnapshot)}
-                showOff
-              />
               {(run.status === "running" || run.status === "queued") && (
                 <Button
                   variant="ghost"
@@ -3521,31 +3439,6 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
                   {retryRun.isPending ? "Retrying…" : "Retry"}
                 </Button>
               )}
-              <Button
-                variant="ghost"
-                size="sm"
-                className="text-xs h-6 px-2"
-                onClick={() => setInspectorOpen(true)}
-              >
-                <Eye className="h-3.5 w-3.5 mr-1" />
-                Inspect run
-              </Button>
-              <HoneycombRunLink
-                runId={run.id}
-                enabled={paperclipDeveloperMode && canUseProviderTrace}
-              />
-              {canUseProviderTrace && !["queued", "running"].includes(run.status) ? (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="text-xs h-6 px-2"
-                  onClick={() => rerunWithTrace.mutate()}
-                  disabled={rerunWithTrace.isPending}
-                >
-                  <RotateCcw className="h-3.5 w-3.5 mr-1" />
-                  {rerunWithTrace.isPending ? "Starting…" : "Re-run with provider trace"}
-                </Button>
-              ) : null}
             </div>
             {/* Adapter type · provider · model */}
             {(() => {
@@ -3828,17 +3721,6 @@ function RunDetail({ run: initialRun, agentRouteId, adapterType, adapterConfig }
       {/* Log viewer */}
       <LogViewer run={run} adapterType={adapterType} />
       <ScrollToBottom />
-      <RunnerInspector
-        runId={run.id}
-        run={run}
-        open={inspectorOpen}
-        onOpenChange={setInspectorOpen}
-        onRerunWithTrace={
-          canUseProviderTrace && !["queued", "running"].includes(run.status)
-            ? () => rerunWithTrace.mutate()
-            : undefined
-        }
-      />
     </div>
   );
 }

--- a/ui/src/pages/AgentOverview.test.tsx
+++ b/ui/src/pages/AgentOverview.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { AgentDetail, AgentRuntimeState, HeartbeatRun, Issue } from "@paperclipai/shared";
+import { describe, expect, it, vi } from "vitest";
+import { AgentOverview } from "./AgentDetail";
+
+vi.mock("@/lib/router", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    Link: ({ to, children, ...props }: { to: string; children: React.ReactNode }) => (
+      <a href={to} {...props}>{children}</a>
+    ),
+  };
+});
+
+vi.mock("../components/MarkdownBody", () => ({
+  MarkdownBody: ({ children }: { children: string }) => <div>{children}</div>,
+}));
+
+describe("AgentOverview", () => {
+  it("prioritizes identity, capability, runtime, skills, tasks, and scoped Audit entry points", () => {
+    const agent = {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "Codex Coder",
+      urlKey: "codexcoder",
+      role: "engineer",
+      title: "Product engineer",
+      status: "active",
+      reportsTo: null,
+      capabilities: "Builds and verifies product changes.",
+      adapterType: "codex_local",
+      adapterConfig: { model: "gpt-5.6-sol" },
+      runtimeConfig: {},
+      chainOfCommand: [],
+      access: { canAssignTasks: true, taskAssignSource: "explicit_grant", membership: null, grants: [] },
+    } as unknown as AgentDetail;
+    const issue = {
+      id: "issue-1",
+      companyId: "company-1",
+      identifier: "PAP-42",
+      title: "Simplify agent information architecture",
+      status: "in_progress",
+      priority: "high",
+      updatedAt: new Date("2026-08-31T12:00:00Z"),
+    } as unknown as Issue;
+    const runtime = {
+      sessionDisplayId: "codex-session-42",
+    } as unknown as AgentRuntimeState;
+
+    const markup = renderToStaticMarkup(
+      <QueryClientProvider client={new QueryClient()}>
+        <AgentOverview
+          agent={agent}
+          runs={[] as HeartbeatRun[]}
+          assignedIssues={[issue]}
+          runtimeState={runtime}
+          directReportCount={2}
+          skillNames={["Design Guide", "Check PR"]}
+          agentRouteId="codexcoder"
+        />
+      </QueryClientProvider>,
+    );
+
+    expect(markup).toContain("Identity");
+    expect(markup).toContain("Capabilities");
+    expect(markup).toContain("Harness / Runtime");
+    expect(markup).toContain("Design Guide");
+    expect(markup).toContain("Simplify agent information architecture");
+    expect(markup).toContain("PAP-42");
+    expect(markup).toContain('href="/activity/costs?agentId=agent-1"');
+    expect(markup).not.toContain("Run Activity");
+    expect(markup).not.toContain("Tasks by Status");
+  });
+});

--- a/ui/src/pages/Agents.production.tsx
+++ b/ui/src/pages/Agents.production.tsx
@@ -6,12 +6,10 @@ import { builtInAgentsApi, type BuiltInAgentState } from "../api/builtInAgents";
 import { environmentsApi } from "../api/environments";
 import { heartbeatsApi } from "../api/heartbeats";
 import { instanceSettingsApi } from "../api/instanceSettings";
-import { accessApi } from "../api/access";
 import { useCompany } from "../context/CompanyContext";
 import { useDialogActions } from "../context/DialogContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { useSidebar } from "../context/SidebarContext";
-import { useStreamlinedUiEnabled } from "../hooks/useStreamlinedUiEnabled";
 import { queryKeys } from "../lib/queryKeys";
 import { isPlatformManagedEnvironment } from "../lib/managed-sandbox-environment";
 import { AgentStatusBadge, AgentStatusCapsule } from "../components/StatusBadge";
@@ -22,12 +20,11 @@ import { EntityRow } from "../components/EntityRow";
 import { BuiltInLifecycleChip } from "../components/BuiltInAgentBadges";
 import { EmptyState } from "../components/EmptyState";
 import { PageSkeleton } from "../components/PageSkeleton";
-import { OrgChart } from "./OrgChart";
 import { relativeTime, cn, agentRouteRef, agentUrl } from "../lib/utils";
 import { PageTabBar } from "../components/PageTabBar";
 import { Tabs } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
-import { AlertTriangle, Bot, Plus, List, Network } from "lucide-react";
+import { AlertTriangle, Bot, Plus, List, GitBranch } from "lucide-react";
 import { AGENT_ROLE_LABELS, type Agent, type Environment, type EnvironmentCapabilities } from "@paperclipai/shared";
 import {
   isStarred,
@@ -191,34 +188,18 @@ function filterOrgTree(nodes: OrgNode[], tab: FilterTab, builtInAgentIds: Set<st
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
-export type AgentsView = "list" | "org";
-
-export function Agents({ initialView = "list" }: { initialView?: AgentsView } = {}) {
+export function Agents() {
   const { selectedCompanyId } = useCompany();
   const { openNewAgent } = useDialogActions();
   const { setBreadcrumbs } = useBreadcrumbs();
   const navigate = useNavigate();
   const location = useLocation();
   const { isMobile } = useSidebar();
-  const { enabled: streamlinedUiEnabled } = useStreamlinedUiEnabled();
   const pathSegment = location.pathname.split("/").pop() ?? "all";
   const requestedTab: FilterTab = isFilterTab(pathSegment) ? pathSegment : "all";
-  const [view, setView] = useState<AgentsView>(() => streamlinedUiEnabled ? initialView : "org");
-  const forceListView = !streamlinedUiEnabled && isMobile;
-  const effectiveView: AgentsView = forceListView ? "list" : view;
-
-  useEffect(() => {
-    setView(streamlinedUiEnabled ? initialView : "org");
-  }, [initialView, streamlinedUiEnabled]);
-
-  const { data: boardAccess } = useQuery({
-    queryKey: queryKeys.access.currentBoardAccess,
-    queryFn: () => accessApi.getCurrentBoardAccess(),
-    retry: false,
-  });
-  const canUseProviderTrace =
-    boardAccess?.source === "local_implicit" ||
-    boardAccess?.isInstanceAdmin === true;
+  const [view, setView] = useState<"list" | "org">("org");
+  const forceListView = isMobile;
+  const effectiveView: "list" | "org" = forceListView ? "list" : view;
 
   const { data: instanceSettings } = useQuery({
     queryKey: queryKeys.instance.settings,
@@ -308,6 +289,12 @@ export function Agents({ initialView = "list" }: { initialView?: AgentsView } = 
     return map;
   }, [runs]);
 
+  const agentMap = useMemo(() => {
+    const map = new Map<string, Agent>();
+    for (const a of agents ?? []) map.set(a.id, a);
+    return map;
+  }, [agents]);
+
   const environmentsById = useMemo(() => {
     const map = new Map<string, Environment>();
     for (const environment of environments ?? []) map.set(environment.id, environment);
@@ -341,7 +328,7 @@ export function Agents({ initialView = "list" }: { initialView?: AgentsView } = 
   }, [builtInAgentsEnabled, instanceSettings, navigate, requestedTab, selectedCompanyId]);
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={Bot} message="Select an organization to view agents." />;
+    return <EmptyState icon={Bot} message="Select a company to view agents." />;
   }
 
   if (isLoading) {
@@ -469,7 +456,6 @@ export function Agents({ initialView = "list" }: { initialView?: AgentsView } = 
                   companyId={selectedCompanyId}
                   runLabel="Run Heartbeat"
                   showStatus={false}
-                  canRunWithProviderTrace={canUseProviderTrace}
                 />
               </div>
               <StarToggle
@@ -510,11 +496,7 @@ export function Agents({ initialView = "list" }: { initialView?: AgentsView } = 
   };
 
   return (
-    <div className={cn(
-      effectiveView === "org"
-        ? "flex h-full min-h-0 flex-col gap-4"
-        : "space-y-4",
-    )}>
+    <div className="space-y-4">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <Tabs value={tab} onValueChange={(v) => navigate(`/agents/${v}`)}>
           <PageTabBar
@@ -524,32 +506,35 @@ export function Agents({ initialView = "list" }: { initialView?: AgentsView } = 
           />
         </Tabs>
         <div className="flex items-center gap-2">
-          {!forceListView ? <div className="flex items-center overflow-hidden rounded-md border border-border" role="group" aria-label="Agent view">
-              <Button
-                type="button"
-                size="icon-sm"
-                variant={effectiveView === "list" ? "secondary" : "ghost"}
-                className="rounded-none"
+          {/* View toggle */}
+          {!forceListView && (
+            <div className="flex items-center border border-border" role="group" aria-label="View mode">
+              <button
+                className={cn(
+                  "p-1.5 transition-colors",
+                  effectiveView === "list" ? "bg-accent text-foreground" : "text-muted-foreground hover:bg-accent/50"
+                )}
                 onClick={() => setView("list")}
                 title="List view"
                 aria-label="List view"
                 aria-pressed={effectiveView === "list"}
               >
                 <List className="h-3.5 w-3.5" />
-              </Button>
-              <Button
-                type="button"
-                size="icon-sm"
-                variant={effectiveView === "org" ? "secondary" : "ghost"}
-                className="rounded-none border-l border-border"
+              </button>
+              <button
+                className={cn(
+                  "p-1.5 transition-colors",
+                  effectiveView === "org" ? "bg-accent text-foreground" : "text-muted-foreground hover:bg-accent/50"
+                )}
                 onClick={() => setView("org")}
                 title="Org chart view"
                 aria-label="Org chart view"
                 aria-pressed={effectiveView === "org"}
               >
-                <Network className="h-3.5 w-3.5" />
-              </Button>
-          </div> : null}
+                <GitBranch className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          )}
           <Button size="sm" variant="outline" onClick={openNewAgent}>
             <Plus className="h-3.5 w-3.5 mr-1.5" />
             New Agent
@@ -587,7 +572,25 @@ export function Agents({ initialView = "list" }: { initialView?: AgentsView } = 
 
       {/* Org chart view */}
       {effectiveView === "org" && filteredOrg.length > 0 && (
-        <OrgChart embedded orgTree={filteredOrg} agents={agents ?? []} />
+        <div className="py-1">
+          {filteredOrg.map((node) => (
+            <OrgTreeNode
+              key={node.id}
+              node={node}
+              depth={0}
+              agentMap={agentMap}
+              liveRunByAgent={liveRunByAgent}
+              environmentByAgentId={environmentByAgentId}
+              environmentDataLoading={environmentDataLoading}
+              showEnvironment={showEnvironmentColumn}
+              tab={tab}
+              memberships={membershipsQuery.data}
+              membershipMutation={membershipMutation}
+              builtInByAgentId={builtInByAgentId}
+              onConfigureBuiltIn={setConfigureState}
+            />
+          ))}
+        </div>
       )}
 
       {effectiveView === "org" && orgTree && orgTree.length > 0 && filteredOrg.length === 0 && (

--- a/ui/src/pages/Agents.test.tsx
+++ b/ui/src/pages/Agents.test.tsx
@@ -381,6 +381,54 @@ describe("Agents", () => {
     expect(heartbeatCell?.textContent).not.toContain("\n");
   });
 
+  it("switches between the preserved list and the interactive org chart with icon buttons", async () => {
+    root = createRoot(container);
+    await act(async () => {
+      root!.render(
+        <QueryClientProvider client={queryClient}>
+          <ToastProvider>
+            <Agents />
+          </ToastProvider>
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    const listToggle = container.querySelector<HTMLButtonElement>('button[aria-label="List view"]');
+    const orgToggle = container.querySelector<HTMLButtonElement>('button[aria-label="Org chart view"]');
+    expect(listToggle?.getAttribute("aria-pressed")).toBe("true");
+    expect(orgToggle?.getAttribute("aria-pressed")).toBe("false");
+    expect(orgToggle?.querySelector(".lucide-network")).not.toBeNull();
+    expect(orgToggle?.querySelector(".lucide-git-branch")).toBeNull();
+    expect(container.querySelector('[data-testid="org-chart-viewport"]')).toBeNull();
+
+    await act(async () => {
+      orgToggle?.click();
+    });
+    await flushReact();
+    await flushReact();
+
+    expect(mockAgentsApi.org).toHaveBeenCalledWith("company-1");
+    expect(orgToggle?.getAttribute("aria-pressed")).toBe("true");
+    const orgViewport = container.querySelector('[data-testid="org-chart-viewport"]');
+    expect(orgViewport).not.toBeNull();
+    expect(orgViewport?.parentElement?.classList.contains("flex-1")).toBe(true);
+    expect(orgViewport?.parentElement?.classList.contains("md:min-h-0")).toBe(true);
+    expect(orgViewport?.parentElement?.classList.contains("h-(--sz-calc-38)")).toBe(false);
+    expect(orgViewport?.parentElement?.parentElement?.classList.contains("h-full")).toBe(true);
+    expect(orgViewport?.parentElement?.parentElement?.classList.contains("min-h-0")).toBe(true);
+    expect(container.querySelector('[aria-label="Zoom in"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label="Zoom out"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label="Fit chart to screen"]')).not.toBeNull();
+
+    await act(async () => {
+      listToggle?.click();
+    });
+    await flushReact();
+    expect(container.querySelector('[data-testid="org-chart-viewport"]')).toBeNull();
+    expect(container.textContent).toContain("gpt-5.4");
+  });
+
   it("gives mobile agent names the full row width after the leading status indicator", async () => {
     mockSidebarState.isMobile = true;
     mockResourceMembershipsApi.listMine.mockResolvedValue({
@@ -901,7 +949,7 @@ describe("Agents", () => {
     await flushReact();
     await flushReact();
 
-    // Switch from the default org view to the list view.
+    // Keep the list view selected before checking its aligned metadata columns.
     const listToggle = Array.from(container.querySelectorAll("button")).find(
       (btn) => btn.querySelector("svg.lucide-list"),
     );
@@ -938,7 +986,7 @@ describe("Agents", () => {
     await flushReact();
     await flushReact();
 
-    // Org view (default).
+    // List view (default).
     const orgAction = container.querySelector('[aria-label="Leave Alpha"]');
     const orgStar = container.querySelector('[aria-label="Star Alpha"]');
     expect(orgAction).not.toBeNull();
@@ -946,7 +994,7 @@ describe("Agents", () => {
     expect(orgAction?.closest(".hidden")).toBeNull();
     expect(orgStar?.closest(".hidden")).not.toBeNull();
 
-    // List view.
+    // List view remains stable after explicitly selecting it.
     const listToggle = Array.from(container.querySelectorAll("button")).find(
       (btn) => btn.querySelector("svg.lucide-list"),
     );

--- a/ui/src/pages/CompanySkills.production.tsx
+++ b/ui/src/pages/CompanySkills.production.tsx
@@ -38,7 +38,6 @@ import { Identity } from "../components/Identity";
 import { AgentIcon } from "../components/AgentIconPicker";
 import { AgentMultiSelect } from "../components/AgentMultiSelect";
 import { useAdapterCapabilities } from "../adapters/use-adapter-capabilities";
-import { useStreamlinedUiEnabled } from "../hooks/useStreamlinedUiEnabled";
 import {
   SkillPolicyDenialNotice,
   useSkillPolicyDenial,
@@ -76,10 +75,6 @@ import {
   resolveSkillRouteToken,
   type CompanySkillRouteSubject,
 } from "../lib/company-skill-routes";
-import {
-  resolveSkillsDiscoveryView,
-  withSkillsDiscoveryView,
-} from "./skills/skills-navigation";
 import {
   SKILL_CREATE_ACCENTS,
   buildBlankSkillDraft,
@@ -131,7 +126,6 @@ import {
   ChevronLeft,
   ChevronRight,
   Code2,
-  Compass,
   Download,
   Eye,
   Filter,
@@ -327,7 +321,7 @@ type SourceFilter = "all" | "company" | "bundled" | "optional" | "external";
 
 const SOURCE_FILTER_LABELS: Record<SourceFilter, string> = {
   all: "All",
-  company: "Organization",
+  company: "Company",
   bundled: "Bundled",
   optional: "Optional",
   external: "External",
@@ -558,14 +552,23 @@ function formatBytes(bytes: number) {
 // Skills Store discovery grid (PAP-10879)
 // ---------------------------------------------------------------------------
 
-export type DiscoveryTab = "installed" | "discover";
+export type DiscoveryTab = "all" | "installed" | "catalog" | "bundled";
+
+const DISCOVERY_TABS: DiscoveryTab[] = ["all", "installed", "catalog", "bundled"];
 
 export function resolveDiscoveryTab(tabParam: string | null): DiscoveryTab {
-  return resolveSkillsDiscoveryView(tabParam);
+  return DISCOVERY_TABS.includes(tabParam as DiscoveryTab)
+    ? (tabParam as DiscoveryTab)
+    : "installed";
 }
 
 export function withDiscoveryTab(current: URLSearchParams, tab: DiscoveryTab): URLSearchParams {
-  return withSkillsDiscoveryView(current, tab);
+  const params = new URLSearchParams(current);
+  if (tab === "installed") params.delete("tab");
+  else params.set("tab", tab);
+  params.delete("category");
+  if (tab !== "installed") params.delete("folder");
+  return params;
 }
 
 export function skillDetailBreadcrumbs(
@@ -594,7 +597,6 @@ const DISCOVERY_SORT_LABELS: Record<DiscoverySort, string> = {
   recent: "Recently updated",
   alphabetical: "Alphabetical",
 };
-
 const DISCOVERY_SORTS: DiscoverySort[] = ["agents", "stars", "forks", "recent", "alphabetical"];
 
 export type DiscoveryCard = {
@@ -620,7 +622,6 @@ export type DiscoveryCard = {
   updatedAt: number;
   sourceBadge?: CompanySkillSourceBadge | null;
   sourceLabel?: string | null;
-  sourceKind?: "bundled" | "optional" | null;
 };
 
 export { SkillCardIcon } from "../components/SkillCardIcon";
@@ -652,7 +653,7 @@ function categorySetKey(categories: string[]) {
 }
 
 function skillSettingsToastBody(skill: Pick<CompanySkillDetail, "categories" | "sharingScope">) {
-  const sharing = skill.sharingScope === "private" ? "Sharing: private" : "Sharing: organization";
+  const sharing = skill.sharingScope === "private" ? "Sharing: private" : "Sharing: company";
   const categories = skill.categories.length ? `Categories: ${skill.categories.join(", ")}` : "Categories: none";
   return `${sharing} | ${categories}`;
 }
@@ -660,36 +661,17 @@ function skillSettingsToastBody(skill: Pick<CompanySkillDetail, "categories" | "
 // Merge installed company skills and the install catalog into one card model.
 // Installed skills win on dedup (they carry the richer social-proof metadata);
 // catalog-only skills fill in the rest of the discoverable surface.
-function discoveryCardIdentity(key: string): string {
-  return key.trim().toLowerCase();
-}
-
-export function buildDiscoveryCards(
+function buildDiscoveryCards(
   installed: CompanySkillListItem[],
   catalog: CatalogSkill[],
 ): DiscoveryCard[] {
-  const installedByKey = new Map<string, CompanySkillListItem>();
-  for (const skill of installed) {
-    const identity = discoveryCardIdentity(skill.key);
-    const existing = installedByKey.get(identity);
-    if (!existing || new Date(skill.updatedAt).getTime() > new Date(existing.updatedAt).getTime()) {
-      installedByKey.set(identity, skill);
-    }
-  }
-
-  const catalogByKey = new Map<string, CatalogSkill>();
-  for (const entry of catalog) {
-    const identity = discoveryCardIdentity(entry.key);
-    if (!catalogByKey.has(identity)) catalogByKey.set(identity, entry);
-  }
-
+  const catalogByKey = new Map(catalog.map((entry) => [entry.key, entry]));
   const cards: DiscoveryCard[] = [];
   const installedKeys = new Set<string>();
 
-  for (const skill of installedByKey.values()) {
-    const identity = discoveryCardIdentity(skill.key);
-    installedKeys.add(identity);
-    const catalogMatch = catalogByKey.get(identity) ?? null;
+  for (const skill of installed) {
+    installedKeys.add(skill.key);
+    const catalogMatch = catalogByKey.get(skill.key) ?? null;
     const required = skill.catalogKind === "bundled" || catalogMatch?.kind === "bundled";
     cards.push({
       key: skill.key,
@@ -714,12 +696,11 @@ export function buildDiscoveryCards(
       updatedAt: new Date(skill.updatedAt).getTime() || 0,
       sourceBadge: skill.sourceBadge,
       sourceLabel: skill.sourceLabel,
-      sourceKind: skill.catalogKind ?? catalogMatch?.kind ?? null,
     });
   }
 
-  for (const [identity, entry] of catalogByKey) {
-    if (installedKeys.has(identity)) continue;
+  for (const entry of catalog) {
+    if (installedKeys.has(entry.key)) continue;
     const required = entry.kind === "bundled";
     cards.push({
       key: entry.key,
@@ -744,7 +725,6 @@ export function buildDiscoveryCards(
       updatedAt: 0,
       sourceBadge: "catalog",
       sourceLabel: entry.packageName ?? "Catalog",
-      sourceKind: entry.kind,
     });
   }
 
@@ -752,7 +732,17 @@ export function buildDiscoveryCards(
 }
 
 function cardsForTab(cards: DiscoveryCard[], tab: DiscoveryTab): DiscoveryCard[] {
-  return tab === "installed" ? cards.filter((card) => card.installed) : cards;
+  switch (tab) {
+    case "installed":
+      return cards.filter((card) => card.installed);
+    case "catalog":
+      return cards.filter((card) => card.catalogRef != null);
+    case "bundled":
+      return cards.filter((card) => card.required);
+    case "all":
+    default:
+      return cards;
+  }
 }
 
 function sortDiscoveryCards(cards: DiscoveryCard[], sort: DiscoverySort, demoteRequired: boolean): DiscoveryCard[] {
@@ -832,8 +822,6 @@ function SkillCard({
   onCreateFolderAndMove?: (card: DiscoveryCard) => void;
   onOpenMove?: (card: DiscoveryCard) => void;
 }) {
-  const source = sourceMeta(card.sourceBadge ?? "catalog", card.sourceLabel ?? null);
-  const SourceIcon = source.icon;
   const badgeFolder = showFolderBadge && card.installed
     ? (card.folderId ? folders?.find((folder) => folder.id === card.folderId) ?? null : null)
     : undefined;
@@ -884,6 +872,16 @@ function SkillCard({
             </div>
           ) : null}
         </div>
+        {/* Where the skill came from (PAP-10907 E); native title gives a hover hint. */}
+        {(() => {
+          const meta = sourceMeta(card.sourceBadge ?? "catalog", card.sourceLabel ?? null);
+          const SourceIcon = meta.icon;
+          return (
+            <span className="shrink-0 text-muted-foreground" title={`From ${meta.label}`} aria-label={`From ${meta.label}`}>
+              <SourceIcon className="h-3.5 w-3.5" aria-hidden="true" />
+            </span>
+          );
+        })()}
         {canMove && folders && onMove && onCreateFolderAndMove ? (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -936,15 +934,9 @@ function SkillCard({
       </p>
 
       <div className="mt-auto pt-3">
-        {/* Installation and agent enablement are separate states. */}
+        {/* Stats: installed agents · stars · forks — stars/forks only when > 0. */}
         <div className="flex items-center gap-2 text-(length:--text-micro) text-muted-foreground">
-          <span>
-            {card.installed
-              ? card.agentCount > 0
-                ? `Enabled for ${card.agentCount} ${card.agentCount === 1 ? "agent" : "agents"}`
-                : "Not enabled for any agents"
-              : "Available to install"}
-          </span>
+          <span>{card.agentCount} {card.agentCount === 1 ? "agent" : "agents"}</span>
           {card.starCount > 0 ? (
             <>
               <span aria-hidden="true">·</span>
@@ -960,14 +952,10 @@ function SkillCard({
         </div>
         <div className="mt-2 flex flex-wrap items-center gap-1">
           {card.installed ? (
-            <Badge variant="secondary" className="text-(length:--text-nano)">
+            <Badge variant="outline" className="border-emerald-500/30 bg-emerald-500/10 text-(length:--text-nano) text-emerald-700 dark:text-emerald-300">
               Installed
             </Badge>
           ) : null}
-          <Badge variant="outline" className="max-w-full text-(length:--text-nano) text-muted-foreground">
-            <SourceIcon className="h-3 w-3" aria-hidden="true" />
-            <span className="truncate">{source.label}</span>
-          </Badge>
           {card.categories.slice(0, 2).map((category) => (
             <SkillCategoryChip key={category} label={category} />
           ))}
@@ -975,10 +963,6 @@ function SkillCard({
             <Badge variant="outline" className="ml-auto border-border bg-muted/60 text-(length:--text-nano) text-muted-foreground">
               <Lock className="h-3 w-3" aria-hidden="true" />
               Bundled
-            </Badge>
-          ) : card.sourceKind === "optional" ? (
-            <Badge variant="outline" className="ml-auto text-(length:--text-nano) text-muted-foreground">
-              Optional
             </Badge>
           ) : null}
         </div>
@@ -1033,6 +1017,8 @@ function CategoryNav({
 
 export function DiscoveryGrid({
   tab,
+  tabCounts,
+  onTabChange,
   categories,
   categoryTotal,
   activeCategory,
@@ -1049,7 +1035,7 @@ export function DiscoveryGrid({
   onCreate,
   onImport,
   onImportFromProject,
-  onBrowseDiscover,
+  onBrowseCatalog,
   onScan,
   scanPending,
   scanStatus,
@@ -1076,9 +1062,10 @@ export function DiscoveryGrid({
   onEnsureMyFolder,
   onOpenMoveCard,
   folderNudgeStorageKey,
-  showBrowseRails = true,
 }: {
   tab: DiscoveryTab;
+  tabCounts: Record<DiscoveryTab, number>;
+  onTabChange: (tab: DiscoveryTab) => void;
   categories: DiscoveryCategory[];
   categoryTotal: number;
   activeCategory: string | null;
@@ -1095,7 +1082,7 @@ export function DiscoveryGrid({
   onCreate: () => void;
   onImport: () => void;
   onImportFromProject: () => void;
-  onBrowseDiscover: () => void;
+  onBrowseCatalog: () => void;
   onScan: (projectId?: string) => void;
   scanPending: boolean;
   scanStatus: string | null;
@@ -1126,43 +1113,22 @@ export function DiscoveryGrid({
   onOpenMoveCard?: (card: DiscoveryCard) => void;
   /** When set and no folders exist yet, show the dismissible all-unfiled nudge (ux-spec §6.3). */
   folderNudgeStorageKey?: string;
-  /** Category/folder navigation stays available in production, but the Streamlined UI relies on search and scrolling. */
-  showBrowseRails?: boolean;
 }) {
-  const installedView = tab === "installed";
-  const viewTitle = installedView ? "Installed skills" : "Discover skills";
-  const viewDescription = installedView
-    ? "Skills available to this organization."
-    : "Browse skills from every available source.";
-  const searchLabel = installedView ? "Search installed skills" : "Search discoverable skills";
   // Source filter (github / skills.sh / local / …) lives in the grid so it
   // narrows whatever the parent already filtered by tab/category/search (PAP-10907 E).
   const [sourceBadgeFilter, setSourceBadgeFilter] = useState<string>("all");
   const availableSources = useMemo(() => {
-    const facets = new Map<string, string>();
-    for (const card of cards) {
-      if (card.sourceKind) {
-        facets.set(`kind:${card.sourceKind}`, card.sourceKind === "bundled" ? "Bundled" : "Optional");
-      }
-      if (card.sourceBadge) {
-        facets.set(`badge:${card.sourceBadge}`, sourceMeta(card.sourceBadge, null).label);
-      }
-    }
-    return Array.from(facets, ([value, label]) => ({ value, label }))
-      .sort((left, right) => left.label.localeCompare(right.label));
+    const set = new Set<string>();
+    for (const card of cards) if (card.sourceBadge) set.add(card.sourceBadge);
+    return Array.from(set).sort();
   }, [cards]);
   useEffect(() => {
-    if (sourceBadgeFilter !== "all" && !availableSources.some((source) => source.value === sourceBadgeFilter)) {
+    if (sourceBadgeFilter !== "all" && !availableSources.includes(sourceBadgeFilter)) {
       setSourceBadgeFilter("all");
     }
   }, [availableSources, sourceBadgeFilter]);
   const sourceFilteredCards = useMemo(
-    () => sourceBadgeFilter === "all"
-      ? cards
-      : cards.filter((card) => {
-          const [facet, value] = sourceBadgeFilter.split(":", 2);
-          return facet === "kind" ? card.sourceKind === value : card.sourceBadge === value;
-        }),
+    () => (sourceBadgeFilter === "all" ? cards : cards.filter((card) => card.sourceBadge === sourceBadgeFilter)),
     [cards, sourceBadgeFilter],
   );
   const sourceFilterActive = sourceBadgeFilter !== "all";
@@ -1172,7 +1138,7 @@ export function DiscoveryGrid({
   // The nested folder tree owns the left rail whenever folders (reserved roots
   // or user folders) exist for the installed view.
   const showFolderRail = Boolean(
-    showBrowseRails && folderResult && folderResult.folders.length > 0 && onFolderSelect && folderActionsReady,
+    folderResult && folderResult.folders.length > 0 && onFolderSelect && folderActionsReady,
   );
   const activeProjectFolder = useMemo(() => {
     if (!folderResult || folderSelection === "all" || folderSelection === "unfiled") return null;
@@ -1205,42 +1171,35 @@ export function DiscoveryGrid({
           />
         </div>
       ) : null}
-      {showBrowseRails ? (
-        <aside className={cn("hidden w-60 shrink-0 flex-col overflow-hidden border-r border-border md:flex", showFolderRail && "md:hidden")}>
-          <div className="border-b border-border px-4 py-4">
-            <h2 className="text-sm font-semibold text-foreground">Browse by category</h2>
-            <p className="text-xs text-muted-foreground">
-              Filter {installedView ? "installed" : "discoverable"} skills.
-            </p>
-          </div>
-          <div className="px-4 pb-1 pt-3 text-(length:--text-micro) font-medium uppercase tracking-wide text-muted-foreground">
-            Categories
-          </div>
-          <div className="min-h-0 flex-1 overflow-y-auto pb-4">
-            <CategoryNav
-              categories={categories}
-              total={categoryTotal}
-              active={activeCategory}
-              onSelect={onCategoryChange}
-            />
-          </div>
-        </aside>
-      ) : null}
+      {/* Secondary category sidebar — the main app nav collapses to a rail while
+          this is present (handled in Layout). */}
+      <aside className={cn("hidden w-60 shrink-0 flex-col overflow-hidden border-r border-border md:flex", showFolderRail && "md:hidden")}>
+        <div className="border-b border-border px-4 py-4">
+          <h2 className="text-sm font-semibold text-foreground">Skills Store</h2>
+          <p className="text-xs text-muted-foreground">Discover, install, fork, share</p>
+        </div>
+        <div className="px-4 pb-1 pt-3 text-(length:--text-micro) font-medium uppercase tracking-wide text-muted-foreground">
+          Categories
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto pb-4">
+          <CategoryNav
+            categories={categories}
+            total={categoryTotal}
+            active={activeCategory}
+            onSelect={onCategoryChange}
+          />
+        </div>
+      </aside>
 
       <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
         {/* Search + sort + actions */}
         <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-3">
-          <div className="w-full">
-            <h1 className="text-lg font-semibold text-foreground">{viewTitle}</h1>
-            <p className="text-xs text-muted-foreground">{viewDescription}</p>
-          </div>
           <div className="flex h-9 min-w-(--sz-12rem) flex-1 items-center gap-2 rounded-md border border-border px-2.5">
             <Search className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
             <input
               value={search}
               onChange={(event) => onSearchChange(event.target.value)}
-              aria-label={searchLabel}
-              placeholder={`${searchLabel}…`}
+              placeholder="Search skills, authors, categories…"
               className="h-full w-full bg-transparent text-base outline-none placeholder:text-muted-foreground sm:text-sm"
             />
           </div>
@@ -1267,10 +1226,8 @@ export function DiscoveryGrid({
               <DropdownMenuTrigger asChild>
                 <Button variant="outline" size="sm">
                   <span className="text-muted-foreground">Source</span>
-                  <span className="ml-1.5">
-                    {sourceBadgeFilter === "all"
-                      ? "All"
-                      : availableSources.find((source) => source.value === sourceBadgeFilter)?.label ?? "All"}
+                  <span className="ml-1.5 capitalize">
+                    {sourceBadgeFilter === "all" ? "All" : sourceMeta(sourceBadgeFilter as CompanySkillSourceBadge, null).label}
                   </span>
                   <ChevronDown className="ml-1 h-3.5 w-3.5" />
                 </Button>
@@ -1278,9 +1235,9 @@ export function DiscoveryGrid({
               <DropdownMenuContent align="end">
                 <DropdownMenuRadioGroup value={sourceBadgeFilter} onValueChange={setSourceBadgeFilter}>
                   <DropdownMenuRadioItem value="all">All sources</DropdownMenuRadioItem>
-                  {availableSources.map((source) => (
-                    <DropdownMenuRadioItem key={source.value} value={source.value}>
-                      {source.label}
+                  {availableSources.map((badge) => (
+                    <DropdownMenuRadioItem key={badge} value={badge}>
+                      {sourceMeta(badge as CompanySkillSourceBadge, null).label}
                     </DropdownMenuRadioItem>
                   ))}
                 </DropdownMenuRadioGroup>
@@ -1297,6 +1254,12 @@ export function DiscoveryGrid({
           >
             <RefreshCw className={cn("h-4 w-4", scanPending && "animate-spin")} />
           </Button>
+          <Button asChild variant="outline" size="sm">
+            <Link to="/skills/studio">
+              <FlaskConical className="h-3.5 w-3.5" />
+              Studio
+            </Link>
+          </Button>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button size="sm" variant="default">
@@ -1310,9 +1273,9 @@ export function DiscoveryGrid({
                 <Pencil className="mr-2 h-4 w-4" />
                 Create new skill
               </DropdownMenuItem>
-              <DropdownMenuItem onSelect={onBrowseDiscover}>
-                <Compass className="mr-2 h-4 w-4" />
-                Discover skills
+              <DropdownMenuItem onSelect={onBrowseCatalog}>
+                <Boxes className="mr-2 h-4 w-4" />
+                Browse catalog
               </DropdownMenuItem>
               <DropdownMenuItem onSelect={onImport}>
                 <Globe className="mr-2 h-4 w-4" />
@@ -1324,7 +1287,7 @@ export function DiscoveryGrid({
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
-          {showBrowseRails && folderResult && onFolderSelect ? (
+          {folderResult && onFolderSelect ? (
             <div className="w-full md:hidden">
               <FolderChip
                 result={folderResult}
@@ -1348,7 +1311,7 @@ export function DiscoveryGrid({
         </div>
 
         {/* Mobile category selector (sidebar is hidden below md) */}
-        {showBrowseRails && categories.length > 0 ? (
+        {categories.length > 0 ? (
           <div className="border-b border-border px-4 py-2 md:hidden">
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -1373,6 +1336,30 @@ export function DiscoveryGrid({
             </DropdownMenu>
           </div>
         ) : null}
+
+        {/* Tab strip — Bundled/required lives at the end */}
+        <div className="border-b border-border px-4">
+          <Tabs value={tab} onValueChange={(value) => onTabChange(value as DiscoveryTab)}>
+            <TabsList variant="line" className="p-0">
+              <TabsTrigger value="all" className="px-3">
+                <span>All</span>
+                <span className="ml-1.5 text-(length:--text-micro) text-muted-foreground">{tabCounts.all}</span>
+              </TabsTrigger>
+              <TabsTrigger value="installed" className="px-3">
+                <span>Installed</span>
+                <span className="ml-1.5 text-(length:--text-micro) text-muted-foreground">{tabCounts.installed}</span>
+              </TabsTrigger>
+              <TabsTrigger value="catalog" className="px-3">
+                <span>Catalog</span>
+                <span className="ml-1.5 text-(length:--text-micro) text-muted-foreground">{tabCounts.catalog}</span>
+              </TabsTrigger>
+              <TabsTrigger value="bundled" className="px-3">
+                <span>Bundled</span>
+                <span className="ml-1.5 text-(length:--text-micro) text-muted-foreground">{tabCounts.bundled}</span>
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+        </div>
 
         {/* Grid body */}
         <div className="min-h-0 flex-1 overflow-auto p-4">
@@ -1424,21 +1411,17 @@ export function DiscoveryGrid({
                 icon={LayoutGrid}
                 message={
                   totalCount === 0
-                    ? installedView
-                      ? "No installed skills yet. Discover a skill or create one."
-                      : "No skills are available to discover yet."
+                    ? "No skills yet. Create one or install from the catalog."
                     : search || activeCategory || sourceFilterActive
                       ? "No skills match your filters."
-                      : "No skills in this view yet."
+                      : "No skills in this tab yet."
                 }
               />
               {totalCount === 0 ? (
                 <div className="mt-3 flex flex-col items-center gap-2">
-                  {installedView ? (
-                    <Button size="sm" onClick={onBrowseDiscover}>
-                      <Compass className="mr-1.5 h-3.5 w-3.5" /> Discover skills
-                    </Button>
-                  ) : null}
+                  <Button size="sm" onClick={onBrowseCatalog}>
+                    <Boxes className="mr-1.5 h-3.5 w-3.5" /> Browse catalog
+                  </Button>
                   <Button size="sm" variant="ghost" onClick={onCreate}>
                     Create a skill
                   </Button>
@@ -1660,7 +1643,7 @@ function NewSkillWizard({
             <span className="text-muted-foreground">Slug</span>
             <span className="font-mono">{effectiveSlug || "skill"}</span>
             <span className="text-muted-foreground">Scope</span>
-            <span>{draft.sharingScope === "private" ? "Private" : "Organization"}</span>
+            <span>{draft.sharingScope === "private" ? "Private" : "Company"}</span>
             <span className="text-muted-foreground">Categories</span>
             <span>{draft.categories.length ? draft.categories.join(", ") : "none"}</span>
           </div>
@@ -1677,9 +1660,9 @@ function NewSkillWizard({
                     draft.sharingScope === scope ? "border-foreground bg-accent/50" : "border-border",
                   )}
                 >
-                  <span className="block font-medium">{scope === "company" ? "Organization" : "Private"}</span>
+                  <span className="block font-medium">{scope === "company" ? "Company" : "Private"}</span>
                   <span className="mt-1 block text-xs text-muted-foreground">
-                    {scope === "company" ? "Visible inside this organization." : "Only visible in your library."}
+                    {scope === "company" ? "Visible inside this company." : "Only visible in your library."}
                   </span>
                 </button>
               ))}
@@ -2191,7 +2174,7 @@ export function InstallPreviewDialog({
             <div className="rounded-md border border-border p-3">
               <div className="mb-1 text-xs uppercase tracking-wide text-muted-foreground">Enable for agents</div>
               <p className="mb-2 text-xs text-muted-foreground">
-                Installing adds the skill to the organization library. Agents can only use it once it is enabled for them.
+                Installing adds the skill to the company library. Agents can only use it once it is enabled for them.
               </p>
               <AgentMultiSelect
                 agents={agents}
@@ -2201,7 +2184,7 @@ export function InstallPreviewDialog({
                   setSelectedAgentIds(next);
                 }}
                 showSelectionPreview={false}
-                emptyMessage="No agents in this organization support skills yet."
+                emptyMessage="No agents in this company support skills yet."
                 isAgentDisabled={(agent) => {
                   const option = agent as AttachAgentOption;
                   return option.required || !option.supportsSkills;
@@ -2331,7 +2314,7 @@ function AttachAgentsPopover({
           </select>
         </div>
       ) : null}
-      emptyMessage={eligible.length === 0 ? "No agents in this organization support skills yet." : "No agents yet."}
+      emptyMessage={eligible.length === 0 ? "No agents in this company support skills yet." : "No agents yet."}
       isAgentDisabled={(agent) => {
         const option = agent as AttachAgentOption;
         return option.required || !option.supportsSkills;
@@ -3383,7 +3366,7 @@ export function SkillDetailPage({
                     <span className="hidden sm:inline">{detail.attachedAgentCount === 1 ? "install" : "installs"}</span>
                   </span>
                 </TooltipTrigger>
-                <TooltipContent>Agents in this organization that currently have this skill installed.</TooltipContent>
+                <TooltipContent>Agents in this company that currently have this skill installed.</TooltipContent>
               </Tooltip>
               <button
                 type="button"
@@ -3613,7 +3596,6 @@ export function SkillDetailPage({
           </Button>
         </div>
       ) : null}
-
       <Dialog open={settingsOpen} onOpenChange={setSettingsOpen}>
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
@@ -3640,7 +3622,7 @@ export function SkillDetailPage({
                 disabled={updateSettingsPending}
                 className="h-9 w-full rounded-md border border-border bg-background px-2 text-sm text-foreground"
               >
-                <option value="company">Organization — visible inside this organization</option>
+                <option value="company">Company — visible inside this company</option>
                 <option value="private">Private — only visible in your library</option>
               </select>
               <p className="text-xs text-muted-foreground">Public link sharing is coming later.</p>
@@ -3672,7 +3654,7 @@ export function SkillDetailPage({
               <div className="rounded-md border border-destructive/40 p-3">
                 <div className="text-xs font-semibold uppercase tracking-wide text-destructive">Danger zone</div>
                 <div className="mt-2 flex items-center justify-between gap-3">
-                  <p className="min-w-0 text-xs text-muted-foreground">Remove this skill from the organization library.</p>
+                  <p className="min-w-0 text-xs text-muted-foreground">Remove this skill from the company library.</p>
                   <Button
                     variant="destructive"
                     size="sm"
@@ -4021,7 +4003,6 @@ export function CompanySkills() {
   const { setBreadcrumbs } = useBreadcrumbs();
   const { pushToast } = useToastActions();
   const adapterCaps = useAdapterCapabilities();
-  const { enabled: streamlinedUiEnabled } = useStreamlinedUiEnabled();
   const policyDenial = useSkillPolicyDenial();
   // Route a failed skill mutation to the persistent policy banner when it is an
   // explicit-policy (State B) or platform-safety (State C) denial; otherwise keep
@@ -4093,17 +4074,7 @@ export function CompanySkills() {
     : "all";
   const selectedCatalogRef = searchParams.get("catalog");
   const tabParam = searchParams.get("tab");
-  const discoveryTab = resolveDiscoveryTab(tabParam ?? (viewParam === "catalog" ? "catalog" : null));
-  const legacyDiscoveryTab = (["all", "installed", "catalog", "bundled"] as const).includes(
-    tabParam as "all" | "installed" | "catalog" | "bundled",
-  )
-    ? (tabParam as "all" | "installed" | "catalog" | "bundled")
-    : "installed";
-  const effectiveDiscoveryTab: DiscoveryTab = streamlinedUiEnabled
-    ? discoveryTab
-    : legacyDiscoveryTab === "installed"
-      ? "installed"
-      : "discover";
+  const discoveryTab = resolveDiscoveryTab(tabParam);
   const detailTab: SkillDetailTab = (["overview", "files", "versions", "agents"] as SkillDetailTab[]).includes(tabParam as SkillDetailTab)
     ? (tabParam as SkillDetailTab)
     : parsedRoute.hasExplicitFilePath || selectedPath !== "SKILL.md"
@@ -4116,23 +4087,9 @@ export function CompanySkills() {
   // selected; selecting either drops into the existing master/detail surfaces.
   const isDiscovery = !isStudioNew && !routeSkillToken && !selectedCatalogRef;
   const folderSelection = normalizeFolderSelection(searchParams.get("folder"));
-  const browseRailsEnabled = !streamlinedUiEnabled;
-  const visibleDiscoveryCategory = browseRailsEnabled ? discoveryCategory : null;
-  const visibleFolderSelection: FolderSelection = browseRailsEnabled ? folderSelection : "all";
 
   function setDiscoveryTab(tab: DiscoveryTab) {
     setSearchParams((current) => withDiscoveryTab(current, tab));
-  }
-
-  function setLegacyDiscoveryTab(tab: "all" | "installed" | "catalog" | "bundled") {
-    setSearchParams((current) => {
-      const params = new URLSearchParams(current);
-      if (tab === "installed") params.delete("tab");
-      else params.set("tab", tab);
-      params.delete("category");
-      if (tab !== "installed") params.delete("folder");
-      return params;
-    });
   }
 
   function setFolderSelection(selection: FolderSelection) {
@@ -4196,36 +4153,20 @@ export function CompanySkills() {
     setCreateError(null);
   }, [isStudioNew, studioForkFromId]);
 
-  // Canonicalize the old split-view and multi-tab URLs into the single Discover
-  // destination while keeping every stale deep link useful.
+  // The old split catalog view no longer exists — catalog/bundled skills now open
+  // as a regular full page keyed by `?catalog=<ref>`. Strip the legacy `view`
+  // param so stale `?view=catalog` deep links land on the new surface (PAP-10907).
   useEffect(() => {
-    if (!streamlinedUiEnabled) return;
-    const legacyTab = searchParams.get("tab");
-    const hasLegacyDiscoveryTab = isDiscovery && ["all", "catalog", "bundled"].includes(legacyTab ?? "");
-    const hasRetiredBrowseFilter = isDiscovery && (searchParams.has("category") || searchParams.has("folder"));
-    if (!searchParams.has("view") && !hasLegacyDiscoveryTab && !hasRetiredBrowseFilter) return;
+    if (!searchParams.has("view")) return;
     setSearchParams(
       (current) => {
         const next = new URLSearchParams(current);
-        if (hasLegacyDiscoveryTab || (next.get("view") === "catalog" && !next.has("tab"))) {
-          next.set("tab", "discover");
-        }
         next.delete("view");
-        if (isDiscovery) {
-          next.delete("category");
-          next.delete("folder");
-        }
         return next;
       },
       { replace: true },
     );
-  }, [isDiscovery, searchParams, setSearchParams, streamlinedUiEnabled]);
-
-  useEffect(() => {
-    if (!streamlinedUiEnabled) return;
-    setSelectMode(false);
-    setSelectedSkillIds([]);
-  }, [streamlinedUiEnabled]);
+  }, [searchParams, setSearchParams]);
 
   const skillsQuery = useQuery({
     queryKey: queryKeys.companySkills.list(selectedCompanyId ?? ""),
@@ -4235,7 +4176,7 @@ export function CompanySkills() {
   const skillFoldersQuery = useQuery({
     queryKey: queryKeys.folders.list(selectedCompanyId ?? "", "skill"),
     queryFn: () => foldersApi.list(selectedCompanyId!, "skill"),
-    enabled: Boolean(selectedCompanyId && ((isDiscovery && effectiveDiscoveryTab === "installed") || routeSkillToken)),
+    enabled: Boolean(selectedCompanyId && ((isDiscovery && discoveryTab === "installed") || routeSkillToken)),
   });
 
   const installedSkills = skillsQuery.data ?? [];
@@ -4284,15 +4225,15 @@ export function CompanySkills() {
 
   // The writable folder to seed a new skill into when creating from the browser.
   const defaultNewSkillFolderId = useMemo(() => {
-    if (visibleFolderSelection === "all" || visibleFolderSelection === "unfiled") return null;
+    if (folderSelection === "all" || folderSelection === "unfiled") return null;
     const model = treeFromResult(skillFoldersQuery.data);
-    const folder = model.byId.get(visibleFolderSelection);
+    const folder = model.byId.get(folderSelection);
     if (!folder) return null;
     // Never seed into read-only reserved subtrees (Bundled / Projects).
     if (folder.path === "bundled" || folder.path.startsWith("bundled/")) return null;
     if (folder.path === "projects" || folder.path.startsWith("projects/")) return null;
     return folder.id;
-  }, [skillFoldersQuery.data, visibleFolderSelection]);
+  }, [folderSelection, skillFoldersQuery.data]);
 
   const updateStatusQuery = useQuery({
     queryKey: queryKeys.companySkills.updateStatus(selectedCompanyId ?? "", selectedSkillId ?? ""),
@@ -4626,15 +4567,15 @@ export function CompanySkills() {
     () => buildDiscoveryCards(installedSkills, catalogListQuery.data ?? []),
     [installedSkills, catalogListQuery.data],
   );
+  const discoveryTabCounts = useMemo(() => ({
+    all: discoveryCards.length,
+    installed: discoveryCards.filter((card) => card.installed).length,
+    catalog: discoveryCards.filter((card) => card.catalogRef != null).length,
+    bundled: discoveryCards.filter((card) => card.required).length,
+  }), [discoveryCards]);
   const discoveryTabCards = useMemo(
-    () => {
-      if (streamlinedUiEnabled) return cardsForTab(discoveryCards, discoveryTab);
-      if (legacyDiscoveryTab === "installed") return discoveryCards.filter((card) => card.installed);
-      if (legacyDiscoveryTab === "catalog") return discoveryCards.filter((card) => card.catalogRef != null);
-      if (legacyDiscoveryTab === "bundled") return discoveryCards.filter((card) => card.required);
-      return discoveryCards;
-    },
-    [discoveryCards, discoveryTab, legacyDiscoveryTab, streamlinedUiEnabled],
+    () => cardsForTab(discoveryCards, discoveryTab),
+    [discoveryCards, discoveryTab],
   );
   const discoveryCategoryCounts = useMemo<DiscoveryCategory[]>(() => {
     const counts = new Map<string, number>();
@@ -4651,24 +4592,24 @@ export function CompanySkills() {
   // Selecting a folder shows its whole subtree (folder + descendants), matching
   // the folder-browser model. `null` means no subtree constraint (All/Unfiled).
   const folderSubtreeIds = useMemo(() => {
-    if (visibleFolderSelection === "all" || visibleFolderSelection === "unfiled") return null;
+    if (folderSelection === "all" || folderSelection === "unfiled") return null;
     const model = treeFromResult(skillFoldersQuery.data);
-    if (!model.byId.has(visibleFolderSelection)) return null;
-    return subtreeFolderIds(model, visibleFolderSelection);
-  }, [skillFoldersQuery.data, visibleFolderSelection]);
+    if (!model.byId.has(folderSelection)) return null;
+    return subtreeFolderIds(model, folderSelection);
+  }, [folderSelection, skillFoldersQuery.data]);
   const visibleDiscoveryCards = useMemo(() => {
     const filtered = discoveryTabCards.filter((card) => {
-      if (visibleDiscoveryCategory && !card.categories.includes(visibleDiscoveryCategory)) return false;
+      if (discoveryCategory && !card.categories.includes(discoveryCategory)) return false;
       // Search spans all folders (user story 5): the folder filter only
       // narrows when the user is browsing, never when searching.
-      if (effectiveDiscoveryTab === "installed" && !discoverySearchActive) {
-        if (visibleFolderSelection === "unfiled" && card.folderId) return false;
+      if (discoveryTab === "installed" && !discoverySearchActive) {
+        if (folderSelection === "unfiled" && card.folderId) return false;
         if (folderSubtreeIds && (!card.folderId || !folderSubtreeIds.has(card.folderId))) return false;
       }
       return discoveryMatchesSearch(card, discoverySearch.trim());
     });
-    return sortDiscoveryCards(filtered, discoverySort, effectiveDiscoveryTab === "discover");
-  }, [discoverySearch, discoverySearchActive, discoverySort, discoveryTabCards, effectiveDiscoveryTab, folderSubtreeIds, visibleDiscoveryCategory, visibleFolderSelection]);
+    return sortDiscoveryCards(filtered, discoverySort, discoveryTab !== "bundled");
+  }, [discoveryTabCards, discoveryCategory, discoverySearch, discoverySearchActive, discoverySort, discoveryTab, folderSelection, folderSubtreeIds]);
 
   const selectedCatalogSkill = catalogDetailQuery.data
     ?? (catalogListQuery.data ?? []).find((entry) => entry.id === selectedCatalogRef || entry.key === selectedCatalogRef)
@@ -4915,9 +4856,9 @@ export function CompanySkills() {
 
   async function openNewSkill() {
     const model = treeFromResult(skillFoldersQuery.data);
-    const selectedFolder = visibleFolderSelection === "all" || visibleFolderSelection === "unfiled"
+    const selectedFolder = folderSelection === "all" || folderSelection === "unfiled"
       ? null
-      : model.byId.get(visibleFolderSelection) ?? null;
+      : model.byId.get(folderSelection) ?? null;
     if (selectedFolder?.systemKey === "my") {
       try {
         const personalFolder = await ensureMyFolder.mutateAsync();
@@ -5120,7 +5061,7 @@ export function CompanySkills() {
       pushToast({
         tone: "success",
         title: "Skill removed",
-        body: `${skill.name} was removed from the organization skill library.`,
+        body: `${skill.name} was removed from the company skill library.`,
       });
     },
     onError: (error) => {
@@ -5129,14 +5070,13 @@ export function CompanySkills() {
   });
 
   const skillFolderResult = skillFoldersQuery.data ?? null;
-  const showInstalledFolders = isDiscovery && effectiveDiscoveryTab === "installed";
-  const showInstalledBulkSelection = showInstalledFolders && !streamlinedUiEnabled;
+  const showInstalledFolders = isDiscovery && discoveryTab === "installed";
   // Rail counts reflect the current category/search scope, never the folder
   // filter itself (ux-spec §5.3).
   const railSkillFolderResult = useMemo(() => {
-    if (!skillFolderResult || effectiveDiscoveryTab !== "installed") return skillFolderResult;
+    if (!skillFolderResult || discoveryTab !== "installed") return skillFolderResult;
     const scoped = discoveryTabCards.filter((card) => {
-      if (visibleDiscoveryCategory && !card.categories.includes(visibleDiscoveryCategory)) return false;
+      if (discoveryCategory && !card.categories.includes(discoveryCategory)) return false;
       return discoveryMatchesSearch(card, discoverySearch.trim());
     });
     const direct = new Map<string, number>();
@@ -5158,14 +5098,14 @@ export function CompanySkills() {
         return { ...folder, itemCount };
       }),
     };
-  }, [discoverySearch, discoveryTabCards, effectiveDiscoveryTab, skillFolderResult, visibleDiscoveryCategory]);
+  }, [skillFolderResult, discoveryTab, discoveryTabCards, discoveryCategory, discoverySearch]);
   const activeSkillFolderDisplayPath = useMemo(
     () => skillFolderDisplayPath(treeFromResult(skillFolderResult), activeDetail?.folderId),
     [skillFolderResult, activeDetail?.folderId],
   );
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={Boxes} message="Select an organization to manage skills." />;
+    return <EmptyState icon={Boxes} message="Select a company to manage skills." />;
   }
 
   function handleAddSkillSource() {
@@ -5205,8 +5145,8 @@ export function CompanySkills() {
   const studioBackHref = studioForkDetailQuery.data ? routeForSkill(studioForkDetailQuery.data) : "/skills";
   const studioTitle = studioForkFromId ? "Fork skill" : "Create a new skill";
   const studioDescription = studioForkFromId
-    ? "Review the fork metadata and create an editable organization copy."
-    : "Create an editable organization skill in the Paperclip workspace.";
+    ? "Review the fork metadata and create an editable company copy."
+    : "Create an editable company skill in the Paperclip workspace.";
   return (
     <>
       {policyDenial.denial ? (
@@ -5219,7 +5159,7 @@ export function CompanySkills() {
           <DialogHeader>
             <DialogTitle>Remove skill</DialogTitle>
             <DialogDescription>
-              Remove this skill from the organization library. If any agents still use it, removal will be blocked until it is detached.
+              Remove this skill from the company library. If any agents still use it, removal will be blocked until it is detached.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-3 text-sm">
@@ -5333,7 +5273,7 @@ export function CompanySkills() {
           <DialogHeader>
             <DialogTitle>Import a skill</DialogTitle>
             <DialogDescription>
-              Paste a local path, GitHub URL, or `skills.sh` command to import a skill into this organization.
+              Paste a local path, GitHub URL, or `skills.sh` command to import a skill into this company.
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-3">
@@ -5468,24 +5408,13 @@ export function CompanySkills() {
           </div>
         </div>
       ) : isDiscovery ? (
-        <>
-        {!streamlinedUiEnabled ? (
-          <div className="px-4 pt-4">
-            <Tabs value={legacyDiscoveryTab} onValueChange={(value) => setLegacyDiscoveryTab(value as "all" | "installed" | "catalog" | "bundled")}>
-              <TabsList variant="line" aria-label="Skills view">
-                <TabsTrigger value="all">All</TabsTrigger>
-                <TabsTrigger value="installed">Installed</TabsTrigger>
-                <TabsTrigger value="catalog">Catalog</TabsTrigger>
-                <TabsTrigger value="bundled">Bundled</TabsTrigger>
-              </TabsList>
-            </Tabs>
-          </div>
-        ) : null}
         <DiscoveryGrid
-          tab={effectiveDiscoveryTab}
+          tab={discoveryTab}
+          tabCounts={discoveryTabCounts}
+          onTabChange={setDiscoveryTab}
           categories={discoveryCategoryCounts}
           categoryTotal={discoveryTabCards.length}
-          activeCategory={visibleDiscoveryCategory}
+          activeCategory={discoveryCategory}
           onCategoryChange={setDiscoveryCategory}
           search={discoverySearch}
           onSearchChange={setDiscoverySearch}
@@ -5495,19 +5424,19 @@ export function CompanySkills() {
           onOpenCard={openDiscoveryCard}
           loading={skillsQuery.isLoading || catalogListQuery.isLoading}
           error={skillsQuery.error?.message ?? catalogListQuery.error?.message ?? null}
-          totalCount={discoveryTabCards.length}
+          totalCount={discoveryCards.length}
           onCreate={() => void openNewSkill()}
           onImport={() => setImportDialogOpen(true)}
           onImportFromProject={() => setImportFromProjectOpen(true)}
-          onBrowseDiscover={() => streamlinedUiEnabled ? setDiscoveryTab("discover") : setLegacyDiscoveryTab("catalog")}
+          onBrowseCatalog={() => setDiscoveryTab("catalog")}
           onScan={(projectId) => scanProjects.mutate(projectId)}
           scanPending={scanProjects.isPending}
           scanStatus={scanStatusMessage}
           folderResult={showInstalledFolders ? railSkillFolderResult : null}
-          folderSelection={visibleFolderSelection}
+          folderSelection={folderSelection}
           foldersLoading={skillFoldersQuery.isLoading}
-          selectMode={showInstalledBulkSelection && selectMode}
-          selectedSkillIds={showInstalledBulkSelection ? selectedSkillIds : []}
+          selectMode={showInstalledFolders && selectMode}
+          selectedSkillIds={selectedSkillIds}
           onFolderSelect={showInstalledFolders ? setFolderSelection : undefined}
           onOpenMobileFolders={showInstalledFolders ? () => setMobileFoldersOpen(true) : undefined}
           onCreateFolder={showInstalledFolders ? () => openCreateFolder() : undefined}
@@ -5529,11 +5458,11 @@ export function CompanySkills() {
           } : undefined}
           onMoveFolder={showInstalledFolders ? (folder, destination) => void moveFolderBetweenScopes(folder, destination) : undefined}
           onDeleteFolder={showInstalledFolders ? setDeleteFolderTarget : undefined}
-          onToggleSelectMode={showInstalledBulkSelection ? () => {
+          onToggleSelectMode={showInstalledFolders ? () => {
             setSelectMode((current) => !current);
             if (selectMode) setSelectedSkillIds([]);
           } : undefined}
-          onSelectCard={showInstalledBulkSelection ? (card, selected) => {
+          onSelectCard={showInstalledFolders ? (card, selected) => {
             if (!card.skillId) return;
             setSelectedSkillIds((current) =>
               selected
@@ -5561,13 +5490,11 @@ export function CompanySkills() {
           onCreateFolderAndMoveCard={showInstalledFolders ? (card) => {
             if (card.skillId) openCreateFolder([card.skillId]);
           } : undefined}
-          onMoveSelected={showInstalledBulkSelection ? (folderId) => void moveSelectedSkills(folderId) : undefined}
-          onCreateFolderAndMoveSelected={showInstalledBulkSelection ? () => openCreateFolder(selectedSkillIds) : undefined}
-          onClearSelected={showInstalledBulkSelection ? () => setSelectedSkillIds([]) : undefined}
+          onMoveSelected={showInstalledFolders ? (folderId) => void moveSelectedSkills(folderId) : undefined}
+          onCreateFolderAndMoveSelected={showInstalledFolders ? () => openCreateFolder(selectedSkillIds) : undefined}
+          onClearSelected={showInstalledFolders ? () => setSelectedSkillIds([]) : undefined}
           folderNudgeStorageKey={showInstalledFolders ? `paperclip:skills-folder-nudge:${selectedCompanyId ?? "none"}` : undefined}
-          showBrowseRails={browseRailsEnabled}
         />
-        </>
       ) : activeView === "installed" && selectedSkillId ? (
         <SkillDetailPage
           detail={activeDetail}

--- a/ui/src/pages/CompanySkills.test.tsx
+++ b/ui/src/pages/CompanySkills.test.tsx
@@ -3,12 +3,13 @@
 import type { ComponentProps, ReactNode } from "react";
 import { flushSync } from "react-dom";
 import { createRoot, type Root } from "react-dom/client";
-import type { CatalogSkill, CompanySkillDetail, CompanySkillVersion, FolderListResult } from "@paperclipai/shared";
+import type { CatalogSkill, CompanySkillDetail, CompanySkillListItem, CompanySkillVersion, FolderListResult } from "@paperclipai/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   DiscoveryGrid,
   InstallPreviewDialog,
   SkillDetailPage,
+  buildDiscoveryCards,
   defaultInstallAgentSelection,
   getSkillVersionDiffSelection,
   resolveDiscoveryTab,
@@ -250,9 +251,7 @@ async function renderDiscoveryGrid(props: Partial<ComponentProps<typeof Discover
   await act(async () => {
     root?.render(
       <DiscoveryGrid
-        tab="all"
-        tabCounts={{ all: 0, installed: 0, catalog: 0, bundled: 0 }}
-        onTabChange={vi.fn()}
+        tab="installed"
         categories={[]}
         categoryTotal={0}
         activeCategory={null}
@@ -269,7 +268,7 @@ async function renderDiscoveryGrid(props: Partial<ComponentProps<typeof Discover
         onCreate={vi.fn()}
         onImport={vi.fn()}
         onImportFromProject={vi.fn()}
-        onBrowseCatalog={vi.fn()}
+        onBrowseDiscover={vi.fn()}
         onScan={vi.fn()}
         scanPending={false}
         scanStatus={null}
@@ -376,14 +375,66 @@ describe("getSkillVersionDiffSelection", () => {
   });
 });
 
-describe("DiscoveryGrid Studio entry points", () => {
-  it("links the header Studio button to Skill Studio", async () => {
-    const node = await renderDiscoveryGrid();
-    const studioLink = Array.from(node.querySelectorAll("a")).find((link) =>
-      link.textContent?.includes("Studio"),
-    );
+describe("DiscoveryGrid IA presentation", () => {
+  it("makes the search scope explicit for Installed and Discover", async () => {
+    let node = await renderDiscoveryGrid({ tab: "installed" });
+    expect(node.querySelector('input[aria-label="Search installed skills"]')).not.toBeNull();
 
-    expect(studioLink?.getAttribute("href")).toBe("/skills/studio");
+    root?.unmount();
+    container?.remove();
+    root = null;
+    container = null;
+
+    node = await renderDiscoveryGrid({ tab: "discover" });
+    expect(node.querySelector('input[aria-label="Search discoverable skills"]')).not.toBeNull();
+    expect(node.textContent).not.toContain("Catalog");
+  });
+
+  it("distinguishes installation from agent enablement on cards", async () => {
+    const installedCard = {
+      key: "installed",
+      skillId: "skill-installed",
+      catalogRef: null,
+      name: "Installed Skill",
+      slug: "installed",
+      author: "Paperclip",
+      version: null,
+      tagline: null,
+      description: null,
+      categories: [],
+      iconUrl: null,
+      color: null,
+      starCount: 0,
+      agentCount: 0,
+      forkCount: 0,
+      installed: true,
+      required: false,
+      forkedFrom: false,
+      updatedAt: 0,
+      sourceBadge: "local" as const,
+      sourceLabel: "Local workspace",
+    };
+    const availableCard = {
+      ...installedCard,
+      key: "available",
+      skillId: null,
+      catalogRef: "catalog-available",
+      name: "Available Skill",
+      slug: "available",
+      installed: false,
+      sourceBadge: "catalog" as const,
+      sourceLabel: "Paperclip catalog",
+    };
+    const node = await renderDiscoveryGrid({
+      tab: "discover",
+      cards: [installedCard, availableCard],
+      totalCount: 2,
+    });
+
+    expect(node.textContent).toContain("Not enabled for any agents");
+    expect(node.textContent).toContain("Available to install");
+    expect(node.textContent).toContain("Local workspace");
+    expect(node.textContent).toContain("Paperclip catalog");
   });
 
   it("uses the create callback from the New menu and empty state", async () => {
@@ -394,6 +445,17 @@ describe("DiscoveryGrid Studio entry points", () => {
     await click(buttonsNamed(node, "Create a skill")[0] as HTMLButtonElement);
 
     expect(onCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses one Discover action instead of Catalog or Bundled navigation", async () => {
+    const onBrowseDiscover = vi.fn();
+    const node = await renderDiscoveryGrid({ onBrowseDiscover });
+
+    await click(buttonsNamed(node, "Discover skills")[0] as HTMLButtonElement);
+
+    expect(onBrowseDiscover).toHaveBeenCalledOnce();
+    expect(node.textContent).not.toContain("Browse catalog");
+    expect(node.textContent).not.toContain("Bundled tab");
   });
 
   it("keeps folder creation in the compact rail control", async () => {
@@ -408,6 +470,29 @@ describe("DiscoveryGrid Studio entry points", () => {
 
     expect(props.onCreateFolderIn).toHaveBeenCalledWith(null);
     expect(props.onCreateFolder).not.toHaveBeenCalled();
+  });
+
+  it("removes category and folder browse rails while keeping search available", async () => {
+    const node = await renderDiscoveryGrid({
+      ...projectFolderGridProps(),
+      categories: [{ slug: "design", count: 1 }],
+      categoryTotal: 1,
+      showBrowseRails: false,
+    });
+
+    expect(node.querySelector('nav[aria-label="Skill folders"]')).toBeNull();
+    expect(node.querySelector("aside")).toBeNull();
+    expect(node.textContent).not.toContain("Browse by category");
+    expect(node.querySelector('input[aria-label="Search installed skills"]')).not.toBeNull();
+  });
+
+  it("omits bulk selection when its entry point is not supplied", async () => {
+    const node = await renderDiscoveryGrid({
+      ...projectFolderGridProps(),
+      onToggleSelectMode: undefined,
+    });
+
+    expect(buttonsNamed(node, "Select")).toHaveLength(0);
   });
 
   it("keeps folder creation available when no folder rail exists", async () => {
@@ -548,15 +633,74 @@ describe("DiscoveryGrid Studio entry points", () => {
 describe("skills discovery tab routing", () => {
   it("opens the folder-first installed view when the URL has no tab", () => {
     expect(resolveDiscoveryTab(null)).toBe("installed");
-    expect(resolveDiscoveryTab("all")).toBe("all");
+    expect(resolveDiscoveryTab("all")).toBe("discover");
+    expect(resolveDiscoveryTab("catalog")).toBe("discover");
+    expect(resolveDiscoveryTab("bundled")).toBe("discover");
   });
 
-  it("keeps All explicit and makes Installed the canonical default URL", () => {
-    const allParams = withDiscoveryTab(new URLSearchParams("folder=my&category=writing"), "all");
-    expect(allParams.toString()).toBe("tab=all");
+  it("uses Discover as the only explicit discovery URL and Installed as the default", () => {
+    const discoverParams = withDiscoveryTab(new URLSearchParams("folder=my&category=writing"), "discover");
+    expect(discoverParams.toString()).toBe("tab=discover");
 
     const installedParams = withDiscoveryTab(new URLSearchParams("tab=all&folder=my"), "installed");
     expect(installedParams.toString()).toBe("folder=my");
+  });
+});
+
+describe("skills discovery card reconciliation", () => {
+  it("renders one installed card when installed and catalog data share a key", () => {
+    const installed = {
+      id: "installed-new",
+      key: "PaperclipAI/Review",
+      name: "Review",
+      slug: "review",
+      updatedAt: new Date("2026-08-30T00:00:00Z"),
+      folderId: null,
+      authorName: "Paperclip",
+      packageVersion: "2.0.0",
+      sourceRef: null,
+      tagline: null,
+      description: "Installed copy",
+      categories: [],
+      iconUrl: null,
+      color: null,
+      starCount: 0,
+      attachedAgentCount: 2,
+      forkCount: 0,
+      catalogKind: "optional",
+      forkedFromSkillId: null,
+      sourceBadge: "catalog",
+      sourceLabel: "Paperclip",
+    } as unknown as CompanySkillListItem;
+    const olderDuplicate = {
+      ...installed,
+      id: "installed-old",
+      key: "paperclipai/review",
+      updatedAt: new Date("2026-08-01T00:00:00Z"),
+    } as CompanySkillListItem;
+    const catalog = {
+      id: "catalog-review",
+      key: "paperclipai/review",
+      name: "Review",
+      slug: "review",
+      kind: "optional",
+      category: "quality",
+      description: "Catalog copy",
+      packageName: "Paperclip",
+      packageVersion: "2.0.0",
+      tags: [],
+    } as unknown as CatalogSkill;
+
+    const cards = buildDiscoveryCards([olderDuplicate, installed], [catalog, { ...catalog, id: "catalog-duplicate" }]);
+
+    expect(cards).toHaveLength(1);
+    expect(cards[0]).toMatchObject({
+      skillId: "installed-new",
+      catalogRef: "catalog-review",
+      installed: true,
+      agentCount: 2,
+      sourceKind: "optional",
+    });
   });
 });
 

--- a/ui/src/pages/Costs.production.tsx
+++ b/ui/src/pages/Costs.production.tsx
@@ -34,17 +34,6 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 const NO_COMPANY = "__none__";
-export type CostsMainTab = "overview" | "budgets" | "providers" | "billers" | "finance";
-
-export interface CostsProps {
-  /** Render inside Audit without a second page-level title or breadcrumb. */
-  embedded?: boolean;
-  initialTab?: CostsMainTab;
-  /** Pin the surface to one tab (used by Audit > Budgets). */
-  lockTab?: boolean;
-  /** Budgets is a peer Audit section, so omit it from the Costs sub-navigation. */
-  hideBudgetsTab?: boolean;
-}
 
 function currentWeekRange(): { from: string; to: string } {
   const now = new Date();
@@ -157,20 +146,14 @@ function FinanceSummaryCard({
   );
 }
 
-export function Costs({
-  embedded = false,
-  initialTab = "overview",
-  lockTab = false,
-  hideBudgetsTab = false,
-}: CostsProps = {}) {
+export function Costs() {
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
 
-  const [mainTab, setMainTab] = useState<CostsMainTab>(initialTab);
+  const [mainTab, setMainTab] = useState<"overview" | "budgets" | "providers" | "billers" | "finance">("overview");
   const [activeProvider, setActiveProvider] = useState("all");
   const [activeBiller, setActiveBiller] = useState("all");
-  const showSummaryChrome = !(embedded && lockTab && initialTab === "budgets");
 
   const {
     preset,
@@ -185,12 +168,8 @@ export function Costs({
   } = useDateRange();
 
   useEffect(() => {
-    if (!embedded) setBreadcrumbs([{ label: "Costs" }]);
-  }, [embedded, setBreadcrumbs]);
-
-  useEffect(() => {
-    setMainTab(initialTab);
-  }, [initialTab]);
+    setBreadcrumbs([{ label: "Costs" }]);
+  }, [setBreadcrumbs]);
 
   const [today, setToday] = useState(() => new Date().toDateString());
   const todayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -261,7 +240,7 @@ export function Costs({
       ]);
       return { summary, byAgent, byProject, byAgentModel };
     },
-    enabled: !!selectedCompanyId && customReady && showSummaryChrome,
+    enabled: !!selectedCompanyId && customReady,
   });
 
   const { data: financeData, isLoading: financeLoading, error: financeError } = useQuery({
@@ -280,7 +259,7 @@ export function Costs({
       ]);
       return { summary, byBiller, byKind, events };
     },
-    enabled: !!selectedCompanyId && customReady && showSummaryChrome,
+    enabled: !!selectedCompanyId && customReady,
   });
 
   const [expandedAgents, setExpandedAgents] = useState<Set<string>>(new Set());
@@ -550,26 +529,22 @@ export function Costs({
   }), [budgetPolicies]);
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={DollarSign} message="Select an organization to view costs." />;
+    return <EmptyState icon={DollarSign} message="Select a company to view costs." />;
   }
 
   const showCustomPrompt = preset === "custom" && !customReady;
   const showOverviewLoading = (spendLoading || financeLoading) && customReady;
   const overviewError = spendError ?? financeError;
+
   return (
     <div className="space-y-6">
-      {showSummaryChrome ? (
-        <div className="space-y-5">
+      <div className="space-y-5">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
             <div>
-              {embedded ? (
-                <h2 className="text-lg font-semibold text-foreground">Costs</h2>
-              ) : (
                 <h1 className="text-3xl font-semibold tracking-tight">Costs</h1>
-              )}
-              <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-                Inference spend, platform fees, credits, and live quota windows.
-              </p>
+                <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+                  Inference spend, platform fees, credits, and live quota windows.
+                </p>
             </div>
 
             <div className="flex flex-wrap items-center gap-2">
@@ -641,19 +616,16 @@ export function Costs({
               icon={ArrowUpRight}
             />
           </div>
-        </div>
-      ) : null}
+      </div>
 
       <Tabs value={mainTab} onValueChange={(value) => setMainTab(value as typeof mainTab)}>
-        {!lockTab ? (
-          <TabsList variant="line" className="justify-start">
-            <TabsTrigger value="overview">Overview</TabsTrigger>
-            {!hideBudgetsTab ? <TabsTrigger value="budgets">Budgets</TabsTrigger> : null}
-            <TabsTrigger value="providers">Providers</TabsTrigger>
-            <TabsTrigger value="billers">Billers</TabsTrigger>
-            <TabsTrigger value="finance">Finance</TabsTrigger>
-          </TabsList>
-        ) : null}
+        <TabsList variant="line" className="justify-start">
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="budgets">Budgets</TabsTrigger>
+          <TabsTrigger value="providers">Providers</TabsTrigger>
+          <TabsTrigger value="billers">Billers</TabsTrigger>
+          <TabsTrigger value="finance">Finance</TabsTrigger>
+        </TabsList>
 
         <TabsContent value="overview" className="mt-4 space-y-4">
           {showCustomPrompt ? (
@@ -936,10 +908,10 @@ export function Costs({
                   return (
                     <section key={scopeType} className="space-y-3">
                       <div>
-                        <h2 className="text-lg font-semibold capitalize">{scopeType === "company" ? "organization" : scopeType} budgets</h2>
+                        <h2 className="text-lg font-semibold capitalize">{scopeType} budgets</h2>
                         <p className="text-sm text-muted-foreground">
                           {scopeType === "company"
-                            ? "Organization-wide monthly policy."
+                            ? "Company-wide monthly policy."
                             : scopeType === "agent"
                               ? "Recurring monthly spend policies for individual agents."
                               : "Lifetime spend policies for execution-bound projects."}
@@ -968,7 +940,7 @@ export function Costs({
                 {budgetPolicies.length === 0 ? (
                   <Card>
                     <CardContent className="px-5 py-8 text-sm text-muted-foreground">
-                      No budget policies yet. Set agent and project budgets from their detail pages, or use the existing organization monthly budget control.
+                      No budget policies yet. Set agent and project budgets from their detail pages, or use the existing company monthly budget control.
                     </CardContent>
                   </Card>
                 ) : null}

--- a/ui/src/pages/Costs.test.tsx
+++ b/ui/src/pages/Costs.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Costs } from "./Costs";
+
+const budgetOverviewMock = vi.hoisted(() => vi.fn());
+const setBreadcrumbsMock = vi.hoisted(() => vi.fn());
+const costsApiMocks = vi.hoisted(() => ({
+  summary: vi.fn(),
+  byAgent: vi.fn(),
+  byProject: vi.fn(),
+  byAgentModel: vi.fn(),
+  financeSummary: vi.fn(),
+  financeByBiller: vi.fn(),
+  financeByKind: vi.fn(),
+  financeEvents: vi.fn(),
+  byProvider: vi.fn(),
+  byBiller: vi.fn(),
+  windowSpend: vi.fn(),
+  quotaWindows: vi.fn(),
+}));
+
+vi.mock("../api/budgets", () => ({
+  budgetsApi: {
+    overview: (...args: unknown[]) => budgetOverviewMock(...args),
+    upsertPolicy: vi.fn(),
+    resolveIncident: vi.fn(),
+  },
+}));
+
+vi.mock("../api/costs", () => ({ costsApi: costsApiMocks }));
+
+vi.mock("../context/CompanyContext", () => ({
+  useCompany: () => ({ selectedCompanyId: "company-1" }),
+}));
+
+vi.mock("../context/BreadcrumbContext", () => ({
+  useBreadcrumbs: () => ({ setBreadcrumbs: setBreadcrumbsMock }),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("Costs embedded Audit surfaces", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    budgetOverviewMock.mockResolvedValue({
+      policies: [],
+      activeIncidents: [],
+      pendingApprovalCount: 0,
+      pausedAgentCount: 0,
+      pausedProjectCount: 0,
+    });
+  });
+
+  afterEach(() => {
+    act(() => root?.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("renders a focused Budgets section without duplicate Costs chrome or spend queries", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Costs embedded initialTab="budgets" lockTab />
+        </QueryClientProvider>,
+      );
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await vi.waitFor(() => {
+        expect(budgetOverviewMock).toHaveBeenCalledWith("company-1");
+        expect(container.textContent).toContain("Budget control plane");
+      });
+    });
+    expect(container.textContent).not.toContain("Inference spend");
+    expect(container.querySelector('[role="tab"]')).toBeFalsy();
+    expect(setBreadcrumbsMock).not.toHaveBeenCalled();
+    for (const mock of Object.values(costsApiMocks)) expect(mock).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/pages/DesignGuide.tsx
+++ b/ui/src/pages/DesignGuide.tsx
@@ -149,7 +149,9 @@ import {
   pendingConnectionIntentInteraction,
   retryConnectionIntentInteraction,
 } from "@/fixtures/issueThreadInteractionFixtures";
-import type { CompanySecret, EnvBinding } from "@paperclipai/shared";
+import type { CompanySecret, EnvBinding, Issue } from "@paperclipai/shared";
+import { CollectionToolbar } from "@/components/CollectionToolbar";
+import { IssueRow } from "@/components/IssueRow";
 import {
   EnvInputsList,
   ExternalSourcesList,
@@ -238,6 +240,15 @@ const DESIGN_GUIDE_DEGRADED_OUTPUTS: IssueWorkProduct[] = [
     metadata: { attachmentId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc", contentType: "video/mp4" },
   } as IssueWorkProduct,
 ];
+
+const DESIGN_GUIDE_TASK = {
+  id: "design-guide-task",
+  identifier: "PAP-427",
+  title: "Reconcile the navigation model across operator surfaces",
+  status: "in_progress",
+  priority: "medium",
+  blockerAttention: false,
+} as unknown as Issue;
 
 /* ------------------------------------------------------------------ */
 /*  Section wrapper                                                    */
@@ -494,7 +505,8 @@ export function DesignGuide() {
                 "StatusBadge", "StatusIcon", "PriorityIcon", "EntityRow", "EmptyState", "MetricCard",
                 "FilterBar", "InlineEditor", "PageSkeleton", "Identity", "CommentThread", "MarkdownEditor",
                 "PropertiesPanel", "Sidebar", "CommandPalette", "EnvironmentVariablesEditor",
-                "InlineBanner", "BuiltInAgentGate", "BuiltInLifecycleChip",
+                "InlineBanner", "BuiltInAgentGate", "BuiltInLifecycleChip", "CollectionToolbar",
+                "IssueRow", "ContextualSidebarFrame",
               ].map((name) => (
                 <Badge key={name} variant="ghost" className="font-mono text-(length:--text-nano)">
                   {name}
@@ -502,6 +514,30 @@ export function DesignGuide() {
               ))}
             </div>
           </SubSection>
+        </div>
+      </Section>
+
+      <Section title="Task Collection">
+        <p className="max-w-prose text-sm text-muted-foreground">
+          CollectionToolbar owns shared geometry while each page owns its state and behavior.
+          The canonical task row is opt-in during migration: status leads, unread work uses
+          title emphasis, metadata remains stable, and the task identifier trails.
+        </p>
+        <CollectionToolbar
+          context={<span className="text-sm font-medium">Recent tasks</span>}
+          search={<Input aria-label="Search task collection example" placeholder="Search tasks..." />}
+          controls={<Button variant="outline" size="sm">Filter</Button>}
+          actions={<Button size="sm">New task</Button>}
+          feedback={<span className="text-xs text-muted-foreground">1 task · Updated newest first</span>}
+        />
+        <div className="overflow-hidden rounded-lg border border-border">
+          <IssueRow
+            issue={DESIGN_GUIDE_TASK}
+            presentation="task"
+            unreadState="visible"
+            metadata={<span className="text-xs text-muted-foreground">Updated 12m ago</span>}
+            actions={<Button variant="ghost" size="xs">More</Button>}
+          />
         </div>
       </Section>
 

--- a/ui/src/pages/InstanceExperimentalSettings.test.tsx
+++ b/ui/src/pages/InstanceExperimentalSettings.test.tsx
@@ -43,7 +43,9 @@ async function flushReact() {
 const CONFERENCE_TOGGLE_SELECTOR =
   'button[aria-label="Toggle conference room chat experimental setting"]';
 const STREAMLINED_TOGGLE_SELECTOR =
-  'button[aria-label="Toggle streamlined left navigation experimental setting"]';
+  'button[aria-label="Toggle Streamlined UI experimental setting"]';
+const TASK_WATCHDOGS_TOGGLE_SELECTOR =
+  'button[aria-label="Toggle task watchdogs experimental setting"]';
 const CLASSIC_TASK_INTERFACE_TOGGLE_SELECTOR =
   'button[aria-label="Toggle classic task interface experimental setting"]';
 const GOALS_SIDEBAR_LINK_TOGGLE_SELECTOR =
@@ -72,6 +74,7 @@ function defaultExperimentalSettings(): InstanceExperimentalSettingsPayload {
     enableManagedSandboxOnly: false,
     enableIsolatedWorkspaces: false,
     enableStreamlinedLeftNavigation: true,
+    enableStreamlinedUi: true,
     enableApps: true,
     enablePipelines: false,
     enableCases: false,
@@ -224,13 +227,30 @@ describe("InstanceExperimentalSettings — Conference Room Chat card (PAP-11233)
     expect(mockInstanceSettingsApi.updateExperimental).not.toHaveBeenCalled();
   });
 
-  it("no longer renders the Streamlined Left Navigation toggle (opt-out retired, PAP-12472)", async () => {
+  it("renders and patches the Streamlined UI experimental toggle on and off", async () => {
     await renderPage();
 
-    const headings = [...container.querySelectorAll("section h2")].map((h) => h.textContent);
-    expect(headings).not.toContain("Streamlined Left Navigation Bar");
-    expect(container.querySelector(STREAMLINED_TOGGLE_SELECTOR)).toBeNull();
-    expect(mockInstanceSettingsApi.updateExperimental).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("Streamlined UI");
+    expect(container.textContent).toContain(
+      "Use the simplified main sidebar, shared Tasks and Inbox presentation, focused task detail layout, and contextual navigation across Agents, Routines, Skills, and Settings.",
+    );
+
+    const toggle = container.querySelector<HTMLButtonElement>(STREAMLINED_TOGGLE_SELECTOR);
+    expect(toggle?.getAttribute("aria-checked")).toBe("true");
+
+    await act(() => toggle?.click());
+    await flushReact();
+    expect(mockInstanceSettingsApi.updateExperimental).toHaveBeenLastCalledWith({
+      enableStreamlinedUi: false,
+    });
+    expect(toggle?.getAttribute("aria-checked")).toBe("false");
+
+    await act(() => toggle?.click());
+    await flushReact();
+    expect(mockInstanceSettingsApi.updateExperimental).toHaveBeenLastCalledWith({
+      enableStreamlinedUi: true,
+    });
+    expect(toggle?.getAttribute("aria-checked")).toBe("true");
   });
 
   it("does not render a Task Watchdogs toggle because watchdogs are always enabled", async () => {

--- a/ui/src/pages/InstanceExperimentalSettings.tsx
+++ b/ui/src/pages/InstanceExperimentalSettings.tsx
@@ -205,6 +205,7 @@ export function InstanceExperimentalSettings() {
   const enableIsolatedWorkspaces = experimentalQuery.data?.enableIsolatedWorkspaces === true;
   // Streamlined left navigation is now the standard sidebar (PAP-12472); the
   // experimental opt-out was retired, so it no longer surfaces a toggle here.
+  const enableStreamlinedUi = experimentalQuery.data?.enableStreamlinedUi !== false;
   const enableConferenceRoomChat = experimentalQuery.data?.enableConferenceRoomChat === true;
   const enableClassicTaskInterface = experimentalQuery.data?.enableClassicTaskInterface === true;
   const enableIssuePlanDecompositions =
@@ -418,6 +419,18 @@ export function InstanceExperimentalSettings() {
           settingKey="enableStatusCards"
           managed={managedKeys.enableStatusCards}
           ariaLabel="Toggle status cards experimental setting"
+        />
+
+        <ExperimentalToggleCard
+          title="Streamlined UI"
+          description="Use the simplified main sidebar, shared Tasks and Inbox presentation, focused task detail layout, and contextual navigation across Agents, Routines, Skills, and Settings."
+          footnote="Turning this off restores the legacy shell and navigation. Task and page data are unchanged."
+          checked={enableStreamlinedUi}
+          onCheckedChange={(checked) => toggleMutation.mutate({ enableStreamlinedUi: checked })}
+          disabled={toggleMutation.isPending}
+          settingKey="enableStreamlinedUi"
+          managed={managedKeys.enableStreamlinedUi}
+          ariaLabel="Toggle Streamlined UI experimental setting"
         />
 
         <ExperimentalToggleCard

--- a/ui/src/pages/OrgChart.production.tsx
+++ b/ui/src/pages/OrgChart.production.tsx
@@ -24,7 +24,6 @@ const GAP_Y = 80;
 const PADDING = 60;
 const MIN_ZOOM = 0.2;
 const MAX_ZOOM = 2;
-const FIT_PADDING = 40;
 const TOUCH_MOVE_THRESHOLD = 6;
 
 // ── Tree layout types ───────────────────────────────────────────────────
@@ -140,28 +139,6 @@ function clampZoom(value: number): number {
   return Math.min(Math.max(value, MIN_ZOOM), MAX_ZOOM);
 }
 
-function fitChartToViewport(
-  containerWidth: number,
-  containerHeight: number,
-  bounds: { width: number; height: number },
-): { zoom: number; pan: Point } | null {
-  if (containerWidth <= FIT_PADDING || containerHeight <= FIT_PADDING) return null;
-
-  const scaleX = (containerWidth - FIT_PADDING) / bounds.width;
-  const scaleY = (containerHeight - FIT_PADDING) / bounds.height;
-  const zoom = clampZoom(Math.min(scaleX, scaleY, 1));
-  const chartWidth = bounds.width * zoom;
-  const chartHeight = bounds.height * zoom;
-
-  return {
-    zoom,
-    pan: {
-      x: (containerWidth - chartWidth) / 2,
-      y: (containerHeight - chartHeight) / 2,
-    },
-  };
-}
-
 function touchPoint(touch: React.Touch): Point {
   return { x: touch.clientX, y: touch.clientY };
 }
@@ -196,16 +173,7 @@ const defaultDotColor = "var(--hex-a3a3a3)";
 
 // ── Main component ──────────────────────────────────────────────────────
 
-export interface OrgChartProps {
-  /** Pre-filtered tree for embedding the chart in another collection page. */
-  orgTree?: OrgNode[];
-  /** Agent records paired with a pre-filtered embedded tree. */
-  agents?: Agent[];
-  /** Hides page-level actions and breadcrumb ownership. */
-  embedded?: boolean;
-}
-
-export function OrgChart({ orgTree: providedOrgTree, agents: providedAgents, embedded = false }: OrgChartProps = {}) {
+export function OrgChart() {
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
   const navigate = useNavigate();
@@ -217,19 +185,17 @@ export function OrgChart({ orgTree: providedOrgTree, agents: providedAgents, emb
   const showImport = !isCloud && !hiddenSettings.has("company.import");
   const showExport = !hiddenSettings.has("company.export");
 
-  const { data: queriedOrgTree, isLoading } = useQuery({
+  const { data: orgTree, isLoading } = useQuery({
     queryKey: queryKeys.org(selectedCompanyId!),
     queryFn: () => agentsApi.org(selectedCompanyId!),
-    enabled: !!selectedCompanyId && providedOrgTree === undefined,
+    enabled: !!selectedCompanyId,
   });
 
-  const { data: queriedAgents } = useQuery({
+  const { data: agents } = useQuery({
     queryKey: queryKeys.agents.list(selectedCompanyId!),
     queryFn: () => agentsApi.list(selectedCompanyId!),
-    enabled: !!selectedCompanyId && providedAgents === undefined,
+    enabled: !!selectedCompanyId,
   });
-  const orgTree = providedOrgTree ?? queriedOrgTree;
-  const agents = providedAgents ?? queriedAgents;
 
   const agentMap = useMemo(() => {
     const m = new Map<string, Agent>();
@@ -238,8 +204,8 @@ export function OrgChart({ orgTree: providedOrgTree, agents: providedAgents, emb
   }, [agents]);
 
   useEffect(() => {
-    if (!embedded) setBreadcrumbs([{ label: "Org Chart" }]);
-  }, [embedded, setBreadcrumbs]);
+    setBreadcrumbs([{ label: "Org Chart" }]);
+  }, [setBreadcrumbs]);
 
   // Layout computation
   const layout = useMemo(() => layoutForest(orgTree ?? []), [orgTree]);
@@ -286,18 +252,26 @@ export function OrgChart({ orgTree: providedOrgTree, agents: providedAgents, emb
   // Center the chart on first load
   const hasInitialized = useRef(false);
   useEffect(() => {
-    hasInitialized.current = false;
-  }, [orgTree]);
-
-  useEffect(() => {
     if (hasInitialized.current || allNodes.length === 0 || !containerRef.current) return;
-    const container = containerRef.current;
-    const fitted = fitChartToViewport(container.clientWidth, container.clientHeight, bounds);
-    if (!fitted) return;
-
     hasInitialized.current = true;
-    setZoom(fitted.zoom);
-    setPan(fitted.pan);
+
+    const container = containerRef.current;
+    const containerW = container.clientWidth;
+    const containerH = container.clientHeight;
+
+    // Fit chart to container
+    const scaleX = (containerW - 40) / bounds.width;
+    const scaleY = (containerH - 40) / bounds.height;
+    const fitZoom = Math.min(scaleX, scaleY, 1);
+
+    const chartW = bounds.width * fitZoom;
+    const chartH = bounds.height * fitZoom;
+
+    setZoom(fitZoom);
+    setPan({
+      x: (containerW - chartW) / 2,
+      y: (containerH - chartH) / 2,
+    });
   }, [allNodes, bounds]);
 
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
@@ -353,15 +327,15 @@ export function OrgChart({ orgTree: providedOrgTree, agents: providedAgents, emb
 
   const fitToScreen = useCallback(() => {
     if (!containerRef.current) return;
-    const fitted = fitChartToViewport(
-      containerRef.current.clientWidth,
-      containerRef.current.clientHeight,
-      bounds,
-    );
-    if (!fitted) return;
-
-    setZoom(fitted.zoom);
-    setPan(fitted.pan);
+    const cW = containerRef.current.clientWidth;
+    const cH = containerRef.current.clientHeight;
+    const scaleX = (cW - 40) / bounds.width;
+    const scaleY = (cH - 40) / bounds.height;
+    const fitZoom = Math.min(scaleX, scaleY, 1);
+    const chartW = bounds.width * fitZoom;
+    const chartH = bounds.height * fitZoom;
+    setZoom(fitZoom);
+    setPan({ x: (cW - chartW) / 2, y: (cH - chartH) / 2 });
   }, [bounds]);
 
   const handleTouchStart = useCallback((e: React.TouchEvent<HTMLDivElement>) => {
@@ -465,10 +439,10 @@ export function OrgChart({ orgTree: providedOrgTree, agents: providedAgents, emb
   }, [pan, zoom]);
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={Network} message="Select an organization to view the org chart." />;
+    return <EmptyState icon={Network} message="Select a company to view the org chart." />;
   }
 
-  if (providedOrgTree === undefined && isLoading) {
+  if (isLoading) {
     return <PageSkeleton variant="org-chart" />;
   }
 
@@ -477,31 +451,25 @@ export function OrgChart({ orgTree: providedOrgTree, agents: providedAgents, emb
   }
 
   return (
-    <div
-      className={embedded
-        ? "flex min-h-(--sz-420px) flex-1 flex-col md:min-h-0"
-        : "flex h-(--sz-calc-38) min-h-(--sz-420px) flex-col md:h-full md:min-h-0"}
-    >
-      {!embedded && (showImport || showExport) ? (
-        <div className="mb-2 flex shrink-0 flex-wrap items-center justify-start gap-2">
-        {showImport ? (
+    <div className="flex h-(--sz-calc-38) min-h-(--sz-420px) flex-col md:h-full md:min-h-0">
+      <div className="mb-2 flex shrink-0 flex-wrap items-center justify-start gap-2">
+        {showImport && (
           <Link to="/company/import">
             <Button variant="outline" size="sm">
               <Upload className="mr-1.5 h-3.5 w-3.5" />
-              Import organization
+              Import company
             </Button>
           </Link>
-        ) : null}
-        {showExport ? (
+        )}
+        {showExport && (
           <Link to="/company/export">
             <Button variant="outline" size="sm">
               <Download className="mr-1.5 h-3.5 w-3.5" />
-              Export organization
+              Export company
             </Button>
           </Link>
-        ) : null}
-        </div>
-      ) : null}
+        )}
+      </div>
       <div
         ref={containerRef}
         data-testid="org-chart-viewport"

--- a/ui/src/pages/OrgChart.test.tsx
+++ b/ui/src/pages/OrgChart.test.tsx
@@ -129,6 +129,8 @@ describe("OrgChart mobile gestures", () => {
   let container: HTMLDivElement;
   let root: ReturnType<typeof createRoot>;
   let queryClient: QueryClient;
+  let viewportWidth: number;
+  let viewportHeight: number;
 
   beforeEach(() => {
     container = document.createElement("div");
@@ -136,19 +138,21 @@ describe("OrgChart mobile gestures", () => {
     queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
+    viewportWidth = 360;
+    viewportHeight = 520;
     orgMock.mockResolvedValue(orgTree);
     listMock.mockResolvedValue(agents);
 
     Object.defineProperty(HTMLElement.prototype, "clientWidth", {
       configurable: true,
       get() {
-        return this.getAttribute("data-testid") === "org-chart-viewport" ? 360 : 0;
+        return this.getAttribute("data-testid") === "org-chart-viewport" ? viewportWidth : 0;
       },
     });
     Object.defineProperty(HTMLElement.prototype, "clientHeight", {
       configurable: true,
       get() {
-        return this.getAttribute("data-testid") === "org-chart-viewport" ? 520 : 0;
+        return this.getAttribute("data-testid") === "org-chart-viewport" ? viewportHeight : 0;
       },
     });
     vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function getRect(this: HTMLElement) {
@@ -158,10 +162,10 @@ describe("OrgChart mobile gestures", () => {
           y: 0,
           left: 0,
           top: 0,
-          right: 360,
-          bottom: 520,
-          width: 360,
-          height: 520,
+          right: viewportWidth,
+          bottom: viewportHeight,
+          width: viewportWidth,
+          height: viewportHeight,
           toJSON: () => ({}),
         };
       }
@@ -262,6 +266,19 @@ describe("OrgChart mobile gestures", () => {
     });
 
     expect(layer.style.transform).toBe("translate(-45px, 40px) scale(1.5)");
+  });
+
+  it("does not produce a negative zoom while the viewport has no usable height", async () => {
+    viewportHeight = 2;
+    const { layer } = await renderOrgChart();
+
+    expect(layer.style.transform).toBe("translate(0px, 0px) scale(1)");
+
+    await act(async () => {
+      (container.querySelector('[aria-label="Fit chart to screen"]') as HTMLButtonElement).click();
+    });
+
+    expect(layer.style.transform).toBe("translate(0px, 0px) scale(1)");
   });
 
   it("shows both portability buttons on self-hosted instances", async () => {

--- a/ui/src/pages/ProjectDetail.test.tsx
+++ b/ui/src/pages/ProjectDetail.test.tsx
@@ -246,6 +246,28 @@ describe("ProjectDetail", () => {
     });
   });
 
+  it("keeps Timeline out of the project task-list controls", async () => {
+    mockLocation.pathname = "/projects/project-1/issues";
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <ProjectDetail />
+        </QueryClientProvider>,
+      );
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    const props = mockIssuesList.mock.calls.at(-1)?.[0];
+    expect(props).toEqual(expect.objectContaining({ projectId: "project-1" }));
+    expect(props).not.toHaveProperty("projectTimelineHref");
+  });
+
   describe("plugin detail-tab deep links", () => {
     const PLUGIN_TAB = "plugin:paperclipai.plugin-llm-wiki:project-knowledge";
     const knowledgeSlot = {

--- a/ui/src/pages/RoutineDetail.production.tsx
+++ b/ui/src/pages/RoutineDetail.production.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Navigate, useNavigate, useParams } from "@/lib/router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { AlertCircle, History, Pencil, Repeat, Sparkles, X } from "lucide-react";
+import { AlertCircle, Repeat, Sparkles } from "lucide-react";
 import { ApiError } from "../api/client";
 import {
   routinesApi,
@@ -18,7 +18,6 @@ import { accessApi } from "../api/access";
 import { useCompany } from "../context/CompanyContext";
 import { useBreadcrumbs } from "../context/BreadcrumbContext";
 import { useToastActions } from "../context/ToastContext";
-import { useStreamlinedUiEnabled } from "../hooks/useStreamlinedUiEnabled";
 import { queryKeys } from "../lib/queryKeys";
 import { copyTextToClipboard } from "../lib/clipboard";
 import { buildMarkdownMentionOptions } from "../lib/company-members";
@@ -35,17 +34,14 @@ import { RunButton } from "../components/AgentActionButtons";
 import { getRecentAssigneeIds, sortAgentsByRecency, trackRecentAssignee } from "../lib/recent-assignees";
 import { getRecentProjectIds, trackRecentProject } from "../lib/recent-projects";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { RoutineOverview } from "../components/RoutineOverview";
-import { RoutineSectionPicker, RoutineSubSidebar } from "../components/RoutineSubSidebar";
 import {
-  isRoutineDetailView,
-  resolveRoutineDetailDestination,
-  routineDetailHref,
-} from "../components/RoutineContextualSidebar";
+  RoutineSubSidebar,
+  RoutineSectionPicker,
+} from "../components/RoutineSubSidebar";
 import { RoutineSaveBar } from "../components/RoutineSaveBar";
 import {
   EDITABLE_SECTIONS,
+  ROUTINE_SECTION_KEYS,
   SECTION_FIELD_KEYS,
   RoutineDetailContext,
   createDefaultNewTrigger,
@@ -60,17 +56,19 @@ import {
   VariablesSection,
   SecretsSection,
   DeliverySection,
-} from "../components/routine-sections/editable-sections";
+} from "../components/routine-sections/editable-sections.production";
 import {
+  RunsSection,
   ActivitySection,
   HistorySection,
-  RunsSection,
 } from "../components/routine-sections/operate-sections";
 import type {
   RoutineDetail as RoutineDetailType,
   RoutineEnvConfig,
   RoutineVariable,
 } from "@paperclipai/shared";
+
+const LAST_SECTION_STORAGE_KEY = "paperclip.routineLastSection";
 
 export function buildRoutineProjectOptions(
   projects: ReadonlyArray<{ id: string; name: string; description?: string | null; archivedAt?: Date | string | null }>,
@@ -86,13 +84,49 @@ export function buildRoutineProjectOptions(
 
 const SECTION_TITLES: Record<RoutineSectionKey, string> = {
   overview: "Overview",
-  triggers: "Schedule",
+  triggers: "Triggers",
   variables: "Variables",
   secrets: "Secrets",
   delivery: "Delivery",
   runs: "Runs",
   activity: "Activity",
-  history: "Version history",
+  history: "History",
+};
+
+function isRoutineSection(value: string | undefined | null): value is RoutineSectionKey {
+  return value != null && ROUTINE_SECTION_KEYS.includes(value as RoutineSectionKey);
+}
+
+function readLastSection(routineId: string): RoutineSectionKey | null {
+  try {
+    const raw = localStorage.getItem(LAST_SECTION_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Record<string, string>;
+    const stored = parsed[routineId];
+    return isRoutineSection(stored) ? stored : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeLastSection(routineId: string, section: RoutineSectionKey) {
+  try {
+    const raw = localStorage.getItem(LAST_SECTION_STORAGE_KEY);
+    const parsed = raw ? (JSON.parse(raw) as Record<string, string>) : {};
+    parsed[routineId] = section;
+    localStorage.setItem(LAST_SECTION_STORAGE_KEY, JSON.stringify(parsed));
+  } catch {
+    /* ignore storage failures */
+  }
+}
+
+/** Back-compat: `?tab=x` query param maps to the new section sub-routes. */
+const LEGACY_TAB_TO_SECTION: Record<string, RoutineSectionKey> = {
+  triggers: "triggers",
+  runs: "runs",
+  activity: "activity",
+  secrets: "secrets",
+  history: "history",
 };
 
 function autoResizeTextarea(element: HTMLTextAreaElement | null) {
@@ -126,7 +160,6 @@ export function RoutineDetail() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const { pushToast } = useToastActions();
-  const { enabled: streamlinedUiEnabled } = useStreamlinedUiEnabled();
   const hydratedRoutineIdRef = useRef<string | null>(null);
   const titleInputRef = useRef<HTMLTextAreaElement | null>(null);
   const descriptionEditorRef = useRef<MarkdownEditorRef>(null);
@@ -135,7 +168,6 @@ export function RoutineDetail() {
   const [secretMessage, setSecretMessage] = useState<SecretMessage | null>(null);
   const [saveConflict, setSaveConflict] = useState(false);
   const [runVariablesOpen, setRunVariablesOpen] = useState(false);
-  const [overviewEditing, setOverviewEditing] = useState(false);
   const [newTrigger, setNewTrigger] = useState(createDefaultNewTrigger);
   const [editDraft, setEditDraft] = useState<RoutineEditDraft>({
     title: "",
@@ -151,25 +183,15 @@ export function RoutineDetail() {
     env: null,
   });
 
-  const legacyOperateSection = !streamlinedUiEnabled && (sectionParam === "runs" || sectionParam === "activity")
-    ? sectionParam
-    : null;
-  const section: RoutineSectionKey = legacyOperateSection
-    ?? (isRoutineDetailView(sectionParam) ? sectionParam : "overview");
+  const section: RoutineSectionKey = isRoutineSection(sectionParam) ? sectionParam : "overview";
 
   const navigateToSection = useCallback(
     (next: RoutineSectionKey, options?: { replace?: boolean }) => {
       if (!routineId) return;
-      if (!streamlinedUiEnabled && (next === "runs" || next === "activity")) {
-        navigate(`/routines/${routineId}/${next}`, { replace: options?.replace ?? true });
-        return;
-      }
-      navigate(
-        resolveRoutineDetailDestination({ routineId, section: next }),
-        { replace: options?.replace ?? true },
-      );
+      writeLastSection(routineId, next);
+      navigate(`/routines/${routineId}/${next}`, { replace: options?.replace ?? true });
     },
-    [navigate, routineId, streamlinedUiEnabled],
+    [navigate, routineId],
   );
 
   const { data: routine, isLoading, error } = useQuery({
@@ -229,7 +251,7 @@ export function RoutineDetail() {
   });
   const createSecret = useMutation({
     mutationFn: (input: { name: string; value: string }) => {
-      if (!selectedCompanyId) throw new Error("Select an organization to create secrets");
+      if (!selectedCompanyId) throw new Error("Select a company to create secrets");
       return secretsApi.create(selectedCompanyId, input);
     },
     onSuccess: () => {
@@ -338,9 +360,12 @@ export function RoutineDetail() {
     autoResizeTextarea(titleInputRef.current);
   }, [editDraft.title, routine?.id]);
 
+  // Persist the section the user lands on so a bare /routines/:id remembers it.
   useEffect(() => {
-    if (section !== "overview") setOverviewEditing(false);
-  }, [routineId, section]);
+    if (routineId && isRoutineSection(sectionParam)) {
+      writeLastSection(routineId, sectionParam);
+    }
+  }, [routineId, sectionParam]);
 
   const copySecretValue = useCallback(
     async (label: string, value: string) => {
@@ -649,18 +674,23 @@ export function RoutineDetail() {
   );
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={Repeat} message="Select an organization to view routines." />;
+    return <EmptyState icon={Repeat} message="Select a company to view routines." />;
   }
 
+  // Back-compat redirect: `?tab=x` → `/routines/:id/x`.
   const legacyTab = new URLSearchParams(window.location.search).get("tab");
-  const validLegacySection = !streamlinedUiEnabled && (sectionParam === "runs" || sectionParam === "activity");
-  if (routineId && (legacyTab || !sectionParam || (!isRoutineDetailView(sectionParam) && !validLegacySection))) {
-    return (
-      <Navigate
-        to={resolveRoutineDetailDestination({ routineId, section: sectionParam, legacyTab })}
-        replace
-      />
-    );
+  if (routineId && legacyTab && LEGACY_TAB_TO_SECTION[legacyTab]) {
+    return <Navigate to={`/routines/${routineId}/${LEGACY_TAB_TO_SECTION[legacyTab]}`} replace />;
+  }
+
+  // Bare /routines/:id → remembered section or overview.
+  if (routineId && !sectionParam) {
+    const landing = readLastSection(routineId) ?? "overview";
+    return <Navigate to={`/routines/${routineId}/${landing}`} replace />;
+  }
+  // Unknown section → overview.
+  if (routineId && sectionParam && !isRoutineSection(sectionParam)) {
+    return <Navigate to={`/routines/${routineId}/overview`} replace />;
   }
 
   if (isLoading) {
@@ -771,52 +801,35 @@ export function RoutineDetail() {
         Skip to section
       </a>
 
-      {/* The global shell owns routine navigation. This surface keeps one
-          content scroll owner and a compact action header. */}
-      <div className="-m-4 flex h-full min-h-0 overflow-hidden md:-m-6">
-        {!streamlinedUiEnabled ? (
-          <RoutineSubSidebar
-            activeSection={section}
-            hrefFor={(next) => next === "runs" || next === "activity"
-              ? `/routines/${routine.id}/${next}`
-              : routineDetailHref(routine.id, next)}
-            isSectionDirty={isSectionDirty}
-            hasLiveRun={hasLiveRun}
-            onNavigate={navigateToSection}
-          />
-        ) : null}
-        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-        {!streamlinedUiEnabled ? (
-          <RoutineSectionPicker
-            activeSection={section}
-            onNavigate={navigateToSection}
-            isSectionDirty={isSectionDirty}
-          />
-        ) : null}
-        <header className="flex min-h-14 shrink-0 flex-wrap items-center gap-3 border-b border-border bg-background px-4 py-2 md:px-6">
+      {/* Bounded to the main scroll area's height so the header + sub-nav stay
+          fixed and only the section content below scrolls (no page-level
+          scroll, no competing sticky points). */}
+      <div className="-m-4 flex h-full min-h-0 flex-col overflow-hidden md:-m-6">
+        {/* Slim page header — fixed at the top of the routine layout. */}
+        <header className="flex h-14 shrink-0 items-center gap-3 border-b border-border bg-background px-6">
           <div className="flex min-w-0 flex-1 items-center gap-3">
-            {section === "overview" && overviewEditing ? (
-              <textarea
-                ref={titleInputRef}
-                data-autosize-title
-                className="min-w-0 flex-1 resize-none overflow-hidden bg-transparent text-base font-semibold leading-7 outline-none placeholder:text-muted-foreground/50"
-                placeholder="Routine title"
-                rows={1}
-                value={editDraft.title}
-                onChange={(event) => {
-                  setEditDraft((current) => ({ ...current, title: event.target.value }));
-                  autoResizeTextarea(event.target);
-                }}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter" && !event.metaKey && !event.ctrlKey && !event.nativeEvent.isComposing) {
-                    event.preventDefault();
+            <textarea
+              ref={titleInputRef}
+              data-autosize-title
+              className="min-w-0 flex-1 resize-none overflow-hidden bg-transparent text-base font-semibold leading-7 outline-none placeholder:text-muted-foreground/50"
+              placeholder="Routine title"
+              rows={1}
+              value={editDraft.title}
+              onChange={(event) => {
+                setEditDraft((current) => ({ ...current, title: event.target.value }));
+                autoResizeTextarea(event.target);
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && !event.metaKey && !event.ctrlKey && !event.nativeEvent.isComposing) {
+                  event.preventDefault();
+                  if (section === "overview") {
                     descriptionEditorRef.current?.focus();
+                  } else {
+                    navigateToSection("overview");
                   }
-                }}
-              />
-            ) : (
-              <h1 className="min-w-0 flex-1 truncate text-xl font-bold">{routine.title}</h1>
-            )}
+                }
+              }}
+            />
             {routine.managedByPlugin ? (
               <Badge variant="outline" className="hidden shrink-0 gap-1.5 text-xs text-muted-foreground sm:inline-flex">
                 <Sparkles className="h-3 w-3" />
@@ -825,45 +838,7 @@ export function RoutineDetail() {
               </Badge>
             ) : null}
           </div>
-          <div className="ml-auto flex shrink-0 items-center gap-2">
-            {section === "history" ? (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => navigate(routineDetailHref(routine.id))}
-              >
-                Back to overview
-              </Button>
-            ) : (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => navigate(routineDetailHref(routine.id, "history"))}
-              >
-                <History className="h-3.5 w-3.5" />
-                History
-              </Button>
-            )}
-            {section === "overview" ? (
-              overviewEditing ? (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => {
-                    discardSection("overview");
-                    setOverviewEditing(false);
-                  }}
-                >
-                  <X className="h-3.5 w-3.5" />
-                  Cancel editing
-                </Button>
-              ) : (
-                <Button variant="outline" size="sm" onClick={() => setOverviewEditing(true)}>
-                  <Pencil className="h-3.5 w-3.5" />
-                  Edit routine
-                </Button>
-              )
-            ) : null}
+          <div className="ml-auto flex shrink-0 items-center gap-3">
             <RunButton onClick={() => setRunVariablesOpen(true)} disabled={runRoutine.isPending} />
             <div className="flex items-center gap-2">
               <ToggleSwitch
@@ -878,48 +853,58 @@ export function RoutineDetail() {
           </div>
         </header>
 
-        <main
-          id="routine-section"
-          role="main"
-          className="min-h-0 min-w-0 flex-1 overflow-y-auto px-4 pb-6 pt-8 md:px-8"
-        >
-          <section
-            aria-labelledby="routine-section-title"
-            className={
-              section === "overview" && !overviewEditing
-                ? "mx-auto w-full max-w-5xl"
-                : isEditableSection
-                  ? "mx-auto w-full max-w-3xl"
-                  : "w-full"
-            }
+        {/* Mobile section picker */}
+        <RoutineSectionPicker
+          activeSection={section}
+          onNavigate={navigateToSection}
+          isSectionDirty={isSectionDirty}
+        />
+
+        <div className="flex min-h-0 flex-1">
+          <RoutineSubSidebar
+            activeSection={section}
+            hrefFor={(target) => `/routines/${routineId}/${target}`}
+            isSectionDirty={isSectionDirty}
+            hasLiveRun={hasLiveRun}
+            onNavigate={(target) => writeLastSection(routineId!, target)}
+          />
+
+          <main
+            id="routine-section"
+            role="main"
+            className="min-h-0 min-w-0 flex-1 overflow-y-auto px-4 pb-6 pt-10 md:px-8"
           >
-            <h2 id="routine-section-title" className="mb-4 text-lg font-semibold">
-              {SECTION_TITLES[section]}
-            </h2>
+            <section
+              aria-labelledby="routine-section-title"
+              className={isEditableSection ? "mx-auto w-full max-w-3xl" : "w-full"}
+            >
+              <h2 id="routine-section-title" className="mb-4 text-lg font-semibold">
+                {SECTION_TITLES[section]}
+              </h2>
 
-            {section === "overview" && (overviewEditing ? <OverviewSection /> : <RoutineOverview />)}
-            {section === "triggers" && <TriggersSection />}
-            {section === "variables" && <VariablesSection />}
-            {section === "secrets" && <SecretsSection />}
-            {section === "delivery" && <DeliverySection />}
-            {section === "runs" && <RunsSection />}
-            {section === "activity" && <ActivitySection />}
-            {section === "history" && <HistorySection />}
+              {section === "overview" && <OverviewSection />}
+              {section === "triggers" && <TriggersSection />}
+              {section === "variables" && <VariablesSection />}
+              {section === "secrets" && <SecretsSection />}
+              {section === "delivery" && <DeliverySection />}
+              {section === "runs" && <RunsSection />}
+              {section === "activity" && <ActivitySection />}
+              {section === "history" && <HistorySection />}
 
-            {isEditableSection && (section !== "overview" || overviewEditing) ? (
-              <RoutineSaveBar
-                dirtyFields={sectionDirtyFields(section)}
-                isSaving={saveRoutine.isPending}
-                saveConflict={saveConflict}
-                onSave={() => {
-                  if (!saveRoutine.isPending && editDraft.title.trim()) saveRoutine.mutate();
-                }}
-                onDiscard={() => discardSection(section)}
-                onReload={reloadLatest}
-              />
-            ) : null}
-          </section>
-        </main>
+              {isEditableSection ? (
+                <RoutineSaveBar
+                  dirtyFields={sectionDirtyFields(section)}
+                  isSaving={saveRoutine.isPending}
+                  saveConflict={saveConflict}
+                  onSave={() => {
+                    if (!saveRoutine.isPending && editDraft.title.trim()) saveRoutine.mutate();
+                  }}
+                  onDiscard={() => discardSection(section)}
+                  onReload={reloadLatest}
+                />
+              ) : null}
+            </section>
+          </main>
         </div>
       </div>
 

--- a/ui/src/pages/Routines.production.tsx
+++ b/ui/src/pages/Routines.production.tsx
@@ -1,6 +1,6 @@
 import { startTransition, useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link, Navigate, useNavigate, useSearchParams } from "@/lib/router";
+import { Link, useNavigate, useSearchParams } from "@/lib/router";
 import { ArrowUpDown, Check, ChevronDown, ChevronRight, Layers, Plus, Repeat } from "lucide-react";
 import { routinesApi } from "../api/routines";
 import { foldersApi } from "../api/folders";
@@ -20,6 +20,7 @@ import { createIssueDetailLocationState } from "../lib/issueDetailBreadcrumb";
 import { collectLiveIssueIds } from "../lib/liveIssueIds";
 import { getRecentAssigneeIds, sortAgentsByRecency, trackRecentAssignee } from "../lib/recent-assignees";
 import { getRecentProjectIds, trackRecentProject } from "../lib/recent-projects";
+import { usePublishSharedQueryData, useSharedPollingQuery } from "../hooks/useSharedPolling";
 import { EmptyState } from "../components/EmptyState";
 import { IssuesList } from "../components/IssuesList";
 import { PageSkeleton } from "../components/PageSkeleton";
@@ -45,13 +46,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { auditSectionHref } from "./audit/audit-navigation";
-import { routineDetailHref } from "../components/RoutineContextualSidebar";
-import { usePublishSharedQueryData, useSharedPollingQuery } from "../hooks/useSharedPolling";
-import { useStreamlinedUiEnabled } from "../hooks/useStreamlinedUiEnabled";
+import { Tabs, TabsContent } from "@/components/ui/tabs";
 import type { RoutineListItem, RoutineVariable } from "@paperclipai/shared";
 import type { FolderListItem } from "@paperclipai/shared";
-import { Tabs } from "@/components/ui/tabs";
 import {
   AllUnfiledBanner,
   BulkBar,
@@ -86,8 +83,8 @@ function autoResizeTextarea(element: HTMLTextAreaElement | null) {
   element.style.height = `${element.scrollHeight}px`;
 }
 
-type RoutineGroupBy = "folder" | "none" | "project" | "assignee";
 type RoutinesTab = "routines" | "runs";
+type RoutineGroupBy = "folder" | "none" | "project" | "assignee";
 type RoutineSortField = "updated" | "created" | "title" | "lastRun";
 type RoutineSortDir = "asc" | "desc";
 
@@ -287,20 +284,28 @@ export function sortRoutines(
   });
 }
 
+function buildRoutinesTabHref(tab: RoutinesTab) {
+  return tab === "runs" ? "/routines?tab=runs" : "/routines";
+}
+
 function RoutineSectionHeader({
   label,
   count,
-  isOpen: _isOpen,
+  isOpen,
 }: {
   label: string;
   count: number;
   isOpen: boolean;
 }) {
   return (
-    <div className="flex items-center gap-2 px-2 py-1.5">
+    <div
+      className={`flex items-center gap-2 rounded-lg border border-border px-3 py-2${
+        isOpen ? " mb-1" : ""
+      }`}
+    >
       <CollapsibleTrigger className="flex items-center gap-1.5">
         <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform [[data-state=open]>&]:rotate-90" />
-        <span data-routine-section-label className="text-sm font-medium">
+        <span className="text-sm font-semibold uppercase tracking-wide">
           {label}
         </span>
       </CollapsibleTrigger>
@@ -334,9 +339,7 @@ export function Routines() {
   const [runDialogRoutine, setRunDialogRoutine] = useState<RoutineListItem | null>(null);
   const [composerOpen, setComposerOpen] = useState(false);
   const [advancedOpen, setAdvancedOpen] = useState(false);
-  const { enabled: streamlinedUiEnabled } = useStreamlinedUiEnabled();
-  const legacyRunsRequested = searchParams.get("tab") === "runs";
-  const activeTab: RoutinesTab = !streamlinedUiEnabled && legacyRunsRequested ? "runs" : "routines";
+  const activeTab: RoutinesTab = searchParams.get("tab") === "runs" ? "runs" : "routines";
   const [draft, setDraft] = useState<{
     title: string;
     description: string;
@@ -380,7 +383,7 @@ export function Routines() {
   const { data: routineFolders, isLoading: foldersLoading } = useQuery({
     queryKey: queryKeys.folders.list(selectedCompanyId!, "routine"),
     queryFn: () => foldersApi.list(selectedCompanyId!, "routine"),
-    enabled: !!selectedCompanyId,
+    enabled: !!selectedCompanyId && activeTab === "routines",
   });
   const { data: agents } = useQuery({
     queryKey: queryKeys.agents.list(selectedCompanyId!),
@@ -400,14 +403,15 @@ export function Routines() {
   const { data: routineExecutionIssues, isLoading: recentRunsLoading, error: recentRunsError } = useQuery({
     queryKey: [...queryKeys.issues.list(selectedCompanyId!), "routine-executions"],
     queryFn: () => issuesApi.list(selectedCompanyId!, { originKind: "routine_execution" }),
-    enabled: !!selectedCompanyId && !streamlinedUiEnabled && activeTab === "runs",
+    enabled: !!selectedCompanyId && activeTab === "runs",
   });
   const liveRunsQueryKey = queryKeys.liveRuns(selectedCompanyId!);
   const sharedLiveRuns = useSharedPollingQuery({
     companyId: selectedCompanyId,
     resourceKey: "live-runs",
     queryKey: liveRunsQueryKey,
-    enabled: !!selectedCompanyId && !streamlinedUiEnabled && activeTab === "runs",
+    enabled: !!selectedCompanyId && activeTab === "runs",
+    // Event-sourced via LiveUpdatesProvider (GitHub issue 9627); no interval poll needed.
     refetchInterval: false,
     leaderOnly: true,
   });
@@ -418,6 +422,7 @@ export function Routines() {
     refetchInterval: sharedLiveRuns.refetchInterval,
   });
   usePublishSharedQueryData(sharedLiveRuns, liveRuns, liveRunsUpdatedAt);
+
   useEffect(() => {
     autoResizeTextarea(titleInputRef.current);
   }, [draft.title, composerOpen]);
@@ -455,7 +460,7 @@ export function Routines() {
           : "Draft saved. Add a default agent before enabling automation.",
         tone: "success",
       });
-      navigate(routineDetailHref(routine.id, "triggers"));
+      navigate(`/routines/${routine.id}?tab=triggers`);
     },
   });
   const createFolder = useMutation({
@@ -549,6 +554,14 @@ export function Routines() {
       });
     },
   });
+  const updateIssue = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: Record<string, unknown> }) =>
+      issuesApi.update(id, data),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: [...queryKeys.issues.list(selectedCompanyId!), "routine-executions"] });
+    },
+  });
+
   const updateRoutineStatus = useMutation({
     mutationFn: ({ id, status }: { id: string; status: string }) => routinesApi.update(id, { status }),
     onMutate: ({ id }) => {
@@ -642,33 +655,11 @@ export function Routines() {
     () => new Map((routineFolders?.folders ?? []).map((folder) => [folder.id, folder])),
     [routineFolders],
   );
+  const liveIssueIds = useMemo(() => collectLiveIssueIds(liveRuns, routineExecutionIssues), [liveRuns, routineExecutionIssues]);
   const visibleRoutines = useMemo(
     () => (routines ?? []).filter((routine) => routine.status !== "archived"),
     [routines],
   );
-  const liveIssueIds = useMemo(
-    () => collectLiveIssueIds(liveRuns, routineExecutionIssues),
-    [liveRuns, routineExecutionIssues],
-  );
-  const recentRunsIssueLinkState = useMemo(
-    () => createIssueDetailLocationState("Recent Runs", "/routines?tab=runs", "issues"),
-    [],
-  );
-  const updateIssue = useMutation({
-    mutationFn: ({ id, data }: { id: string; data: Record<string, unknown> }) => issuesApi.update(id, data),
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: [...queryKeys.issues.list(selectedCompanyId!), "routine-executions"],
-      });
-    },
-  });
-
-  function handleLegacyTabChange(tab: string) {
-    const nextTab: RoutinesTab = tab === "runs" ? "runs" : "routines";
-    startTransition(() => {
-      navigate(nextTab === "runs" ? "/routines?tab=runs" : "/routines");
-    });
-  }
   const folderFilteredRoutines = useMemo(() => {
     if (routineViewState.groupBy !== "folder") return visibleRoutines;
     if (folderSelection === "all") return visibleRoutines;
@@ -703,17 +694,33 @@ export function Routines() {
     () => buildRoutineSections(sortedRoutines, routineViewState.groupBy, projectById, agentById, folderById),
     [agentById, folderById, projectById, routineViewState.groupBy, sortedRoutines],
   );
+  const recentRunsIssueLinkState = useMemo(
+    () =>
+      createIssueDetailLocationState(
+        "Recent Runs",
+        buildRoutinesTabHref("runs"),
+        "issues",
+      ),
+    [],
+  );
   const currentAssignee = draft.assigneeAgentId ? agentById.get(draft.assigneeAgentId) ?? null : null;
   const currentProject = draft.projectId ? projectById.get(draft.projectId) ?? null : null;
   const activeFolder = selectedFolderFromList(routineFolders?.folders ?? [], folderSelection);
   const hasRoutineFolders = (routineFolders?.folders.length ?? 0) > 0;
-  const showFolderRail = routineViewState.groupBy === "folder" && hasRoutineFolders;
+  const showFolderRail = activeTab === "routines" && routineViewState.groupBy === "folder" && hasRoutineFolders;
 
   function updateRoutineView(patch: Partial<RoutineViewState>) {
     setRoutineViewState((current) => {
       const next = { ...current, ...patch };
       saveRoutineViewState(routineViewStateKey, next);
       return next;
+    });
+  }
+
+  function handleTabChange(tab: string) {
+    const nextTab = tab === "runs" ? "runs" : "routines";
+    startTransition(() => {
+      navigate(buildRoutinesTabHref(nextTab));
     });
   }
 
@@ -789,100 +796,46 @@ export function Routines() {
   }
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={Repeat} message="Select an organization to view routines." />;
-  }
-
-  if (streamlinedUiEnabled && legacyRunsRequested) {
-    return <Navigate to={auditSectionHref("runs", { entityType: "routine" })} replace />;
+    return <EmptyState icon={Repeat} message="Select a company to view routines." />;
   }
 
   if (isLoading) {
     return <PageSkeleton variant="issues-list" />;
   }
 
-  if (!streamlinedUiEnabled && activeTab === "runs") {
-    return (
-      <div className="space-y-6">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-          <div className="space-y-1">
-            <h1 className="text-2xl font-semibold tracking-tight">Routines</h1>
-            <p className="text-sm text-muted-foreground">
-              Recurring work definitions that materialize into auditable execution tasks.
-            </p>
-          </div>
-          <Button onClick={openCreateRoutine}>
-            <Plus className="mr-2 h-4 w-4" />
-            Create routine
-          </Button>
-        </div>
-        <Tabs value={activeTab} onValueChange={handleLegacyTabChange}>
-          <PageTabBar
-            align="start"
-            value={activeTab}
-            onValueChange={handleLegacyTabChange}
-            items={[
-              { value: "routines", label: "Routines" },
-              { value: "runs", label: "Recent Runs" },
-            ]}
-          />
-        </Tabs>
-        <IssuesList
-          issues={routineExecutionIssues ?? []}
-          isLoading={recentRunsLoading}
-          error={recentRunsError as Error | null}
-          agents={agents}
-          projects={projects}
-          liveIssueIds={liveIssueIds}
-          viewStateKey="paperclip:routine-recent-runs-view"
-          issueLinkState={recentRunsIssueLinkState}
-          onUpdateIssue={(id, data) => updateIssue.mutate({ id, data })}
-        />
-      </div>
-    );
-  }
-
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div className="space-y-1">
-          <h1 className="text-xl font-bold">Routines</h1>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Routines
+          </h1>
           <p className="text-sm text-muted-foreground">
             Recurring work definitions that materialize into auditable execution tasks.
           </p>
         </div>
-        <div className="flex items-center gap-2">
-          {streamlinedUiEnabled ? (
-          <Button variant="outline" asChild>
-            <Link to={auditSectionHref("runs", { entityType: "routine" })}>View runs</Link>
-          </Button>
-          ) : null}
-          <Button onClick={openCreateRoutine}>
-            <Plus className="mr-2 h-4 w-4" />
-            Create routine
-          </Button>
-        </div>
+        <Button onClick={openCreateRoutine}>
+          <Plus className="mr-2 h-4 w-4" />
+          Create routine
+        </Button>
       </div>
 
-      {!streamlinedUiEnabled ? (
-        <Tabs value={activeTab} onValueChange={handleLegacyTabChange}>
-          <PageTabBar
-            align="start"
-            value={activeTab}
-            onValueChange={handleLegacyTabChange}
-            items={[
-              { value: "routines", label: "Routines" },
-              { value: "runs", label: "Recent Runs" },
-            ]}
-          />
-        </Tabs>
-      ) : null}
-
-      <div className="flex flex-col gap-4">
-        <div className="flex items-center justify-between gap-3">
-          <p className="text-sm text-muted-foreground">
-            {visibleRoutines.length} routine{visibleRoutines.length === 1 ? "" : "s"}
-          </p>
-          <div className="flex items-center gap-1">
+      <Tabs value={activeTab} onValueChange={handleTabChange}>
+        <PageTabBar
+          align="start"
+          value={activeTab}
+          onValueChange={handleTabChange}
+          items={[
+            { value: "routines", label: "Routines" },
+            { value: "runs", label: "Recent Runs" },
+          ]}
+        />
+        <TabsContent value="routines" className="space-y-4">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-sm text-muted-foreground">
+              {visibleRoutines.length} routine{visibleRoutines.length === 1 ? "" : "s"}
+            </p>
+            <div className="flex items-center gap-1">
               <Popover>
                 <PopoverTrigger asChild>
                   <Button variant="ghost" size="sm" className="text-xs" title="Sort">
@@ -966,19 +919,33 @@ export function Routines() {
                   {selectMode ? "Done" : "Select"}
                 </Button>
               ) : null}
+            </div>
           </div>
-        </div>
-        {routineViewState.groupBy === "folder" ? (
-          <div className="md:hidden">
-            <FolderChip
-              result={railFolderResult}
-              selection={folderSelection}
-              allLabel="All routines"
-              onClick={() => setMobileFoldersOpen(true)}
-            />
-          </div>
-        ) : null}
-      </div>
+          {routineViewState.groupBy === "folder" ? (
+            <div className="md:hidden">
+              <FolderChip
+                result={railFolderResult}
+                selection={folderSelection}
+                allLabel="All routines"
+                onClick={() => setMobileFoldersOpen(true)}
+              />
+            </div>
+          ) : null}
+        </TabsContent>
+        <TabsContent value="runs">
+          <IssuesList
+            issues={routineExecutionIssues ?? []}
+            isLoading={recentRunsLoading}
+            error={recentRunsError as Error | null}
+            agents={agents}
+            projects={projects}
+            liveIssueIds={liveIssueIds}
+            viewStateKey="paperclip:routine-recent-runs-view"
+            issueLinkState={recentRunsIssueLinkState}
+            onUpdateIssue={(id, data) => updateIssue.mutate({ id, data })}
+          />
+        </TabsContent>
+      </Tabs>
 
       <Dialog
         open={composerOpen}
@@ -1263,7 +1230,8 @@ export function Routines() {
         </Card>
       ) : null}
 
-      <div className={cn(showFolderRail && "flex gap-4")}>
+      {activeTab === "routines" ? (
+        <div className={cn(showFolderRail && "flex gap-4")}>
           {showFolderRail ? (
             <FolderRail
               result={railFolderResult}
@@ -1414,6 +1382,7 @@ export function Routines() {
           )}
           </div>
         </div>
+      ) : null}
 
       <FolderFormDialog
         open={folderDialogOpen}

--- a/ui/src/pages/Routines.test.tsx
+++ b/ui/src/pages/Routines.test.tsx
@@ -1054,7 +1054,7 @@ describe("Routines page", () => {
       await flush();
     });
 
-    expect(container.querySelector('a[data-redirect][href="/activity/runs?entityType=routine"]'))
+    expect(container.querySelector('a[data-redirect][href="/activity/runs"]'))
       .not.toBeNull();
     expect(issuesListMock).not.toHaveBeenCalled();
 

--- a/ui/src/pages/Routines.test.tsx
+++ b/ui/src/pages/Routines.test.tsx
@@ -29,6 +29,7 @@ const issuesListRenderMock = vi.fn(({ issues }: { issues: Issue[] }) => (
 const inlineEntitySelectorRenderMock = vi.fn((props: { options?: Array<{ id: string }> }) => props);
 
 vi.mock("@/lib/router", () => ({
+  Navigate: ({ to }: { to: string }) => <a data-redirect href={to}>Redirect</a>,
   Link: ({ to, children, ...props }: AnchorHTMLAttributes<HTMLAnchorElement> & { to: string; children: ReactNode }) => (
     <a href={to} {...props}>
       {children}
@@ -677,8 +678,7 @@ describe("Routines page", () => {
       });
     }
 
-    const sectionLabels = Array.from(container.querySelectorAll("span"))
-      .filter((element) => element.className.includes("uppercase") && element.className.includes("tracking-wide"))
+    const sectionLabels = Array.from(container.querySelectorAll("[data-routine-section-label]"))
       .map((element) => element.textContent);
     expect(sectionLabels).toEqual(["RPI", "Test", "Unfiled"]);
 
@@ -1034,13 +1034,9 @@ describe("Routines page", () => {
     });
   });
 
-  it("shows recent runs through the issues list scoped to routine execution issues", async () => {
+  it("keeps the list focused on routines and links run history to Audit", async () => {
     currentSearch = "tab=runs";
     routinesListMock.mockResolvedValue([createRoutine({ id: "routine-1" })]);
-    issuesListMock.mockResolvedValue([
-      createIssue({ id: "issue-1", title: "Routine execution A" }),
-      createIssue({ id: "issue-2", title: "Routine execution B", identifier: "PAP-1001", issueNumber: 1001 }),
-    ]);
 
     const root = createRoot(container);
     const queryClient = new QueryClient({
@@ -1058,13 +1054,9 @@ describe("Routines page", () => {
       await flush();
     });
 
-    for (let attempts = 0; attempts < 5 && issuesListMock.mock.calls.length === 0; attempts += 1) {
-      await act(async () => {
-        await flush();
-      });
-    }
-
-    expect(issuesListMock).toHaveBeenCalledWith("company-1", { originKind: "routine_execution" });
+    expect(container.querySelector('a[data-redirect][href="/activity/runs?entityType=routine"]'))
+      .not.toBeNull();
+    expect(issuesListMock).not.toHaveBeenCalled();
 
     await act(async () => {
       root.unmount();

--- a/ui/src/pages/Routines.tsx
+++ b/ui/src/pages/Routines.tsx
@@ -793,7 +793,7 @@ export function Routines() {
   }
 
   if (streamlinedUiEnabled && legacyRunsRequested) {
-    return <Navigate to={auditSectionHref("runs", { entityType: "routine" })} replace />;
+    return <Navigate to={auditSectionHref("runs", {})} replace />;
   }
 
   if (isLoading) {
@@ -852,9 +852,9 @@ export function Routines() {
         </div>
         <div className="flex items-center gap-2">
           {streamlinedUiEnabled ? (
-          <Button variant="outline" asChild>
-            <Link to={auditSectionHref("runs", { entityType: "routine" })}>View runs</Link>
-          </Button>
+            <Button variant="outline" asChild>
+              <Link to={auditSectionHref("runs", {})}>View all runs</Link>
+            </Button>
           ) : null}
           <Button onClick={openCreateRoutine}>
             <Plus className="mr-2 h-4 w-4" />

--- a/ui/src/pages/Timeline.test.tsx
+++ b/ui/src/pages/Timeline.test.tsx
@@ -11,6 +11,7 @@ const mockSetBreadcrumbs = vi.hoisted(() => vi.fn());
 const mockWorkTimelineApi = vi.hoisted(() => ({
   get: vi.fn(),
 }));
+const mockLocation = vi.hoisted(() => ({ search: "" }));
 
 vi.mock("@/context/CompanyContext", () => ({
   useCompany: () => ({ selectedCompanyId: "company-1" }),
@@ -25,7 +26,7 @@ vi.mock("@/api/workTimeline", () => ({
 }));
 
 vi.mock("@/lib/router", () => ({
-  useLocation: () => ({ pathname: "/PAP/timeline" }),
+  useLocation: () => ({ pathname: "/PAP/timeline", search: mockLocation.search }),
 }));
 
 vi.mock("@/components/RequestCollapsedSidebar", () => ({
@@ -130,6 +131,7 @@ describe("Timeline", () => {
       defaultOptions: { queries: { retry: false } },
     });
     mockWorkTimelineApi.get.mockResolvedValue(emptyTimeline);
+    mockLocation.search = "";
   });
 
   afterEach(() => {
@@ -154,6 +156,27 @@ describe("Timeline", () => {
     await flushReact();
 
     expect(container.querySelector('[data-testid="request-collapsed-sidebar"]')).not.toBeNull();
+  });
+
+  it("applies project scope from the project Timeline control", async () => {
+    mockLocation.search = "?projectId=11111111-1111-4111-8111-111111111111";
+    root = createRoot(container);
+
+    flushSync(() => {
+      root?.render(
+        <QueryClientProvider client={queryClient}>
+          <Timeline />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    expect(container.textContent).toContain("Project Timeline");
+    expect(mockWorkTimelineApi.get).toHaveBeenCalledWith(
+      "company-1",
+      expect.objectContaining({ projectId: "11111111-1111-4111-8111-111111111111" }),
+      expect.anything(),
+    );
   });
 
   it("renders range controls plus icon zoom controls without the user lens selector or visible-duration readout", async () => {

--- a/ui/src/pages/Timeline.tsx
+++ b/ui/src/pages/Timeline.tsx
@@ -30,6 +30,8 @@ import {
 } from "@/components/timeline/WorkTimelineChart";
 import { formatDuration, TIMELINE_COLORS } from "@/lib/timeline/layout";
 import { cn } from "@/lib/utils";
+import { useLocation } from "@/lib/router";
+import { useStreamlinedUiEnabled } from "@/hooks/useStreamlinedUiEnabled";
 
 type RangePreset = "today" | "7d" | "30d" | "custom";
 const TIMELINE_PAGE_LIMIT = 500;
@@ -302,9 +304,15 @@ function TimelineSummaryStats({
   );
 }
 
-export function Timeline() {
+export function Timeline({ embedded = false }: { embedded?: boolean } = {}) {
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
+  const location = useLocation();
+  const { enabled: streamlinedUiEnabled } = useStreamlinedUiEnabled();
+  const scopedProjectId = useMemo(
+    () => streamlinedUiEnabled ? new URLSearchParams(location.search).get("projectId") || undefined : undefined,
+    [location.search, streamlinedUiEnabled],
+  );
   const [zoom, setZoom] = useState<ZoomLevel>("day");
   const [zoomScale, setZoomScale] = useState<number | undefined>(undefined);
   const zoomTouched = useRef(false);
@@ -313,18 +321,20 @@ export function Timeline() {
   const [visibleWindow, setVisibleWindow] = useState<VisibleTimelineWindow | null>(null);
 
   useEffect(() => {
-    setBreadcrumbs([{ label: "Timeline" }]);
-  }, [setBreadcrumbs]);
+    if (!embedded) {
+      setBreadcrumbs([{ label: scopedProjectId ? "Project Timeline" : "Timeline" }]);
+    }
+  }, [embedded, scopedProjectId, setBreadcrumbs]);
 
   const dateRangeError = rangeError(dateRange);
   const params: WorkTimelineParams | null = useMemo(() => {
     const window = rangeWindow(dateRange);
     if (!window) return null;
-    return window;
-  }, [dateRange]);
+    return scopedProjectId ? { ...window, projectId: scopedProjectId } : window;
+  }, [dateRange, scopedProjectId]);
 
   const { data, isLoading, error } = useQuery({
-    queryKey: [...queryKeys.workTimeline(selectedCompanyId ?? ""), dateRange.fromDate, dateRange.toDate],
+    queryKey: [...queryKeys.workTimeline(selectedCompanyId ?? ""), dateRange.fromDate, dateRange.toDate, scopedProjectId ?? null],
     queryFn: ({ signal }) => loadTimelineWindow(selectedCompanyId!, params!, signal),
     enabled: !!selectedCompanyId && !!params,
   });
@@ -351,7 +361,7 @@ export function Timeline() {
   if (!selectedCompanyId) {
     return (
       <>
-        <RequestCollapsedSidebar />
+        {!embedded && <RequestCollapsedSidebar />}
         <EmptyState icon={GanttChartSquare} message="Select an organization to view its work timeline." />
       </>
     );
@@ -360,7 +370,9 @@ export function Timeline() {
   const header = (
     <div className="flex items-center gap-2">
       <GanttChartSquare className="h-6 w-6 text-muted-foreground" />
-      <h1 className="text-3xl font-semibold tracking-tight">Work Timeline</h1>
+      <h1 className="text-3xl font-semibold tracking-tight">
+        {scopedProjectId ? "Project Timeline" : "Work Timeline"}
+      </h1>
     </div>
   );
 
@@ -463,7 +475,7 @@ export function Timeline() {
 
   return (
     <div className="space-y-6">
-      <RequestCollapsedSidebar />
+      {!embedded && <RequestCollapsedSidebar />}
       {header}
       {toolbar}
 
@@ -491,7 +503,10 @@ export function Timeline() {
       {data && !isLoading && !dateRangeError && (
         data.spans.length === 0 ? (
           <div className="space-y-3">
-            <EmptyState icon={GanttChartSquare} message="No activity in this window." />
+            <EmptyState
+              icon={GanttChartSquare}
+              message={scopedProjectId ? "No project activity in this window." : "No activity in this window."}
+            />
             <div className="flex flex-wrap items-center justify-end gap-3">
               {rangeControls}
             </div>

--- a/ui/src/pages/agent-detail-navigation.test.ts
+++ b/ui/src/pages/agent-detail-navigation.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_DETAIL_NAVIGATION,
+  agentDetailHref,
+  agentLegacyAuditSection,
+  agentScopedAuditHref,
+  parseAgentDetailView,
+} from "./agent-detail-navigation";
+
+describe("agent detail navigation", () => {
+  it("exposes the complete local information architecture", () => {
+    expect(AGENT_DETAIL_NAVIGATION.flatMap((section) => section.items.map((item) => item.value))).toEqual([
+      "overview",
+      "instructions",
+      "skills",
+      "runtime",
+      "secrets",
+      "tools",
+      "permissions",
+      "api-keys",
+      "revisions",
+    ]);
+  });
+
+  it("canonicalizes legacy local paths", () => {
+    expect(parseAgentDetailView("dashboard")).toBe("overview");
+    expect(parseAgentDetailView("configuration")).toBe("runtime");
+    expect(parseAgentDetailView("prompts")).toBe("instructions");
+    expect(agentDetailHref("codexcoder", "permissions")).toBe("/agents/codexcoder/permissions");
+  });
+
+  it("maps legacy operational pages into scoped Audit sections", () => {
+    expect(agentLegacyAuditSection("runs")).toBe("runs");
+    expect(agentLegacyAuditSection("audit")).toBe("activity");
+    expect(agentLegacyAuditSection("budget")).toBe("budgets");
+    expect(agentScopedAuditHref("agent-1", "activity")).toBe("/activity?mode=agents&agentId=agent-1");
+    expect(agentScopedAuditHref("agent-1", "costs")).toBe("/activity/costs?agentId=agent-1");
+  });
+});

--- a/ui/src/pages/agent-detail-navigation.ts
+++ b/ui/src/pages/agent-detail-navigation.ts
@@ -1,0 +1,76 @@
+import { auditSectionHref, type AuditSection } from "./audit/audit-navigation";
+
+export type AgentDetailView =
+  | "overview"
+  | "instructions"
+  | "skills"
+  | "runtime"
+  | "secrets"
+  | "tools"
+  | "permissions"
+  | "api-keys"
+  | "revisions"
+  | "run-detail";
+
+export type AgentLocalDetailView = Exclude<AgentDetailView, "run-detail">;
+
+export const AGENT_DETAIL_NAVIGATION: ReadonlyArray<{
+  label: string;
+  items: ReadonlyArray<{ value: AgentLocalDetailView; label: string }>;
+}> = [
+  {
+    label: "Agent",
+    items: [
+      { value: "overview", label: "Overview" },
+      { value: "instructions", label: "Instructions" },
+      { value: "skills", label: "Skills" },
+    ],
+  },
+  {
+    label: "Runtime",
+    items: [
+      { value: "runtime", label: "Harness / Runtime" },
+      { value: "secrets", label: "Secrets" },
+      { value: "tools", label: "Tools" },
+    ],
+  },
+  {
+    label: "Governance",
+    items: [
+      { value: "permissions", label: "Permissions / Trust" },
+      { value: "api-keys", label: "API Keys" },
+      { value: "revisions", label: "Revisions" },
+    ],
+  },
+] as const;
+
+export function parseAgentDetailView(value: string | null): AgentLocalDetailView {
+  if (value === "instructions" || value === "prompts") return "instructions";
+  if (value === "skills") return "skills";
+  if (value === "runtime" || value === "configure" || value === "configuration") return "runtime";
+  if (value === "secrets") return "secrets";
+  if (value === "tools") return "tools";
+  if (value === "permissions" || value === "trust") return "permissions";
+  if (value === "api-keys" || value === "keys") return "api-keys";
+  if (value === "revisions" || value === "history") return "revisions";
+  return "overview";
+}
+
+export function agentDetailHref(agentRef: string, view: AgentLocalDetailView = "overview") {
+  return `/agents/${agentRef}/${view}`;
+}
+
+export function agentLegacyAuditSection(value: string | null): AuditSection | null {
+  if (value === "runs") return "runs";
+  if (value === "audit" || value === "activity") return "activity";
+  if (value === "cost" || value === "costs") return "costs";
+  if (value === "budget" || value === "budgets") return "budgets";
+  return null;
+}
+
+export function agentScopedAuditHref(agentId: string, section: AuditSection) {
+  return auditSectionHref(section, {
+    mode: section === "activity" ? "agents" : undefined,
+    agentId,
+  });
+}

--- a/ui/src/pages/audit/AuditFeed.production.tsx
+++ b/ui/src/pages/audit/AuditFeed.production.tsx
@@ -40,7 +40,7 @@ const ACTION_DOMAINS: { value: string; label: string }[] = [
   { value: "goal.", label: "Goals" },
   { value: "tool_gateway.", label: "Tools" },
   { value: "cost.", label: "Costs" },
-  { value: "company.", label: "Organization" },
+  { value: "company.", label: "Company" },
 ];
 
 /** Entity types offered in the filter (server does an exact match). */
@@ -48,11 +48,9 @@ const ENTITY_TYPES: { value: string; label: string }[] = [
   { value: ALL, label: "All entities" },
   { value: "issue", label: "Task" },
   { value: "agent", label: "Agent" },
-  { value: "heartbeat_run", label: "Run" },
-  { value: "routine", label: "Routine" },
   { value: "project", label: "Project" },
   { value: "goal", label: "Goal" },
-  { value: "company", label: "Organization" },
+  { value: "company", label: "Company" },
 ];
 
 /**
@@ -69,10 +67,6 @@ export interface AuditFeedProps {
    * agent filter is hidden and every query/export carries this agentId.
    */
   lockedAgentId?: string;
-  /** Pin the feed to one run while preserving the existing run-detail links. */
-  lockedRunId?: string;
-  /** Pin the feed to an entity such as a routine. */
-  lockedEntity?: { type: string; id: string; label?: string };
   /** Hide the section header/description (the AgentDetail tab supplies its own chrome). */
   hideHeader?: boolean;
   /**
@@ -266,8 +260,6 @@ function AuditUpsell() {
 export function AuditFeed({
   companyId,
   lockedAgentId,
-  lockedRunId,
-  lockedEntity,
   hideHeader,
   mode,
   onModeChange,
@@ -304,17 +296,14 @@ export function AuditFeed({
   // The per-agent tab keeps the legacy privileged scope because it always
   // carries an attribution filter and must not silently downgrade to the basic
   // tier. Everywhere else the mode picks the scope, defaulting to all actors.
-  const resolvedMode: AuditFeedMode = lockedAgentId || lockedRunId ? "agents" : mode ?? "all";
-  const hasLockedScope = Boolean(lockedAgentId || lockedRunId || lockedEntity);
+  const resolvedMode: AuditFeedMode = lockedAgentId ? "agents" : mode ?? "all";
 
   const filters: AuditActionFilters = {
     actorScope: resolvedMode,
     agentId: lockedAgentId ?? (agent === ALL ? undefined : agent),
-    runId: lockedRunId,
     responsibleUserId: responsibleUser === ALL ? undefined : responsibleUser,
     action: actionDomain === ALL ? undefined : actionDomain,
-    entityType: lockedEntity?.type ?? (entityType === ALL ? undefined : entityType),
-    entityId: lockedEntity?.id,
+    entityType: entityType === ALL ? undefined : entityType,
     from: toStartIso(dateFrom),
     to: toEndIso(dateTo),
   };
@@ -327,19 +316,14 @@ export function AuditFeed({
       || dateFrom
       || dateTo,
   );
-  const hasPrivilegedFilters = Boolean(
-    !hasLockedScope && (agent !== ALL || responsibleUser !== ALL),
-  );
 
   const feed = useInfiniteQuery({
     queryKey: queryKeys.audit.agentActions(companyId, {
       actorScope: filters.actorScope,
       agentId: filters.agentId,
-      runId: filters.runId,
       responsibleUserId: filters.responsibleUserId,
       action: filters.action,
       entityType: filters.entityType,
-      entityId: filters.entityId,
       from: filters.from,
       to: filters.to,
     }),
@@ -367,7 +351,7 @@ export function AuditFeed({
   // page as authoritative until every cached page has been fetched again.
   const accessTier = hasBasicPage ? "basic" : feed.data?.pages[0]?.accessTier;
   const hasMixedAccessTiers = hasBasicPage && hasFullPage;
-  const canUseAdvancedControls = lockedAgentId || lockedRunId
+  const canUseAdvancedControls = lockedAgentId
     ? true
     : accessTier === "full";
   // The recovery refetch below gets one shot. If it does not clear the mixed
@@ -382,22 +366,23 @@ export function AuditFeed({
     hasMixedAccessTiers && downgradeRecoveryAttempted && !feed.isFetching,
   );
   const recoveringFromAccessDowngrade = Boolean(
-    !hasLockedScope
+    !lockedAgentId
       && !downgradeRecoveryExhausted
-      && ((permissionDenied && hasPrivilegedFilters) || hasMixedAccessTiers),
+      && ((permissionDenied && hasActiveFilters) || hasMixedAccessTiers),
   );
   // A reader without `audit:view_agent_actions` can still land on the
   // agent-actions mode through an old `/audit` deep link. Drop them into the
   // shared all-activity feed instead of blocking the whole page with the upsell.
   const fallingBackToAllActivity = Boolean(
-    permissionDenied && !hasLockedScope && resolvedMode === "agents" && onModeChange,
+    permissionDenied && !lockedAgentId && resolvedMode === "agents" && onModeChange,
   );
-  // Keep both modes explicit in the Audit IA. Basic readers can see that Agent
-  // Actions exists, but cannot switch into the privileged scope.
+  // The privileged mode is only offered to callers the server already answered
+  // at the full tier — everyone else just gets the basic all-activity feed.
   const showModeToggle = Boolean(
-    !hasLockedScope
+    !lockedAgentId
       && onModeChange
       && !fallingBackToAllActivity
+      && (resolvedMode === "agents" || accessTier === "full"),
   );
 
   useEffect(() => {
@@ -405,11 +390,15 @@ export function AuditFeed({
   }, [fallingBackToAllActivity, onModeChange]);
 
   useEffect(() => {
-    if (!hasLockedScope && (accessTier === "basic" || recoveringFromAccessDowngrade)) {
+    if (!lockedAgentId && (accessTier === "basic" || recoveringFromAccessDowngrade)) {
       setAgent(ALL);
       setResponsibleUser(ALL);
+      setActionDomain(ALL);
+      setEntityType(ALL);
+      setDateFrom("");
+      setDateTo("");
     }
-  }, [accessTier, hasLockedScope, recoveringFromAccessDowngrade]);
+  }, [accessTier, hasMixedAccessTiers, lockedAgentId, recoveringFromAccessDowngrade]);
 
   // Recover from a mid-pagination downgrade with exactly one refetch. `feed`
   // gets a new identity on every render, so an unguarded refetch here re-fires
@@ -439,11 +428,9 @@ export function AuditFeed({
       const blob = await auditApi.exportAgentActionsCsv(companyId, {
         actorScope: filters.actorScope,
         agentId: filters.agentId,
-        runId: filters.runId,
         responsibleUserId: filters.responsibleUserId,
         action: filters.action,
         entityType: filters.entityType,
-        entityId: filters.entityId,
         from: filters.from,
         to: filters.to,
       });
@@ -478,11 +465,11 @@ export function AuditFeed({
       {!hideHeader ? (
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
-            <h2 className="text-lg font-semibold text-foreground">Activity</h2>
+            <h1 className="text-lg font-semibold text-foreground">Activity</h1>
             <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
               {resolvedMode === "agents"
                 ? "Every recorded agent action, newest first — with the responsible person and run behind each one."
-                : "Everything happening in your organization, newest first — people, agents, and the system. Each line is one recorded action."}
+                : "Everything happening in your company, newest first — people, agents, and the system. Each line is one recorded action."}
             </p>
           </div>
         </div>
@@ -491,32 +478,15 @@ export function AuditFeed({
       {showModeToggle ? (
         <Tabs value={resolvedMode} onValueChange={(value) => onModeChange?.(value as AuditFeedMode)}>
           <TabsList aria-label="Activity scope">
-            <TabsTrigger value="all">Activity</TabsTrigger>
-            <TabsTrigger
-              value="agents"
-              disabled={accessTier === "basic"}
-              title={accessTier === "basic" ? "Agent Actions requires audit access" : undefined}
-            >
-              Agent Actions
-            </TabsTrigger>
+            <TabsTrigger value="all">All activity</TabsTrigger>
+            <TabsTrigger value="agents">Agent actions</TabsTrigger>
           </TabsList>
         </Tabs>
       ) : null}
 
-      {hasLockedScope ? (
-        <div className="border-y border-border px-1 py-2 text-xs text-muted-foreground">
-          {lockedRunId
-            ? `Scoped to run ${lockedRunId.slice(0, 8)}`
-            : lockedAgentId
-              ? "Scoped to one agent"
-              : `Scoped to ${lockedEntity?.label ?? lockedEntity?.type ?? "entity"}`}
-        </div>
-      ) : null}
-
-      <div className="flex flex-wrap items-end gap-3 border-y border-border py-3">
-        {canUseAdvancedControls && !lockedAgentId && !lockedRunId ? (
-          <label className="grid gap-1 text-(length:--text-micro) font-medium text-muted-foreground">
-            <span>Agent</span>
+      {canUseAdvancedControls ? (
+        <div className="flex flex-wrap items-center gap-2">
+          {!lockedAgentId ? (
             <Select value={agent} onValueChange={setAgent}>
               <SelectTrigger className="w-40">
                 <SelectValue placeholder="Agent" />
@@ -530,31 +500,23 @@ export function AuditFeed({
                 ))}
               </SelectContent>
             </Select>
-          </label>
-        ) : null}
-        {canUseAdvancedControls ? (
-          <label className="grid gap-1 text-(length:--text-micro) font-medium text-muted-foreground">
-            <span>Responsible user</span>
-            <Select value={responsibleUser} onValueChange={setResponsibleUser}>
-              {/* Wide enough for "All responsible users" — w-44 truncated it. */}
-              <SelectTrigger className="w-52">
-                <SelectValue placeholder="Responsible user" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value={ALL}>All responsible users</SelectItem>
-                {(userDirectory.data?.users ?? []).map((u) => (
-                  <SelectItem key={u.principalId} value={u.principalId}>
-                    {u.user?.name ?? u.user?.email ?? u.principalId.slice(0, 8)}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </label>
-        ) : null}
-        <label className="grid gap-1 text-(length:--text-micro) font-medium text-muted-foreground">
-          <span>Action</span>
+          ) : null}
+          <Select value={responsibleUser} onValueChange={setResponsibleUser}>
+            {/* Wide enough for "All responsible users" — w-44 truncated it. */}
+            <SelectTrigger className="w-52">
+              <SelectValue placeholder="Responsible user" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL}>All responsible users</SelectItem>
+              {(userDirectory.data?.users ?? []).map((u) => (
+                <SelectItem key={u.principalId} value={u.principalId}>
+                  {u.user?.name ?? u.user?.email ?? u.principalId.slice(0, 8)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
           <Select value={actionDomain} onValueChange={setActionDomain}>
-            <SelectTrigger className="w-40">
+            <SelectTrigger className="w-36">
               <SelectValue placeholder="Action" />
             </SelectTrigger>
             <SelectContent>
@@ -565,26 +527,18 @@ export function AuditFeed({
               ))}
             </SelectContent>
           </Select>
-        </label>
-        {!lockedEntity ? (
-          <label className="grid gap-1 text-(length:--text-micro) font-medium text-muted-foreground">
-            <span>Entity</span>
-            <Select value={entityType} onValueChange={setEntityType}>
-              <SelectTrigger className="w-40">
-                <SelectValue placeholder="Entity" />
-              </SelectTrigger>
-              <SelectContent>
-                {ENTITY_TYPES.map((e) => (
-                  <SelectItem key={e.value} value={e.value}>
-                    {e.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </label>
-        ) : null}
-        <label className="grid gap-1 text-(length:--text-micro) font-medium text-muted-foreground">
-          <span>From</span>
+          <Select value={entityType} onValueChange={setEntityType}>
+            <SelectTrigger className="w-36">
+              <SelectValue placeholder="Entity" />
+            </SelectTrigger>
+            <SelectContent>
+              {ENTITY_TYPES.map((e) => (
+                <SelectItem key={e.value} value={e.value}>
+                  {e.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
           <Input
             type="date"
             aria-label="From date"
@@ -593,9 +547,6 @@ export function AuditFeed({
             onChange={(e) => setDateFrom(e.target.value)}
             className="w-36"
           />
-        </label>
-        <label className="grid gap-1 text-(length:--text-micro) font-medium text-muted-foreground">
-          <span>To</span>
           <Input
             type="date"
             aria-label="To date"
@@ -604,13 +555,11 @@ export function AuditFeed({
             onChange={(e) => setDateTo(e.target.value)}
             className="w-36"
           />
-        </label>
-        {hasActiveFilters ? (
-          <Button variant="ghost" size="sm" onClick={clearFilters}>
-            Clear filters
-          </Button>
-        ) : null}
-        {canUseAdvancedControls ? (
+          {hasActiveFilters ? (
+            <Button variant="ghost" size="sm" onClick={clearFilters}>
+              Clear filters
+            </Button>
+          ) : null}
           <Button
             variant="outline"
             size="sm"
@@ -621,8 +570,8 @@ export function AuditFeed({
             <Download className="mr-1.5 h-4 w-4" />
             {exporting ? "Exporting…" : "Export CSV"}
           </Button>
-        ) : null}
-      </div>
+        </div>
+      ) : null}
 
       {recoveringFromAccessDowngrade || fallingBackToAllActivity ? (
         <Card>
@@ -658,7 +607,7 @@ export function AuditFeed({
                   ? "Try a wider date range or different filters."
                   : resolvedMode === "agents"
                     ? "As soon as your agents start doing things, their actions show up here."
-                    : "As soon as anyone in your organization does something, it shows up here."}
+                    : "As soon as anyone in your company does something, it shows up here."}
               </p>
             </div>
             {hasActiveFilters ? (
@@ -669,18 +618,20 @@ export function AuditFeed({
           </CardContent>
         </Card>
       ) : (
-        <div className="border-y border-border">
-          <ul className={cn("divide-y divide-border")} aria-label="Audit activity">
-            {items.map((record) => (
-              <AuditRow
-                key={record.id}
-                record={record}
-                agentMap={agentMap}
-                userProfileMap={userProfileMap}
-              />
-            ))}
-          </ul>
-        </div>
+        <Card>
+          <CardContent className="px-0 py-0">
+            <ul className={cn("divide-y divide-border")}>
+              {items.map((record) => (
+                <AuditRow
+                  key={record.id}
+                  record={record}
+                  agentMap={agentMap}
+                  userProfileMap={userProfileMap}
+                />
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
       )}
 
       {feed.hasNextPage ? (

--- a/ui/src/pages/audit/AuditFeed.test.tsx
+++ b/ui/src/pages/audit/AuditFeed.test.tsx
@@ -109,6 +109,8 @@ describe("AuditFeed", () => {
     props: {
       companyId?: string;
       lockedAgentId?: string;
+      lockedRunId?: string;
+      lockedEntity?: { type: string; id: string; label?: string };
       mode?: "all" | "agents";
       onModeChange?: (mode: "all" | "agents") => void;
     } = {},
@@ -121,6 +123,8 @@ describe("AuditFeed", () => {
           <AuditFeed
             companyId={props.companyId ?? "company-1"}
             lockedAgentId={props.lockedAgentId}
+            lockedRunId={props.lockedRunId}
+            lockedEntity={props.lockedEntity}
             mode={props.mode}
             onModeChange={props.onModeChange}
           />
@@ -218,12 +222,16 @@ describe("AuditFeed", () => {
     expect(container.textContent).not.toContain("All agents");
     expect(container.textContent).not.toContain("All responsible users");
     expect(container.textContent).not.toContain("Export CSV");
+    expect(container.textContent).toContain("Action");
+    expect(container.textContent).toContain("Entity");
+    expect(container.textContent).toContain("From");
+    expect(container.textContent).toContain("To");
   });
 
   it("clears privileged filters and recovers the basic feed after an access downgrade", async () => {
     let permissionRevoked = false;
-    listAgentActionsMock.mockImplementation((_companyId: string, filters: { from?: string }) => {
-      if (permissionRevoked && filters.from) {
+    listAgentActionsMock.mockImplementation((_companyId: string, filters: { agentId?: string }) => {
+      if (permissionRevoked && filters.agentId) {
         return Promise.reject(
           new ApiError("Missing permission: audit:view_agent_actions", 403, { error: "Missing permission" }),
         );
@@ -236,35 +244,27 @@ describe("AuditFeed", () => {
     });
     await render();
 
-    const fromDate = container.querySelector<HTMLInputElement>('input[aria-label="From date"]');
-    expect(fromDate).toBeTruthy();
-    const setInputValue = Object.getOwnPropertyDescriptor(
-      window.HTMLInputElement.prototype,
-      "value",
-    )?.set;
-    expect(setInputValue).toBeTruthy();
+    permissionRevoked = true;
+    await clickButton("All agents");
+    const fableOption = Array.from(document.body.querySelectorAll<HTMLElement>('[role="option"]'))
+      .find((option) => option.textContent?.trim() === "Fable");
+    expect(fableOption).toBeTruthy();
     await act(async () => {
-      permissionRevoked = true;
-      setInputValue!.call(fromDate, "2026-08-01");
-      fromDate!.dispatchEvent(new Event("input", { bubbles: true }));
+      fableOption!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
-    // The recovery settles across the 403, the filter reset, and the basic-tier
-    // refetch. The privileged filter fires first (from set), then the recovery
-    // refetch clears it (from undefined). Wait for that recovery refetch and the
-    // dropped filter chrome instead of a fixed flush count.
     await waitForCondition(
       () =>
-        listAgentActionsMock.mock.calls.some(([, filters]) => filters.from)
-        && listAgentActionsMock.mock.calls.at(-1)?.[1]?.from === undefined
+        listAgentActionsMock.mock.calls.some(([, filters]) => filters.agentId)
+        && listAgentActionsMock.mock.calls.at(-1)?.[1]?.agentId === undefined
         && !container.textContent?.includes("All agents"),
       "the basic feed after the access downgrade",
       20_000,
     );
 
-    expect(listAgentActionsMock.mock.calls.some(([, filters]) => filters.from)).toBe(true);
+    expect(listAgentActionsMock.mock.calls.some(([, filters]) => filters.agentId)).toBe(true);
     await vi.waitFor(() => {
       expect(listAgentActionsMock.mock.calls.at(-1)?.[1]).toEqual(
-        expect.objectContaining({ actorScope: "all", from: undefined }),
+        expect.objectContaining({ actorScope: "all", agentId: undefined }),
       );
       expect(container.textContent).toContain("commented on");
       expect(container.textContent).not.toContain("Paperclip Enterprise view");
@@ -431,13 +431,13 @@ describe("AuditFeed", () => {
     });
     await flushReact();
 
-    expect(container.textContent).toContain("All activity");
-    expect(container.textContent).toContain("Agent actions");
+    expect(container.textContent).toContain("Activity");
+    expect(container.textContent).toContain("Agent Actions");
     expect(listAgentActionsMock.mock.calls[0]?.[1]).toEqual(
       expect.objectContaining({ actorScope: "all" }),
     );
 
-    await clickTab("Agent actions");
+    await clickTab("Agent Actions");
     await flushReact();
 
     expect(listAgentActionsMock.mock.calls.at(-1)?.[1]).toEqual(
@@ -479,8 +479,9 @@ describe("AuditFeed", () => {
     listAgentActionsMock.mockResolvedValue({ items: [record()], nextCursor: null, accessTier: "basic" });
     await render({ mode: "all", onModeChange: vi.fn() });
 
-    expect(container.querySelector('[role="tab"]')).toBeFalsy();
-    expect(container.textContent).not.toContain("Agent actions");
+    const tabs = Array.from(container.querySelectorAll<HTMLButtonElement>('[role="tab"]'));
+    expect(tabs.map((tab) => tab.textContent?.trim())).toEqual(["Activity", "Agent Actions"]);
+    expect(tabs.find((tab) => tab.textContent?.trim() === "Agent Actions")?.disabled).toBe(true);
     // The basic feed itself still renders.
     expect(container.textContent).toContain("commented on");
   });
@@ -504,6 +505,33 @@ describe("AuditFeed", () => {
     await render({ mode: "agents" });
 
     expect(container.textContent).toContain("Paperclip Enterprise view");
+  });
+
+  it("renders a flat activity list with clearly labeled filters", async () => {
+    await render();
+
+    const list = container.querySelector('ul[aria-label="Audit activity"]');
+    expect(list).toBeTruthy();
+    expect(list?.closest('[data-slot="card"]')).toBeFalsy();
+    expect(container.textContent).toContain("Agent");
+    expect(container.textContent).toContain("Responsible user");
+    expect(container.textContent).toContain("Action");
+    expect(container.textContent).toContain("Entity");
+  });
+
+  it("pins run and entity scopes into distinct audit requests", async () => {
+    await render({ lockedRunId: "run-42" });
+    expect(listAgentActionsMock.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ actorScope: "agents", runId: "run-42" }),
+    );
+    expect(container.textContent).toContain("Scoped to run run-42");
+
+    flushSync(() => root.unmount());
+    await render({ lockedEntity: { type: "routine", id: "routine-7", label: "Nightly triage" } });
+    expect(listAgentActionsMock.mock.calls.at(-1)?.[1]).toEqual(
+      expect.objectContaining({ entityType: "routine", entityId: "routine-7" }),
+    );
+    expect(container.textContent).toContain("Scoped to Nightly triage");
   });
 
   it("only offers action domains present in the agent-action feed", async () => {

--- a/ui/src/pages/audit/AuditHub.test.tsx
+++ b/ui/src/pages/audit/AuditHub.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuditHub } from "./AuditHub";
+
+const navigateMock = vi.hoisted(() => vi.fn());
+const setSearchParamsMock = vi.hoisted(() => vi.fn());
+const setBreadcrumbsMock = vi.hoisted(() => vi.fn());
+let currentSearch = "";
+
+vi.mock("@/context/CompanyContext", () => ({
+  useCompany: () => ({ selectedCompanyId: "company-1" }),
+}));
+
+vi.mock("@/context/BreadcrumbContext", () => ({
+  useBreadcrumbs: () => ({ setBreadcrumbs: setBreadcrumbsMock }),
+}));
+
+vi.mock("@/context/SidebarContext", () => ({
+  useSidebar: () => ({ isMobile: false }),
+}));
+
+vi.mock("@/lib/router", () => ({
+  useNavigate: () => navigateMock,
+  useSearchParams: () => [new URLSearchParams(currentSearch), setSearchParamsMock],
+}));
+
+vi.mock("./AuditFeed", () => ({
+  AuditFeed: (props: Record<string, unknown>) => (
+    <div
+      data-testid="audit-feed"
+      data-mode={props.mode}
+      data-agent={props.lockedAgentId}
+      data-run={props.lockedRunId}
+      data-entity={JSON.stringify(props.lockedEntity ?? null)}
+    />
+  ),
+}));
+
+vi.mock("./AuditRuns", () => ({
+  AuditRuns: ({ companyId }: { companyId: string }) => (
+    <div data-testid="audit-runs" data-company={companyId} />
+  ),
+}));
+
+vi.mock("@/pages/Costs", () => ({
+  Costs: (props: Record<string, unknown>) => (
+    <div
+      data-testid="audit-costs"
+      data-initial-tab={props.initialTab}
+      data-lock-tab={String(props.lockTab ?? false)}
+      data-hide-budgets={String(props.hideBudgetsTab ?? false)}
+    />
+  ),
+}));
+
+vi.mock("@/pages/Timeline", () => ({
+  Timeline: ({ embedded }: { embedded?: boolean }) => (
+    <div data-testid="audit-timeline" data-embedded={String(embedded ?? false)} />
+  ),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe("AuditHub", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    currentSearch = "";
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    flushSync(() => root?.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  function render(section: "activity" | "runs" | "costs" | "budgets" | "timeline") {
+    root = createRoot(container);
+    flushSync(() => root.render(<AuditHub section={section} />));
+  }
+
+  it("uses one clear section model and passes deep-link scopes to Activity", () => {
+    currentSearch = "mode=agents&agentId=agent-1&runId=run-1&entityType=routine&entityId=routine-1";
+    render("activity");
+
+    expect(container.querySelectorAll('[role="tab"]')).toHaveLength(5);
+    expect(container.textContent).toContain("Activity");
+    expect(container.textContent).toContain("Runs");
+    expect(container.textContent).toContain("Costs");
+    expect(container.textContent).toContain("Budgets");
+    expect(container.textContent).toContain("Timeline");
+    const feed = container.querySelector<HTMLElement>('[data-testid="audit-feed"]');
+    expect(feed?.dataset.mode).toBe("agents");
+    expect(feed?.dataset.agent).toBe("agent-1");
+    expect(feed?.dataset.run).toBe("run-1");
+    expect(feed?.dataset.entity).toBe(JSON.stringify({ type: "routine", id: "routine-1" }));
+    expect(setBreadcrumbsMock).toHaveBeenCalledWith([{ label: "Audit" }]);
+  });
+
+  it("renders Timeline as the section after Budgets", () => {
+    render("timeline");
+
+    const labels = Array.from(container.querySelectorAll<HTMLElement>('[role="tab"]'))
+      .map((tab) => tab.textContent?.trim());
+    expect(labels).toEqual(["Activity", "Runs", "Costs", "Budgets", "Timeline"]);
+    expect(container.querySelector<HTMLElement>('[data-testid="audit-timeline"]')?.dataset.embedded)
+      .toBe("true");
+  });
+
+  it("renders Costs and Budgets as intentional peer sections", () => {
+    render("budgets");
+    let costs = container.querySelector<HTMLElement>('[data-testid="audit-costs"]');
+    expect(costs?.dataset.initialTab).toBe("budgets");
+    expect(costs?.dataset.lockTab).toBe("true");
+
+    flushSync(() => root.unmount());
+    render("costs");
+    costs = container.querySelector<HTMLElement>('[data-testid="audit-costs"]');
+    expect(costs?.dataset.initialTab).toBe("overview");
+    expect(costs?.dataset.hideBudgets).toBe("true");
+  });
+
+  it("keeps the current entity scope when moving between Audit sections", () => {
+    currentSearch = "entityType=routine&entityId=routine-1";
+    render("activity");
+
+    const runsTab = Array.from(container.querySelectorAll<HTMLElement>('[role="tab"]'))
+      .find((tab) => tab.textContent?.trim() === "Runs");
+    expect(runsTab).toBeTruthy();
+    flushSync(() => {
+      runsTab!.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 0 }));
+      runsTab!.dispatchEvent(new MouseEvent("click", { bubbles: true, button: 0 }));
+    });
+    expect(navigateMock).toHaveBeenCalledWith(
+      "/activity/runs?entityType=routine&entityId=routine-1",
+    );
+  });
+});

--- a/ui/src/pages/audit/AuditHub.test.tsx
+++ b/ui/src/pages/audit/AuditHub.test.tsx
@@ -40,8 +40,14 @@ vi.mock("./AuditFeed", () => ({
 }));
 
 vi.mock("./AuditRuns", () => ({
-  AuditRuns: ({ companyId }: { companyId: string }) => (
-    <div data-testid="audit-runs" data-company={companyId} />
+  AuditRuns: ({ companyId, routineId }: { companyId: string; routineId?: string }) => (
+    <div data-testid="audit-runs" data-company={companyId} data-routine={routineId} />
+  ),
+}));
+
+vi.mock("./RoutineAuditActivity", () => ({
+  RoutineAuditActivity: ({ companyId, routineId }: { companyId: string; routineId: string }) => (
+    <div data-testid="routine-audit-activity" data-company={companyId} data-routine={routineId} />
   ),
 }));
 
@@ -87,7 +93,7 @@ describe("AuditHub", () => {
   }
 
   it("uses one clear section model and passes deep-link scopes to Activity", () => {
-    currentSearch = "mode=agents&agentId=agent-1&runId=run-1&entityType=routine&entityId=routine-1";
+    currentSearch = "mode=agents&agentId=agent-1&runId=run-1";
     render("activity");
 
     expect(container.querySelectorAll('[role="tab"]')).toHaveLength(5);
@@ -100,8 +106,27 @@ describe("AuditHub", () => {
     expect(feed?.dataset.mode).toBe("agents");
     expect(feed?.dataset.agent).toBe("agent-1");
     expect(feed?.dataset.run).toBe("run-1");
-    expect(feed?.dataset.entity).toBe(JSON.stringify({ type: "routine", id: "routine-1" }));
+    expect(feed?.dataset.entity).toBe(JSON.stringify(null));
     expect(setBreadcrumbsMock).toHaveBeenCalledWith([{ label: "Audit" }]);
+  });
+
+  it("uses routine-scoped activity instead of the privileged organization feed", () => {
+    currentSearch = "entityType=routine&entityId=routine-1";
+    render("activity");
+
+    expect(container.querySelector('[data-testid="audit-feed"]')).toBeNull();
+    const activity = container.querySelector<HTMLElement>('[data-testid="routine-audit-activity"]');
+    expect(activity?.dataset.company).toBe("company-1");
+    expect(activity?.dataset.routine).toBe("routine-1");
+  });
+
+  it("passes routine scope to the Runs section", () => {
+    currentSearch = "entityType=routine&entityId=routine-1";
+    render("runs");
+
+    const runs = container.querySelector<HTMLElement>('[data-testid="audit-runs"]');
+    expect(runs?.dataset.company).toBe("company-1");
+    expect(runs?.dataset.routine).toBe("routine-1");
   });
 
   it("renders Timeline as the section after Budgets", () => {

--- a/ui/src/pages/audit/AuditHub.tsx
+++ b/ui/src/pages/audit/AuditHub.tsx
@@ -10,6 +10,7 @@ import { Costs } from "@/pages/Costs";
 import { Timeline } from "@/pages/Timeline";
 import { AuditFeed, type AuditFeedMode } from "./AuditFeed";
 import { AuditRuns } from "./AuditRuns";
+import { RoutineAuditActivity } from "./RoutineAuditActivity";
 import {
   AUDIT_SECTIONS,
   auditScopeFromSearchParams,
@@ -24,6 +25,7 @@ export function AuditHub({ section }: { section: AuditSection }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const scope = auditScopeFromSearchParams(searchParams);
   const mode: AuditFeedMode = scope.mode === "agents" ? "agents" : "all";
+  const routineId = scope.entityType === "routine" ? scope.entityId ?? undefined : undefined;
 
   useEffect(() => {
     const current = AUDIT_SECTIONS.find((candidate) => candidate.value === section);
@@ -72,7 +74,9 @@ export function AuditHub({ section }: { section: AuditSection }) {
         <PageTabBar items={AUDIT_SECTIONS} value={section} align="start" />
       </Tabs>
 
-      {section === "activity" ? (
+      {section === "activity" && routineId ? (
+        <RoutineAuditActivity companyId={selectedCompanyId} routineId={routineId} />
+      ) : section === "activity" ? (
         <AuditFeed
           companyId={selectedCompanyId}
           hideHeader
@@ -87,7 +91,7 @@ export function AuditHub({ section }: { section: AuditSection }) {
           }
         />
       ) : section === "runs" ? (
-        <AuditRuns companyId={selectedCompanyId} />
+        <AuditRuns companyId={selectedCompanyId} routineId={routineId} />
       ) : section === "budgets" ? (
         <Costs embedded initialTab="budgets" lockTab />
       ) : section === "timeline" ? (

--- a/ui/src/pages/audit/AuditHub.tsx
+++ b/ui/src/pages/audit/AuditHub.tsx
@@ -1,0 +1,100 @@
+import { useCallback, useEffect } from "react";
+import { History } from "lucide-react";
+import { EmptyState } from "@/components/EmptyState";
+import { PageTabBar } from "@/components/PageTabBar";
+import { Tabs } from "@/components/ui/tabs";
+import { useBreadcrumbs } from "@/context/BreadcrumbContext";
+import { useCompany } from "@/context/CompanyContext";
+import { useNavigate, useSearchParams } from "@/lib/router";
+import { Costs } from "@/pages/Costs";
+import { Timeline } from "@/pages/Timeline";
+import { AuditFeed, type AuditFeedMode } from "./AuditFeed";
+import { AuditRuns } from "./AuditRuns";
+import {
+  AUDIT_SECTIONS,
+  auditScopeFromSearchParams,
+  auditSectionHref,
+  type AuditSection,
+} from "./audit-navigation";
+
+export function AuditHub({ section }: { section: AuditSection }) {
+  const navigate = useNavigate();
+  const { selectedCompanyId } = useCompany();
+  const { setBreadcrumbs } = useBreadcrumbs();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const scope = auditScopeFromSearchParams(searchParams);
+  const mode: AuditFeedMode = scope.mode === "agents" ? "agents" : "all";
+
+  useEffect(() => {
+    const current = AUDIT_SECTIONS.find((candidate) => candidate.value === section);
+    setBreadcrumbs([
+      { label: "Audit", href: section === "activity" ? undefined : "/activity" },
+      ...(section === "activity" || !current ? [] : [{ label: current.label }]),
+    ]);
+  }, [section, setBreadcrumbs]);
+
+  const handleModeChange = useCallback(
+    (next: AuditFeedMode) => {
+      setSearchParams(
+        (current) => {
+          const params = new URLSearchParams(current);
+          if (next === "agents") params.set("mode", "agents");
+          else params.delete("mode");
+          return params;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  if (!selectedCompanyId) {
+    return <EmptyState icon={History} message="Select an organization to view Audit." />;
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-semibold tracking-tight text-foreground">Audit</h1>
+        <p className="mt-2 max-w-3xl text-sm leading-6 text-muted-foreground">
+          Review what happened, inspect agent runs, and understand the costs and budget controls
+          behind your organization.
+        </p>
+      </div>
+
+      <Tabs
+        value={section}
+        onValueChange={(value) => {
+          const next = value as AuditSection;
+          navigate(auditSectionHref(next, scope));
+        }}
+      >
+        <PageTabBar items={AUDIT_SECTIONS} value={section} align="start" />
+      </Tabs>
+
+      {section === "activity" ? (
+        <AuditFeed
+          companyId={selectedCompanyId}
+          hideHeader
+          mode={mode}
+          onModeChange={handleModeChange}
+          lockedAgentId={scope.agentId ?? undefined}
+          lockedRunId={scope.runId ?? undefined}
+          lockedEntity={
+            scope.entityType && scope.entityId
+              ? { type: scope.entityType, id: scope.entityId }
+              : undefined
+          }
+        />
+      ) : section === "runs" ? (
+        <AuditRuns companyId={selectedCompanyId} />
+      ) : section === "budgets" ? (
+        <Costs embedded initialTab="budgets" lockTab />
+      ) : section === "timeline" ? (
+        <Timeline embedded />
+      ) : (
+        <Costs embedded initialTab="overview" hideBudgetsTab />
+      )}
+    </div>
+  );
+}

--- a/ui/src/pages/audit/AuditRuns.test.tsx
+++ b/ui/src/pages/audit/AuditRuns.test.tsx
@@ -4,12 +4,13 @@ import type { ReactNode } from "react";
 import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import type { HeartbeatRun } from "@paperclipai/shared";
+import type { HeartbeatRun, RoutineRunSummary } from "@paperclipai/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AuditRuns } from "./AuditRuns";
 
 const listAgentsMock = vi.hoisted(() => vi.fn());
 const listRunsMock = vi.hoisted(() => vi.fn());
+const listRoutineRunsMock = vi.hoisted(() => vi.fn());
 const setSearchParamsMock = vi.hoisted(() => vi.fn());
 let currentSearch = "";
 
@@ -21,6 +22,12 @@ vi.mock("@/api/heartbeats", () => ({
   heartbeatsApi: {
     list: (companyId: string, agentId?: string, limit?: number, options?: unknown) =>
       listRunsMock(companyId, agentId, limit, options),
+  },
+}));
+
+vi.mock("@/api/routines", () => ({
+  routinesApi: {
+    listRuns: (routineId: string, limit?: number) => listRoutineRunsMock(routineId, limit),
   },
 }));
 
@@ -50,6 +57,30 @@ function run(overrides: Partial<HeartbeatRun> = {}): HeartbeatRun {
   } as HeartbeatRun;
 }
 
+function routineRun(overrides: Partial<RoutineRunSummary> = {}): RoutineRunSummary {
+  return {
+    id: "routine-run-1",
+    companyId: "company-1",
+    routineId: "routine-1",
+    triggerId: "trigger-1",
+    source: "schedule",
+    status: "succeeded",
+    triggeredAt: new Date("2026-08-31T18:00:00.000Z"),
+    idempotencyKey: null,
+    triggerPayload: null,
+    dispatchFingerprint: null,
+    linkedIssueId: "issue-1",
+    coalescedIntoRunId: null,
+    failureReason: null,
+    completedAt: new Date("2026-08-31T18:01:05.000Z"),
+    createdAt: new Date("2026-08-31T18:00:00.000Z"),
+    updatedAt: new Date("2026-08-31T18:01:05.000Z"),
+    linkedIssue: { id: "issue-1", identifier: "TES-42", title: "Publish forecast" },
+    trigger: { id: "trigger-1", kind: "schedule", label: "Daily forecast" },
+    ...overrides,
+  } as RoutineRunSummary;
+}
+
 async function flushReact() {
   for (let index = 0; index < 3; index += 1) {
     await new Promise((resolve) => window.setTimeout(resolve, 0));
@@ -66,6 +97,7 @@ describe("AuditRuns", () => {
     document.body.appendChild(container);
     listAgentsMock.mockResolvedValue([{ id: "agent-1", name: "Fable" }]);
     listRunsMock.mockResolvedValue([run()]);
+    listRoutineRunsMock.mockResolvedValue([routineRun()]);
   });
 
   afterEach(() => {
@@ -74,13 +106,13 @@ describe("AuditRuns", () => {
     vi.clearAllMocks();
   });
 
-  async function render() {
+  async function render(routineId?: string) {
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     root = createRoot(container);
     flushSync(() => {
       root.render(
         <QueryClientProvider client={queryClient}>
-          <AuditRuns companyId="company-1" />
+          <AuditRuns companyId="company-1" routineId={routineId} />
         </QueryClientProvider>,
       );
     });
@@ -107,5 +139,16 @@ describe("AuditRuns", () => {
 
     expect(listRunsMock).toHaveBeenCalledWith("company-1", "agent-1", 200, { summary: true });
     expect(container.textContent).toContain("Clear filters");
+  });
+
+  it("loads routine runs directly when the Audit scope is a routine", async () => {
+    await render("routine-1");
+
+    expect(listRoutineRunsMock).toHaveBeenCalledWith("routine-1", 200);
+    expect(listAgentsMock).not.toHaveBeenCalled();
+    expect(listRunsMock).not.toHaveBeenCalled();
+    expect(container.textContent).toContain("Publish forecast");
+    expect(container.textContent).toContain("Daily forecast");
+    expect(container.querySelector('a[href="/issues/TES-42"]')).toBeTruthy();
   });
 });

--- a/ui/src/pages/audit/AuditRuns.test.tsx
+++ b/ui/src/pages/audit/AuditRuns.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { HeartbeatRun } from "@paperclipai/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuditRuns } from "./AuditRuns";
+
+const listAgentsMock = vi.hoisted(() => vi.fn());
+const listRunsMock = vi.hoisted(() => vi.fn());
+const setSearchParamsMock = vi.hoisted(() => vi.fn());
+let currentSearch = "";
+
+vi.mock("@/api/agents", () => ({
+  agentsApi: { list: (companyId: string) => listAgentsMock(companyId) },
+}));
+
+vi.mock("@/api/heartbeats", () => ({
+  heartbeatsApi: {
+    list: (companyId: string, agentId?: string, limit?: number, options?: unknown) =>
+      listRunsMock(companyId, agentId, limit, options),
+  },
+}));
+
+vi.mock("@/lib/router", () => ({
+  Link: ({ to, children, ...props }: { to: string; children: ReactNode }) => (
+    <a href={to} {...props}>{children}</a>
+  ),
+  useSearchParams: () => [new URLSearchParams(currentSearch), setSearchParamsMock],
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+function run(overrides: Partial<HeartbeatRun> = {}): HeartbeatRun {
+  return {
+    id: "run-12345678",
+    companyId: "company-1",
+    agentId: "agent-1",
+    invocationSource: "manual",
+    status: "succeeded",
+    startedAt: new Date("2026-08-31T18:00:00.000Z"),
+    finishedAt: new Date("2026-08-31T18:01:05.000Z"),
+    resultJson: { summary: "Reviewed the release checklist" },
+    error: null,
+    createdAt: new Date("2026-08-31T18:00:00.000Z"),
+    ...overrides,
+  } as HeartbeatRun;
+}
+
+async function flushReact() {
+  for (let index = 0; index < 3; index += 1) {
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  }
+}
+
+describe("AuditRuns", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    currentSearch = "";
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    listAgentsMock.mockResolvedValue([{ id: "agent-1", name: "Fable" }]);
+    listRunsMock.mockResolvedValue([run()]);
+  });
+
+  afterEach(() => {
+    flushSync(() => root?.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  async function render() {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    root = createRoot(container);
+    flushSync(() => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <AuditRuns companyId="company-1" />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+  }
+
+  it("renders a filterable flat run list with existing run-detail links", async () => {
+    await render();
+
+    expect(listRunsMock).toHaveBeenCalledWith("company-1", undefined, 200, { summary: true });
+    expect(container.textContent).toContain("Agent");
+    expect(container.textContent).toContain("Status");
+    expect(container.textContent).toContain("Reviewed the release checklist");
+    expect(container.textContent).toContain("1m 5s");
+    const list = container.querySelector('ul[aria-label="Recent runs"]');
+    expect(list).toBeTruthy();
+    expect(list?.closest('[data-slot="card"]')).toBeFalsy();
+    expect(container.querySelector('a[href="/agents/agent-1/runs/run-12345678"]')).toBeTruthy();
+  });
+
+  it("uses the agent deep-link filter for both the query key and request", async () => {
+    currentSearch = "agentId=agent-1&runStatus=succeeded";
+    await render();
+
+    expect(listRunsMock).toHaveBeenCalledWith("company-1", "agent-1", 200, { summary: true });
+    expect(container.textContent).toContain("Clear filters");
+  });
+});

--- a/ui/src/pages/audit/AuditRuns.tsx
+++ b/ui/src/pages/audit/AuditRuns.tsx
@@ -1,0 +1,208 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import type { HeartbeatRun } from "@paperclipai/shared";
+import { Activity, CircleDotDashed } from "lucide-react";
+import { agentsApi } from "@/api/agents";
+import { heartbeatsApi } from "@/api/heartbeats";
+import { EmptyState } from "@/components/EmptyState";
+import { StatusBadge } from "@/components/StatusBadge";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { queryKeys } from "@/lib/queryKeys";
+import { Link, useSearchParams } from "@/lib/router";
+import { relativeTime } from "@/lib/utils";
+
+const ALL = "__all";
+const RUN_LIMIT = 200;
+
+function runSummary(run: HeartbeatRun) {
+  const result = run.resultJson as { summary?: unknown; result?: unknown } | null;
+  const value = result?.summary ?? result?.result ?? run.error;
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function runDuration(run: HeartbeatRun) {
+  const start = run.startedAt ? new Date(run.startedAt).getTime() : null;
+  const end = run.finishedAt ? new Date(run.finishedAt).getTime() : null;
+  if (start == null || end == null || !Number.isFinite(start) || !Number.isFinite(end)) return null;
+  const seconds = Math.max(0, Math.round((end - start) / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  return `${minutes}m ${seconds % 60}s`;
+}
+
+function readableSource(source: string) {
+  return source.replaceAll("_", " ");
+}
+
+export function AuditRuns({ companyId }: { companyId: string }) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const agentId = searchParams.get("agentId") ?? ALL;
+  const status = searchParams.get("runStatus") ?? ALL;
+  const agents = useQuery({
+    queryKey: queryKeys.agents.list(companyId),
+    queryFn: () => agentsApi.list(companyId),
+  });
+  const runs = useQuery({
+    queryKey: queryKeys.audit.runs(companyId, agentId === ALL ? null : agentId),
+    queryFn: () =>
+      heartbeatsApi.list(companyId, agentId === ALL ? undefined : agentId, RUN_LIMIT, {
+        summary: true,
+      }),
+    refetchInterval: 15_000,
+  });
+  const agentById = useMemo(
+    () => new Map((agents.data ?? []).map((agent) => [agent.id, agent])),
+    [agents.data],
+  );
+  const statuses = useMemo(
+    () => Array.from(new Set((runs.data ?? []).map((run) => run.status))).sort(),
+    [runs.data],
+  );
+  const visibleRuns = useMemo(
+    () => (runs.data ?? []).filter((run) => status === ALL || run.status === status),
+    [runs.data, status],
+  );
+
+  const updateFilter = (key: "agentId" | "runStatus", value: string) => {
+    setSearchParams(
+      (current) => {
+        const next = new URLSearchParams(current);
+        if (value === ALL) next.delete(key);
+        else next.set(key, value);
+        return next;
+      },
+      { replace: true },
+    );
+  };
+
+  const clearFilters = () => {
+    setSearchParams(
+      (current) => {
+        const next = new URLSearchParams(current);
+        next.delete("agentId");
+        next.delete("runStatus");
+        return next;
+      },
+      { replace: true },
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold text-foreground">Runs</h2>
+        <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+          Recent agent executions across the organization. Open a run to inspect its transcript,
+          output, and task context.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-end gap-3 border-y border-border py-3">
+        <label className="grid gap-1 text-(length:--text-micro) font-medium text-muted-foreground">
+          <span>Agent</span>
+          <Select value={agentId} onValueChange={(value) => updateFilter("agentId", value)}>
+            <SelectTrigger className="w-48">
+              <SelectValue placeholder="All agents" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL}>All agents</SelectItem>
+              {(agents.data ?? []).map((agent) => (
+                <SelectItem key={agent.id} value={agent.id}>
+                  {agent.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </label>
+        <label className="grid gap-1 text-(length:--text-micro) font-medium text-muted-foreground">
+          <span>Status</span>
+          <Select value={status} onValueChange={(value) => updateFilter("runStatus", value)}>
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="All statuses" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL}>All statuses</SelectItem>
+              {statuses.map((value) => (
+                <SelectItem key={value} value={value}>
+                  {readableSource(value)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </label>
+        {agentId !== ALL || status !== ALL ? (
+          <Button variant="ghost" size="sm" onClick={clearFilters}>
+            Clear filters
+          </Button>
+        ) : null}
+      </div>
+
+      {runs.isLoading ? (
+        <div className="border-y border-border py-14 text-center text-sm text-muted-foreground">
+          Loading runs…
+        </div>
+      ) : runs.error ? (
+        <div className="flex flex-col items-center gap-3 border-y border-border py-14 text-center">
+          <p className="text-sm text-muted-foreground">
+            {runs.error instanceof Error ? runs.error.message : "Failed to load runs."}
+          </p>
+          <Button variant="outline" size="sm" onClick={() => runs.refetch()}>
+            Try again
+          </Button>
+        </div>
+      ) : visibleRuns.length === 0 ? (
+        <EmptyState
+          icon={agentId !== ALL || status !== ALL ? CircleDotDashed : Activity}
+          message={agentId !== ALL || status !== ALL ? "No runs match these filters." : "No runs yet."}
+        />
+      ) : (
+        <ul className="divide-y divide-border border-y border-border" aria-label="Recent runs">
+          {visibleRuns.map((run) => {
+            const agent = agentById.get(run.agentId);
+            const summary = runSummary(run);
+            const duration = runDuration(run);
+            return (
+              <li key={run.id}>
+                <Link
+                  to={`/agents/${run.agentId}/runs/${run.id}`}
+                  className="flex flex-col gap-2 px-1 py-3 text-inherit no-underline transition-colors hover:bg-muted/50 sm:flex-row sm:items-start sm:justify-between sm:px-3"
+                >
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="font-medium text-foreground">
+                        {agent?.name ?? "Unknown agent"}
+                      </span>
+                      <span className="font-mono text-(length:--text-micro) text-muted-foreground">
+                        {run.id.slice(0, 8)}
+                      </span>
+                      <StatusBadge status={run.status} />
+                    </div>
+                    <p className="mt-1 truncate text-sm text-muted-foreground">
+                      {summary ?? `${readableSource(run.invocationSource)} run`}
+                    </p>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-2 text-xs text-muted-foreground sm:justify-end">
+                    <span className="capitalize">{readableSource(run.invocationSource)}</span>
+                    {duration ? <span>{duration}</span> : null}
+                    <time dateTime={new Date(run.createdAt).toISOString()}>
+                      {relativeTime(run.createdAt)}
+                    </time>
+                  </div>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <p className="text-xs text-muted-foreground">Showing the {RUN_LIMIT} most recent runs.</p>
+    </div>
+  );
+}

--- a/ui/src/pages/audit/AuditRuns.tsx
+++ b/ui/src/pages/audit/AuditRuns.tsx
@@ -1,9 +1,10 @@
 import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import type { HeartbeatRun } from "@paperclipai/shared";
+import type { HeartbeatRun, RoutineRunSummary } from "@paperclipai/shared";
 import { Activity, CircleDotDashed } from "lucide-react";
 import { agentsApi } from "@/api/agents";
 import { heartbeatsApi } from "@/api/heartbeats";
+import { routinesApi } from "@/api/routines";
 import { EmptyState } from "@/components/EmptyState";
 import { StatusBadge } from "@/components/StatusBadge";
 import { Button } from "@/components/ui/button";
@@ -41,13 +42,98 @@ function readableSource(source: string) {
   return source.replaceAll("_", " ");
 }
 
-export function AuditRuns({ companyId }: { companyId: string }) {
+function routineRunTitle(run: RoutineRunSummary) {
+  return run.linkedIssue?.title ?? run.trigger?.label ?? "Routine run";
+}
+
+function RoutineScopedRuns({
+  runs,
+  isLoading,
+  error,
+  onRetry,
+}: {
+  runs: RoutineRunSummary[];
+  isLoading: boolean;
+  error: Error | null;
+  onRetry: () => void;
+}) {
+  if (isLoading) {
+    return (
+      <div className="border-y border-border py-14 text-center text-sm text-muted-foreground">
+        Loading routine runs…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center gap-3 border-y border-border py-14 text-center">
+        <p className="text-sm text-muted-foreground">{error.message}</p>
+        <Button variant="outline" size="sm" onClick={onRetry}>Try again</Button>
+      </div>
+    );
+  }
+
+  if (runs.length === 0) {
+    return <EmptyState icon={Activity} message="No routine runs yet." />;
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold text-foreground">Routine runs</h2>
+        <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+          Executions created by this routine, newest first.
+        </p>
+      </div>
+      <ul className="divide-y divide-border border-y border-border" aria-label="Routine runs">
+        {runs.map((run) => {
+          const content = (
+            <>
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-medium text-foreground">{routineRunTitle(run)}</span>
+                  <StatusBadge status={run.status} />
+                </div>
+                <p className="mt-1 truncate text-sm text-muted-foreground">
+                  {run.trigger?.label ?? readableSource(run.source)}
+                </p>
+              </div>
+              <div className="flex shrink-0 items-center gap-2 text-xs text-muted-foreground sm:justify-end">
+                <span className="capitalize">{readableSource(run.source)}</span>
+                <time dateTime={new Date(run.triggeredAt).toISOString()}>
+                  {relativeTime(run.triggeredAt)}
+                </time>
+              </div>
+            </>
+          );
+          const rowClassName = "flex flex-col gap-2 px-1 py-3 text-inherit no-underline transition-colors hover:bg-muted/50 sm:flex-row sm:items-start sm:justify-between sm:px-3";
+          return (
+            <li key={run.id}>
+              {run.linkedIssue ? (
+                <Link to={`/issues/${run.linkedIssue.identifier ?? run.linkedIssue.id}`} className={rowClassName}>
+                  {content}
+                </Link>
+              ) : (
+                <div className={rowClassName}>{content}</div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+      <p className="text-xs text-muted-foreground">Showing the {RUN_LIMIT} most recent routine runs.</p>
+    </div>
+  );
+}
+
+export function AuditRuns({ companyId, routineId }: { companyId: string; routineId?: string }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const agentId = searchParams.get("agentId") ?? ALL;
   const status = searchParams.get("runStatus") ?? ALL;
   const agents = useQuery({
     queryKey: queryKeys.agents.list(companyId),
     queryFn: () => agentsApi.list(companyId),
+    enabled: !routineId,
   });
   const runs = useQuery({
     queryKey: queryKeys.audit.runs(companyId, agentId === ALL ? null : agentId),
@@ -55,6 +141,13 @@ export function AuditRuns({ companyId }: { companyId: string }) {
       heartbeatsApi.list(companyId, agentId === ALL ? undefined : agentId, RUN_LIMIT, {
         summary: true,
       }),
+    refetchInterval: 15_000,
+    enabled: !routineId,
+  });
+  const routineRuns = useQuery({
+    queryKey: [...queryKeys.routines.runs(routineId ?? ""), "audit"],
+    queryFn: () => routinesApi.listRuns(routineId!, RUN_LIMIT),
+    enabled: Boolean(routineId),
     refetchInterval: 15_000,
   });
   const agentById = useMemo(
@@ -93,6 +186,17 @@ export function AuditRuns({ companyId }: { companyId: string }) {
       { replace: true },
     );
   };
+
+  if (routineId) {
+    return (
+      <RoutineScopedRuns
+        runs={routineRuns.data ?? []}
+        isLoading={routineRuns.isLoading}
+        error={routineRuns.error instanceof Error ? routineRuns.error : null}
+        onRetry={() => void routineRuns.refetch()}
+      />
+    );
+  }
 
   return (
     <div className="space-y-4">

--- a/ui/src/pages/audit/CompanyActivity.production.tsx
+++ b/ui/src/pages/audit/CompanyActivity.production.tsx
@@ -3,27 +3,26 @@ import { History } from "lucide-react";
 import { useSearchParams } from "@/lib/router";
 import { useCompany } from "../../context/CompanyContext";
 import { useBreadcrumbs } from "../../context/BreadcrumbContext";
-import { useStreamlinedUiEnabled } from "../../hooks/useStreamlinedUiEnabled";
 import { EmptyState } from "../../components/EmptyState";
-import { AuditFeed, type AuditFeedMode } from "./AuditFeed";
-import { AuditHub } from "./AuditHub";
+import { AuditFeed, type AuditFeedMode } from "./AuditFeed.production";
 
 /**
- * Canonical `/:company/activity` entrypoint for the Audit hub. It retains the
- * shared all-actors and privileged Agent Actions modes while Runs, Costs,
- * Budgets, and Timeline live as peer sections. The mode lives in `?mode=` so `/audit` deep
- * links can preset it and links stay shareable. The server enforces both tiers.
+ * Company activity page — the single merged surface for `/:company/activity`
+ * (PAP-16302). It replaces both the old 200-row activity list and the separate
+ * `/audit` page: all company readers get the shared all-actors feed, and callers
+ * with `audit:view_agent_actions` can switch to the privileged agent-action
+ * audit. The mode lives in `?mode=` so `/audit` deep links can preset it and
+ * links stay shareable. The server enforces both tiers regardless.
  */
 export function CompanyActivity() {
-  const { enabled: streamlinedUiEnabled } = useStreamlinedUiEnabled();
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
   const [searchParams, setSearchParams] = useSearchParams();
   const mode: AuditFeedMode = searchParams.get("mode") === "agents" ? "agents" : "all";
 
   useEffect(() => {
-    if (!streamlinedUiEnabled) setBreadcrumbs([{ label: "Activity" }]);
-  }, [setBreadcrumbs, streamlinedUiEnabled]);
+    setBreadcrumbs([{ label: "Activity" }]);
+  }, [setBreadcrumbs]);
 
   const handleModeChange = useCallback(
     (next: AuditFeedMode) => {
@@ -34,16 +33,16 @@ export function CompanyActivity() {
           else params.delete("mode");
           return params;
         },
+        // The mode is a view toggle, not a navigation step — don't stack history
+        // entries the back button has to walk through.
         { replace: true },
       );
     },
     [setSearchParams],
   );
 
-  if (streamlinedUiEnabled) return <AuditHub section="activity" />;
-
   if (!selectedCompanyId) {
-    return <EmptyState icon={History} message="Select an organization to view activity." />;
+    return <EmptyState icon={History} message="Select a company to view activity." />;
   }
 
   return <AuditFeed companyId={selectedCompanyId} mode={mode} onModeChange={handleModeChange} />;

--- a/ui/src/pages/audit/RoutineAuditActivity.test.tsx
+++ b/ui/src/pages/audit/RoutineAuditActivity.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RoutineAuditActivity } from "./RoutineAuditActivity";
+
+const getRoutineMock = vi.hoisted(() => vi.fn());
+const listRoutineRunsMock = vi.hoisted(() => vi.fn());
+const routineActivityMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/api/routines", () => ({
+  routinesApi: {
+    get: (routineId: string) => getRoutineMock(routineId),
+    listRuns: (routineId: string, limit?: number) => listRoutineRunsMock(routineId, limit),
+    activity: (
+      companyId: string,
+      routineId: string,
+      scope: { triggerIds: string[]; runIds: string[] },
+    ) => routineActivityMock(companyId, routineId, scope),
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function flushReact() {
+  for (let index = 0; index < 3; index += 1) {
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  }
+}
+
+describe("RoutineAuditActivity", () => {
+  let container: HTMLDivElement;
+  let root: ReturnType<typeof createRoot>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    getRoutineMock.mockResolvedValue({ triggers: [{ id: "trigger-1" }, { id: "trigger-2" }] });
+    listRoutineRunsMock.mockResolvedValue([{ id: "run-1" }, { id: "run-2" }]);
+    routineActivityMock.mockResolvedValue([
+      {
+        id: "event-1",
+        action: "routine.run.completed",
+        details: { runId: "run-1" },
+        createdAt: new Date("2026-08-31T18:01:05.000Z"),
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    flushSync(() => root?.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it("loads activity through the routine endpoint with its trigger and run scope", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    root = createRoot(container);
+    flushSync(() => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <RoutineAuditActivity companyId="company-1" routineId="routine-1" />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    expect(getRoutineMock).toHaveBeenCalledWith("routine-1");
+    expect(listRoutineRunsMock).toHaveBeenCalledWith("routine-1", 200);
+    expect(routineActivityMock).toHaveBeenCalledWith("company-1", "routine-1", {
+      triggerIds: ["trigger-1", "trigger-2"],
+      runIds: ["run-1", "run-2"],
+    });
+    expect(container.textContent).toContain("routine.run.completed");
+  });
+});

--- a/ui/src/pages/audit/RoutineAuditActivity.tsx
+++ b/ui/src/pages/audit/RoutineAuditActivity.tsx
@@ -1,0 +1,63 @@
+import { useQuery } from "@tanstack/react-query";
+import { Activity } from "lucide-react";
+import { routinesApi } from "@/api/routines";
+import { EmptyState } from "@/components/EmptyState";
+import { RoutineActivityRow } from "@/components/RoutineActivityRow";
+import { Button } from "@/components/ui/button";
+import { queryKeys } from "@/lib/queryKeys";
+
+export function RoutineAuditActivity({
+  companyId,
+  routineId,
+}: {
+  companyId: string;
+  routineId: string;
+}) {
+  const activity = useQuery({
+    queryKey: [...queryKeys.routines.activity(companyId, routineId), "audit"],
+    queryFn: async () => {
+      const [routine, runs] = await Promise.all([
+        routinesApi.get(routineId),
+        routinesApi.listRuns(routineId, 200),
+      ]);
+      return routinesApi.activity(companyId, routineId, {
+        triggerIds: routine.triggers.map((trigger) => trigger.id),
+        runIds: runs.map((run) => run.id),
+      });
+    },
+  });
+
+  if (activity.isLoading) {
+    return (
+      <div className="border-y border-border py-14 text-center text-sm text-muted-foreground">
+        Loading routine activity…
+      </div>
+    );
+  }
+
+  if (activity.error) {
+    return (
+      <div className="flex flex-col items-center gap-3 border-y border-border py-14 text-center">
+        <p className="text-sm text-muted-foreground">
+          {activity.error instanceof Error ? activity.error.message : "Failed to load routine activity."}
+        </p>
+        <Button variant="outline" size="sm" onClick={() => activity.refetch()}>
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
+  const events = activity.data ?? [];
+  if (events.length === 0) {
+    return <EmptyState icon={Activity} message="No routine activity yet." />;
+  }
+
+  return (
+    <div className="border-y border-border" aria-label="Routine activity">
+      {events.map((event) => (
+        <RoutineActivityRow key={event.id} event={event} />
+      ))}
+    </div>
+  );
+}

--- a/ui/src/pages/audit/audit-navigation.test.ts
+++ b/ui/src/pages/audit/audit-navigation.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  agentAuditHref,
+  auditScopeFromSearchParams,
+  auditSectionHref,
+  routineAuditHref,
+  runAuditHref,
+} from "./audit-navigation";
+
+describe("audit navigation", () => {
+  it("builds stable section routes", () => {
+    expect(auditSectionHref("activity")).toBe("/activity");
+    expect(auditSectionHref("runs")).toBe("/activity/runs");
+    expect(auditSectionHref("costs")).toBe("/activity/costs");
+    expect(auditSectionHref("budgets")).toBe("/activity/budgets");
+    expect(auditSectionHref("timeline")).toBe("/activity/timeline");
+  });
+
+  it("provides agent, routine, and run scoped links", () => {
+    expect(agentAuditHref("agent-1")).toBe("/activity?mode=agents&agentId=agent-1");
+    expect(agentAuditHref("agent-1", "runs")).toBe("/activity/runs?agentId=agent-1");
+    expect(routineAuditHref("routine-1")).toBe(
+      "/activity?entityType=routine&entityId=routine-1",
+    );
+    expect(runAuditHref("run-1", "agent-1")).toBe(
+      "/activity?mode=agents&agentId=agent-1&runId=run-1",
+    );
+  });
+
+  it("reads supported scope parameters without treating arbitrary query data as filters", () => {
+    expect(auditScopeFromSearchParams(new URLSearchParams(
+      "mode=agents&agentId=agent-1&entityType=routine&entityId=routine-1&ignored=yes",
+    ))).toEqual({
+      mode: "agents",
+      agentId: "agent-1",
+      runId: null,
+      entityType: "routine",
+      entityId: "routine-1",
+    });
+  });
+});

--- a/ui/src/pages/audit/audit-navigation.ts
+++ b/ui/src/pages/audit/audit-navigation.ts
@@ -1,0 +1,64 @@
+export type AuditSection = "activity" | "runs" | "costs" | "budgets" | "timeline";
+
+export const AUDIT_SECTIONS: ReadonlyArray<{
+  value: AuditSection;
+  label: string;
+  href: string;
+}> = [
+  { value: "activity", label: "Activity", href: "/activity" },
+  { value: "runs", label: "Runs", href: "/activity/runs" },
+  { value: "costs", label: "Costs", href: "/activity/costs" },
+  { value: "budgets", label: "Budgets", href: "/activity/budgets" },
+  { value: "timeline", label: "Timeline", href: "/activity/timeline" },
+];
+
+export interface AuditLinkScope {
+  mode?: "all" | "agents";
+  agentId?: string | null;
+  runId?: string | null;
+  entityType?: string | null;
+  entityId?: string | null;
+}
+
+export function auditSectionHref(section: AuditSection, scope: AuditLinkScope = {}) {
+  const base = AUDIT_SECTIONS.find((candidate) => candidate.value === section)?.href ?? "/activity";
+  const search = new URLSearchParams();
+  if (scope.mode === "agents") search.set("mode", "agents");
+  if (scope.agentId) search.set("agentId", scope.agentId);
+  if (scope.runId) search.set("runId", scope.runId);
+  if (scope.entityType) search.set("entityType", scope.entityType);
+  if (scope.entityId) search.set("entityId", scope.entityId);
+  const query = search.toString();
+  return query ? `${base}?${query}` : base;
+}
+
+/** Link target for an agent's attributed activity or company-wide run history. */
+export function agentAuditHref(agentId: string, section: "activity" | "runs" = "activity") {
+  return auditSectionHref(section, {
+    mode: section === "activity" ? "agents" : undefined,
+    agentId,
+  });
+}
+
+/** Link target for the immutable activity recorded directly against a routine. */
+export function routineAuditHref(routineId: string) {
+  return auditSectionHref("activity", {
+    entityType: "routine",
+    entityId: routineId,
+  });
+}
+
+/** Link target for the attributed activity behind a specific run. */
+export function runAuditHref(runId: string, agentId?: string | null) {
+  return auditSectionHref("activity", { mode: "agents", runId, agentId });
+}
+
+export function auditScopeFromSearchParams(searchParams: URLSearchParams): AuditLinkScope {
+  return {
+    mode: searchParams.get("mode") === "agents" ? "agents" : "all",
+    agentId: searchParams.get("agentId"),
+    runId: searchParams.get("runId"),
+    entityType: searchParams.get("entityType"),
+    entityId: searchParams.get("entityId"),
+  };
+}

--- a/ui/src/pages/skills/skills-navigation.test.ts
+++ b/ui/src/pages/skills/skills-navigation.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveSkillsDiscoveryView,
+  resolveSkillsNavigationView,
+  SKILLS_NAVIGATION_HREFS,
+  withSkillsDiscoveryView,
+} from "./skills-navigation";
+
+describe("skills navigation", () => {
+  it("defaults to Installed and exposes stable canonical hrefs", () => {
+    expect(resolveSkillsDiscoveryView(null)).toBe("installed");
+    expect(resolveSkillsNavigationView("/PAP/skills", "")).toBe("installed");
+    expect(SKILLS_NAVIGATION_HREFS).toEqual({
+      installed: "/skills",
+      discover: "/skills?tab=discover",
+      authored: "/skills/studio",
+    });
+  });
+
+  it.each(["discover", "all", "catalog", "bundled"])(
+    "maps the legacy %s tab to Discover",
+    (tab) => {
+      expect(resolveSkillsDiscoveryView(tab)).toBe("discover");
+      expect(resolveSkillsNavigationView("/PAP/skills", `?tab=${tab}`)).toBe("discover");
+    },
+  );
+
+  it("treats catalog detail links as Discover and Studio routes as My Skills", () => {
+    expect(resolveSkillsNavigationView("/PAP/skills", "?catalog=skill-1")).toBe("discover");
+    expect(resolveSkillsNavigationView("/PAP/skills", "?view=catalog")).toBe("discover");
+    expect(resolveSkillsNavigationView("/PAP/skills/studio/skill-1", "?tab=files")).toBe("authored");
+  });
+
+  it("canonicalizes view changes without carrying incompatible filters", () => {
+    expect(withSkillsDiscoveryView(
+      new URLSearchParams("tab=catalog&folder=my&category=writing&source=bundled"),
+      "discover",
+    ).toString()).toBe("tab=discover&source=bundled");
+
+    expect(withSkillsDiscoveryView(
+      new URLSearchParams("tab=discover&folder=my&source=external"),
+      "installed",
+    ).toString()).toBe("folder=my&source=external");
+  });
+});

--- a/ui/src/pages/skills/skills-navigation.ts
+++ b/ui/src/pages/skills/skills-navigation.ts
@@ -1,0 +1,41 @@
+export type SkillsNavigationView = "installed" | "discover" | "authored";
+
+export const SKILLS_NAVIGATION_HREFS: Record<SkillsNavigationView, string> = {
+  installed: "/skills",
+  discover: "/skills?tab=discover",
+  authored: "/skills/studio",
+};
+
+export function resolveSkillsDiscoveryView(tabParam: string | null): Exclude<SkillsNavigationView, "authored"> {
+  // Preserve old discovery links while presenting one canonical Discover view.
+  return ["discover", "all", "catalog", "bundled"].includes(tabParam ?? "")
+    ? "discover"
+    : "installed";
+}
+
+export function withSkillsDiscoveryView(
+  current: URLSearchParams,
+  view: Exclude<SkillsNavigationView, "authored">,
+): URLSearchParams {
+  const params = new URLSearchParams(current);
+  if (view === "installed") params.delete("tab");
+  else params.set("tab", "discover");
+  params.delete("view");
+  params.delete("category");
+  if (view !== "installed") params.delete("folder");
+  return params;
+}
+
+export function resolveSkillsNavigationView(
+  pathname: string,
+  search: string | URLSearchParams = "",
+): SkillsNavigationView {
+  const segments = pathname.split("/").filter(Boolean);
+  const skillsIndex = segments.findIndex((segment) => segment.toLowerCase() === "skills");
+  const skillsRoute = skillsIndex >= 0 ? segments.slice(skillsIndex + 1) : [];
+  if (skillsRoute[0]?.toLowerCase() === "studio") return "authored";
+
+  const params = typeof search === "string" ? new URLSearchParams(search) : search;
+  if (params.has("catalog") || params.get("view") === "catalog") return "discover";
+  return resolveSkillsDiscoveryView(params.get("tab"));
+}

--- a/ui/storybook/stories/skills-store-discovery.stories.tsx
+++ b/ui/storybook/stories/skills-store-discovery.stories.tsx
@@ -1,9 +1,14 @@
 import { useMemo, useState } from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { DiscoveryGrid, type DiscoveryCard, type DiscoveryCategory } from "@/pages/CompanySkills";
+import {
+  DiscoveryGrid,
+  type DiscoveryCard,
+  type DiscoveryCategory,
+  type DiscoveryTab,
+} from "@/pages/CompanySkills";
 
-type DiscoveryTab = "all" | "installed" | "catalog" | "bundled";
 type DiscoverySort = "agents" | "stars" | "forks" | "recent" | "alphabetical";
+const STORY_NOW = new Date("2026-08-31T12:00:00Z").getTime();
 
 const MOCK_CARDS: DiscoveryCard[] = [
   {
@@ -25,7 +30,7 @@ const MOCK_CARDS: DiscoveryCard[] = [
     installed: true,
     required: false,
     forkedFrom: false,
-    updatedAt: Date.now() - 2 * 86_400_000,
+    updatedAt: STORY_NOW - 2 * 86_400_000,
     sourceBadge: "github",
   },
   {
@@ -47,7 +52,7 @@ const MOCK_CARDS: DiscoveryCard[] = [
     installed: false,
     required: false,
     forkedFrom: false,
-    updatedAt: Date.now() - 5 * 86_400_000,
+    updatedAt: STORY_NOW - 5 * 86_400_000,
     sourceBadge: "skills_sh",
   },
   {
@@ -69,7 +74,7 @@ const MOCK_CARDS: DiscoveryCard[] = [
     installed: true,
     required: false,
     forkedFrom: false,
-    updatedAt: Date.now() - 9 * 86_400_000,
+    updatedAt: STORY_NOW - 9 * 86_400_000,
     sourceBadge: "local",
   },
   {
@@ -91,7 +96,7 @@ const MOCK_CARDS: DiscoveryCard[] = [
     installed: true,
     required: false,
     forkedFrom: true,
-    updatedAt: Date.now() - 1 * 86_400_000,
+    updatedAt: STORY_NOW - 1 * 86_400_000,
     sourceBadge: "paperclip",
   },
   {
@@ -135,7 +140,7 @@ const MOCK_CARDS: DiscoveryCard[] = [
     installed: true,
     required: false,
     forkedFrom: false,
-    updatedAt: Date.now() - 3 * 86_400_000,
+    updatedAt: STORY_NOW - 3 * 86_400_000,
     sourceBadge: "github",
   },
   {
@@ -179,7 +184,7 @@ const MOCK_CARDS: DiscoveryCard[] = [
     installed: true,
     required: false,
     forkedFrom: false,
-    updatedAt: Date.now() - 4 * 86_400_000,
+    updatedAt: STORY_NOW - 4 * 86_400_000,
     sourceBadge: "local",
   },
   {
@@ -201,7 +206,7 @@ const MOCK_CARDS: DiscoveryCard[] = [
     installed: true,
     required: true,
     forkedFrom: false,
-    updatedAt: Date.now() - 30 * 86_400_000,
+    updatedAt: STORY_NOW - 30 * 86_400_000,
     sourceBadge: "paperclip",
   },
   {
@@ -223,22 +228,17 @@ const MOCK_CARDS: DiscoveryCard[] = [
     installed: true,
     required: true,
     forkedFrom: false,
-    updatedAt: Date.now() - 28 * 86_400_000,
+    updatedAt: STORY_NOW - 28 * 86_400_000,
     sourceBadge: "url",
   },
 ];
 
-const DISCOVERY_TABS: DiscoveryTab[] = ["all", "installed", "catalog", "bundled"];
-
 function cardsForTab(cards: DiscoveryCard[], tab: DiscoveryTab): DiscoveryCard[] {
-  if (tab === "installed") return cards.filter((c) => c.installed);
-  if (tab === "catalog") return cards.filter((c) => c.catalogRef != null);
-  if (tab === "bundled") return cards.filter((c) => c.required);
-  return cards;
+  return tab === "installed" ? cards.filter((card) => card.installed) : cards;
 }
 
 function DiscoveryGridHarness({
-  initialTab = "all",
+  initialTab = "installed",
   cards = MOCK_CARDS,
 }: {
   initialTab?: DiscoveryTab;
@@ -264,7 +264,7 @@ function DiscoveryGridHarness({
       if (!q) return true;
       return `${card.name} ${card.author} ${card.categories.join(" ")}`.toLowerCase().includes(q);
     });
-    const demote = tab !== "bundled";
+    const demote = tab === "discover";
     return [...filtered].sort((a, b) => {
       if (demote && a.required !== b.required) return a.required ? 1 : -1;
       if (sort === "stars") return b.starCount - a.starCount;
@@ -275,24 +275,9 @@ function DiscoveryGridHarness({
     });
   }, [tabCards, category, search, sort, tab]);
 
-  const tabCounts = useMemo(
-    () => ({
-      all: cards.length,
-      installed: cards.filter((c) => c.installed).length,
-      catalog: cards.filter((c) => c.catalogRef != null).length,
-      bundled: cards.filter((c) => c.required).length,
-    }),
-    [cards],
-  ) as Record<DiscoveryTab, number>;
-
   return (
     <DiscoveryGrid
       tab={tab}
-      tabCounts={tabCounts}
-      onTabChange={(next) => {
-        setTab(next);
-        setCategory(null);
-      }}
       categories={categories}
       categoryTotal={tabCards.length}
       activeCategory={category}
@@ -309,7 +294,10 @@ function DiscoveryGridHarness({
       onCreate={() => {}}
       onImport={() => {}}
       onImportFromProject={() => {}}
-      onBrowseCatalog={() => setTab("catalog")}
+      onBrowseDiscover={() => {
+        setTab("discover");
+        setCategory(null);
+      }}
       onScan={() => {}}
       scanPending={false}
       scanStatus={null}
@@ -327,7 +315,6 @@ export default meta;
 
 type Story = StoryObj<typeof DiscoveryGridHarness>;
 
-export const AllSkills: Story = { args: { initialTab: "all" } };
-export const InstalledTab: Story = { args: { initialTab: "installed" } };
-export const BundledRequiredTab: Story = { args: { initialTab: "bundled" } };
-export const EmptyLibrary: Story = { args: { initialTab: "all", cards: [] } };
+export const Installed: Story = { args: { initialTab: "installed" } };
+export const Discover: Story = { args: { initialTab: "discover" } };
+export const EmptyInstalledLibrary: Story = { args: { initialTab: "installed", cards: [] } };


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Operators use several board surfaces to manage agents, routines, skills, and audits.
> - These surfaces currently use different density, toolbar, and detail-navigation patterns.
> - The differences make the product feel less coherent.
> - This pull request applies the streamlined shell to the main workspace surfaces.
> - The benefit is a consistent presentation across shipped control-plane features.

## Linked Issues or Issue Description

**What existing behavior does this improve?**

The agent, routine, skill, audit, cost, timeline, organization, and project surfaces.

**Subsystem affected**

ui/ — React + Vite board UI.

**Current behavior**

Each surface uses a separate mix of headers, toolbars, sidebars, and page density. Some detail views replace the global navigation.

**Proposed behavior**

Use the streamlined shell and shared contextual navigation. Keep the global navigation visible. Align collection toolbars and content density.

**Reason and benefit**

Operators can move between surfaces without relearning page structure. Shared patterns also reduce future UI drift.

**Breaking changes**

None. This presentation depends on the experimental setting from the base PR.

## What Changed

- Apply streamlined layouts to agents, routines, skills, audits, costs, timeline, and organization pages.
- Add reusable collection toolbar and issue-row presentation.
- Keep routine and agent detail navigation in a secondary contextual sidebar.
- Add production comparison fixtures and focused component tests.

## Verification

- Run `pnpm --filter ./ui typecheck`.
- Run the focused agent, routine, skill, audit, timeline, and organization Vitest suites.
- Review the surface stories in Storybook.

## Risks

- The change affects many visible pages, so visual regressions are the main risk.
- The legacy presentation remains available when the experiment is disabled.
- This is the second PR in a four-PR stack. It depends on the foundation PR.

> I checked `ROADMAP.md`. This work is UI polish for shipped capabilities. It does not duplicate a planned core feature.

## Model Used

- OpenAI Codex with GPT-5.6 Sol. The model used agentic reasoning, code execution, browser inspection, and image analysis. This environment does not expose the context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

