### PR TITLE
feat(ui): refine streamlined task experience

### DIFF
--- a/ui/src/App.activity-routing.test.tsx
+++ b/ui/src/App.activity-routing.test.tsx
@@ -1,11 +1,10 @@
 // @vitest-environment jsdom
 
-// Regression guard for PAP-16302: `/audit` was merged into the single rich
-// Activity page. Both the company-prefixed `/:company/audit` and the bare
-// `/audit` (PAP-16300's unprefixed redirect) must keep resolving — as redirects
-// into `/:company/activity?mode=agents`, so old deep links land on the
-// agent-actions scope instead of 404ing. This drives the real <App> route table
-// so removing either registration fails loudly.
+// Regression guard for the Audit hub: Activity remains the canonical root,
+// while Runs, Costs, and Budgets live beneath it. Company-prefixed and bare
+// legacy routes must keep resolving with their query filters intact; `/audit`
+// specifically retains the historical Agent Actions preset. This drives the
+// real <App> route table so removing either registration fails loudly.
 
 import type { ReactNode } from "react";
 import { flushSync } from "react-dom";
@@ -13,6 +12,12 @@ import { createRoot } from "react-dom/client";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "./App";
+
+const streamlinedUiState = vi.hoisted(() => ({ enabled: true, loaded: true }));
+
+vi.mock("./hooks/useStreamlinedUiEnabled", () => ({
+  useStreamlinedUiEnabled: () => streamlinedUiState,
+}));
 
 // jsdom's CSS parser rejects the custom-property marker rule stitches inserts
 // (`--sxs{--sxs:N}`), pulled into <App>'s eager import graph transitively via
@@ -44,6 +49,11 @@ vi.hoisted(() => {
 // owns the "No company matches prefix" NotFound. For routing we only need it to
 // resolve the :companyPrefix segment and render its nested routes.
 vi.mock("./components/Layout", async () => {
+  const { Outlet } = await import("react-router-dom");
+  return { Layout: () => <Outlet /> };
+});
+
+vi.mock("./components/Layout.production", async () => {
   const { Outlet } = await import("react-router-dom");
   return { Layout: () => <Outlet /> };
 });
@@ -81,6 +91,28 @@ vi.mock("./pages/Issues", () => ({
     const location = useLocation();
     return <div>{`TASKS_PAGE@${location.pathname}`}</div>;
   },
+}));
+
+vi.mock("./pages/audit/CompanyActivity.production", () => ({
+  CompanyActivity: () => {
+    const location = useLocation();
+    return <div>{`PRODUCTION_ACTIVITY@${location.pathname}${location.search}`}</div>;
+  },
+}));
+
+vi.mock("./pages/Costs.production", () => ({
+  Costs: () => {
+    const location = useLocation();
+    return <div>{`PRODUCTION_COSTS@${location.pathname}${location.search}`}</div>;
+  },
+}));
+
+vi.mock("./pages/NotFound", () => ({
+  NotFoundPage: ({ scope }: { scope: string }) => <div>{`NOT_FOUND:${scope}`}</div>,
+}));
+
+vi.mock("./pages/PluginPage", () => ({
+  PluginPage: () => <div>PRODUCTION_PLUGIN_FALLBACK</div>,
 }));
 
 const PAP_COMPANY = {
@@ -144,6 +176,8 @@ describe("App Activity routing (PAP-16302)", () => {
     container = document.createElement("div");
     document.body.appendChild(container);
     companyState = { companies: [PAP_COMPANY], selected: PAP_COMPANY };
+    streamlinedUiState.enabled = true;
+    streamlinedUiState.loaded = true;
   });
 
   afterEach(() => {
@@ -177,6 +211,27 @@ describe("App Activity routing (PAP-16302)", () => {
     flushSync(() => root.unmount());
   });
 
+  it("serves each canonical Audit section under Activity", async () => {
+    const root = renderAppAt(container, "/PAP/activity/runs?agentId=agent-1");
+    await waitForRoute(container, "AUDIT_RUNS@/PAP/activity/runs?agentId=agent-1");
+    flushSync(() => root.unmount());
+  });
+
+  it("redirects legacy costs and preserves its deep-link filters", async () => {
+    const root = renderAppAt(container, "/PAP/costs?range=30d#usage");
+    await waitForRoute(container, "AUDIT_COSTS@/PAP/activity/costs?range=30d");
+    flushSync(() => root.unmount());
+  });
+
+  it("redirects legacy Audit sections to their canonical destination", async () => {
+    const root = renderAppAt(container, "/PAP/audit/budgets?projectId=project-1");
+    await waitForRoute(
+      container,
+      "AUDIT_BUDGETS@/PAP/activity/budgets?projectId=project-1",
+    );
+    flushSync(() => root.unmount());
+  });
+
   it("keeps the company from the URL when /:company/audit is not the selected company", async () => {
     // A shared /ACME/audit link opened by someone whose selected company is PAP
     // must still show ACME's activity. The redirect target is written absolute
@@ -203,6 +258,50 @@ describe("App Activity routing (PAP-16302)", () => {
     const root = renderAppAt(container, "/tasks");
     await waitForRoute(container, "TASKS_PAGE@/PAP/issues");
     expect(container.textContent).not.toContain("/tasks/dashboard");
+    flushSync(() => root.unmount());
+  });
+
+  it("redirects a bare legacy section through to the prefixed Audit hub", async () => {
+    const root = renderAppAt(container, "/runs?runStatus=succeeded");
+    await waitForRoute(container, "AUDIT_RUNS@/PAP/activity/runs?runStatus=succeeded");
+    flushSync(() => root.unmount());
+  });
+
+  it("uses the production Activity and Costs routes when Streamlined UI is disabled", async () => {
+    streamlinedUiState.enabled = false;
+    const activityRoot = renderAppAt(container, "/PAP/activity");
+    await waitForRoute(container, "PRODUCTION_ACTIVITY@/PAP/activity");
+    flushSync(() => activityRoot.unmount());
+
+    const costsRoot = renderAppAt(container, "/PAP/costs?range=30d");
+    await waitForRoute(container, "PRODUCTION_COSTS@/PAP/costs?range=30d");
+    flushSync(() => costsRoot.unmount());
+  });
+
+  it("omits streamlined-only Audit routes when Streamlined UI is disabled", async () => {
+    streamlinedUiState.enabled = false;
+    const root = renderAppAt(container, "/PAP/activity/runs");
+    await waitForRoute(container, "PRODUCTION_PLUGIN_FALLBACK");
+    expect(container.textContent).not.toContain("AUDIT_RUNS");
+    flushSync(() => root.unmount());
+  });
+
+  it("does not mount streamlined routes before the experiment setting loads", async () => {
+    streamlinedUiState.loaded = false;
+    const root = renderAppAt(container, "/PAP/activity");
+    expect(container.textContent).not.toContain("ACTIVITY_PAGE");
+    expect(container.textContent).not.toContain("PRODUCTION_ACTIVITY");
+
+    streamlinedUiState.enabled = false;
+    streamlinedUiState.loaded = true;
+    flushSync(() => {
+      root.render(
+        <MemoryRouter initialEntries={["/PAP/activity"]}>
+          <App />
+        </MemoryRouter>,
+      );
+    });
+    await waitForRoute(container, "PRODUCTION_ACTIVITY@/PAP/activity");
     flushSync(() => root.unmount());
   });
 });

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,9 +1,10 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, type ReactNode } from "react";
 import type { ToolConnectionCredentialSource } from "@paperclipai/shared";
 import { Navigate, Outlet, Route, Routes, useActiveCompanyPrefix, useLocation, useParams } from "@/lib/router";
 import { Button } from "@/components/ui/button";
 import { useTranslation } from "@/i18n";
 import { Layout } from "./components/Layout";
+import { Layout as ProductionLayout } from "./components/Layout.production";
 import { ConferenceRoomChatGate } from "./components/ConferenceRoomChatGate";
 import { TaskChatLab } from "./pages/TaskChatLab";
 import { PipelinesExperimentalGate } from "./components/PipelinesExperimentalGate";
@@ -48,7 +49,6 @@ import { Artifacts } from "./pages/Artifacts";
 import { GoalDetail } from "./pages/GoalDetail";
 import { Approvals } from "./pages/Approvals";
 import { ApprovalDetail } from "./pages/ApprovalDetail";
-import { Costs } from "./pages/Costs";
 import { CompanyActivity } from "./pages/audit/CompanyActivity";
 import { AuditHub } from "./pages/audit/AuditHub";
 import { Inbox } from "./pages/Inbox";
@@ -85,7 +85,6 @@ import { PluginManager } from "./pages/PluginManager";
 import { PluginSettings } from "./pages/PluginSettings";
 import { AdapterManager } from "./pages/AdapterManager";
 import { PluginPage } from "./pages/PluginPage";
-import { OrgChart } from "./pages/OrgChart";
 import { NewAgent } from "./pages/NewAgent";
 import { AuthPage } from "./pages/Auth";
 import { BoardClaimPage } from "./pages/BoardClaim";
@@ -103,6 +102,7 @@ import {
 } from "./lib/onboarding-route";
 import { filterHiddenInstanceSettingsPath, normalizeRememberedInstanceSettingsPath } from "./lib/instance-settings";
 import { useCloudInstance } from "./hooks/useCloudInstance";
+import { useStreamlinedUiEnabled } from "./hooks/useStreamlinedUiEnabled";
 import { cloudStackCreateUrl } from "./lib/cloudLinks";
 import { navigateTopLevel } from "@/lib/browserNavigation";
 
@@ -110,13 +110,45 @@ const CompanyExport = lazy(() =>
   import("./pages/CompanyExport").then((module) => ({ default: module.CompanyExport })),
 );
 
-function boardRoutes() {
+const ProductionAgents = lazy(() =>
+  import("./pages/Agents.production").then((module) => ({ default: module.Agents })),
+);
+const ProductionAgentDetail = lazy(() =>
+  import("./pages/AgentDetail.production").then((module) => ({ default: module.AgentDetail })),
+);
+const ProductionRoutines = lazy(() =>
+  import("./pages/Routines.production").then((module) => ({ default: module.Routines })),
+);
+const ProductionRoutineDetail = lazy(() =>
+  import("./pages/RoutineDetail.production").then((module) => ({ default: module.RoutineDetail })),
+);
+const ProductionCompanySkills = lazy(() =>
+  import("./pages/CompanySkills.production").then((module) => ({ default: module.CompanySkills })),
+);
+const ProductionCompanyActivity = lazy(() =>
+  import("./pages/audit/CompanyActivity.production").then((module) => ({ default: module.CompanyActivity })),
+);
+const ProductionCosts = lazy(() =>
+  import("./pages/Costs.production").then((module) => ({ default: module.Costs })),
+);
+const ProductionOrgChart = lazy(() =>
+  import("./pages/OrgChart.production").then((module) => ({ default: module.OrgChart })),
+);
+
+function ProductionSurface({ children }: { children: ReactNode }) {
+  return <Suspense fallback={<PaperclipLoading />}>{children}</Suspense>;
+}
+
+function boardRoutes(streamlinedUiEnabled: boolean) {
   return (
     <>
       <Route index element={<Navigate to="dashboard" replace />} />
       <Route path="dashboard" element={<Dashboard />} />
       <Route path="dashboard/live" element={<DashboardLive />} />
-      <Route path="timeline" element={<Timeline />} />
+      <Route
+        path="timeline"
+        element={streamlinedUiEnabled ? <AuditCompatibilityRedirect to="/activity/timeline" /> : <Timeline />}
+      />
       <Route path="onboarding" element={<OnboardingRoutePage />} />
       <Route path="companies" element={<Companies />} />
       <Route path="company/settings" element={<CompanySettings />} />
@@ -214,19 +246,29 @@ function boardRoutes() {
       <Route path="skills/studio/new" element={<SkillStudio />} />
       <Route path="skills/studio/:skillId" element={<SkillStudio />} />
       <Route path="skills/:skillId/studio" element={<LegacySkillStudioRedirect />} />
-      <Route path="skills/*" element={<CompanySkills />} />
+      <Route
+        path="skills/*"
+        element={streamlinedUiEnabled ? <CompanySkills /> : <ProductionSurface><ProductionCompanySkills /></ProductionSurface>}
+      />
       <Route path="settings" element={<LegacySettingsRedirect />} />
       <Route path="settings/*" element={<LegacySettingsRedirect />} />
       <Route path="plugins/:pluginId" element={<PluginPage />} />
-      <Route path="org" element={<OrgChart />} />
+      <Route
+        path="org"
+        element={streamlinedUiEnabled ? <Navigate to="/agents/all" replace /> : <ProductionSurface><ProductionOrgChart /></ProductionSurface>}
+      />
       <Route path="agents" element={<Navigate to="/agents/all" replace />} />
       {AGENT_FILTER_TABS.map((tab) => (
-        <Route key={tab} path={`agents/${tab}`} element={<Agents />} />
+        <Route
+          key={tab}
+          path={`agents/${tab}`}
+          element={streamlinedUiEnabled ? <Agents /> : <ProductionSurface><ProductionAgents /></ProductionSurface>}
+        />
       ))}
       <Route path="agents/new" element={<NewAgent />} />
-      <Route path="agents/:agentId" element={<AgentDetail />} />
-      <Route path="agents/:agentId/:tab" element={<AgentDetail />} />
-      <Route path="agents/:agentId/runs/:runId" element={<AgentDetail />} />
+      <Route path="agents/:agentId" element={streamlinedUiEnabled ? <AgentDetail /> : <ProductionSurface><ProductionAgentDetail /></ProductionSurface>} />
+      <Route path="agents/:agentId/:tab" element={streamlinedUiEnabled ? <AgentDetail /> : <ProductionSurface><ProductionAgentDetail /></ProductionSurface>} />
+      <Route path="agents/:agentId/runs/:runId" element={streamlinedUiEnabled ? <AgentDetail /> : <ProductionSurface><ProductionAgentDetail /></ProductionSurface>} />
       <Route path="projects" element={<Projects />} />
       <Route path="projects/:projectId" element={<ProjectDetail />} />
       <Route path="projects/:projectId/overview" element={<ProjectDetail />} />
@@ -253,7 +295,7 @@ function boardRoutes() {
       {import.meta.env.DEV ? (
         <Route path="tests/perf/long-thread" element={<IssueChatLongThreadPerf />} />
       ) : null}
-      <Route path="routines" element={<Routines />} />
+      <Route path="routines" element={streamlinedUiEnabled ? <Routines /> : <ProductionSurface><ProductionRoutines /></ProductionSurface>} />
       <Route
         path="cases"
         element={<CasesExperimentalGate><Cases /></CasesExperimentalGate>}
@@ -305,8 +347,8 @@ function boardRoutes() {
         path="pipelines/:pipelineId/cases/:caseId"
         element={<PipelinesExperimentalGate><PipelineItemLegacyRedirect /></PipelinesExperimentalGate>}
       />
-      <Route path="routines/:routineId" element={<RoutineDetail />} />
-      <Route path="routines/:routineId/:section" element={<RoutineDetail />} />
+      <Route path="routines/:routineId" element={streamlinedUiEnabled ? <RoutineDetail /> : <ProductionSurface><ProductionRoutineDetail /></ProductionSurface>} />
+      <Route path="routines/:routineId/:section" element={streamlinedUiEnabled ? <RoutineDetail /> : <ProductionSurface><ProductionRoutineDetail /></ProductionSurface>} />
       <Route element={<IsolatedWorkspacesRouteGate />}>
         <Route element={<ExecutionWorkspaceCompanyGate />}>
           <Route path="execution-workspaces/:workspaceId" element={<ExecutionWorkspaceDetail />} />
@@ -324,15 +366,29 @@ function boardRoutes() {
       <Route path="approvals/pending" element={<Approvals />} />
       <Route path="approvals/all" element={<Approvals />} />
       <Route path="approvals/:approvalId" element={<ApprovalDetail />} />
-      <Route path="costs" element={<Costs />} />
-      <Route path="activity" element={<CompanyActivity />} />
-      <Route path="activity/runs" element={<AuditHub section="runs" />} />
-      <Route path="activity/costs" element={<AuditHub section="costs" />} />
-      <Route path="activity/budgets" element={<AuditHub section="budgets" />} />
-      <Route path="activity/timeline" element={<AuditHub section="timeline" />} />
-      {/* `/audit` merged into the single Activity page (PAP-16302). Existing deep
-          links keep working, preset to the agent-actions scope. */}
-      <Route path="audit" element={<Navigate to="/activity?mode=agents" replace />} />
+      <Route path="activity" element={streamlinedUiEnabled ? <CompanyActivity /> : <ProductionSurface><ProductionCompanyActivity /></ProductionSurface>} />
+      {streamlinedUiEnabled ? (
+        <>
+          <Route path="activity/runs" element={<AuditHub section="runs" />} />
+          <Route path="activity/costs" element={<AuditHub section="costs" />} />
+          <Route path="activity/budgets" element={<AuditHub section="budgets" />} />
+          <Route path="activity/timeline" element={<AuditHub section="timeline" />} />
+          <Route path="audit" element={<AuditCompatibilityRedirect to="/activity" forceAgentMode />} />
+          <Route path="audit/activity" element={<AuditCompatibilityRedirect to="/activity" />} />
+          <Route path="audit/runs" element={<AuditCompatibilityRedirect to="/activity/runs" />} />
+          <Route path="audit/costs" element={<AuditCompatibilityRedirect to="/activity/costs" />} />
+          <Route path="audit/budgets" element={<AuditCompatibilityRedirect to="/activity/budgets" />} />
+          <Route path="audit/timeline" element={<AuditCompatibilityRedirect to="/activity/timeline" />} />
+          <Route path="runs" element={<AuditCompatibilityRedirect to="/activity/runs" />} />
+          <Route path="costs" element={<AuditCompatibilityRedirect to="/activity/costs" />} />
+          <Route path="budgets" element={<AuditCompatibilityRedirect to="/activity/budgets" />} />
+        </>
+      ) : (
+        <>
+          <Route path="costs" element={<ProductionSurface><ProductionCosts /></ProductionSurface>} />
+          <Route path="audit" element={<Navigate to="/activity?mode=agents" replace />} />
+        </>
+      )}
       {/* Conference Room Chat surfaces (PAP-136/PAP-137): routes stay
           registered but redirect to the company home while the experimental
           flag is off. The board-level `artifacts` mount below is the new
@@ -580,6 +636,20 @@ function StatusCardsLegacyRedirect() {
   return <Navigate to={`${base}/status${cardId ? `/${cardId}` : ""}`} replace />;
 }
 
+function AuditCompatibilityRedirect({
+  to,
+  forceAgentMode = false,
+}: {
+  to: string;
+  forceAgentMode?: boolean;
+}) {
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
+  if (forceAgentMode) searchParams.set("mode", "agents");
+  const search = searchParams.toString();
+  return <Navigate to={`${to}${search ? `?${search}` : ""}${location.hash}`} replace />;
+}
+
 function UnprefixedBoardRedirect() {
   const location = useLocation();
   const { companies, selectedCompany, loading } = useCompany();
@@ -654,6 +724,8 @@ function NoCompaniesStartPage() {
 }
 
 export function App() {
+  const { enabled: streamlinedUiEnabled, loaded: streamlinedUiLoaded } = useStreamlinedUiEnabled();
+
   return (
     <>
       <Routes>
@@ -666,7 +738,7 @@ export function App() {
         <Route path="ux-lab/responsible-user-denial" element={<ResponsibleUserDenialUxLab />} />
         <Route path="ux-lab/cross-issue-collaboration" element={<CrossIssueCollaborationUxLab />} />
 
-        <Route element={<CloudAccessGate />}>
+        <Route element={streamlinedUiLoaded ? <CloudAccessGate /> : <PaperclipLoading />}>
           <Route index element={<CompanyRootRedirect />} />
           <Route path="onboarding" element={<OnboardingRoutePage />} />
           <Route path="instance" element={<LegacySettingsRedirect />} />
@@ -694,6 +766,16 @@ export function App() {
           <Route path="pipelines/:pipelineId/cases/:caseId" element={<UnprefixedBoardRedirect />} />
           <Route path="artifacts" element={<UnprefixedBoardRedirect />} />
           <Route path="audit" element={<UnprefixedBoardRedirect />} />
+          {streamlinedUiEnabled ? (
+            <>
+              <Route path="audit/*" element={<UnprefixedBoardRedirect />} />
+              <Route path="activity" element={<UnprefixedBoardRedirect />} />
+              <Route path="activity/*" element={<UnprefixedBoardRedirect />} />
+              <Route path="runs" element={<UnprefixedBoardRedirect />} />
+              <Route path="costs" element={<UnprefixedBoardRedirect />} />
+              <Route path="budgets" element={<UnprefixedBoardRedirect />} />
+            </>
+          ) : null}
           <Route path="decisions" element={<UnprefixedBoardRedirect />} />
           <Route path="u/:userSlug" element={<UnprefixedBoardRedirect />} />
           <Route path="skills/studio" element={<UnprefixedBoardRedirect />} />
@@ -726,8 +808,8 @@ export function App() {
           <Route path="execution-workspaces/:workspaceId/runtime-logs" element={<UnprefixedExecutionWorkspaceRedirect />} />
           <Route path="execution-workspaces/:workspaceId/issues" element={<UnprefixedExecutionWorkspaceRedirect />} />
           <Route path="execution-workspaces/:workspaceId/routines" element={<UnprefixedExecutionWorkspaceRedirect />} />
-          <Route path=":companyPrefix" element={<Layout />}>
-            {boardRoutes()}
+          <Route path=":companyPrefix" element={streamlinedUiEnabled ? <Layout /> : <ProductionLayout />}>
+            {boardRoutes(streamlinedUiEnabled)}
           </Route>
           <Route path="*" element={<NotFoundPage scope="global" />} />
         </Route>

--- a/ui/src/components/BlockedInboxView.test.tsx
+++ b/ui/src/components/BlockedInboxView.test.tsx
@@ -164,6 +164,7 @@ describe("BlockedInboxView", () => {
     const { root } = renderWithClient(
       <BlockedInboxView
         {...blockedViewProps}
+        presentation="task"
       />,
       container,
     );
@@ -258,6 +259,7 @@ describe("BlockedInboxView", () => {
     const { root } = renderWithClient(
       <BlockedInboxView
         {...blockedViewProps}
+        presentation="task"
       />,
       container,
     );
@@ -269,6 +271,40 @@ describe("BlockedInboxView", () => {
     expect(rowText.indexOf("Board")).toBeGreaterThan(rowText.indexOf("Needs decision"));
     expect(rowText).not.toContain("Accept or reject");
     expect(container.querySelector('[data-testid="blocked-row-reason-column"]')?.textContent).toContain("Needs decision");
+    const taskRow = container.querySelector('[data-slot="task-row"]');
+    const identifier = container.querySelector('[data-slot="task-row-identifier"]');
+    const timestamp = container.querySelector('[data-slot="task-row-timestamp"]');
+    expect(taskRow).not.toBeNull();
+    expect(taskRow?.className).not.toContain("border-b");
+    expect(identifier).not.toBeNull();
+    expect(timestamp).not.toBeNull();
+    if (!identifier || !timestamp) throw new Error("Expected canonical identifier and timestamp columns");
+    expect(identifier.compareDocumentPosition(timestamp) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+
+    act(() => root.unmount());
+  });
+
+  it("restores the legacy status/id prefix, timestamp column, and row divider", async () => {
+    mockIssuesApi.list.mockResolvedValue([
+      makeIssue(
+        "issue-legacy",
+        "PAP-41",
+        "Legacy blocked row",
+        attention({ owner: { type: "board", agentId: null, userId: null, label: "Board" } }),
+      ),
+    ]);
+
+    const { root } = renderWithClient(
+      <BlockedInboxView {...blockedViewProps} presentation="legacy" />,
+      container,
+    );
+    await waitFor(() => container.textContent?.includes("Legacy blocked row") === true);
+
+    expect(container.querySelector('[data-slot="task-row"]')).toBeNull();
+    expect(container.querySelector('[data-testid="blocked-row-age"]')).not.toBeNull();
+    const row = container.querySelector("a")?.parentElement;
+    expect(row?.className).toContain("border-b");
+    expect(row?.textContent).toContain("PAP-41");
 
     act(() => root.unmount());
   });

--- a/ui/src/components/BlockedInboxView.tsx
+++ b/ui/src/components/BlockedInboxView.tsx
@@ -19,7 +19,7 @@ import {
 } from "../lib/blockedInbox";
 import { BlockedReasonChip } from "./BlockedReasonChip";
 import { IssueGroupHeader } from "./IssueGroupHeader";
-import { IssueRow } from "./IssueRow";
+import { IssueRow, type IssueRowPresentation } from "./IssueRow";
 import { Identity } from "./Identity";
 import { StatusIcon } from "./StatusIcon";
 import { Button } from "@/components/ui/button";
@@ -41,6 +41,7 @@ interface BlockedInboxViewProps {
   showStatusColumn: boolean;
   showIdentifierColumn: boolean;
   showUpdatedColumn: boolean;
+  presentation?: IssueRowPresentation;
 }
 
 const BLOCKED_LIST_LIMIT = 200;
@@ -61,6 +62,7 @@ export function BlockedInboxView({
   showStatusColumn,
   showIdentifierColumn,
   showUpdatedColumn,
+  presentation = "legacy",
 }: BlockedInboxViewProps) {
   const [collapsedVariants, setCollapsedVariants] = useState<Set<string>>(() => new Set());
 
@@ -124,7 +126,10 @@ export function BlockedInboxView({
             {Array.from({ length: 2 }).map((__, rowIdx) => (
               <div
                 key={rowIdx}
-                className="flex items-center gap-3 border-b border-border/60 px-3 py-2.5 sm:px-4"
+                className={cn(
+                  "flex items-center gap-3 px-3 py-2.5 sm:px-4",
+                  presentation === "legacy" && "border-b border-border/60",
+                )}
               >
                 <div className="h-3.5 w-3.5 animate-pulse rounded-full bg-muted" />
                 <div className="h-4 w-16 animate-pulse rounded bg-muted/70" />
@@ -219,6 +224,7 @@ export function BlockedInboxView({
               showStatusColumn={showStatusColumn}
               showIdentifierColumn={showIdentifierColumn}
               showUpdatedColumn={showUpdatedColumn}
+              presentation={presentation}
             />
           ))
         ) : (
@@ -226,7 +232,7 @@ export function BlockedInboxView({
             const isCollapsed = collapsedVariants.has(group.variant);
             return (
               <div key={group.variant} data-testid={`blocked-inbox-group-${group.variant}`}>
-                <div className="px-3 sm:px-4">
+                <div className={presentation === "task" ? "rounded-lg px-3 sm:pl-0 sm:pr-4" : "px-3 sm:px-4"}>
                   <IssueGroupHeader
                     label={`${group.label} · ${group.rows.length}`}
                     collapsible
@@ -248,6 +254,7 @@ export function BlockedInboxView({
                         showStatusColumn={showStatusColumn}
                         showIdentifierColumn={showIdentifierColumn}
                         showUpdatedColumn={showUpdatedColumn}
+                        presentation={presentation}
                       />
                     ))}
                   </div>
@@ -271,6 +278,7 @@ interface BlockedInboxRowProps {
   showStatusColumn: boolean;
   showIdentifierColumn: boolean;
   showUpdatedColumn: boolean;
+  presentation: IssueRowPresentation;
 }
 
 function resolveOwnerName(
@@ -299,6 +307,7 @@ function BlockedInboxRow({
   showStatusColumn,
   showIdentifierColumn,
   showUpdatedColumn,
+  presentation,
 }: BlockedInboxRowProps) {
   const { label: ownerName, isAgent } = resolveOwnerName(row, agentNameById, userLabelById);
   const stoppedAge = formatStoppedAge(row.attention.stoppedSinceAt);
@@ -330,7 +339,7 @@ function BlockedInboxRow({
       ) : (
         <span className="hidden w-(--sz-150px) shrink-0 sm:inline-flex" aria-hidden="true" />
       )}
-      {showUpdatedColumn ? (
+      {presentation === "legacy" && showUpdatedColumn ? (
         <span className="hidden w-(--sz-5_75rem) text-right text-muted-foreground sm:inline" data-testid="blocked-row-age">
           {stoppedAge}
         </span>
@@ -359,15 +368,22 @@ function BlockedInboxRow({
     <IssueRow
       issue={row.issue}
       issueLinkState={issueLinkState}
-      showDivider
-      desktopMetaLeading={
+      presentation={presentation}
+      showDivider={presentation === "legacy"}
+      statusSlot={presentation === "task"
+        ? showStatusColumn
+          ? <StatusIcon status={row.issue.status} blockerAttention={blockerAttention} />
+          : <span className="inline-flex size-4" aria-hidden="true" />
+        : undefined}
+      showIdentifier={presentation === "task" ? showIdentifierColumn : undefined}
+      desktopMetaLeading={presentation === "legacy" ? (
         <BlockedRowDesktopMeta
           row={row}
           blockerAttention={blockerAttention}
           showStatusColumn={showStatusColumn}
           showIdentifierColumn={showIdentifierColumn}
         />
-      }
+      ) : undefined}
       mobileLeading={
         <span className="flex shrink-0 items-center gap-1.5 pt-px">
           <StatusIcon status={row.issue.status} blockerAttention={blockerAttention} />
@@ -382,6 +398,7 @@ function BlockedInboxRow({
       }
       mobileMeta={mobileMeta}
       desktopTrailing={desktopTrailing}
+      trailingMeta={presentation === "task" && showUpdatedColumn ? stoppedAge : null}
     />
   );
 }

--- a/ui/src/components/IssueColumns.test.tsx
+++ b/ui/src/components/IssueColumns.test.tsx
@@ -2,9 +2,14 @@
 
 import { createRoot } from "react-dom/client";
 import { flushSync } from "react-dom";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Issue } from "@paperclipai/shared";
-import { InboxIssueMetaLeading, InboxIssueTrailingColumns } from "./IssueColumns";
+import {
+  InboxIssueMetaLeading,
+  InboxIssueTrailingColumns,
+  IssueColumnPicker,
+  issueColumnDescription,
+} from "./IssueColumns";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -42,7 +47,42 @@ function renderLeading(element: React.ReactElement): string {
   return container.textContent ?? "";
 }
 
+describe("IssueColumnPicker presentation options", () => {
+  it("offers date group separators as a toggle in the Columns menu", () => {
+    const onToggleDateGroupSeparators = vi.fn();
+    renderLeading(
+      <IssueColumnPicker
+        availableColumns={["status", "id", "updated"]}
+        visibleColumnSet={new Set(["status", "id", "updated"] as const)}
+        onToggleColumn={() => undefined}
+        showDateGroupSeparators
+        onToggleDateGroupSeparators={onToggleDateGroupSeparators}
+        onResetColumns={() => undefined}
+        title="Choose which task columns stay visible"
+        iconOnly
+        rowPresentation="task"
+      />,
+    );
+
+    const columnsButton = container?.querySelector<HTMLButtonElement>('button[title="Columns"]');
+    expect(columnsButton).not.toBeNull();
+    act(() => columnsButton?.dispatchEvent(new MouseEvent("pointerdown", { bubbles: true })));
+
+    const option = Array.from(document.body.querySelectorAll<HTMLElement>('[role="menuitemcheckbox"]'))
+      .find((item) => item.textContent?.includes("Date group separators"));
+    expect(option?.getAttribute("aria-checked")).toBe("true");
+
+    act(() => option?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(onToggleDateGroupSeparators).toHaveBeenCalledWith(false);
+  });
+});
+
 describe("InboxIssueMetaLeading live state", () => {
+  it("describes the canonical identifier at the trailing edge", () => {
+    expect(issueColumnDescription("id", "task")).toContain("trailing edge");
+    expect(issueColumnDescription("id", "legacy")).not.toContain("trailing edge");
+  });
+
   it("shows the own Live chip for a running issue and never the subtree chip", () => {
     const text = renderLeading(
       <InboxIssueMetaLeading

--- a/ui/src/components/IssueColumns.tsx
+++ b/ui/src/components/IssueColumns.tsx
@@ -47,8 +47,25 @@ const issueColumnDescriptions: Record<InboxIssueColumn, string> = {
   updated: "Latest visible activity time.",
 };
 
+export function issueColumnDescription(
+  column: InboxIssueColumn,
+  presentation: "legacy" | "task" = "legacy",
+): string {
+  if (column === "id" && presentation === "task") {
+    return "Task identifier like PAP-1009 on the trailing edge.";
+  }
+  if (column === "status" && presentation === "task") {
+    return "Task state icon on the leading edge.";
+  }
+  return issueColumnDescriptions[column];
+}
+
+export function issueActivityTimestamp(issue: Issue): string {
+  return timeAgo(issue.lastActivityAt ?? issue.lastExternalCommentAt ?? issue.updatedAt);
+}
+
 export function issueActivityText(issue: Issue): string {
-  return `Updated ${timeAgo(issue.lastActivityAt ?? issue.lastExternalCommentAt ?? issue.updatedAt)}`;
+  return `Updated ${issueActivityTimestamp(issue)}`;
 }
 
 function issueTrailingGridTemplate(columns: InboxIssueColumn[]): string {
@@ -69,16 +86,22 @@ export function IssueColumnPicker({
   availableColumns,
   visibleColumnSet,
   onToggleColumn,
+  showDateGroupSeparators,
+  onToggleDateGroupSeparators,
   onResetColumns,
   title,
   iconOnly = false,
+  rowPresentation = "legacy",
 }: {
   availableColumns: InboxIssueColumn[];
   visibleColumnSet: ReadonlySet<InboxIssueColumn>;
   onToggleColumn: (column: InboxIssueColumn, enabled: boolean) => void;
+  showDateGroupSeparators?: boolean;
+  onToggleDateGroupSeparators?: (enabled: boolean) => void;
   onResetColumns: () => void;
   title: string;
   iconOnly?: boolean;
+  rowPresentation?: "legacy" | "task";
 }) {
   return (
     <DropdownMenu>
@@ -119,11 +142,28 @@ export function IssueColumnPicker({
                 {issueColumnLabels[column]}
               </span>
               <span className="text-xs leading-relaxed text-muted-foreground">
-                {issueColumnDescriptions[column]}
+                {issueColumnDescription(column, rowPresentation)}
               </span>
             </span>
           </DropdownMenuCheckboxItem>
         ))}
+        {showDateGroupSeparators !== undefined && onToggleDateGroupSeparators ? (
+          <DropdownMenuCheckboxItem
+            checked={showDateGroupSeparators}
+            onSelect={(event) => event.preventDefault()}
+            onCheckedChange={(checked) => onToggleDateGroupSeparators(checked === true)}
+            className="items-start rounded-lg px-3 py-2.5 pl-8"
+          >
+            <span className="flex flex-col gap-0.5">
+              <span className="text-sm font-medium text-foreground">
+                Date group separators
+              </span>
+              <span className="text-xs leading-relaxed text-muted-foreground">
+                Show Today, Yesterday, and Earlier rules on newest-first task lists.
+              </span>
+            </span>
+          </DropdownMenuCheckboxItem>
+        ) : null}
         <DropdownMenuSeparator />
         <DropdownMenuItem
           onSelect={onResetColumns}
@@ -262,7 +302,7 @@ export function InboxIssueTrailingColumns({
   assigneeContent?: ReactNode;
   onFilterWorkspace?: (workspaceId: string) => void;
 }) {
-  const activityText = timeAgo(issue.lastActivityAt ?? issue.lastExternalCommentAt ?? issue.updatedAt);
+  const activityText = issueActivityTimestamp(issue);
   const userLabel = assigneeUserName ?? formatAssigneeUserLabel(issue.assigneeUserId, currentUserId) ?? "User";
   const originatingActor = deriveOriginatingActor(issue);
   const originatingUserId = originatingActor?.kind === "user" ? originatingActor.id : null;

--- a/ui/src/components/IssueFiltersPopover.test.tsx
+++ b/ui/src/components/IssueFiltersPopover.test.tsx
@@ -58,6 +58,7 @@ describe("IssueFiltersPopover", () => {
     act(() => {
       root.render(
         <IssueFiltersPopover
+          presentation="streamlined"
           state={defaultIssueFilterState}
           onChange={vi.fn()}
           activeFilterCount={0}
@@ -74,6 +75,7 @@ describe("IssueFiltersPopover", () => {
     expect(popoverContent).not.toBeNull();
     expect(popoverContent?.className).toContain("overflow-y-auto");
     expect(popoverContent?.className).toContain("max-h-(--sz-calc-9)");
+    expect(popoverContent?.querySelectorAll(".overflow-y-auto").length).toBe(0);
 
     const layoutGrid = Array.from(popoverContent?.querySelectorAll("div") ?? []).find((element) =>
       element.className.includes("md:grid-cols-3"),
@@ -88,6 +90,7 @@ describe("IssueFiltersPopover", () => {
     act(() => {
       root.render(
         <IssueFiltersPopover
+          presentation="streamlined"
           state={defaultIssueFilterState}
           onChange={vi.fn()}
           activeFilterCount={0}
@@ -105,5 +108,125 @@ describe("IssueFiltersPopover", () => {
     // Status section still renders, Priority section is gated off (PAP-411).
     expect(popoverContent?.textContent).toContain("Status");
     expect(popoverContent?.textContent).not.toContain("Priority");
+  });
+
+  it("searches long option lists while the popover remains the only scroll owner", () => {
+    const root = createRoot(container);
+    const agents = Array.from({ length: 7 }, (_, index) => ({
+      id: `agent-${index + 1}`,
+      name: `Agent ${index + 1}`,
+    }));
+
+    act(() => {
+      root.render(
+        <IssueFiltersPopover
+          presentation="streamlined"
+          state={defaultIssueFilterState}
+          onChange={vi.fn()}
+          activeFilterCount={0}
+          agents={agents}
+          enableExternalObjectFilters={false}
+        />,
+      );
+    });
+
+    const input = container.querySelector<HTMLInputElement>('input[aria-label="Search responsible"]');
+    expect(input).not.toBeNull();
+    act(() => {
+      const valueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set;
+      valueSetter?.call(input, "Agent 7");
+      input?.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const responsibleOptions = container.querySelector('[data-filter-options="responsible"]');
+    expect(responsibleOptions?.textContent).toContain("Agent 7");
+    expect(responsibleOptions?.textContent).not.toContain("Agent 1");
+    expect(container.querySelector('[data-testid="popover-content"]')?.querySelectorAll(".overflow-y-auto").length).toBe(0);
+
+    act(() => root.unmount());
+  });
+
+  it("restores per-section scrolling and hides added option searches in legacy presentation", () => {
+    const root = createRoot(container);
+    const agents = Array.from({ length: 7 }, (_, index) => ({
+      id: `agent-${index + 1}`,
+      name: `Agent ${index + 1}`,
+    }));
+
+    act(() => {
+      root.render(
+        <IssueFiltersPopover
+          state={defaultIssueFilterState}
+          onChange={vi.fn()}
+          activeFilterCount={0}
+          agents={agents}
+          projects={Array.from({ length: 7 }, (_, index) => ({
+            id: `project-${index + 1}`,
+            name: `Project ${index + 1}`,
+          }))}
+          presentation="legacy"
+          enableExternalObjectFilters={false}
+        />,
+      );
+    });
+
+    const popoverContent = container.querySelector("[data-testid='popover-content']");
+    expect(popoverContent?.className).not.toContain("overflow-y-auto");
+    expect(container.querySelector('input[aria-label="Search responsible"]')).toBeNull();
+    expect(container.querySelector('[data-filter-options="responsible"]')?.className).toContain("overflow-y-auto");
+    expect(container.querySelector('[data-filter-options="projects"]')?.className).toContain("overflow-y-auto");
+
+    act(() => root.unmount());
+  });
+
+  it("integrates Inbox category and approval status into the filter menu", () => {
+    const root = createRoot(container);
+    const onChange = vi.fn();
+    const onCategoryChange = vi.fn();
+    const onApprovalStatusChange = vi.fn();
+    const onClear = vi.fn();
+
+    act(() => {
+      root.render(
+        <IssueFiltersPopover
+          presentation="streamlined"
+          state={defaultIssueFilterState}
+          onChange={onChange}
+          activeFilterCount={2}
+          enableExternalObjectFilters={false}
+          inboxScopeFilters={{
+            category: "approvals",
+            approvalStatus: "actionable",
+            showApprovalStatus: true,
+            onCategoryChange,
+            onApprovalStatusChange,
+            onClear,
+          }}
+        />,
+      );
+    });
+
+    const categoryOptions = container.querySelector('[data-filter-options="inbox-category"]');
+    const approvalOptions = container.querySelector('[data-filter-options="inbox-approval-status"]');
+    expect(categoryOptions?.textContent).toContain("All categories");
+    expect(categoryOptions?.querySelector('button[aria-pressed="true"]')?.textContent).toContain("Approvals");
+    expect(approvalOptions?.querySelector('button[aria-pressed="true"]')?.textContent).toContain("Needs action");
+
+    const allCategoriesButton = Array.from(categoryOptions?.querySelectorAll("button") ?? [])
+      .find((button) => button.textContent?.includes("All categories"));
+    const resolvedButton = Array.from(approvalOptions?.querySelectorAll("button") ?? [])
+      .find((button) => button.textContent?.includes("Resolved"));
+    act(() => allCategoriesButton?.click());
+    act(() => resolvedButton?.click());
+    expect(onCategoryChange).toHaveBeenCalledWith("everything");
+    expect(onApprovalStatusChange).toHaveBeenCalledWith("resolved");
+
+    const clearButton = Array.from(container.querySelectorAll("button"))
+      .find((button) => button.textContent?.trim() === "Clear");
+    act(() => clearButton?.click());
+    expect(onChange).toHaveBeenCalledWith(defaultIssueFilterState);
+    expect(onClear).toHaveBeenCalledTimes(1);
+
+    act(() => root.unmount());
   });
 });

--- a/ui/src/components/IssueFiltersPopover.tsx
+++ b/ui/src/components/IssueFiltersPopover.tsx
@@ -4,7 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { Bot, Filter, HardDrive, Search, User, X } from "lucide-react";
+import { Bot, Check, Filter, HardDrive, Search, User, X } from "lucide-react";
 import { PriorityIcon } from "./PriorityIcon";
 import { SHOW_TASK_PRIORITY_UI } from "../lib/ui-flags";
 import { StatusIcon } from "./StatusIcon";
@@ -17,12 +17,15 @@ import {
   issuePriorityOrder,
   issueQuickFilterPresets,
   issueStatusOrder,
+  searchIssueFilterOptions,
   toggleIssueFilterValue,
   type IssueFilterState,
 } from "../lib/issue-filters";
 import { externalObjectIconForCategory } from "../lib/external-objects";
 import { externalObjectStatusIcon } from "../lib/status-colors";
 import { formatAssigneeUserLabel } from "../lib/assignees";
+import type { InboxApprovalFilter, InboxCategoryFilter } from "../lib/inbox";
+import { cn } from "../lib/utils";
 
 type AgentOption = {
   id: string;
@@ -52,6 +55,55 @@ type CreatorOption = {
   searchText?: string;
 };
 
+type InboxScopeFilters = {
+  category: InboxCategoryFilter;
+  approvalStatus: InboxApprovalFilter;
+  showApprovalStatus: boolean;
+  onCategoryChange: (value: InboxCategoryFilter) => void;
+  onApprovalStatusChange: (value: InboxApprovalFilter) => void;
+  onClear: () => void;
+};
+
+const INBOX_CATEGORY_OPTIONS: ReadonlyArray<[InboxCategoryFilter, string]> = [
+  ["everything", "All categories"],
+  ["issues_i_touched", "My recent tasks"],
+  ["join_requests", "Join requests"],
+  ["approvals", "Approvals"],
+  ["failed_runs", "Failed runs"],
+  ["alerts", "Alerts"],
+];
+
+const INBOX_APPROVAL_STATUS_OPTIONS: ReadonlyArray<[InboxApprovalFilter, string]> = [
+  ["all", "All approval statuses"],
+  ["actionable", "Needs action"],
+  ["resolved", "Resolved"],
+];
+
+const SEARCHABLE_FILTER_THRESHOLD = 6;
+
+function FilterOptionSearch({
+  value,
+  onChange,
+  label,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  label: string;
+}) {
+  return (
+    <div className="relative">
+      <Search className="pointer-events-none absolute left-2 top-1/2 h-3 w-3 -translate-y-1/2 text-muted-foreground" />
+      <Input
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={`Search ${label.toLowerCase()}...`}
+        aria-label={`Search ${label.toLowerCase()}`}
+        className="h-8 pl-7 text-xs"
+      />
+    </div>
+  );
+}
+
 export function IssueFiltersPopover({
   state,
   onChange,
@@ -66,6 +118,8 @@ export function IssueFiltersPopover({
   iconOnly = false,
   workspaces,
   creators,
+  presentation = "legacy",
+  inboxScopeFilters,
 }: {
   state: IssueFilterState;
   onChange: (patch: Partial<IssueFilterState>) => void;
@@ -80,8 +134,31 @@ export function IssueFiltersPopover({
   iconOnly?: boolean;
   workspaces?: WorkspaceOption[];
   creators?: CreatorOption[];
+  presentation?: "legacy" | "streamlined";
+  inboxScopeFilters?: InboxScopeFilters;
 }) {
+  const streamlined = presentation === "streamlined";
   const [creatorSearch, setCreatorSearch] = useState("");
+  const [assigneeSearch, setAssigneeSearch] = useState("");
+  const [projectSearch, setProjectSearch] = useState("");
+  const [labelSearch, setLabelSearch] = useState("");
+  const [workspaceSearch, setWorkspaceSearch] = useState("");
+  const visibleAgents = useMemo(
+    () => searchIssueFilterOptions(agents, assigneeSearch, (option) => option.name),
+    [agents, assigneeSearch],
+  );
+  const visibleProjects = useMemo(
+    () => searchIssueFilterOptions(projects, projectSearch, (option) => option.name),
+    [projects, projectSearch],
+  );
+  const visibleLabels = useMemo(
+    () => searchIssueFilterOptions(labels, labelSearch, (option) => option.name),
+    [labels, labelSearch],
+  );
+  const visibleWorkspaces = useMemo(
+    () => searchIssueFilterOptions(workspaces, workspaceSearch, (option) => option.name),
+    [workspaces, workspaceSearch],
+  );
   const creatorOptions = creators ?? [];
   const creatorOptionById = useMemo(
     () => new Map(creatorOptions.map((option) => [option.id, option])),
@@ -111,6 +188,10 @@ export function IssueFiltersPopover({
     }),
     [creatorOptionById, currentUserId, state.creators],
   );
+  const clearFilters = () => {
+    onChange(defaultIssueFilterState);
+    inboxScopeFilters?.onClear();
+  };
 
   return (
     <Popover>
@@ -125,7 +206,7 @@ export function IssueFiltersPopover({
               className="ml-1 hidden h-3 w-3 sm:block"
               onClick={(event) => {
                 event.stopPropagation();
-                onChange(defaultIssueFilterState);
+                clearFilters();
               }}
             />
           ) : null}
@@ -133,7 +214,9 @@ export function IssueFiltersPopover({
       </PopoverTrigger>
       <PopoverContent
         align="end"
-        className="w-(--sz-calc-10) max-h-(--sz-calc-9) overflow-y-auto overscroll-contain p-0"
+        className={streamlined
+          ? "w-(--sz-calc-10) max-h-(--sz-calc-9) overflow-y-auto overscroll-contain p-0"
+          : "w-(--sz-calc-10) p-0"}
       >
         <div className="space-y-3 p-3">
           <div className="flex items-center justify-between">
@@ -142,12 +225,74 @@ export function IssueFiltersPopover({
               <button
                 type="button"
                 className="text-xs text-muted-foreground hover:text-foreground"
-                onClick={() => onChange(defaultIssueFilterState)}
+                onClick={clearFilters}
               >
                 Clear
               </button>
             ) : null}
           </div>
+
+          {inboxScopeFilters ? (
+            <>
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div className="space-y-1" data-filter-options="inbox-category">
+                  <span className="text-xs text-muted-foreground">Category</span>
+                  <div className="space-y-0.5">
+                    {INBOX_CATEGORY_OPTIONS.map(([value, label]) => {
+                      const selected = inboxScopeFilters.category === value;
+                      return (
+                        <button
+                          key={value}
+                          type="button"
+                          aria-pressed={selected}
+                          className={cn(
+                            "flex w-full items-center justify-between rounded-sm px-2 py-1 text-left text-sm",
+                            selected
+                              ? "bg-accent/50 text-foreground"
+                              : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                          )}
+                          onClick={() => inboxScopeFilters.onCategoryChange(value)}
+                        >
+                          <span>{label}</span>
+                          {selected ? <Check className="h-3.5 w-3.5" /> : null}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                {inboxScopeFilters.showApprovalStatus ? (
+                  <div className="space-y-1" data-filter-options="inbox-approval-status">
+                    <span className="text-xs text-muted-foreground">Approval status</span>
+                    <div className="space-y-0.5">
+                      {INBOX_APPROVAL_STATUS_OPTIONS.map(([value, label]) => {
+                        const selected = inboxScopeFilters.approvalStatus === value;
+                        return (
+                          <button
+                            key={value}
+                            type="button"
+                            aria-pressed={selected}
+                            className={cn(
+                              "flex w-full items-center justify-between rounded-sm px-2 py-1 text-left text-sm",
+                              selected
+                                ? "bg-accent/50 text-foreground"
+                                : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                            )}
+                            onClick={() => inboxScopeFilters.onApprovalStatusChange(value)}
+                          >
+                            <span>{label}</span>
+                            {selected ? <Check className="h-3.5 w-3.5" /> : null}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+
+              <div className="border-t border-border" />
+            </>
+          ) : null}
 
           <div className="space-y-1.5">
             <span className="text-xs text-muted-foreground">Quick filters</span>
@@ -215,7 +360,10 @@ export function IssueFiltersPopover({
             <div className="min-w-0 space-y-3">
               <div className="space-y-1">
                 <span className="text-xs text-muted-foreground">Responsible</span>
-                <div className="max-h-32 space-y-0.5 overflow-y-auto">
+                {streamlined && (agents?.length ?? 0) + (currentUserId ? 2 : 1) > SEARCHABLE_FILTER_THRESHOLD ? (
+                  <FilterOptionSearch value={assigneeSearch} onChange={setAssigneeSearch} label="Responsible" />
+                ) : null}
+                <div data-filter-options="responsible" className={streamlined ? "space-y-0.5" : "max-h-32 space-y-0.5 overflow-y-auto"}>
                   <label className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1 hover:bg-accent/50">
                     <Checkbox
                       checked={state.assignees.includes("__unassigned")}
@@ -233,7 +381,7 @@ export function IssueFiltersPopover({
                       <span className="text-sm">Me</span>
                     </label>
                   ) : null}
-                  {(agents ?? []).map((agent) => (
+                  {(streamlined ? visibleAgents : agents ?? []).map((agent) => (
                     <label key={agent.id} className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1 hover:bg-accent/50">
                       <Checkbox
                         checked={state.assignees.includes(agent.id)}
@@ -275,7 +423,7 @@ export function IssueFiltersPopover({
                       className="h-8 pl-7 text-xs"
                     />
                   </div>
-                  <div className="max-h-32 space-y-0.5 overflow-y-auto">
+                  <div data-filter-options="creators" className={streamlined ? "space-y-0.5" : "max-h-32 space-y-0.5 overflow-y-auto"}>
                     {visibleCreatorOptions.length > 0 ? visibleCreatorOptions.map((creator) => {
                       const selected = state.creators.includes(creator.id);
                       return (
@@ -302,8 +450,11 @@ export function IssueFiltersPopover({
               {projects && projects.length > 0 ? (
                 <div className="space-y-1">
                   <span className="text-xs text-muted-foreground">Project</span>
-                  <div className="max-h-32 space-y-0.5 overflow-y-auto">
-                    {projects.map((project) => (
+                  {streamlined && projects.length > SEARCHABLE_FILTER_THRESHOLD ? (
+                    <FilterOptionSearch value={projectSearch} onChange={setProjectSearch} label="Projects" />
+                  ) : null}
+                  <div data-filter-options="projects" className={streamlined ? "space-y-0.5" : "max-h-32 space-y-0.5 overflow-y-auto"}>
+                    {(streamlined ? visibleProjects : projects).map((project) => (
                       <label key={project.id} className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1 hover:bg-accent/50">
                         <Checkbox
                           checked={state.projects.includes(project.id)}
@@ -321,8 +472,11 @@ export function IssueFiltersPopover({
               {labels && labels.length > 0 ? (
                 <div className="space-y-1">
                   <span className="text-xs text-muted-foreground">Labels</span>
-                  <div className="max-h-32 space-y-0.5 overflow-y-auto">
-                    {labels.map((label) => (
+                  {streamlined && labels.length > SEARCHABLE_FILTER_THRESHOLD ? (
+                    <FilterOptionSearch value={labelSearch} onChange={setLabelSearch} label="Labels" />
+                  ) : null}
+                  <div data-filter-options="labels" className={streamlined ? "space-y-0.5" : "max-h-32 space-y-0.5 overflow-y-auto"}>
+                    {(streamlined ? visibleLabels : labels).map((label) => (
                       <label key={label.id} className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1 hover:bg-accent/50">
                         <Checkbox
                           checked={state.labels.includes(label.id)}
@@ -339,8 +493,11 @@ export function IssueFiltersPopover({
               {workspaces && workspaces.length > 0 ? (
                 <div className="space-y-1">
                   <span className="text-xs text-muted-foreground">Workspace</span>
-                  <div className="max-h-32 space-y-0.5 overflow-y-auto">
-                    {workspaces.map((workspace) => (
+                  {streamlined && workspaces.length > SEARCHABLE_FILTER_THRESHOLD ? (
+                    <FilterOptionSearch value={workspaceSearch} onChange={setWorkspaceSearch} label="Workspaces" />
+                  ) : null}
+                  <div data-filter-options="workspaces" className={streamlined ? "space-y-0.5" : "max-h-32 space-y-0.5 overflow-y-auto"}>
+                    {(streamlined ? visibleWorkspaces : workspaces).map((workspace) => (
                       <label key={workspace.id} className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1 hover:bg-accent/50">
                         <Checkbox
                           checked={state.workspaces.includes(workspace.id)}

--- a/ui/src/components/IssueProperties.test.tsx
+++ b/ui/src/components/IssueProperties.test.tsx
@@ -148,7 +148,14 @@ vi.mock("./AgentIconPicker", () => ({
 }));
 
 vi.mock("@/lib/router", () => ({
-  Link: ({ children, to, ...props }: { children: ReactNode; to: string } & ComponentProps<"a">) => <a href={to} {...props}>{children}</a>,
+  Link: ({
+    children,
+    to,
+    state: _state,
+    disableIssueQuicklook: _disableIssueQuicklook,
+    issuePrefetch: _issuePrefetch,
+    ...props
+  }: { children: ReactNode; to: string; state?: unknown; disableIssueQuicklook?: boolean; issuePrefetch?: unknown } & ComponentProps<"a">) => <a href={to} {...props}>{children}</a>,
   useCaseHref: () => (caseId: string) => `/cases/${caseId}`,
   useLocation: () => ({ hash: "", pathname: "/", search: "", state: null, key: "test" }),
 }));
@@ -497,11 +504,256 @@ describe("IssueProperties", () => {
       ],
     });
     mockInstanceSettingsApi.getExperimental.mockResolvedValue({
+      enableTaskWatchdogs: false,
+      enableStreamlinedUi: true,
     });
   });
 
   afterEach(() => {
     document.body.innerHTML = "";
+  });
+
+  it("marks the task-detail property typography and section rhythm", () => {
+    const root = renderProperties(container, {
+      issue: createIssue(),
+      childIssues: [],
+      onUpdate: vi.fn(),
+      inline: true,
+    });
+
+    const surface = container.querySelector(".task-detail-properties");
+    expect(surface).not.toBeNull();
+    expect(surface?.classList).toContain("pl-4");
+    expect(surface?.querySelectorAll('[data-property-section="true"]').length).toBeGreaterThan(1);
+    expect(surface?.querySelector('[data-property-value="true"]')).not.toBeNull();
+    expect(surface?.querySelector('[data-property-section="true"] > div')?.classList)
+      .toContain("text-muted-foreground/70");
+    const projectLabel = surface?.querySelector('[data-property-label="Project"]');
+    const labelsLabel = surface?.querySelector('[data-property-label="Labels"]');
+    if (!projectLabel || !labelsLabel) throw new Error("Expected Project and Labels rows");
+    expect(projectLabel.compareDocumentPosition(labelsLabel) & Node.DOCUMENT_POSITION_FOLLOWING)
+      .toBeTruthy();
+
+    act(() => root.unmount());
+  });
+
+  it("stacks property chips vertically and aligns each label with the first chip", async () => {
+    const blockedBy = Array.from({ length: 3 }, (_, index) => ({
+      id: `blocker-${index + 1}`,
+      identifier: `BLOCK-${index + 1}`,
+      title: `Blocker ${index + 1}`,
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+    })) as NonNullable<Issue["blockedBy"]>;
+    const blocks = Array.from({ length: 3 }, (_, index) => ({
+      id: `blocked-${index + 1}`,
+      identifier: `BLOCKED-${index + 1}`,
+      title: `Blocked task ${index + 1}`,
+      status: "todo",
+      priority: "medium",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+    })) as NonNullable<Issue["blocks"]>;
+    const labels = Array.from({ length: 3 }, (_, index) => createLabel({
+      id: `label-${index + 1}`,
+      name: `Label ${index + 1}`,
+    }));
+    const childIssues = Array.from({ length: 3 }, (_, index) => createIssue({
+      id: `child-${index + 1}`,
+      identifier: `SUB-${index + 1}`,
+      title: `Subtask ${index + 1}`,
+    }));
+    const root = renderProperties(container, {
+      issue: createIssue({
+        blockedBy,
+        blocks,
+        labels,
+        labelIds: labels.map((label) => label.id),
+      }),
+      childIssues,
+      onUpdate: vi.fn(),
+      sidePanelContentOnly: true,
+    });
+    await flush();
+
+    for (const label of ["Labels", "Blocked by", "Blocking", "Subtasks"]) {
+      const labelNode = container.querySelector(`[data-property-label="${label}"]`);
+      const row = labelNode?.closest('[data-property-row="true"]');
+      const value = row?.querySelector('[data-property-value="true"]');
+      expect(row?.classList).toContain("items-start");
+      expect(labelNode?.classList).toContain("mt-0.5");
+      expect(value?.classList).toContain("flex-col");
+      expect(value?.classList).toContain("items-start");
+    }
+
+    for (const label of ["Labels", "Blocked by", "Subtasks"]) {
+      const trigger = findRowTrigger(container, label);
+      const chipStack = trigger?.querySelector("div");
+      expect(chipStack?.classList).toContain("flex-col");
+      expect(chipStack?.classList).toContain("items-start");
+    }
+
+    const blockingValue = container
+      .querySelector('[data-property-label="Blocking"]')
+      ?.closest('[data-property-row="true"]')
+      ?.querySelector('[data-property-value="true"] > div');
+    expect(blockingValue?.classList).toContain("flex-col");
+
+    act(() => root.unmount());
+  });
+
+  it("renders the lone Properties header as the active filled tab", async () => {
+    const headerSlot = document.createElement("div");
+    headerSlot.id = "properties-pane-header-slot";
+    document.body.appendChild(headerSlot);
+
+    const root = renderProperties(container, {
+      issue: createIssue(),
+      childIssues: [],
+      onUpdate: vi.fn(),
+    });
+    await flush();
+
+    const tab = headerSlot.querySelector<HTMLButtonElement>('[role="tab"]');
+    expect(tab?.textContent).toBe("Properties");
+    expect(tab?.getAttribute("aria-selected")).toBe("true");
+    expect(tab?.classList).toContain("bg-muted");
+    expect(tab?.classList).toContain("px-3");
+    expect(tab?.classList).toContain("inline-flex");
+
+    act(() => root.unmount());
+  });
+
+  it("uses the same filled active-tab treatment in a multi-tab pane header", async () => {
+    const headerSlot = document.createElement("div");
+    headerSlot.id = "properties-pane-header-slot";
+    document.body.appendChild(headerSlot);
+
+    const root = renderProperties(container, {
+      issue: createIssue(),
+      childIssues: [createIssue({ id: "child-1", identifier: "PAP-2", title: "Child task" })],
+      onUpdate: vi.fn(),
+    });
+    await flush();
+
+    const tabs = Array.from(headerSlot.querySelectorAll<HTMLButtonElement>('[role="tab"]'));
+    const propertiesTab = tabs.find((tab) => tab.textContent === "Properties");
+    const subtasksTab = tabs.find((tab) => tab.textContent?.includes("Subtasks"));
+    const tabItems = Array.from(headerSlot.querySelectorAll<HTMLElement>('[data-slot="task-detail-pane-tab"]'));
+    const tabDividers = Array.from(headerSlot.querySelectorAll<HTMLElement>('[data-slot="task-detail-pane-tab-divider"]'));
+    const subtasksLabel = subtasksTab?.querySelector<HTMLElement>('[title="Subtasks"]');
+    const subtasksCount = Array.from(subtasksTab?.querySelectorAll<HTMLElement>("span") ?? [])
+      .find((span) => span.textContent === "1");
+    const closeSubtasks = headerSlot.querySelector<HTMLButtonElement>('[aria-label="Close Subtasks tab"]');
+    const openClosedTab = headerSlot.querySelector<HTMLButtonElement>('[aria-label="Open closed sidebar tab"]');
+
+    expect(propertiesTab?.getAttribute("data-state")).toBe("active");
+    expect(subtasksTab?.getAttribute("data-state")).toBe("inactive");
+    expect(tabItems).toHaveLength(2);
+    expect(tabDividers).toHaveLength(1);
+    expect(tabDividers[0]?.classList).toContain("h-4");
+    expect(propertiesTab?.classList).toContain("mx-1.5");
+    expect(propertiesTab?.classList).toContain("px-3");
+    expect(subtasksTab?.classList).toContain("px-3");
+    expect(subtasksTab?.classList).toContain("hover:bg-accent/50");
+    expect(subtasksLabel?.classList).toContain("task-detail-pane-tab-label");
+    expect(subtasksLabel?.classList).toContain("flex-1");
+    expect(subtasksLabel?.classList).toContain("overflow-hidden");
+    expect(subtasksLabel?.classList).toContain("whitespace-nowrap");
+    expect(subtasksCount?.classList).toContain("group-hover/pane-tab:opacity-0");
+    expect(closeSubtasks?.classList).toContain("opacity-0");
+    expect(closeSubtasks?.classList).toContain("right-2.5");
+    expect(closeSubtasks?.classList).toContain("group-hover/pane-tab:opacity-100");
+    expect(openClosedTab?.classList).toContain("size-6");
+    expect(openClosedTab?.classList).not.toContain("ml-1");
+    expect(openClosedTab?.disabled).toBe(true);
+    for (const tab of tabs) {
+      expect(tab.classList).toContain("task-detail-pane-tab");
+      expect(tab.classList).toContain("h-7");
+      expect(tab.classList).toContain("rounded-md");
+    }
+
+    await act(async () => {
+      subtasksTab?.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 0 }));
+    });
+
+    expect(propertiesTab?.getAttribute("data-state")).toBe("inactive");
+    expect(subtasksTab?.getAttribute("data-state")).toBe("active");
+
+    await act(async () => closeSubtasks?.click());
+    expect(headerSlot.querySelector('[role="tab"][data-state="active"]')?.textContent).toBe("Properties");
+    expect(headerSlot.textContent).not.toContain("Subtasks");
+    expect(openClosedTab?.disabled).toBe(false);
+
+    await act(async () => {
+      openClosedTab?.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0 }));
+      openClosedTab?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+    let reopenSubtasks: HTMLElement | undefined;
+    await waitForAssertion(() => {
+      reopenSubtasks = Array.from(document.body.querySelectorAll<HTMLElement>('[role="menuitem"]'))
+        .find((item) => item.textContent === "Subtasks");
+      expect(reopenSubtasks).not.toBeUndefined();
+    });
+
+    await act(async () => {
+      reopenSubtasks?.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0 }));
+      reopenSubtasks?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
+    expect(headerSlot.querySelector('[role="tab"][data-state="active"]')?.textContent).toContain("Subtasks");
+
+    act(() => root.unmount());
+  });
+
+  it("restores master's production property styling when Streamlined UI is off", async () => {
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({
+      enableTaskWatchdogs: false,
+      enableStreamlinedUi: false,
+      enableClassicTaskInterface: false,
+    });
+
+    const root = renderProperties(container, {
+      issue: createIssue(),
+      childIssues: [],
+      onUpdate: vi.fn(),
+      inline: true,
+    });
+    await waitForAssertion(() => {
+      expect(container.querySelector(".task-detail-properties")).toBeNull();
+      expect(container.querySelector('[role="tab"]')).toBeNull();
+    });
+    expect(container.textContent).toContain("Status");
+    expect(container.textContent).toContain("Triage");
+
+    act(() => root.unmount());
+  });
+
+  it("restores master's plain Properties pane header when Streamlined UI is off", async () => {
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({
+      enableTaskWatchdogs: false,
+      enableStreamlinedUi: false,
+      enableClassicTaskInterface: false,
+    });
+    const headerSlot = document.createElement("div");
+    headerSlot.id = "properties-pane-header-slot";
+    document.body.appendChild(headerSlot);
+
+    const root = renderProperties(container, {
+      issue: createIssue(),
+      childIssues: [],
+      onUpdate: vi.fn(),
+    });
+    await waitForAssertion(() => {
+      expect(headerSlot.textContent).toBe("Properties");
+      expect(headerSlot.querySelector('[role="tab"]')).toBeNull();
+      expect(container.querySelector(".task-detail-properties")).toBeNull();
+    });
+
+    act(() => root.unmount());
   });
 
   it("does not show a Plan tab for a planning-mode issue without a plan document", async () => {
@@ -852,9 +1104,7 @@ describe("IssueProperties", () => {
     act(() => root.unmount());
   });
 
-  it("exposes the classic-layout add sub-issue pill action", async () => {
-    // The chat shell hosts the full tree in the center pane; the slim pill row
-    // + its Add sub-task button only render in the classic layout (PAP-496).
+  it("exposes the add-subtask action from the relationships picker", async () => {
     mockInstanceSettingsApi.getExperimental.mockResolvedValue({
       enableClassicTaskInterface: true,
     });
@@ -865,16 +1115,14 @@ describe("IssueProperties", () => {
       onAddSubIssue,
       onUpdate: vi.fn(),
     });
-    // Wait for the classic-layout settings query to resolve (the pane starts in
-    // the chat shell until it does).
     await waitForAssertion(() => {
-      expect(container.textContent).toContain("Add sub-task");
+      expect(container.textContent).toContain("Add subtask");
     });
 
-    expect(container.textContent).toContain("Sub-tasks");
+    expect(container.textContent).toContain("Subtasks");
 
     const addButton = Array.from(container.querySelectorAll("button"))
-      .find((button) => button.textContent?.includes("Add sub-task"));
+      .find((button) => button.textContent?.includes("Add subtask"));
     expect(addButton).not.toBeUndefined();
 
     await act(async () => {
@@ -886,16 +1134,31 @@ describe("IssueProperties", () => {
     act(() => root.unmount());
   });
 
-  it("does not duplicate sub-tasks in the properties pane in the chat shell", async () => {
+  it("gives sub-tasks a dedicated chat-shell panel tab", async () => {
+    const onAddSubIssue = vi.fn();
     const root = renderProperties(container, {
       issue: createIssue(),
-      childIssues: [],
+      childIssues: [createIssue({ id: "child-2", identifier: "PAP-2", title: "Panel child" })],
+      onAddSubIssue,
       onUpdate: vi.fn(),
+      inline: true,
     });
     await flush();
 
-    expect(container.textContent).not.toContain("Add sub-task");
-    expect(container.textContent).not.toContain("Sub-tasks");
+    const subtasksTab = Array.from(container.querySelectorAll<HTMLButtonElement>('button[role="tab"]'))
+      .find((button) => button.textContent?.includes("Subtasks"));
+    expect(subtasksTab).not.toBeUndefined();
+    await act(async () => {
+      subtasksTab!.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 0 }));
+    });
+    expect(container.textContent).toContain("Panel child");
+    expect(container.textContent).toContain("0 of 1 complete");
+    expect(container.textContent).toContain("Next action");
+    expect(container.querySelector('[data-slot="task-row"]')).not.toBeNull();
+    const addButton = Array.from(container.querySelectorAll("button"))
+      .find((button) => button.textContent?.includes("Add subtask"));
+    await act(async () => addButton!.click());
+    expect(onAddSubIssue).toHaveBeenCalledOnce();
 
     act(() => root.unmount());
   });
@@ -943,7 +1206,7 @@ describe("IssueProperties", () => {
     act(() => root.unmount());
   });
 
-  it("renders blocked-by issues as direct chips and edits them from an add action", async () => {
+  it("edits blockers from the blocked-by relationship flyout", async () => {
     const onUpdate = vi.fn();
     mockIssuesApi.list.mockResolvedValue([
       createIssue({ id: "issue-3", identifier: "PAP-3", title: "New blocker", status: "todo" }),
@@ -969,24 +1232,13 @@ describe("IssueProperties", () => {
     });
     await flush();
 
-    const blockerLink = container.querySelector('a[href="/issues/PAP-2"]');
-    expect(blockerLink).not.toBeNull();
-    expect(blockerLink?.textContent).toContain("PAP-2");
-    expect(blockerLink?.closest("button")).toBeNull();
-    expect(blockerLink?.className).toContain("px-2");
-    expect(blockerLink?.className).toContain("py-0.5");
-    expect(blockerLink?.className).toContain("text-xs");
-    const removeButton = container.querySelector('button[aria-label="Remove PAP-2 as blocker"]');
-    expect(removeButton?.className).toContain("absolute");
-    expect(container.textContent).toContain("Add blocker");
+    const blockerTrigger = findRowTrigger(container, "Blocked by");
+    expect(blockerTrigger?.textContent).toContain("PAP-2");
+    expect(container.textContent).not.toContain("Add blocker");
     expect(container.querySelector('input[placeholder="Search tasks..."]')).toBeNull();
 
-    const addButton = Array.from(container.querySelectorAll("button"))
-      .find((button) => button.textContent?.includes("Add blocker"));
-    expect(addButton).not.toBeUndefined();
-
     await act(async () => {
-      addButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      blockerTrigger!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
     await flush();
 
@@ -1022,12 +1274,11 @@ describe("IssueProperties", () => {
     });
     await flush();
 
-    const addButton = Array.from(container.querySelectorAll("button"))
-      .find((button) => button.textContent?.includes("Add blocker"));
-    expect(addButton).not.toBeUndefined();
+    const blockerTrigger = findRowTrigger(container, "Blocked by");
+    expect(blockerTrigger).not.toBeUndefined();
 
     await act(async () => {
-      addButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      blockerTrigger!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
     await flush();
 
@@ -1059,7 +1310,7 @@ describe("IssueProperties", () => {
     act(() => root.unmount());
   });
 
-  it("removes a blocked-by issue from the chip remove action after confirmation", async () => {
+  it("removes a blocked-by issue by toggling it in the relationship flyout", async () => {
     const onUpdate = vi.fn();
     const root = renderProperties(container, {
       issue: createIssue({
@@ -1090,21 +1341,20 @@ describe("IssueProperties", () => {
     });
     await flush();
 
-    const removeButton = container.querySelector('button[aria-label="Remove PAP-2 as blocker"]');
-    expect(removeButton).not.toBeNull();
+    const blockerTrigger = findRowTrigger(container, "Blocked by");
+    expect(blockerTrigger).not.toBeUndefined();
 
     await act(async () => {
-      removeButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      blockerTrigger!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
     await flush();
 
-    expect(document.body.textContent).toContain("Remove PAP-2: Existing blocker as a blocker for this task.");
-    const confirmButton = Array.from(document.body.querySelectorAll("button"))
-      .find((button) => button.textContent?.includes("Remove blocker"));
-    expect(confirmButton).not.toBeUndefined();
+    const selectedBlocker = Array.from(container.querySelectorAll("button"))
+      .find((button) => button.textContent?.includes("PAP-2 Existing blocker"));
+    expect(selectedBlocker).not.toBeUndefined();
 
     await act(async () => {
-      confirmButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      selectedBlocker!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
     expect(onUpdate).toHaveBeenCalledWith({ blockedByIssueIds: ["issue-4"] });
@@ -1112,7 +1362,7 @@ describe("IssueProperties", () => {
     act(() => root.unmount());
   });
 
-  it("opens visit and remove actions when a blocked-by chip is tapped on mobile", async () => {
+  it("uses the same blocked-by relationship picker on mobile", async () => {
     mockSidebarState.isMobile = true;
     const onUpdate = vi.fn();
     const root = renderProperties(container, {
@@ -1144,36 +1394,20 @@ describe("IssueProperties", () => {
     });
     await flush();
 
-    expect(container.querySelector('a[href="/issues/PAP-2"]')).toBeNull();
-    expect(container.querySelector('button[aria-label="Remove PAP-2 as blocker"]')).toBeNull();
-    const blockerActions = container.querySelector('button[aria-label="Actions for blocker PAP-2"]');
-    expect(blockerActions).not.toBeNull();
+    const blockerTrigger = findRowTrigger(container, "Blocked by");
+    expect(blockerTrigger?.textContent).toContain("PAP-2");
 
     await act(async () => {
-      blockerActions!.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true, button: 0 }));
-      blockerActions!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      blockerTrigger!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
     await flush();
 
-    const visitLink = Array.from(document.body.querySelectorAll('a[href="/issues/PAP-2"]'))
-      .find((link) => link.textContent?.includes("Visit task"));
-    expect(visitLink).not.toBeUndefined();
-    const removeMenuItem = Array.from(document.body.querySelectorAll('[data-slot="dropdown-menu-item"]'))
-      .find((item) => item.textContent?.includes("Remove blocker"));
-    expect(removeMenuItem).not.toBeUndefined();
+    const selectedBlocker = Array.from(container.querySelectorAll("button"))
+      .find((button) => button.textContent?.includes("PAP-2 Existing blocker"));
+    expect(selectedBlocker).not.toBeUndefined();
 
     await act(async () => {
-      removeMenuItem!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-    await flush();
-
-    expect(document.body.textContent).toContain("Remove PAP-2: Existing blocker as a blocker for this task.");
-    const confirmButton = Array.from(document.body.querySelectorAll("button"))
-      .find((button) => button.textContent?.includes("Remove blocker"));
-    expect(confirmButton).not.toBeUndefined();
-
-    await act(async () => {
-      confirmButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      selectedBlocker!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
     expect(onUpdate).toHaveBeenCalledWith({ blockedByIssueIds: ["issue-4"] });
@@ -1181,12 +1415,7 @@ describe("IssueProperties", () => {
     act(() => root.unmount());
   });
 
-  it("collapses long blocked-by and sub-task lists until the more button is clicked", async () => {
-    // The sub-task pill row (with its collapse control) is classic-layout only
-    // now — the chat shell promotes sub-tasks to their own pane tab (PAP-496).
-    mockInstanceSettingsApi.getExperimental.mockResolvedValue({
-      enableClassicTaskInterface: true,
-    });
+  it("summarizes long blocked-by and subtask relationships in their picker triggers", async () => {
     const blockedBy = Array.from({ length: 7 }, (_, index) => ({
       id: `blocker-${index + 1}`,
       identifier: `BLOCK-${index + 1}`,
@@ -1207,71 +1436,46 @@ describe("IssueProperties", () => {
       onUpdate: vi.fn(),
       inline: true,
     });
-    // Wait for the classic-layout settings query to resolve so the sub-task
-    // pill row renders (the pane starts in the chat shell until it does).
-    await waitForAssertion(() => {
-      expect(container.textContent).toContain("SUB-5");
-    });
+    await flush();
 
-    expect(container.textContent).toContain("BLOCK-5");
-    expect(container.textContent).not.toContain("BLOCK-6");
-    expect(container.textContent).not.toContain("SUB-6");
-    expect(
-      Array.from(container.querySelectorAll("button")).filter((button) =>
-        button.textContent?.trim() === "Show 2 more",
-      ),
-    ).toHaveLength(2);
+    const blockedByTrigger = findRowTrigger(container, "Blocked by");
+    expect(blockedByTrigger?.textContent).toContain("BLOCK-1");
+    expect(blockedByTrigger?.textContent).toContain("BLOCK-2");
+    expect(blockedByTrigger?.textContent).toContain("+5 more");
+    expect(blockedByTrigger?.textContent).not.toContain("BLOCK-7");
 
-    const expandBlockedBy = Array.from(container.querySelectorAll("button")).find((button) =>
-      button.textContent?.trim() === "Show 2 more",
-    );
-    expect(expandBlockedBy).not.toBeUndefined();
+    const subtasksTrigger = findRowTrigger(container, "Subtasks");
+    expect(subtasksTrigger?.textContent).toContain("SUB-1");
+    expect(subtasksTrigger?.textContent).toContain("SUB-2");
+    expect(subtasksTrigger?.textContent).toContain("+5 more");
+    expect(subtasksTrigger?.textContent).not.toContain("SUB-7");
+
     await act(async () => {
-      expandBlockedBy!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      blockedByTrigger!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
+    await flush();
 
-    expect(container.textContent).toContain("BLOCK-6");
     expect(container.textContent).toContain("BLOCK-7");
-    expect(container.textContent).not.toContain("SUB-6");
-    expect(container.textContent).toContain("Show less");
 
-    const expandSubTasks = Array.from(container.querySelectorAll("button")).find((button) =>
-      button.textContent?.trim() === "Show 2 more",
-    );
-    expect(expandSubTasks).not.toBeUndefined();
     await act(async () => {
-      expandSubTasks!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      blockedByTrigger!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
+    await flush();
+    await act(async () => {
+      subtasksTrigger!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flush();
 
-    expect(container.textContent).toContain("SUB-6");
     expect(container.textContent).toContain("SUB-7");
-    expect(
-      Array.from(container.querySelectorAll("button")).filter((button) =>
-        button.textContent?.trim() === "Show 2 more",
-      ),
-    ).toHaveLength(0);
-    expect(
-      Array.from(container.querySelectorAll("button")).filter((button) =>
-        button.textContent?.trim() === "Show less",
-      ),
-    ).toHaveLength(2);
-
-    const collapseBlockedBy = Array.from(container.querySelectorAll("button")).find((button) =>
-      button.textContent?.trim() === "Show less",
-    );
-    expect(collapseBlockedBy).not.toBeUndefined();
-    await act(async () => {
-      collapseBlockedBy!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
-
-    expect(container.textContent).not.toContain("BLOCK-6");
-    expect(container.textContent).toContain("SUB-6");
-    expect(container.textContent).toContain("Show 2 more");
 
     act(() => root.unmount());
   });
 
   it("collapses long blocking and related task lists until the more button is clicked", async () => {
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({
+      enableTaskWatchdogs: false,
+      enableClassicTaskInterface: true,
+    });
     const blocking = Array.from({ length: 7 }, (_, index) => ({
       id: `blocking-${index + 1}`,
       identifier: `BLOCKING-${index + 1}`,
@@ -1308,9 +1512,11 @@ describe("IssueProperties", () => {
     });
     await flush();
 
+    await waitForAssertion(() => {
+      expect(container.textContent).toContain("RELATED-5");
+    });
     expect(container.textContent).toContain("BLOCKING-5");
     expect(container.textContent).not.toContain("BLOCKING-6");
-    expect(container.textContent).toContain("RELATED-5");
     expect(container.textContent).not.toContain("RELATED-6");
     expect(
       Array.from(container.querySelectorAll("button")).filter((button) =>
@@ -1395,7 +1601,7 @@ describe("IssueProperties", () => {
     act(() => root.unmount());
   });
 
-  it("resets expanded relation previews when the issue changes", async () => {
+  it("updates the blocked-by relationship summary when the issue changes", async () => {
     const blockedBy = Array.from({ length: 7 }, (_, index) => ({
       id: `blocker-${index + 1}`,
       identifier: `BLOCK-${index + 1}`,
@@ -1426,21 +1632,24 @@ describe("IssueProperties", () => {
     });
     await flush();
 
-    const expandBlockedBy = Array.from(container.querySelectorAll("button")).find((button) =>
-      button.textContent?.trim() === "Show 2 more",
-    );
-    expect(expandBlockedBy).not.toBeUndefined();
-    await act(async () => {
-      expandBlockedBy!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    });
+    expect(findRowTrigger(container, "Blocked by")?.textContent).toContain("BLOCK-1");
+    expect(findRowTrigger(container, "Blocked by")?.textContent).toContain("+5 more");
 
-    expect(container.textContent).toContain("BLOCK-6");
+    const nextBlockedBy = [{
+      id: "next-blocker",
+      identifier: "NEXT-1",
+      title: "Next blocker",
+      status: "todo" as const,
+      priority: "medium" as const,
+      assigneeAgentId: null,
+      assigneeUserId: null,
+    }];
 
     act(() => {
       root.render(
         <QueryClientProvider client={queryClient}>
           <IssueProperties
-            issue={createIssue({ id: "issue-b", blockedBy })}
+            issue={createIssue({ id: "issue-b", blockedBy: nextBlockedBy })}
             childIssues={[]}
             onUpdate={vi.fn()}
             inline
@@ -1450,8 +1659,9 @@ describe("IssueProperties", () => {
     });
     await flush();
 
-    expect(container.textContent).not.toContain("BLOCK-6");
-    expect(container.textContent).toContain("Show 2 more");
+    expect(findRowTrigger(container, "Blocked by")?.textContent).toContain("NEXT-1");
+    expect(findRowTrigger(container, "Blocked by")?.textContent).not.toContain("BLOCK-1");
+    expect(findRowTrigger(container, "Blocked by")?.textContent).not.toContain("more");
 
     act(() => root.unmount());
   });
@@ -1477,6 +1687,33 @@ describe("IssueProperties", () => {
     await waitForAssertion(() => {
       expect(findRowTrigger(container, "Project")?.textContent).toContain("Archived Project");
     });
+
+    act(() => root.unmount());
+  });
+
+  it("uses the configured project color and icon in the project property", async () => {
+    mockProjectsApi.list.mockResolvedValue([
+      createProject({
+        name: "Configured Project",
+        color: "#0ea5e9",
+        icon: "rocket",
+      }),
+    ]);
+
+    const root = renderProperties(container, {
+      issue: createIssue({ projectId: "project-1" }),
+      childIssues: [],
+      onUpdate: vi.fn(),
+      sidePanelContentOnly: true,
+    });
+    await waitForAssertion(() => {
+      expect(findRowTrigger(container, "Project")?.textContent).toContain("Configured Project");
+    });
+
+    const projectTrigger = findRowTrigger(container, "Project");
+    const projectTile = projectTrigger?.querySelector<HTMLElement>('span.inline-flex[aria-hidden="true"]');
+    expect(projectTile?.style.backgroundColor).toBe("rgb(14, 165, 233)");
+    expect(projectTile?.querySelector("svg")?.classList).toContain("lucide-rocket");
 
     act(() => root.unmount());
   });
@@ -1560,6 +1797,15 @@ describe("IssueProperties", () => {
     expect(container.textContent).toMatch(/StartedApr 6, 2026, \d{1,2}:35 (AM|PM)/);
     expect(container.textContent).toMatch(/CompletedApr 6, 2026, \d{1,2}:36 (AM|PM)/);
 
+    for (const label of ["Started", "Completed", "Created"]) {
+      const labelNode = container.querySelector(`[data-property-label="${label}"]`);
+      const value = labelNode?.parentElement?.querySelector<HTMLElement>('[data-property-value="true"] > span');
+      expect(value?.classList).toContain("min-w-0");
+      expect(value?.classList).toContain("truncate");
+      expect(value?.classList).toContain("whitespace-nowrap");
+      expect(value?.title).toBe(value?.textContent);
+    }
+
     act(() => root.unmount());
   });
 
@@ -1608,11 +1854,18 @@ describe("IssueProperties", () => {
       onUpdate: vi.fn(),
     });
     await flush();
+    await flush();
 
     const branchCopyButton = container.querySelector<HTMLButtonElement>(
       'button[aria-label="Copy pap-1-workspace to clipboard"]',
     );
+    const folderCopyButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Copy /tmp/paperclip/PAP-1 to clipboard"]',
+    );
     expect(branchCopyButton).not.toBeNull();
+    expect(folderCopyButton?.querySelector('[data-middle-truncate="true"]')?.textContent)
+      .toBe("/tmp/paperclip/PAP-1");
+    expect(folderCopyButton?.title).toBe("/tmp/paperclip/PAP-1");
 
     await act(async () => {
       branchCopyButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
@@ -1653,7 +1906,7 @@ describe("IssueProperties", () => {
     act(() => root.unmount());
   });
 
-  it("shows related task references below sub-issues", async () => {
+  it("separates referenced tasks from tasks that mention this task", async () => {
     const root = renderProperties(container, {
       issue: createIssue({
         relatedWork: {
@@ -1672,22 +1925,49 @@ describe("IssueProperties", () => {
               sources: [{ kind: "description", sourceRecordId: null, label: "description", matchedText: "PAP-22" }],
             },
           ],
-          inbound: [],
+          inbound: [
+            {
+              issue: {
+                id: "issue-23",
+                identifier: "PAP-23",
+                title: "Mentions this task",
+                status: "in_progress",
+                priority: "medium",
+                assigneeAgentId: null,
+                assigneeUserId: null,
+              },
+              mentionCount: 1,
+              sources: [{ kind: "description", sourceRecordId: null, label: "description", matchedText: "PAP-1" }],
+            },
+          ],
         },
       }),
       childIssues: [],
       onUpdate: vi.fn(),
+      inline: true,
     });
     await flush();
 
     expect(container.textContent).not.toContain("Task ids");
-    expect(container.textContent).toContain("Related tasks");
+    expect(container.textContent).not.toContain("Related tasks");
+    const referencesTab = Array.from(container.querySelectorAll<HTMLButtonElement>('button[role="tab"]'))
+      .find((button) => button.textContent === "References");
+    await act(async () => {
+      referencesTab!.dispatchEvent(new MouseEvent("mousedown", { bubbles: true, button: 0 }));
+    });
+    expect(container.textContent).toContain("Referenced");
     expect(container.textContent).toContain("PAP-22");
+    expect(container.textContent).toContain("Mentioned in");
+    expect(container.textContent).toContain("PAP-23");
 
     act(() => root.unmount());
   });
 
   it("hides related task references already covered by blockers, blocking, and sub-issues", async () => {
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({
+      enableTaskWatchdogs: false,
+      enableClassicTaskInterface: true,
+    });
     const root = renderProperties(container, {
       issue: createIssue({
         blockedBy: [
@@ -1768,12 +2048,14 @@ describe("IssueProperties", () => {
     });
     await flush();
 
-    expect(container.textContent).not.toContain("Related tasks");
+    await waitForAssertion(() => {
+      expect(container.textContent).not.toContain("Referenced");
+    });
 
     act(() => root.unmount());
   });
 
-  it("shows an add-label button when labels already exist and opens the picker", async () => {
+  it("opens the label picker from its relationship value without a redundant add button", async () => {
     const root = renderProperties(container, {
       issue: createIssue({
         labels: [{ id: "label-1", companyId: "company-1", name: "Bug", color: "#ef4444", createdAt: new Date("2026-04-06T12:00:00.000Z"), updatedAt: new Date("2026-04-06T12:00:00.000Z") }],
@@ -1785,12 +2067,17 @@ describe("IssueProperties", () => {
     });
     await flush();
 
-    const addLabelButton = container.querySelector('button[aria-label="Add label"]');
-    expect(addLabelButton).not.toBeNull();
+    expect(container.querySelector('button[aria-label="Add label"]')).toBeNull();
     expect(container.querySelector('input[placeholder="Search labels..."]')).toBeNull();
+    const labelsTrigger = findRowTrigger(container, "Labels");
+    expect(labelsTrigger?.textContent).toContain("Bug");
+    const labelChip = labelsTrigger?.querySelector<HTMLElement>('[title="Bug"]');
+    expect(labelChip?.classList).toContain("border-0");
+    expect(labelChip?.style.borderColor).toBe("");
+    expect(labelChip?.style.color).not.toBe("");
 
     await act(async () => {
-      addLabelButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      labelsTrigger!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
     await flush();
 
@@ -1978,10 +2265,10 @@ describe("IssueProperties", () => {
     });
     await flush();
 
-    const addLabelButton = container.querySelector('button[aria-label="Add label"]');
-    expect(addLabelButton).not.toBeNull();
+    const labelsTrigger = findRowTrigger(container, "Labels");
+    expect(labelsTrigger?.textContent).toContain("Bug");
     await act(async () => {
-      addLabelButton!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      labelsTrigger!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
     await flush();
 

--- a/ui/src/components/IssuesList.test.tsx
+++ b/ui/src/components/IssuesList.test.tsx
@@ -13,6 +13,7 @@ import {
   issueAgeSeparatorLabel,
 } from "./IssuesList";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { taskCollectionPreferencesStorageKey } from "../lib/task-collection-preferences";
 
 const companyState = vi.hoisted(() => ({
   selectedCompanyId: "company-1",
@@ -28,6 +29,7 @@ const mockIssuesApi = vi.hoisted(() => ({
 }));
 
 const mockKanbanBoard = vi.hoisted(() => vi.fn());
+const mockNavigate = vi.hoisted(() => vi.fn());
 
 const mockAuthApi = vi.hoisted(() => ({
   getSession: vi.fn(),
@@ -61,7 +63,7 @@ vi.mock("../context/DialogContext", () => ({
 }));
 
 vi.mock("@/lib/router", () => ({
-  useNavigate: () => vi.fn(),
+  useNavigate: () => mockNavigate,
   Link: ({
     children,
     to,
@@ -130,6 +132,11 @@ vi.mock("./IssueRow", () => ({
     checklistDependencyChips,
     checklistRowId,
     externalObjectSummary,
+    presentation,
+    leadingControl,
+    treeGuides,
+    showIdentifier,
+    trailingMeta,
   }: {
     issue: Issue;
     desktopMetaLeading?: ReactNode;
@@ -140,20 +147,32 @@ vi.mock("./IssueRow", () => ({
     checklistDependencyChips?: ReactNode;
     checklistRowId?: string;
     externalObjectSummary?: { total: number } | null;
+    presentation?: "legacy" | "task";
+    leadingControl?: ReactNode;
+    treeGuides?: number;
+    showIdentifier?: boolean;
+    trailingMeta?: ReactNode;
   }) => (
     <div
       data-testid="issue-row"
+      data-presentation={presentation}
+      data-tree-guides={treeGuides ?? 0}
+      data-show-identifier={showIdentifier ? "true" : "false"}
+      data-trailing-meta={typeof trailingMeta === "string" ? trailingMeta : undefined}
+      data-has-desktop-trailing={desktopTrailing ? "true" : "false"}
       id={checklistRowId}
       data-step={checklistStepNumber ?? undefined}
       data-current-step={checklistCurrentStep ? "true" : undefined}
       data-title-class={titleClassName ?? undefined}
     >
       <span>{issue.title}</span>
+      {leadingControl}
       {externalObjectSummary ? (
         <span data-testid="external-object-summary">{externalObjectSummary.total}</span>
       ) : null}
       {desktopMetaLeading}
       {desktopTrailing}
+      {trailingMeta}
       {checklistDependencyChips}
     </div>
   ),
@@ -324,6 +343,7 @@ describe("IssuesList", () => {
     document.body.appendChild(container);
     dialogState.openNewIssue.mockReset();
     mockKanbanBoard.mockReset();
+    mockNavigate.mockReset();
     mockIssuesApi.list.mockReset();
     mockIssuesApi.listLabels.mockReset();
     mockAuthApi.getSession.mockReset();
@@ -343,6 +363,7 @@ describe("IssuesList", () => {
     mockInstanceSettingsApi.getExperimental.mockResolvedValue({
       enableIsolatedWorkspaces: false,
       enableExternalObjects: false,
+      enableStreamlinedUi: true,
     });
     setDocumentScrollMetrics({ innerHeight: 600, scrollY: 0, scrollHeight: 2400 });
     mockExternalObjectsApi.getIssueSummaries.mockResolvedValue({ summaries: {} });
@@ -352,6 +373,50 @@ describe("IssuesList", () => {
   afterEach(() => {
     vi.useRealTimers();
     container.remove();
+  });
+
+  it("uses the master list and legacy persistence when Streamlined UI is off", async () => {
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({
+      enableIsolatedWorkspaces: false,
+      enableExternalObjects: false,
+      enableStreamlinedUi: false,
+    });
+    localStorage.setItem(
+      taskCollectionPreferencesStorageKey({
+        companyId: "company-1",
+        collectionKey: "paperclip:test-issues",
+      }),
+      JSON.stringify({
+        version: 1,
+        companyId: "company-1",
+        collectionKey: "paperclip:test-issues",
+        viewState: { viewMode: "board" },
+        columns: [],
+      }),
+    );
+
+    const { root } = renderWithQueryClient(
+      <IssuesList
+        issues={[createIssue({ id: "legacy-issue", title: "Master task row" })]}
+        isLoading={false}
+        agents={[]}
+        projects={[]}
+        viewStateKey="paperclip:test-issues"
+        rowPresentation="task"
+        toolbarPresentation="collection"
+        onUpdateIssue={() => undefined}
+      />,
+      container,
+    );
+
+    await waitForAssertion(() => {
+      const row = container.querySelector("[data-testid='issue-row']");
+      expect(row).not.toBeNull();
+      expect(row?.getAttribute("data-presentation")).toBeNull();
+      expect(container.querySelector("[data-testid='kanban-board']")).toBeNull();
+    });
+
+    act(() => root.unmount());
   });
 
   it("forwards external-object summaries into issue rows", async () => {
@@ -380,6 +445,7 @@ describe("IssuesList", () => {
         agents={[]}
         projects={[]}
         viewStateKey="paperclip:test-issues"
+        rowPresentation="task"
         onUpdateIssue={() => undefined}
       />,
       container,
@@ -395,6 +461,80 @@ describe("IssuesList", () => {
     });
   });
 
+  it("keeps the canonical task-row presentation opt in per collection", async () => {
+    const { root } = renderWithQueryClient(
+      <IssuesList
+        issues={[createIssue()]}
+        agents={[]}
+        projects={[]}
+        viewStateKey="paperclip:test-issues"
+        rowPresentation="task"
+        onUpdateIssue={() => undefined}
+      />,
+      container,
+    );
+
+    await waitForAssertion(() => {
+      const row = container.querySelector("[data-testid='issue-row']");
+      expect(row?.getAttribute("data-presentation")).toBe("task");
+      expect(row?.getAttribute("data-show-identifier")).toBe("true");
+      expect(row?.getAttribute("data-trailing-meta")).toMatch(/\S/);
+      expect(row?.getAttribute("data-trailing-meta")).not.toContain("Updated");
+      expect(row?.getAttribute("data-has-desktop-trailing")).toBe("false");
+      expect(row?.querySelector('[data-slot="task-row-disclosure-spacer"]')).not.toBeNull();
+    });
+
+    act(() => root.unmount());
+  });
+
+  it("reserves a disclosure column after each ancestor guide in canonical task trees", async () => {
+    const parent = createIssue({ id: "parent", identifier: "PAP-1", title: "Parent task" });
+    const child = createIssue({ id: "child", identifier: "PAP-2", parentId: parent.id, title: "Child task" });
+    const { root } = renderWithQueryClient(
+      <IssuesList
+        issues={[parent, child]}
+        agents={[]}
+        projects={[]}
+        viewStateKey="paperclip:test-issues"
+        rowPresentation="task"
+        onUpdateIssue={() => undefined}
+      />,
+      container,
+    );
+
+    await waitForAssertion(() => {
+      const rows = Array.from(container.querySelectorAll('[data-testid="issue-row"]'));
+      const parentRow = rows.find((row) => row.textContent?.includes("Parent task"));
+      const childRow = rows.find((row) => row.textContent?.includes("Child task"));
+      expect(parentRow?.getAttribute("data-tree-guides")).toBe("0");
+      expect(parentRow?.querySelector('button[aria-label="Collapse sub-tasks"]')).not.toBeNull();
+      expect(childRow?.getAttribute("data-tree-guides")).toBe("1");
+      expect(childRow?.querySelector('[data-slot="task-row-disclosure-spacer"]')).not.toBeNull();
+    });
+
+    act(() => root.unmount());
+  });
+
+  it("keeps the shared collection toolbar opt in per surface", async () => {
+    const { root } = renderWithQueryClient(
+      <IssuesList
+        issues={[createIssue()]}
+        agents={[]}
+        projects={[]}
+        viewStateKey="paperclip:test-issues"
+        toolbarPresentation="collection"
+        onUpdateIssue={() => undefined}
+      />,
+      container,
+    );
+
+    await waitForAssertion(() => {
+      expect(container.querySelector("[role='toolbar'][aria-label='Task controls']")).not.toBeNull();
+    });
+
+    act(() => root.unmount());
+  });
+
   it("does not load external-object summaries when the experimental flag is disabled", async () => {
     const { root } = renderWithQueryClient(
       <IssuesList
@@ -402,6 +542,7 @@ describe("IssuesList", () => {
         agents={[]}
         projects={[]}
         viewStateKey="paperclip:test-issues"
+        rowPresentation="task"
         onUpdateIssue={() => undefined}
       />,
       container,
@@ -458,6 +599,7 @@ describe("IssuesList", () => {
         agents={[]}
         projects={[]}
         viewStateKey="paperclip:test-issues"
+        rowPresentation="task"
         onUpdateIssue={() => undefined}
       />,
       container,
@@ -780,6 +922,7 @@ describe("IssuesList", () => {
         agents={[]}
         projects={[]}
         viewStateKey="paperclip:test-issues"
+        rowPresentation="task"
         onUpdateIssue={() => undefined}
       />,
       container,
@@ -2013,11 +2156,11 @@ describe("IssuesList", () => {
     });
   });
 
-  it("draws day and week separators between recency-sorted rows", async () => {
-    const now = Date.now();
-    const hourAgo = new Date(now - 60 * 60 * 1000);
-    const threeDaysAgo = new Date(now - 3 * 24 * 60 * 60 * 1000);
-    const tenDaysAgo = new Date(now - 10 * 24 * 60 * 60 * 1000);
+  it("draws local-calendar separators between date-sorted rows", async () => {
+    const now = new Date();
+    const hourAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 12);
+    const threeDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 3, 12);
+    const tenDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 10, 12);
 
     const { root } = renderWithQueryClient(
       <IssuesList
@@ -2029,6 +2172,7 @@ describe("IssuesList", () => {
         agents={[]}
         projects={[]}
         viewStateKey="paperclip:test-issues"
+        rowPresentation="task"
         onUpdateIssue={() => undefined}
       />,
       container,
@@ -2037,7 +2181,13 @@ describe("IssuesList", () => {
     await waitForAssertion(() => {
       const separators = Array.from(container.querySelectorAll("[data-issues-date-separator]"));
       const labels = separators.map((el) => el.getAttribute("aria-label"));
-      expect(labels).toEqual(["Older than a day", "Older than a week"]);
+      expect(labels).toEqual(["Today", "Earlier"]);
+      expect(separators.every((separator) => (
+        separator.querySelectorAll("[data-date-group-rule]").length === 2
+      ))).toBe(true);
+      expect(separators.every((separator) => (
+        separator.querySelector("[data-date-group-label]")?.classList.contains("text-muted-foreground/70")
+      ))).toBe(true);
     });
 
     act(() => {
@@ -2045,18 +2195,65 @@ describe("IssuesList", () => {
     });
   });
 
-  it("draws both separators when adjacent rows skip the middle age bucket", async () => {
-    const now = Date.now();
+  it("can hide date group separators from the persisted Columns option", async () => {
+    const collectionKey = "paperclip:test-issues";
+    localStorage.setItem(
+      taskCollectionPreferencesStorageKey({
+        companyId: "company-1",
+        collectionKey,
+      }),
+      JSON.stringify({
+        version: 1,
+        companyId: "company-1",
+        collectionKey,
+        viewState: { showDateGroupSeparators: false },
+        columns: ["status", "id", "updated"],
+      }),
+    );
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 12);
+    const threeDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 3, 12);
 
     const { root } = renderWithQueryClient(
       <IssuesList
         issues={[
-          createIssue({ id: "issue-recent", identifier: "PAP-1", title: "Just updated", updatedAt: new Date(now - 60 * 60 * 1000) }),
-          createIssue({ id: "issue-old", identifier: "PAP-2", title: "Over a week old", updatedAt: new Date(now - 10 * 24 * 60 * 60 * 1000) }),
+          createIssue({ id: "issue-recent", title: "Just updated", updatedAt: today }),
+          createIssue({ id: "issue-old", title: "Earlier task", updatedAt: threeDaysAgo }),
+        ]}
+        agents={[]}
+        projects={[]}
+        viewStateKey={collectionKey}
+        rowPresentation="task"
+        onUpdateIssue={() => undefined}
+      />,
+      container,
+    );
+
+    await waitForAssertion(() => {
+      expect(container.textContent).toContain("Earlier task");
+      expect(container.querySelector("[data-issues-date-separator]")).toBeNull();
+    });
+
+    act(() => {
+      root.unmount();
+    });
+  });
+
+  it("does not synthesize an empty Yesterday group", async () => {
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 12);
+    const tenDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 10, 12);
+
+    const { root } = renderWithQueryClient(
+      <IssuesList
+        issues={[
+          createIssue({ id: "issue-recent", identifier: "PAP-1", title: "Just updated", updatedAt: today }),
+          createIssue({ id: "issue-old", identifier: "PAP-2", title: "Over a week old", updatedAt: tenDaysAgo }),
         ]}
         agents={[]}
         projects={[]}
         viewStateKey="paperclip:test-issues"
+        rowPresentation="task"
         onUpdateIssue={() => undefined}
       />,
       container,
@@ -2065,7 +2262,7 @@ describe("IssuesList", () => {
     await waitForAssertion(() => {
       const labels = Array.from(container.querySelectorAll("[data-issues-date-separator]"))
         .map((el) => el.getAttribute("aria-label"));
-      expect(labels).toEqual(["Older than a day", "Older than a week"]);
+      expect(labels).toEqual(["Today", "Earlier"]);
     });
 
     act(() => {
@@ -2074,18 +2271,22 @@ describe("IssuesList", () => {
   });
 
   it("places separators around expanded nested rows in visible order", async () => {
-    const now = Date.now();
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 12);
+    const threeDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 3, 12);
+    const tenDaysAgo = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 10, 12);
 
     const { root } = renderWithQueryClient(
       <IssuesList
         issues={[
-          createIssue({ id: "issue-parent", identifier: "PAP-1", title: "Recent parent", updatedAt: new Date(now - 60 * 60 * 1000) }),
-          createIssue({ id: "issue-child", identifier: "PAP-2", parentId: "issue-parent", title: "Older child", updatedAt: new Date(now - 3 * 24 * 60 * 60 * 1000) }),
-          createIssue({ id: "issue-old", identifier: "PAP-3", title: "Old root", updatedAt: new Date(now - 10 * 24 * 60 * 60 * 1000) }),
+          createIssue({ id: "issue-parent", identifier: "PAP-1", title: "Recent parent", updatedAt: today }),
+          createIssue({ id: "issue-child", identifier: "PAP-2", parentId: "issue-parent", title: "Older child", updatedAt: threeDaysAgo }),
+          createIssue({ id: "issue-old", identifier: "PAP-3", title: "Old root", updatedAt: tenDaysAgo }),
         ]}
         agents={[]}
         projects={[]}
         viewStateKey="paperclip:test-issues"
+        rowPresentation="task"
         onUpdateIssue={() => undefined}
       />,
       container,
@@ -2096,10 +2297,10 @@ describe("IssuesList", () => {
         container.querySelectorAll("[data-testid='issue-row'], [data-issues-date-separator]"),
       ).map((element) => element.getAttribute("aria-label") ?? element.firstElementChild?.textContent);
       expect(visibleOrder).toEqual([
+        "Today",
         "Recent parent",
-        "Older than a day",
+        "Earlier",
         "Older child",
-        "Older than a week",
         "Old root",
       ]);
     });
@@ -2109,18 +2310,21 @@ describe("IssuesList", () => {
     });
   });
 
-  it("omits date separators when all rows share a recency bucket", async () => {
-    const now = Date.now();
+  it("emits one Today heading when all rows share today's calendar group", async () => {
+    const now = new Date();
+    const todayMorning = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 9);
+    const todayNoon = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 12);
 
     const { root } = renderWithQueryClient(
       <IssuesList
         issues={[
-          createIssue({ id: "issue-a", identifier: "PAP-1", title: "One", updatedAt: new Date(now - 60 * 60 * 1000) }),
-          createIssue({ id: "issue-b", identifier: "PAP-2", title: "Two", updatedAt: new Date(now - 2 * 60 * 60 * 1000) }),
+          createIssue({ id: "issue-a", identifier: "PAP-1", title: "One", updatedAt: todayNoon }),
+          createIssue({ id: "issue-b", identifier: "PAP-2", title: "Two", updatedAt: todayMorning }),
         ]}
         agents={[]}
         projects={[]}
         viewStateKey="paperclip:test-issues"
+        rowPresentation="task"
         onUpdateIssue={() => undefined}
       />,
       container,
@@ -2129,7 +2333,8 @@ describe("IssuesList", () => {
     await waitForAssertion(() => {
       expect(container.querySelector("[data-testid='issue-row']")).not.toBeNull();
     });
-    expect(container.querySelectorAll("[data-issues-date-separator]").length).toBe(0);
+    expect(Array.from(container.querySelectorAll("[data-issues-date-separator]"))
+      .map((element) => element.getAttribute("aria-label"))).toEqual(["Today"]);
 
     act(() => {
       root.unmount();
@@ -2137,24 +2342,15 @@ describe("IssuesList", () => {
   });
 });
 
-describe("issueAgeBucket", () => {
+describe("legacy issue age separators", () => {
   const now = new Date("2026-04-10T12:00:00.000Z").getTime();
 
-  it("buckets by day and week boundaries", () => {
+  it("retains the rolling day and week boundaries used by the legacy list", () => {
     expect(issueAgeBucket(new Date(now - 60 * 60 * 1000), now)).toBe(0);
     expect(issueAgeBucket(new Date(now - 3 * 24 * 60 * 60 * 1000), now)).toBe(1);
     expect(issueAgeBucket(new Date(now - 10 * 24 * 60 * 60 * 1000), now)).toBe(2);
-  });
-
-  it("labels the day and week separators", () => {
     expect(issueAgeSeparatorLabel(1)).toBe("Older than a day");
     expect(issueAgeSeparatorLabel(2)).toBe("Older than a week");
-  });
-
-  it("returns every boundary crossed between adjacent rows", () => {
-    expect(issueAgeBucketsCrossed(0, 1)).toEqual([1]);
-    expect(issueAgeBucketsCrossed(1, 2)).toEqual([2]);
     expect(issueAgeBucketsCrossed(0, 2)).toEqual([1, 2]);
-    expect(issueAgeBucketsCrossed(2, 1)).toEqual([]);
   });
 });

--- a/ui/src/components/Layout.production.tsx
+++ b/ui/src/components/Layout.production.tsx
@@ -1,15 +1,12 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Outlet, useLocation, useNavigate, useNavigationType, useParams } from "@/lib/router";
-import { Sidebar } from "./Sidebar";
-import { CompanySettingsSidebar } from "./CompanySettingsSidebar";
+import { Sidebar } from "./Sidebar.production";
+import { CompanySettingsSidebar } from "./CompanySettingsSidebar.production";
 import { CompanySettingsNav } from "./access/CompanySettingsNav";
-import { AppsSidebar } from "./AppsSidebar";
-import { AppDetailSidebar } from "./AppConnectionSidebar";
-import { AgentContextualSidebar } from "./AgentContextualSidebar";
-import { RoutineContextualSidebar } from "./RoutineContextualSidebar";
-import { SkillsContextualSidebar } from "./SkillsContextualSidebar";
-import { BreadcrumbBar } from "./BreadcrumbBar";
+import { AppsSidebar } from "./AppsSidebar.production";
+import { AppDetailSidebar } from "./AppConnectionSidebar.production";
+import { BreadcrumbBar } from "./BreadcrumbBar.production";
 import { PropertiesPanel } from "./PropertiesPanel";
 import { CommandPalette } from "./CommandPalette";
 import { NewIssueDialog } from "./NewIssueDialog";
@@ -23,17 +20,15 @@ import { WorktreeBanner } from "./WorktreeBanner";
 import { DevRestartBanner } from "./DevRestartBanner";
 import { StandaloneBrowserControls } from "./StandaloneBrowserControls";
 import { RouteErrorBoundary } from "./RouteErrorBoundary";
-import { SidebarShell } from "./SidebarShell";
-import { SecondarySidebar } from "./SecondarySidebar";
-import { ContextualSidebarFrame } from "./ContextualSidebarFrame";
-import { SidebarAccountMenu } from "./SidebarAccountMenu";
+import { SidebarShell } from "./SidebarShell.production";
+import { SecondarySidebar } from "./SecondarySidebar.production";
+import { SidebarAccountMenu } from "./SidebarAccountMenu.production";
 import { useDialogActions } from "../context/DialogContext";
 import { GeneralSettingsProvider } from "../context/GeneralSettingsContext";
 import { usePanel } from "../context/PanelContext";
 import { useCompany } from "../context/CompanyContext";
 import { useSidebar } from "../context/SidebarContext";
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
-import { useStreamlinedUiEnabled } from "../hooks/useStreamlinedUiEnabled";
 import { useCompanyPageMemory } from "../hooks/useCompanyPageMemory";
 import { healthApi } from "../api/health";
 import { instanceSettingsApi } from "../api/instanceSettings";
@@ -48,12 +43,6 @@ import {
 import { queryKeys } from "../lib/queryKeys";
 import { scheduleMainContentFocus } from "../lib/main-content-focus";
 import { pinDocumentScrollToZero } from "../lib/pin-document-scroll";
-import {
-  classifyShellRoute,
-  getCompanyPathSegments,
-  rememberContextualSidebarOrigin,
-  type ContextualSidebarSurface,
-} from "../lib/shell-navigation";
 import { cn } from "../lib/utils";
 import { NotFoundPage } from "../pages/NotFound";
 import { PluginSlotMount, resolveRouteSidebarSlot, usePluginSlots } from "../plugins/slots";
@@ -62,17 +51,34 @@ function getCompanyRouteSegment(pathname: string, companyPrefix: string | undefi
   return getCompanyPathSegments(pathname, companyPrefix)[0]?.toLowerCase() ?? null;
 }
 
+function getCompanyPathSegments(pathname: string, companyPrefix: string | undefined): string[] {
+  if (!companyPrefix) return [];
+  const segments = pathname.split("/").filter(Boolean);
+  if (segments.length < 2) return [];
+  if (segments[0]?.toUpperCase() !== companyPrefix.toUpperCase()) return [];
+  return segments.slice(1);
+}
+
 const RESERVED_APP_SUBPATHS = new Set([
   "browse",
   "connections",
   "connect",
-  "vercel-connect",
   "review",
   "attention",
   "gateways",
   "advanced",
   "app",
 ]);
+
+function isSkillsStoreRoute(pathname: string, companyPrefix: string | undefined) {
+  const segments = pathname.split("/").filter(Boolean);
+  if (segments[0]?.toLowerCase() === "skills") return true;
+  if (!companyPrefix) return false;
+  return (
+    segments[0]?.toUpperCase() === companyPrefix.toUpperCase() &&
+    segments[1]?.toLowerCase() === "skills"
+  );
+}
 
 export function Layout() {
   const {
@@ -100,23 +106,16 @@ export function Layout() {
   const {
     companyPrefix,
     pluginRoutePath: matchedPluginRoutePath,
-    agentId,
-    routineId,
-  } = useParams<{
-    companyPrefix: string;
-    pluginRoutePath?: string;
-    agentId?: string;
-    routineId?: string;
-  }>();
+  } = useParams<{ companyPrefix: string; pluginRoutePath?: string }>();
   const navigate = useNavigate();
   const location = useLocation();
   const navigationType = useNavigationType();
-  const { enabled: streamlinedUiEnabled } = useStreamlinedUiEnabled();
-  const shellRoute = classifyShellRoute(location.pathname, companyPrefix);
-  const isCompanySettingsRoute = shellRoute.builtInContextualSurface === "settings";
-  const companyPathSegments = shellRoute.companySegments;
-  const isTaskDetailRoute = shellRoute.isTaskDetail;
-  const useStreamlinedTaskDetailShell = streamlinedUiEnabled && isTaskDetailRoute;
+  const isCompanySettingsRoute = [
+    "/company/settings",
+    "/company/export",
+    "/company/import",
+  ].some((settingsPath) => location.pathname.includes(settingsPath));
+  const companyPathSegments = getCompanyPathSegments(location.pathname, companyPrefix);
   const isToolsRoute = companyPathSegments[0]?.toLowerCase() === "tools";
   const isAppsRoute = companyPathSegments[0]?.toLowerCase() === "apps";
   const appDetailConnectionId =
@@ -127,6 +126,9 @@ export function Layout() {
     isAppsRoute && companyPathSegments[1]?.toLowerCase() === "app" && companyPathSegments[2]
       ? companyPathSegments[2]
       : null;
+  // The Skills Store renders its own secondary (category) sidebar, so the main
+  // app nav collapses to its rail throughout the Skills Store section (PAP-10879).
+  const isSkillsRoute = isSkillsStoreRoute(location.pathname, companyPrefix);
   const onboardingTriggered = useRef(false);
   const lastMainScrollTop = useRef(0);
   const previousPathname = useRef<string | null>(null);
@@ -164,14 +166,12 @@ export function Layout() {
     }),
     [routeSidebarCompanyId, routeSidebarCompanyPrefix],
   );
-  // Most contextual routes replace the global navigation inside the same
-  // sidebar shell. Skills, Apps, Agent details, and Routine details are the
-  // exceptions in Streamlined UI: their local navigation is a second rail
-  // beside the persistent company nav.
-  const sharedSecondarySidebar = isCompanySettingsRoute ? (
+  // Takeover routes (company settings, plugin `routeSidebar`) no longer replace
+  // the app `<Sidebar/>`. Instead the host collapses it to its rail and renders
+  // the contextual sidebar in a second pane (PAP-10695). One resolver drives
+  // both desktop (SecondarySidebar) and mobile (off-canvas drawer).
+  const secondarySidebar = isCompanySettingsRoute ? (
     <CompanySettingsSidebar />
-  ) : !streamlinedUiEnabled && shellRoute.builtInContextualSurface === "skills" ? (
-    <SkillsContextualSidebar />
   ) : appDetailConnectionId ? (
     <AppDetailSidebar kind="connection" connectionId={appDetailConnectionId} />
   ) : appDetailApplicationId ? (
@@ -179,53 +179,14 @@ export function Layout() {
   ) : isAppsRoute || isToolsRoute ? (
     <AppsSidebar />
   ) : routeSidebarSlot ? (
-    streamlinedUiEnabled ? (
-      <ContextualSidebarFrame
-        surface={`plugin:${routeSidebarSlot.id}`}
-        title={routeSidebarSlot.displayName}
-      >
-        <PluginSlotMount
-          slot={routeSidebarSlot}
-          context={sidebarContext}
-          className="min-h-0 flex-1"
-          missingBehavior="placeholder"
-        />
-      </ContextualSidebarFrame>
-    ) : (
-      <PluginSlotMount
-        slot={routeSidebarSlot}
-        context={sidebarContext}
-        className="h-full w-full"
-        missingBehavior="placeholder"
-      />
-    )
+    <PluginSlotMount
+      slot={routeSidebarSlot}
+      context={sidebarContext}
+      className="h-full w-full"
+      missingBehavior="placeholder"
+    />
   ) : null;
-  const secondarySidebar = streamlinedUiEnabled && shellRoute.builtInContextualSurface === "agent" && agentId ? (
-    <AgentContextualSidebar agentRef={agentId} />
-  ) : streamlinedUiEnabled && shellRoute.builtInContextualSurface === "routine" && routineId ? (
-    <RoutineContextualSidebar routineId={routineId} />
-  ) : streamlinedUiEnabled && shellRoute.builtInContextualSurface === "skills" ? (
-    <SkillsContextualSidebar />
-  ) : sharedSecondarySidebar;
   const hasSecondarySidebar = secondarySidebar != null;
-  const keepsPrimarySidebar = streamlinedUiEnabled && hasSecondarySidebar && (
-    shellRoute.builtInContextualSurface === "skills"
-    || shellRoute.builtInContextualSurface === "agent"
-    || shellRoute.builtInContextualSurface === "routine"
-    || isAppsRoute
-    || isToolsRoute
-  );
-  const replacesPrimarySidebar = streamlinedUiEnabled && hasSecondarySidebar && !keepsPrimarySidebar;
-  const showsAdjacentSecondarySidebar = hasSecondarySidebar && (!streamlinedUiEnabled || keepsPrimarySidebar);
-  const contextualSurface: ContextualSidebarSurface | null = !streamlinedUiEnabled || !hasSecondarySidebar
-    ? null
-    : routeSidebarSlot && !shellRoute.builtInContextualSurface
-      ? `plugin:${routeSidebarSlot.id}`
-      : shellRoute.builtInContextualSurface;
-  const previousShellRoute = useRef<{
-    pathname: string;
-    surface: ContextualSidebarSurface | null;
-  } | null>(null);
   const { data: health } = useQuery({
     queryKey: queryKeys.health,
     queryFn: () => healthApi.get(),
@@ -241,28 +202,16 @@ export function Layout() {
     queryFn: () => instanceSettingsApi.getGeneral(),
   }).data?.keyboardShortcuts === true;
 
+  // A secondary sidebar always collapses the app sidebar to its rail (still
+  // peek-able) — a hard invariant that overrides the user pin while the route
+  // is active, but does NOT mutate the persisted preference. Clearing the force
+  // on cleanup restores the user's expanded/collapsed choice when navigating
+  // off the takeover route (PAP-10694).
+  const forceRailCollapsed = hasSecondarySidebar || isSkillsRoute;
   useLayoutEffect(() => {
-    setForceCollapsed(!streamlinedUiEnabled && hasSecondarySidebar);
+    setForceCollapsed(forceRailCollapsed);
     return () => setForceCollapsed(false);
-  }, [hasSecondarySidebar, setForceCollapsed, streamlinedUiEnabled]);
-
-  useEffect(() => {
-    const previous = previousShellRoute.current;
-    if (
-      contextualSurface
-      && companyPrefix
-      && previous
-      && previous.surface !== contextualSurface
-      && previous.pathname !== location.pathname
-    ) {
-      rememberContextualSidebarOrigin({
-        surface: contextualSurface,
-        companyPrefix,
-        previousPathname: previous.pathname,
-      });
-    }
-    previousShellRoute.current = { pathname: location.pathname, surface: contextualSurface };
-  }, [companyPrefix, contextualSurface, location.pathname]);
+  }, [forceRailCollapsed, setForceCollapsed]);
 
   useEffect(() => {
     if (companiesLoading || onboardingTriggered.current) return;
@@ -650,57 +599,44 @@ export function Layout() {
           >
             <div className="flex flex-1 min-h-0 overflow-hidden">
               <div className="w-60 shrink-0 overflow-hidden">
-                {hasSecondarySidebar ? (
-                  <SecondarySidebar>{secondarySidebar}</SecondarySidebar>
-                ) : (
-                  <Sidebar />
-                )}
+                {hasSecondarySidebar ? secondarySidebar : <Sidebar />}
               </div>
             </div>
             <SidebarAccountMenu
               deploymentMode={health?.deploymentMode}
               serverGit={health?.serverInfo?.git}
               version={health?.version}
-              forceExpanded={replacesPrimarySidebar}
             />
           </div>
         ) : (
           <SidebarShell
             open={sidebarOpen}
-            collapsed={replacesPrimarySidebar ? false : collapsed}
-            peeking={replacesPrimarySidebar ? false : peeking}
+            collapsed={collapsed}
+            peeking={peeking}
             resizable
-            onPanelMouseEnter={replacesPrimarySidebar ? undefined : handlePanelPointerEnter}
-            onPanelMouseLeave={replacesPrimarySidebar ? undefined : handlePanelPointerLeave}
-            onPanelFocusCapture={!replacesPrimarySidebar && collapsed ? handlePanelFocus : undefined}
-            onPanelBlurCapture={!replacesPrimarySidebar && collapsed ? handlePanelBlur : undefined}
+            onPanelMouseEnter={handlePanelPointerEnter}
+            onPanelMouseLeave={handlePanelPointerLeave}
+            onPanelFocusCapture={collapsed ? handlePanelFocus : undefined}
+            onPanelBlurCapture={collapsed ? handlePanelBlur : undefined}
           >
             <div className="flex flex-1 min-h-0">
-              {replacesPrimarySidebar ? (
-                <SecondarySidebar>{secondarySidebar}</SecondarySidebar>
-              ) : (
-                <Sidebar />
-              )}
+              <Sidebar />
             </div>
             <SidebarAccountMenu
               deploymentMode={health?.deploymentMode}
               serverGit={health?.serverInfo?.git}
               version={health?.version}
-              forceExpanded={replacesPrimarySidebar}
             />
           </SidebarShell>
         )}
 
-        {!isMobile && showsAdjacentSecondarySidebar && !keepsPrimarySidebar ? (
-          <SecondarySidebar className="w-60 shrink-0">
-            {secondarySidebar}
-          </SecondarySidebar>
+        {!isMobile && hasSecondarySidebar ? (
+          <SecondarySidebar>{secondarySidebar}</SecondarySidebar>
         ) : null}
 
         <div className={cn("flex min-w-0 flex-col", isMobile ? "w-full" : "h-full flex-1")}>
           <div
             className={cn(
-              !isMobile && useStreamlinedTaskDetailShell && "hidden",
               isMobile && "sticky top-0 z-20 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/85",
             )}
           >
@@ -712,23 +648,8 @@ export function Layout() {
               </div>
             ) : null}
           </div>
-          <div className={cn(
-            isMobile ? "block" : "flex flex-1 min-h-0",
-            !isMobile && useStreamlinedTaskDetailShell && "streamlined-task-detail-surface",
-          )}>
-            {!isMobile && keepsPrimarySidebar ? (
-              <SecondarySidebar className="w-60 shrink-0 bg-background">
-                {secondarySidebar}
-              </SecondarySidebar>
-            ) : null}
-            <div className={cn(!isMobile && useStreamlinedTaskDetailShell ? "flex min-w-0 flex-1 flex-col" : "contents")}>
-              {!isMobile && useStreamlinedTaskDetailShell ? (
-                <>
-                  <StandaloneBrowserControls mobile={false} />
-                  <BreadcrumbBar taskDetailLayout />
-                </>
-              ) : null}
-              <main
+          <div className={cn(isMobile ? "block" : "flex flex-1 min-h-0")}>
+            <main
               id="main-content"
               ref={mainContentRef}
               tabIndex={-1}
@@ -748,10 +669,6 @@ export function Layout() {
               }
               className={cn(
                 "flex-1 p-4 outline-none md:p-6",
-                // The task thread owns its scrollable top spacing. Leaving the
-                // page shell's top padding in place creates a stationary dark
-                // strip below the breadcrumb while messages scroll behind it.
-                !isMobile && useStreamlinedTaskDetailShell && "pt-0 pr-0 md:pt-0 md:pr-0",
                 // Reserve the scrollbar gutter on desktop so pages whose height
                 // changes (e.g. switching skill-detail tabs) don't widen/shift
                 // when the vertical scrollbar appears or disappears (PAP-10907).
@@ -770,9 +687,8 @@ export function Layout() {
                   <Outlet />
                 </RouteErrorBoundary>
               )}
-              </main>
-            </div>
-            <PropertiesPanel taskDetailLayout={!isMobile && useStreamlinedTaskDetailShell} />
+            </main>
+            <PropertiesPanel />
           </div>
         </div>
       </div>

--- a/ui/src/components/Layout.test.tsx
+++ b/ui/src/components/Layout.test.tsx
@@ -18,7 +18,6 @@ const mockInstanceSettingsApi = vi.hoisted(() => ({
 const mockNavigate = vi.hoisted(() => vi.fn());
 const mockSetSelectedCompanyId = vi.hoisted(() => vi.fn());
 const mockSetSidebarOpen = vi.hoisted(() => vi.fn());
-const mockSetForceCollapsed = vi.hoisted(() => vi.fn());
 const mockCompanyState = vi.hoisted(() => ({
   companies: [{ id: "company-1", issuePrefix: "PAP", name: "Paperclip" }],
   selectedCompany: { id: "company-1", issuePrefix: "PAP", name: "Paperclip" },
@@ -30,6 +29,7 @@ const mockPluginSlots = vi.hoisted(() => ({
 const mockUsePluginSlots = vi.hoisted(() => vi.fn());
 const mockPluginSlotContexts = vi.hoisted(() => [] as Array<Record<string, unknown>>);
 const mockSetPeeking = vi.hoisted(() => vi.fn());
+const mockSetForceCollapsed = vi.hoisted(() => vi.fn());
 const mockSidebarState = vi.hoisted(() => ({
   sidebarOpen: true,
   isMobile: false,
@@ -44,16 +44,20 @@ vi.mock("@/lib/router", () => ({
   useNavigate: () => mockNavigate,
   useNavigationType: () => "PUSH",
   useParams: () => {
-    const [firstSegment, secondSegment] = currentPathname.split("/").filter(Boolean);
+    const [firstSegment, secondSegment, entityId] = currentPathname.split("/").filter(Boolean);
     return {
       companyPrefix: firstSegment ?? "PAP",
       pluginRoutePath: secondSegment,
+      agentId: secondSegment === "agents" ? entityId : undefined,
+      routineId: secondSegment === "routines" ? entityId : undefined,
     };
   },
 }));
 
 vi.mock("./Sidebar", () => ({
-  Sidebar: () => <div>Main company nav</div>,
+  Sidebar: ({ contentHeaderControls }: { contentHeaderControls?: boolean }) => (
+    <div data-content-header-controls={String(contentHeaderControls ?? false)}>Main company nav</div>
+  ),
 }));
 
 vi.mock("./CompanySettingsSidebar", () => ({
@@ -62,6 +66,18 @@ vi.mock("./CompanySettingsSidebar", () => ({
 
 vi.mock("./AppsSidebar", () => ({
   AppsSidebar: () => <div>Apps sidebar</div>,
+}));
+
+vi.mock("./AgentContextualSidebar", () => ({
+  AgentContextualSidebar: ({ agentRef }: { agentRef: string }) => <div>Agent sidebar {agentRef}</div>,
+}));
+
+vi.mock("./RoutineContextualSidebar", () => ({
+  RoutineContextualSidebar: ({ routineId }: { routineId: string }) => <div>Routine sidebar {routineId}</div>,
+}));
+
+vi.mock("./SkillsContextualSidebar", () => ({
+  SkillsContextualSidebar: () => <div>Skills sidebar</div>,
 }));
 
 vi.mock("./AppConnectionSidebar", () => ({
@@ -188,12 +204,10 @@ vi.mock("../context/SidebarContext", () => ({
     toggleSidebar: vi.fn(),
     toggleCollapsed: vi.fn(),
     collapsed: mockSidebarState.collapsed,
-    collapseLocked: false,
     peeking: mockSidebarState.peeking,
     setPeeking: mockSetPeeking,
-    isMobile: mockSidebarState.isMobile,
-    forceCollapsed: false,
     setForceCollapsed: mockSetForceCollapsed,
+    isMobile: mockSidebarState.isMobile,
     routeRequestsCollapsed: false,
     setRouteRequestsCollapsed: vi.fn(),
   }),
@@ -272,6 +286,7 @@ describe("Layout", () => {
     mockSidebarState.collapsed = false;
     mockSidebarState.peeking = false;
     mockSetPeeking.mockClear();
+    mockSetForceCollapsed.mockClear();
   });
 
   afterEach(() => {
@@ -304,6 +319,36 @@ describe("Layout", () => {
     expect(container.textContent).not.toContain(
       "Sign-in is required and this instance is intended for private-network access.",
     );
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("scopes the Streamlined task-detail surface to the main pane and right sidebar row", async () => {
+    currentPathname = "/PAP/issues/PAP-1";
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({
+      enableApps: true,
+      enableStreamlinedUi: true,
+    });
+    const root = createRoot(container);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Layout />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+
+    expect(container.querySelector(".streamlined-task-detail-surface")).not.toBeNull();
+    expect(container.querySelector("#main-content")?.classList.contains("pt-0")).toBe(true);
+    expect(container.querySelector("#main-content")?.classList.contains("md:pt-0")).toBe(true);
+    expect(container.querySelector("#main-content")?.classList.contains("pr-0")).toBe(true);
+    expect(container.querySelector("#main-content")?.classList.contains("md:pr-0")).toBe(true);
 
     await act(async () => {
       root.unmount();
@@ -384,7 +429,7 @@ describe("Layout", () => {
     await act(async () => { root.unmount(); });
   });
 
-  it("keeps the app sidebar and shows the settings sidebar in the secondary pane on settings routes", async () => {
+  it("replaces the app sidebar with settings navigation on settings routes", async () => {
     currentPathname = "/PAP/company/settings/access";
     mockPluginSlots.slots = [
       {
@@ -425,14 +470,38 @@ describe("Layout", () => {
     await flushReact();
     await flushReact();
 
-    // Takeover model (PAP-10695): the app sidebar is kept (collapsed to its
-    // rail) AND the settings sidebar renders in the secondary pane.
     expect(container.textContent).toContain("Company settings sidebar");
-    expect(container.textContent).toContain("Main company nav");
+    expect(container.textContent).not.toContain("Main company nav");
     expect(container.textContent).not.toContain("Company rail");
     expect(container.textContent).not.toContain("Instance sidebar");
     expect(container.textContent).not.toContain("Plugin route sidebar");
-    // The route asks the host to collapse the app sidebar to its rail.
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("keeps the global sidebar beside legacy settings navigation when Streamlined UI is off", async () => {
+    currentPathname = "/PAP/company/settings/access";
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({
+      enableApps: true,
+      enableStreamlinedUi: false,
+    });
+    const root = createRoot(container);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Layout />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+
+    expect(container.textContent).toContain("Main company nav");
+    expect(container.textContent).toContain("Company settings sidebar");
     expect(mockSetForceCollapsed).toHaveBeenCalledWith(true);
 
     await act(async () => {
@@ -499,10 +568,9 @@ describe("Layout", () => {
     await flushReact();
 
     expect(container.textContent).toContain("Company settings sidebar");
-    expect(container.textContent).toContain("Main company nav");
+    expect(container.textContent).not.toContain("Main company nav");
     expect(container.textContent).not.toContain("Company rail");
     expect(container.textContent).not.toContain("Plugin route sidebar");
-    expect(mockSetForceCollapsed).toHaveBeenCalledWith(true);
 
     await act(async () => {
       root.unmount();
@@ -529,8 +597,7 @@ describe("Layout", () => {
       await flushReact();
 
       expect(container.textContent).toContain("Company settings sidebar");
-      expect(container.textContent).toContain("Main company nav");
-      expect(mockSetForceCollapsed).toHaveBeenCalledWith(true);
+      expect(container.textContent).not.toContain("Main company nav");
 
       await act(async () => {
         root.unmount();
@@ -538,7 +605,7 @@ describe("Layout", () => {
     },
   );
 
-  it("keeps the app sidebar and shows the Apps sidebar in the secondary pane on legacy tools routes", async () => {
+  it("keeps the company nav beside Apps navigation on legacy tools routes", async () => {
     currentPathname = "/PAP/tools/runtime";
     const root = createRoot(container);
     const queryClient = new QueryClient({
@@ -558,7 +625,6 @@ describe("Layout", () => {
     expect(container.textContent).toContain("Apps sidebar");
     expect(container.textContent).toContain("Main company nav");
     expect(container.textContent).not.toContain("Company settings sidebar");
-    expect(mockSetForceCollapsed).toHaveBeenCalledWith(true);
 
     await act(async () => {
       root.unmount();
@@ -585,7 +651,6 @@ describe("Layout", () => {
 
     expect(container.textContent).toContain("Apps sidebar");
     expect(container.textContent).toContain("Main company nav");
-    expect(mockSetForceCollapsed).toHaveBeenCalledWith(true);
     const secondaryRail = container.querySelector("[data-secondary-sidebar]");
     expect(secondaryRail?.classList.contains("w-60")).toBe(true);
     expect(secondaryRail?.classList.contains("shrink-0")).toBe(true);
@@ -753,7 +818,7 @@ describe("Layout", () => {
     });
   });
 
-  it("forces the app sidebar rail only for the Skills Store route", async () => {
+  it("keeps global navigation beside Skills, Agent, and Routine details", async () => {
     async function renderAt(pathname: string) {
       currentPathname = pathname;
       const root = createRoot(container);
@@ -773,22 +838,121 @@ describe("Layout", () => {
       return root;
     }
 
-    let root = await renderAt("/PAP/skills/studio");
+    for (const [pathname, sidebarText] of [
+      ["/PAP/skills/studio", "Skills sidebar"],
+      ["/PAP/agents/briefing-analyst/skills", "Agent sidebar briefing-analyst"],
+      ["/PAP/agents/briefing-analyst/runs/run-1", "Agent sidebar briefing-analyst"],
+      ["/PAP/routines/routine-1/overview", "Routine sidebar routine-1"],
+    ] as const) {
+      const root = await renderAt(pathname);
+      expect(container.textContent).toContain(sidebarText);
+      expect(container.textContent).toContain("Main company nav");
+      const secondaryRail = container.querySelector("[data-secondary-sidebar]");
+      expect(secondaryRail?.classList.contains("w-60")).toBe(true);
+      expect(secondaryRail?.classList.contains("bg-background")).toBe(true);
+      const breadcrumb = Array.from(container.querySelectorAll("div"))
+        .find((element) => element.textContent === "Breadcrumbs");
+      expect(breadcrumb).toBeDefined();
+      expect(
+        breadcrumb && secondaryRail
+          ? breadcrumb.compareDocumentPosition(secondaryRail) & Node.DOCUMENT_POSITION_FOLLOWING
+          : 0,
+      ).not.toBe(0);
+      await act(async () => {
+        root.unmount();
+      });
+      container.innerHTML = "";
+    }
+  });
+
+  it("keeps global navigation on legacy Agent and Routine detail routes", async () => {
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({
+      enableApps: true,
+      enableStreamlinedUi: false,
+    });
+
+    for (const pathname of [
+      "/PAP/agents/briefing-analyst/skills",
+      "/PAP/routines/routine-1/overview",
+    ]) {
+      currentPathname = pathname;
+      const root = createRoot(container);
+      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+      await act(async () => {
+        root.render(
+          <QueryClientProvider client={queryClient}>
+            <Layout />
+          </QueryClientProvider>,
+        );
+      });
+      await flushReact();
+      await flushReact();
+
+      expect(container.textContent).toContain("Main company nav");
+      expect(container.textContent).not.toContain("Agent sidebar");
+      expect(container.textContent).not.toContain("Routine sidebar");
+
+      await act(async () => {
+        root.unmount();
+      });
+      container.innerHTML = "";
+    }
+  });
+
+  it("keeps the global rail beside Skills navigation in the legacy shell", async () => {
+    currentPathname = "/PAP/skills/studio";
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({
+      enableApps: true,
+      enableStreamlinedUi: false,
+    });
+    const root = createRoot(container);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Layout />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+
+    expect(container.textContent).toContain("Main company nav");
+    expect(container.textContent).toContain("Skills sidebar");
     expect(mockSetForceCollapsed).toHaveBeenCalledWith(true);
-    await act(async () => {
-      root.unmount();
-    });
-
-    mockSetForceCollapsed.mockClear();
-    container.innerHTML = "";
-
-    root = await renderAt("/PAP/agents/briefing-analyst/skills");
-    expect(mockSetForceCollapsed).not.toHaveBeenCalledWith(true);
-    expect(mockSetForceCollapsed).toHaveBeenCalledWith(false);
 
     await act(async () => {
       root.unmount();
     });
+  });
+
+  it("keeps Agent and Routine collection routes in global navigation", async () => {
+    for (const pathname of ["/PAP/agents/all", "/PAP/agents/new", "/PAP/routines"]) {
+      currentPathname = pathname;
+      const root = createRoot(container);
+      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+      await act(async () => {
+        root.render(
+          <QueryClientProvider client={queryClient}>
+            <Layout />
+          </QueryClientProvider>,
+        );
+      });
+      await flushReact();
+      await flushReact();
+
+      expect(container.textContent).toContain("Main company nav");
+      expect(container.textContent).not.toContain("Agent sidebar");
+      expect(container.textContent).not.toContain("Routine sidebar");
+
+      await act(async () => {
+        root.unmount();
+      });
+      container.innerHTML = "";
+    }
   });
 
   it("renders a route-scoped plugin sidebar for a matching plugin page route", async () => {
@@ -832,14 +996,11 @@ describe("Layout", () => {
     await flushReact();
     await flushReact();
 
-    // Takeover model (PAP-10695): the app sidebar coexists with the plugin's
-    // route sidebar, which renders in the secondary pane.
     expect(container.textContent).toContain("Plugin route sidebar: Wiki Sidebar");
-    expect(container.querySelector("[data-plugin-slot-class='h-full w-full']")).not.toBeNull();
-    expect(container.textContent).toContain("Main company nav");
+    expect(container.querySelector("[data-plugin-slot-class='min-h-0 flex-1']")).not.toBeNull();
+    expect(container.textContent).not.toContain("Main company nav");
     expect(container.textContent).not.toContain("Company settings sidebar");
     expect(container.textContent).not.toContain("Instance sidebar");
-    expect(mockSetForceCollapsed).toHaveBeenCalledWith(true);
 
     await act(async () => {
       root.unmount();
@@ -894,7 +1055,7 @@ describe("Layout", () => {
       }),
     );
     expect(container.textContent).toContain("Plugin route sidebar: Wiki Sidebar");
-    expect(container.textContent).toContain("Main company nav");
+    expect(container.textContent).not.toContain("Main company nav");
 
     await act(async () => {
       root.unmount();
@@ -1022,9 +1183,6 @@ describe("Layout", () => {
 
     expect(container.textContent).toContain("Main company nav");
     expect(container.textContent).not.toContain("Plugin route sidebar");
-    // No secondary pane, so the route must not force the sidebar collapsed.
-    expect(mockSetForceCollapsed).not.toHaveBeenCalledWith(true);
-    expect(mockSetForceCollapsed).toHaveBeenCalledWith(false);
 
     await act(async () => {
       root.unmount();

--- a/ui/src/components/Layout.test.tsx
+++ b/ui/src/components/Layout.test.tsx
@@ -429,7 +429,7 @@ describe("Layout", () => {
     await act(async () => { root.unmount(); });
   });
 
-  it("replaces the app sidebar with settings navigation on settings routes", async () => {
+  it("keeps the app sidebar beside settings navigation on settings routes", async () => {
     currentPathname = "/PAP/company/settings/access";
     mockPluginSlots.slots = [
       {
@@ -471,7 +471,10 @@ describe("Layout", () => {
     await flushReact();
 
     expect(container.textContent).toContain("Company settings sidebar");
-    expect(container.textContent).not.toContain("Main company nav");
+    expect(container.textContent).toContain("Main company nav");
+    const secondaryRail = container.querySelector("[data-secondary-sidebar]");
+    expect(secondaryRail?.classList.contains("w-60")).toBe(true);
+    expect(secondaryRail?.classList.contains("bg-background")).toBe(true);
     expect(container.textContent).not.toContain("Company rail");
     expect(container.textContent).not.toContain("Instance sidebar");
     expect(container.textContent).not.toContain("Plugin route sidebar");
@@ -550,7 +553,7 @@ describe("Layout", () => {
     });
   });
 
-  it("renders the company settings sidebar on instance settings routes", async () => {
+  it("keeps the company nav beside settings on instance settings routes", async () => {
     currentPathname = "/PAP/company/settings/instance/general";
     const root = createRoot(container);
     const queryClient = new QueryClient({
@@ -568,7 +571,7 @@ describe("Layout", () => {
     await flushReact();
 
     expect(container.textContent).toContain("Company settings sidebar");
-    expect(container.textContent).not.toContain("Main company nav");
+    expect(container.textContent).toContain("Main company nav");
     expect(container.textContent).not.toContain("Company rail");
     expect(container.textContent).not.toContain("Plugin route sidebar");
 
@@ -578,7 +581,7 @@ describe("Layout", () => {
   });
 
   it.each(["/PAP/company/export", "/PAP/company/import"])(
-    "renders the shared settings sidebar on %s",
+    "keeps the company nav beside the shared settings sidebar on %s",
     async (pathname) => {
       currentPathname = pathname;
       const root = createRoot(container);
@@ -597,7 +600,7 @@ describe("Layout", () => {
       await flushReact();
 
       expect(container.textContent).toContain("Company settings sidebar");
-      expect(container.textContent).not.toContain("Main company nav");
+      expect(container.textContent).toContain("Main company nav");
 
       await act(async () => {
         root.unmount();

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -209,7 +209,8 @@ export function Layout() {
   ) : sharedSecondarySidebar;
   const hasSecondarySidebar = secondarySidebar != null;
   const keepsPrimarySidebar = streamlinedUiEnabled && hasSecondarySidebar && (
-    shellRoute.builtInContextualSurface === "skills"
+    shellRoute.builtInContextualSurface === "settings"
+    || shellRoute.builtInContextualSurface === "skills"
     || shellRoute.builtInContextualSurface === "agent"
     || shellRoute.builtInContextualSurface === "routine"
     || isAppsRoute

--- a/ui/src/components/LegacyIssuesList.tsx
+++ b/ui/src/components/LegacyIssuesList.tsx
@@ -53,7 +53,6 @@ import {
   InboxIssueTrailingColumns,
   IssueColumnPicker,
   issueActivityText,
-  issueActivityTimestamp,
   issueTrailingColumns,
 } from "./IssueColumns";
 import { StatusIcon } from "./StatusIcon";
@@ -61,10 +60,7 @@ import { EmptyState } from "./EmptyState";
 import { Identity } from "./Identity";
 import { IssueGroupHeader } from "./IssueGroupHeader";
 import { IssueFiltersPopover } from "./IssueFiltersPopover";
-import { IssueRow, type IssueRowPresentation } from "./IssueRow";
-import { CollectionToolbar, type CollectionToolbarProps } from "./CollectionToolbar";
-import { IssuesList as LegacyIssuesList } from "./LegacyIssuesList";
-import { useStreamlinedUiEnabled } from "../hooks/useStreamlinedUiEnabled";
+import { IssueRow } from "./IssueRow";
 import { PageSkeleton } from "./PageSkeleton";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -89,12 +85,6 @@ import { buildSubIssueDefaultsForViewer } from "../lib/subIssueDefaults";
 import { statusBadge } from "../lib/status-colors";
 import { workflowSort } from "../lib/workflow-sort";
 import { isSuccessfulRunHandoffRequired } from "../lib/successful-run-handoff";
-import {
-  loadTaskCollectionPreferences,
-  saveTaskCollectionPreferences,
-  type TaskCollectionPreferenceLocation,
-} from "../lib/task-collection-preferences";
-import { taskDateGroup, taskDateGroupSeparator, type TaskDateGroup } from "../lib/task-date-groups";
 import { deriveOriginatingActor, ISSUE_STATUSES, type Issue, type IssueStatus, type Project } from "@paperclipai/shared";
 import { Badge } from "@/components/ui/badge";
 const ISSUE_SEARCH_DEBOUNCE_MS = 250;
@@ -164,7 +154,6 @@ export type IssueViewState = IssueFilterState & {
   groupBy: "status" | "priority" | "assignee" | "project" | "workspace" | "parent" | "none";
   viewMode: "list" | "board";
   nestingEnabled: boolean;
-  showDateGroupSeparators: boolean;
   collapsedGroups: string[];
   collapsedParents: string[];
   boardCardDensity: BoardCardDensity;
@@ -179,7 +168,6 @@ const defaultViewState: IssueViewState = {
   groupBy: "none",
   viewMode: "list",
   nestingEnabled: true,
-  showDateGroupSeparators: true,
   collapsedGroups: [],
   collapsedParents: [],
   boardCardDensity: "auto",
@@ -201,42 +189,38 @@ function normalizeBoardColumnPageSize(value: unknown): BoardColumnPageSize {
     : KANBAN_COLUMN_DEFAULT_PAGE_SIZE;
 }
 
-function normalizeIssueViewState(value: unknown): IssueViewState {
-  const parsed = value && typeof value === "object" ? value as Partial<IssueViewState> : {};
-  return {
-    ...defaultViewState,
-    ...parsed,
-    ...normalizeIssueFilterState(parsed),
-    sortField: ["status", "priority", "title", "created", "updated", "workflow"].includes(parsed.sortField ?? "")
-      ? parsed.sortField as IssueSortField
-      : defaultViewState.sortField,
-    sortDir: parsed.sortDir === "asc" ? "asc" : "desc",
-    groupBy: ["status", "priority", "assignee", "project", "workspace", "parent", "none"].includes(parsed.groupBy ?? "")
-      ? parsed.groupBy as IssueViewState["groupBy"]
-      : defaultViewState.groupBy,
-    viewMode: parsed.viewMode === "board" ? "board" : "list",
-    nestingEnabled: parsed.nestingEnabled !== false,
-    showDateGroupSeparators: parsed.showDateGroupSeparators !== false,
-    collapsedGroups: Array.isArray(parsed.collapsedGroups)
-      ? parsed.collapsedGroups.filter((entry): entry is string => typeof entry === "string")
-      : [],
-    collapsedParents: Array.isArray(parsed.collapsedParents)
-      ? parsed.collapsedParents.filter((entry): entry is string => typeof entry === "string")
-      : [],
-    boardCardDensity: normalizeBoardCardDensity(parsed.boardCardDensity),
-    boardColdLaneMode: normalizeBoardColdLaneMode(parsed.boardColdLaneMode),
-    boardColumnPageSize: normalizeBoardColumnPageSize(parsed.boardColumnPageSize),
-  };
+function getViewState(key: string): IssueViewState {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      return {
+        ...defaultViewState,
+        ...parsed,
+        ...normalizeIssueFilterState(parsed),
+        boardCardDensity: normalizeBoardCardDensity(parsed.boardCardDensity),
+        boardColdLaneMode: normalizeBoardColdLaneMode(parsed.boardColdLaneMode),
+        boardColumnPageSize: normalizeBoardColumnPageSize(parsed.boardColumnPageSize),
+      };
+    }
+  } catch { /* ignore */ }
+  return { ...defaultViewState };
+}
+
+function saveViewState(key: string, state: IssueViewState) {
+  localStorage.setItem(key, JSON.stringify(state));
 }
 
 function getInitialViewState(
-  stored: { viewState: IssueViewState; source: "current" | "legacy" | "default" },
+  key: string,
   initialAssignees?: string[],
   defaultSortField?: IssueSortField,
 ): IssueViewState {
-  const base = stored.source === "default" && defaultSortField
-    ? { ...stored.viewState, sortField: defaultSortField, sortDir: "asc" as const }
-    : stored.viewState;
+  const hasStored = hasStoredViewState(key);
+  const stored = getViewState(key);
+  const base = !hasStored && defaultSortField
+    ? { ...stored, sortField: defaultSortField, sortDir: "asc" as const }
+    : stored;
   if (!initialAssignees) return base;
   return {
     ...base,
@@ -246,34 +230,53 @@ function getInitialViewState(
 }
 
 function getInitialWorkspaceViewState(
-  stored: { viewState: IssueViewState; source: "current" | "legacy" | "default" },
+  key: string,
   initialAssignees?: string[],
   initialWorkspaces?: string[],
   defaultSortField?: IssueSortField,
 ): IssueViewState {
-  const initial = getInitialViewState(stored, initialAssignees, defaultSortField);
-  if (!initialWorkspaces) return initial;
+  const stored = getInitialViewState(key, initialAssignees, defaultSortField);
+  if (!initialWorkspaces) return stored;
   return {
-    ...initial,
+    ...stored,
     workspaces: initialWorkspaces,
     statuses: [],
   };
+}
+
+function hasStoredViewState(key: string): boolean {
+  try {
+    return localStorage.getItem(key) !== null;
+  } catch {
+    return false;
+  }
 }
 
 function getIssueColumnsStorageKey(key: string): string {
   return `${key}:issue-columns`;
 }
 
-function loadIssueCollectionPreferences(
-  location: TaskCollectionPreferenceLocation,
-) {
-  return loadTaskCollectionPreferences<IssueViewState, InboxIssueColumn>({
-    ...location,
-    defaultViewState: defaultViewState,
-    defaultColumns: DEFAULT_INBOX_ISSUE_COLUMNS,
-    normalizeViewState: normalizeIssueViewState,
-    normalizeColumns: (value) => normalizeInboxIssueColumns(Array.isArray(value) ? value : []),
-  });
+function loadIssueColumns(key: string): InboxIssueColumn[] {
+  try {
+    const raw = localStorage.getItem(getIssueColumnsStorageKey(key));
+    if (raw === null) return DEFAULT_INBOX_ISSUE_COLUMNS;
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return DEFAULT_INBOX_ISSUE_COLUMNS;
+    return normalizeInboxIssueColumns(parsed);
+  } catch {
+    return DEFAULT_INBOX_ISSUE_COLUMNS;
+  }
+}
+
+function saveIssueColumns(key: string, columns: InboxIssueColumn[]) {
+  try {
+    localStorage.setItem(
+      getIssueColumnsStorageKey(key),
+      JSON.stringify(normalizeInboxIssueColumns(columns)),
+    );
+  } catch {
+    // Ignore localStorage failures.
+  }
 }
 
 function sortIssues(issues: Issue[], state: IssueViewState): Issue[] {
@@ -302,18 +305,13 @@ function sortIssues(issues: Issue[], state: IssueViewState): Issue[] {
   return sorted;
 }
 
-// Only recency sorts (newest first) get date separators — for any other
-// sort/direction the boundaries would be meaningless.
-function issueDateSeparatorField(state: IssueViewState): "createdAt" | "updatedAt" | null {
-  if (state.sortDir !== "desc") return null;
-  if (state.sortField === "created") return "createdAt";
-  if (state.sortField === "updated") return "updatedAt";
-  return null;
-}
-
 const AGE_BUCKET_DAY_MS = 24 * 60 * 60 * 1000;
 const AGE_BUCKET_WEEK_MS = 7 * AGE_BUCKET_DAY_MS;
 
+// Recency buckets for the date separators shown in date-sorted lists:
+//   0 = within the last day, 1 = within the last week, 2 = older than a week.
+// A separator is drawn between rows whenever the bucket increases, so the
+// "1 day" and "1 week" boundaries appear as the list ages downward.
 export function issueAgeBucket(date: Date | string, now: number = Date.now()): 0 | 1 | 2 {
   const age = now - new Date(date).getTime();
   if (age < AGE_BUCKET_DAY_MS) return 0;
@@ -335,22 +333,28 @@ export function issueAgeBucketsCrossed(
   return crossedBuckets;
 }
 
+// Only recency sorts (newest first) get date separators — for any other
+// sort/direction the boundaries would be meaningless.
+function issueDateSeparatorField(state: IssueViewState): "createdAt" | "updatedAt" | null {
+  if (state.sortDir !== "desc") return null;
+  if (state.sortField === "created") return "createdAt";
+  if (state.sortField === "updated") return "updatedAt";
+  return null;
+}
+
 function IssueDateSeparator({ label }: { label: string }) {
   return (
     <div
-      className="flex items-center gap-3 px-3 py-1.5 sm:pl-0 sm:pr-4"
+      className="flex items-center gap-2 px-3 py-1.5 sm:pl-0 sm:pr-4"
       role="separator"
       aria-label={label}
       data-issues-date-separator=""
     >
-      <span className="h-px min-w-0 flex-1 bg-border/80" aria-hidden="true" data-date-group-rule="" />
-      <span
-        className="shrink-0 text-(length:--text-nano) font-medium uppercase tracking-wider text-muted-foreground/70"
-        data-date-group-label=""
-      >
+      <div className="h-px flex-1 bg-border" />
+      <span className="text-(length:--text-nano) font-medium uppercase tracking-wider text-muted-foreground">
         {label}
       </span>
-      <span className="h-px min-w-0 flex-1 bg-border/80" aria-hidden="true" data-date-group-rule="" />
+      <div className="h-px flex-1 bg-border" />
     </div>
   );
 }
@@ -491,25 +495,7 @@ interface IssuesListProps {
   issueBadgeById?: Map<string, string>;
   onLoadMoreIssues?: () => void;
   onSearchChange?: (search: string) => void;
-  /** Opt in per surface while the canonical task row rolls out across collections. */
-  rowPresentation?: IssueRowPresentation;
-  /** Opt in per surface while the shared collection toolbar rolls out. */
-  toolbarPresentation?: "legacy" | "collection";
   onUpdateIssue: (id: string, data: Record<string, unknown>) => void;
-}
-
-function LegacyIssuesToolbar({ context, search, controls }: CollectionToolbarProps) {
-  return (
-    <div className="flex items-center justify-between gap-2 sm:gap-3">
-      <div className="flex min-w-0 items-center gap-2 sm:gap-3">
-        {context}
-        {search}
-      </div>
-      <div className="flex shrink-0 items-center gap-0.5 sm:gap-1">
-        {controls}
-      </div>
-    </div>
-  );
 }
 
 function IssueSearchInput({
@@ -693,12 +679,7 @@ function SubIssueProgressSummaryStrip({
 // Mobile-only indent for nested task rows (desktop uses IssueRow treeGuides).
 const MOBILE_TREE_INDENT = ["", "pl-4 sm:pl-0", "pl-8 sm:pl-0", "pl-12 sm:pl-0", "pl-16 sm:pl-0"];
 
-export function IssuesList(props: IssuesListProps) {
-  const { enabled: streamlinedUiEnabled } = useStreamlinedUiEnabled();
-  return streamlinedUiEnabled ? <StreamlinedIssuesList {...props} /> : <LegacyIssuesList {...props} />;
-}
-
-function StreamlinedIssuesList({
+export function IssuesList({
   issues,
   isLoading,
   error,
@@ -725,8 +706,6 @@ function StreamlinedIssuesList({
   issueBadgeById,
   onLoadMoreIssues,
   onSearchChange,
-  rowPresentation = "legacy",
-  toolbarPresentation = "legacy",
   onUpdateIssue,
 }: IssuesListProps) {
   const rootRef = useRef<HTMLDivElement | null>(null);
@@ -781,28 +760,17 @@ function StreamlinedIssuesList({
 
   // Scope the storage key per company so folding/view state is independent across companies.
   const scopedKey = selectedCompanyId ? `${viewStateKey}:${selectedCompanyId}` : viewStateKey;
-  const preferenceLocation: TaskCollectionPreferenceLocation = {
-    companyId: selectedCompanyId ?? "__unscoped__",
-    collectionKey: viewStateKey,
-    legacyViewStorageKey: scopedKey,
-    legacyColumnsStorageKey: getIssueColumnsStorageKey(scopedKey),
-  };
   const initialAssigneesKey = initialAssignees?.join("|") ?? "";
   const initialWorkspacesKey = initialWorkspaces?.join("|") ?? "";
-  const initialPreferencesRef = useRef<ReturnType<typeof loadIssueCollectionPreferences> | null>(null);
-  if (initialPreferencesRef.current === null) {
-    initialPreferencesRef.current = loadIssueCollectionPreferences(preferenceLocation);
-  }
-  const initialPreferences = initialPreferencesRef.current;
 
   const [viewState, setViewState] = useState<IssueViewState>(() =>
-    getInitialWorkspaceViewState(initialPreferences, initialAssignees, initialWorkspaces, defaultSortField),
+    getInitialWorkspaceViewState(scopedKey, initialAssignees, initialWorkspaces, defaultSortField),
   );
   const [assigneePickerIssueId, setAssigneePickerIssueId] = useState<string | null>(null);
   const [assigneeSearch, setAssigneeSearch] = useState("");
   const [issueSearch, setIssueSearch] = useState(initialSearch ?? "");
   const [renderedIssueRowLimit, setRenderedIssueRowLimit] = useState(INITIAL_ISSUE_ROW_RENDER_LIMIT);
-  const [visibleIssueColumns, setVisibleIssueColumns] = useState<InboxIssueColumn[]>(initialPreferences.columns);
+  const [visibleIssueColumns, setVisibleIssueColumns] = useState<InboxIssueColumn[]>(() => loadIssueColumns(scopedKey));
   const renderedIssueIdsRef = useRef("");
   const initialServerFillRequestedRef = useRef(false);
   const deferredIssueSearch = useDeferredValue(issueSearch);
@@ -818,39 +786,25 @@ function StreamlinedIssuesList({
     const nextContextKey = `${scopedKey}::${initialAssigneesKey}::${initialWorkspacesKey}`;
     if (prevViewStateContextKey.current !== nextContextKey) {
       prevViewStateContextKey.current = nextContextKey;
-      const preferences = loadIssueCollectionPreferences(preferenceLocation);
-      setViewState(getInitialWorkspaceViewState(preferences, initialAssignees, initialWorkspaces, defaultSortField));
-      setVisibleIssueColumns(preferences.columns);
+      setViewState(getInitialWorkspaceViewState(scopedKey, initialAssignees, initialWorkspaces, defaultSortField));
     }
-  }, [
-    scopedKey,
-    initialAssignees,
-    initialAssigneesKey,
-    initialWorkspaces,
-    initialWorkspacesKey,
-    defaultSortField,
-    preferenceLocation.companyId,
-    preferenceLocation.collectionKey,
-    preferenceLocation.legacyViewStorageKey,
-    preferenceLocation.legacyColumnsStorageKey,
-  ]);
+  }, [scopedKey, initialAssignees, initialAssigneesKey, initialWorkspaces, initialWorkspacesKey, defaultSortField]);
+
+  const prevColumnsScopedKey = useRef(scopedKey);
+  useEffect(() => {
+    if (prevColumnsScopedKey.current !== scopedKey) {
+      prevColumnsScopedKey.current = scopedKey;
+      setVisibleIssueColumns(loadIssueColumns(scopedKey));
+    }
+  }, [scopedKey]);
 
   const updateView = useCallback((patch: Partial<IssueViewState>) => {
     setViewState((prev) => {
       const next = { ...prev, ...patch };
-      saveTaskCollectionPreferences(preferenceLocation, {
-        viewState: next,
-        columns: visibleIssueColumns,
-      });
+      saveViewState(scopedKey, next);
       return next;
     });
-  }, [
-    preferenceLocation.companyId,
-    preferenceLocation.collectionKey,
-    preferenceLocation.legacyColumnsStorageKey,
-    preferenceLocation.legacyViewStorageKey,
-    visibleIssueColumns,
-  ]);
+  }, [scopedKey]);
 
   useEffect(() => {
     if (!experimentalSettingsLoaded || externalObjectsEnabled || viewState.externalObjectStatuses.length === 0) return;
@@ -1093,12 +1047,8 @@ function StreamlinedIssuesList({
     [issues, liveIssueIds],
   );
   const visibleTrailingIssueColumns = useMemo(
-    () => issueTrailingColumns.filter((column) =>
-      visibleIssueColumnSet.has(column)
-      && availableIssueColumnSet.has(column)
-      && (rowPresentation === "legacy" || column !== "updated"),
-    ),
-    [availableIssueColumnSet, rowPresentation, visibleIssueColumnSet],
+    () => issueTrailingColumns.filter((column) => visibleIssueColumnSet.has(column) && availableIssueColumnSet.has(column)),
+    [availableIssueColumnSet, visibleIssueColumnSet],
   );
 
   const issueById = useMemo(() => {
@@ -1685,17 +1635,8 @@ function StreamlinedIssuesList({
   const setIssueColumns = useCallback((next: InboxIssueColumn[]) => {
     const normalized = normalizeInboxIssueColumns(next);
     setVisibleIssueColumns(normalized);
-    saveTaskCollectionPreferences(preferenceLocation, {
-      viewState,
-      columns: normalized,
-    });
-  }, [
-    preferenceLocation.companyId,
-    preferenceLocation.collectionKey,
-    preferenceLocation.legacyColumnsStorageKey,
-    preferenceLocation.legacyViewStorageKey,
-    viewState,
-  ]);
+    saveIssueColumns(scopedKey, normalized);
+  }, [scopedKey]);
 
   const toggleIssueColumn = useCallback((column: InboxIssueColumn, enabled: boolean) => {
     if (enabled) {
@@ -1712,7 +1653,6 @@ function StreamlinedIssuesList({
   }, [onUpdateIssue]);
 
   let remainingRowsToRender = viewState.viewMode === "list" ? renderedIssueRowLimit : Number.POSITIVE_INFINITY;
-  const IssuesToolbar = toolbarPresentation === "collection" ? CollectionToolbar : LegacyIssuesToolbar;
 
   return (
     <div ref={rootRef} className="space-y-4">
@@ -1725,15 +1665,12 @@ function StreamlinedIssuesList({
       ) : null}
 
       {/* Toolbar */}
-      <IssuesToolbar
-        ariaLabel={toolbarPresentation === "collection" ? "Task controls" : undefined}
-        context={(
+      <div className="flex items-center justify-between gap-2 sm:gap-3">
+        <div className="flex min-w-0 items-center gap-2 sm:gap-3">
           <Button size="sm" variant="outline" onClick={() => openCreateIssueDialog()}>
             <Plus className="h-4 w-4 sm:mr-1" />
             <span className="hidden sm:inline">{createButtonLabel}</span>
           </Button>
-        )}
-        search={(
           <IssueSearchInput
             value={issueSearch}
             onDebouncedChange={(nextSearch) => {
@@ -1741,9 +1678,9 @@ function StreamlinedIssuesList({
               onSearchChange?.(nextSearch);
             }}
           />
-        )}
-        controls={(
-          <>
+        </div>
+
+        <div className="flex items-center gap-0.5 sm:gap-1 shrink-0">
           {/* View mode toggle */}
           <div className="flex items-center border border-border rounded-md overflow-hidden mr-1" role="group" aria-label="View mode">
             <button
@@ -1860,15 +1797,13 @@ function StreamlinedIssuesList({
             availableColumns={availableIssueColumns}
             visibleColumnSet={visibleIssueColumnSet}
             onToggleColumn={toggleIssueColumn}
-            showDateGroupSeparators={viewState.showDateGroupSeparators}
-            onToggleDateGroupSeparators={(enabled) => updateView({ showDateGroupSeparators: enabled })}
             onResetColumns={() => setIssueColumns(DEFAULT_INBOX_ISSUE_COLUMNS)}
             title="Choose which task columns stay visible"
             iconOnly
-            rowPresentation={rowPresentation}
           />
 
           <IssueFiltersPopover
+            presentation="legacy"
             state={viewState}
             onChange={updateView}
             buttonVariant="outline"
@@ -1882,7 +1817,6 @@ function StreamlinedIssuesList({
             enableRoutineVisibilityFilter={enableRoutineVisibilityFilter}
             iconOnly
             workspaces={isolatedWorkspacesEnabled ? workspaceOptions : undefined}
-            presentation={rowPresentation === "task" ? "streamlined" : "legacy"}
           />
 
           {/* Sort (list view only) */}
@@ -1969,9 +1903,8 @@ function StreamlinedIssuesList({
               </PopoverContent>
             </Popover>
           )}
-          </>
-        )}
-      />
+        </div>
+      </div>
 
       {(isLoading || externalObjectFilterLoading) && <PageSkeleton variant="issues-list" />}
       {error && <p className="text-sm text-destructive">{error.message}</p>}
@@ -2167,7 +2100,6 @@ function StreamlinedIssuesList({
                     >
                       <IssueRow
                         issue={issue}
-                        presentation={rowPresentation}
                         issueLinkState={issueLinkState}
                         selected={selectedNavKey === `issue:${issue.id}`}
                         onMouseEnter={() => setNavSelectionFromPointer(`issue:${issue.id}`)}
@@ -2215,37 +2147,6 @@ function StreamlinedIssuesList({
                           </>
                         )}
                         className={cn(isMutedIssue && "opacity-70", selectedNavKey === `issue:${issue.id}` && "bg-accent/50 hover:bg-accent/50")}
-                        leadingControl={rowPresentation === "task" ? (
-                          hasChildren ? (
-                            <button
-                              type="button"
-                              data-slot="icon-button"
-                              className="inline-flex h-4 w-4 shrink-0 items-center justify-center"
-                              aria-label={isExpanded ? "Collapse sub-tasks" : "Expand sub-tasks"}
-                              onClick={toggleCollapse}
-                            >
-                              <ChevronRight className={cn("h-3.5 w-3.5 transition-transform", isExpanded && "rotate-90")} />
-                            </button>
-                          ) : (
-                            <span data-slot="task-row-disclosure-spacer" className="h-4 w-4 shrink-0" aria-hidden="true" />
-                          )
-                        ) : undefined}
-                        statusSlot={rowPresentation === "task" ? (
-                          <span className="inline-flex items-center" onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}>
-                            <StatusIcon status={issue.status} size="md" blockerAttention={issue.blockerAttention} onChange={(s) => onUpdateIssue(issue.id, { status: s })} />
-                          </span>
-                        ) : undefined}
-                        metadata={rowPresentation === "task" ? (
-                          <InboxIssueMetaLeading
-                            issue={issue}
-                            isLive={liveIssueIds?.has(issue.id) === true}
-                            subtreeLiveCount={subtreeLiveCounts.get(issue.id) ?? 0}
-                            showStatus={false}
-                            showIdentifier={false}
-                            checklistStepNumber={checklistStepNumber}
-                          />
-                        ) : undefined}
-                        showIdentifier={visibleIssueColumnSet.has("id") && availableIssueColumnSet.has("id")}
                         mobileLeading={
                           hasChildren ? (
                             <button type="button" data-slot="icon-button" onClick={toggleCollapse}>
@@ -2257,7 +2158,7 @@ function StreamlinedIssuesList({
                             </span>
                           )
                         }
-                        desktopMetaLeading={rowPresentation === "legacy" ? (
+                        desktopMetaLeading={(
                           <>
                             {hasChildren ? (
                               <button
@@ -2285,13 +2186,8 @@ function StreamlinedIssuesList({
                               )}
                             />
                           </>
-                        ) : undefined}
+                        )}
                         mobileMeta={issueActivityText(issue).toLowerCase()}
-                        trailingMeta={rowPresentation === "task"
-                          && visibleIssueColumnSet.has("updated")
-                          && availableIssueColumnSet.has("updated")
-                          ? issueActivityTimestamp(issue)
-                          : undefined}
                         desktopTrailing={(
                           visibleTrailingIssueColumns.length > 0 ? (
                             <InboxIssueTrailingColumns
@@ -2424,43 +2320,28 @@ function StreamlinedIssuesList({
                   );
                 };
 
-                const separatorField = viewState.showDateGroupSeparators
-                  ? issueDateSeparatorField(viewState)
-                  : null;
-                const separatorNow = new Date();
+                const separatorField = issueDateSeparatorField(viewState);
+                const separatorNow = Date.now();
                 const nodes: ReactNode[] = [];
-                let previousDateGroup: TaskDateGroup | null = null;
-                let previousAgeBucket: 0 | 1 | 2 | null = null;
+                let prevBucket: 0 | 1 | 2 | null = null;
                 const appendIssueRow = (issue: Issue, depth: number) => {
                   const node = renderIssueRow(issue, depth);
                   // Skip rows the render budget dropped so separators never
                   // dangle above an unrendered (or absent) row.
                   if (node === null) return;
-                  if (separatorField && rowPresentation === "task") {
-                    const currentDateGroup = taskDateGroup(issue[separatorField], separatorNow);
-                    const separatorLabel = taskDateGroupSeparator(previousDateGroup, currentDateGroup);
-                    if (separatorLabel) {
-                      nodes.push(
-                        <IssueDateSeparator
-                          key={`date-sep-${issue.id}-${currentDateGroup}`}
-                          label={separatorLabel}
-                        />,
-                      );
-                    }
-                    previousDateGroup = currentDateGroup;
-                  } else if (separatorField) {
-                    const currentAgeBucket = issueAgeBucket(issue[separatorField], separatorNow.getTime());
-                    for (const crossedBucket of previousAgeBucket === null
+                  if (separatorField) {
+                    const bucket = issueAgeBucket(issue[separatorField], separatorNow);
+                    for (const crossedBucket of prevBucket === null
                       ? []
-                      : issueAgeBucketsCrossed(previousAgeBucket, currentAgeBucket)) {
+                      : issueAgeBucketsCrossed(prevBucket, bucket)) {
                       nodes.push(
                         <IssueDateSeparator
-                          key={`date-sep-${issue.id}-${crossedBucket}`}
+                          key={`age-sep-${issue.id}-${crossedBucket}`}
                           label={issueAgeSeparatorLabel(crossedBucket)}
                         />,
                       );
                     }
-                    previousAgeBucket = currentAgeBucket;
+                    prevBucket = bucket;
                   }
                   nodes.push(node);
                   if (!viewState.collapsedParents.includes(issue.id)) {

--- a/ui/src/components/NewIssueDialog.tsx
+++ b/ui/src/components/NewIssueDialog.tsx
@@ -21,8 +21,10 @@ import {
   issueExecutionWorkspaceModeForExistingWorkspace,
 } from "../lib/project-workspace-defaults";
 import { useProjectOrder } from "../hooks/useProjectOrder";
+import { useStreamlinedUiEnabled } from "../hooks/useStreamlinedUiEnabled";
 import { getRecentAssigneeIds, sortAgentsByRecency, trackRecentAssignee } from "../lib/recent-assignees";
 import { getRecentProjectIds, trackRecentProject } from "../lib/recent-projects";
+import { recordRecentTask } from "../lib/recent-tasks";
 import { buildExecutionPolicy } from "../lib/issue-execution-policy";
 import { isIssueWorkMode, nextWorkMode, workModeMetaFor, workModeMetaList } from "../lib/work-mode-meta";
 import { useToastActions } from "../context/ToastContext";
@@ -472,6 +474,7 @@ export function NewIssueDialog() {
   const statuses = useMemo(() => buildStatusOptions(), []);
   const queryClient = useQueryClient();
   const { pushToast } = useToastActions();
+  const { enabled: streamlinedUiEnabled } = useStreamlinedUiEnabled();
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const titleRef = useRef("");
@@ -641,6 +644,7 @@ export function NewIssueDialog() {
       return { issue, companyId, failures };
     },
     onSuccess: ({ issue, companyId, failures }) => {
+      if (streamlinedUiEnabled) recordRecentTask(issue, currentUserId);
       queryClient.invalidateQueries({ queryKey: queryKeys.issues.list(companyId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.issues.listMineByMe(companyId) });
       queryClient.invalidateQueries({ queryKey: queryKeys.issues.listTouchedByMe(companyId) });

--- a/ui/src/components/PropertiesPanel.test.tsx
+++ b/ui/src/components/PropertiesPanel.test.tsx
@@ -45,8 +45,12 @@ async function flushReact() {
 describe("PropertiesPanel", () => {
   let container: HTMLDivElement;
   let root: Root | null = null;
+  let originalInnerWidth: number;
 
-  async function renderPanel({ panelVisible = true }: { panelVisible?: boolean } = {}) {
+  async function renderPanel({
+    panelVisible = true,
+    taskDetailLayout = false,
+  }: { panelVisible?: boolean; taskDetailLayout?: boolean } = {}) {
     mockPanelState.panelContent = <div data-testid="panel-content">content</div>;
     mockPanelState.panelVisible = panelVisible;
     root = createRoot(container);
@@ -55,7 +59,7 @@ describe("PropertiesPanel", () => {
       root!.render(
         <QueryClientProvider client={queryClient}>
           <TooltipProvider>
-            <PropertiesPanel />
+            <PropertiesPanel taskDetailLayout={taskDetailLayout} />
           </TooltipProvider>
         </QueryClientProvider>,
       );
@@ -64,6 +68,8 @@ describe("PropertiesPanel", () => {
   }
 
   beforeEach(() => {
+    originalInnerWidth = window.innerWidth;
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1440 });
     container = document.createElement("div");
     document.body.appendChild(container);
     window.localStorage.clear();
@@ -76,12 +82,14 @@ describe("PropertiesPanel", () => {
     });
     root = null;
     container.remove();
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: originalInnerWidth });
     vi.clearAllMocks();
   });
 
   describe("classic task interface on (legacy panel)", () => {
     beforeEach(() => {
       mockInstanceSettingsApi.getExperimental.mockResolvedValue({
+        enableStreamlinedUi: true,
         enableClassicTaskInterface: true,
       });
     });
@@ -108,32 +116,59 @@ describe("PropertiesPanel", () => {
   describe("classic task interface off (default resizable pane)", () => {
     beforeEach(() => {
       mockInstanceSettingsApi.getExperimental.mockResolvedValue({
+        enableStreamlinedUi: true,
         enableClassicTaskInterface: false,
       });
     });
 
-    it("renders the default 322px width with a drag grip and a maximize button", async () => {
-      await renderPanel();
+    it("renders the Paper task-detail rail width with a drag grip and a maximize button", async () => {
+      await renderPanel({ taskDetailLayout: true });
       const aside = container.querySelector("aside");
       expect(aside).not.toBeNull();
-      expect(aside!.style.width).toBe("322px");
+      expect(aside!.style.width).toBe("434px");
       expect(aside!.querySelector('[role="separator"][aria-label="Resize panel"]')).not.toBeNull();
       expect(container.querySelector('[aria-label="Maximize side panel"]')).not.toBeNull();
       const inner = aside!.querySelector<HTMLDivElement>(":scope > div:not([role])");
-      expect(inner!.style.width).toBe("322px");
-      expect(inner!.style.minWidth).toBe("322px");
+      expect(inner!.style.width).toBe("434px");
+      expect(inner!.style.minWidth).toBe("434px");
+      expect(aside!.querySelector("header")?.className).toContain(
+        "h-(--side-panel-header-height)",
+      );
     });
 
-    it("uses the pressed side-panel toggle instead of an X to hide the open pane", async () => {
+    it("removes the left divider only while the sidebar is maximized", async () => {
+      await renderPanel({ taskDetailLayout: true });
+      const aside = container.querySelector("aside")!;
+      const maximize = container.querySelector<HTMLButtonElement>(
+        '[aria-label="Maximize side panel"]',
+      )!;
+
+      expect(aside.className).toContain("border-l");
+      maximize.click();
+      await flushReact();
+
+      expect(aside.className).not.toContain("border-l");
+      expect(container.querySelector("section")?.getAttribute("data-maximized")).toBe("true");
+    });
+
+    it("uses an X to close the Streamlined task-detail sidebar", async () => {
+      await renderPanel({ taskDetailLayout: true });
+      const close = container.querySelector<HTMLButtonElement>('[aria-label="Close side panel"]');
+      expect(close).not.toBeNull();
+      expect(close!.querySelector(".lucide-x")).not.toBeNull();
+      expect(container.querySelector('[aria-label="Toggle side panel"]')).toBeNull();
+
+      close!.click();
+      expect(mockSetPanelVisible).toHaveBeenCalledWith(false);
+    });
+
+    it("keeps the production toggle control outside Streamlined task detail", async () => {
       await renderPanel();
       const toggle = container.querySelector<HTMLButtonElement>('[aria-label="Toggle side panel"]');
       expect(toggle).not.toBeNull();
       expect(toggle!.getAttribute("aria-pressed")).toBe("true");
       expect(toggle!.querySelector(".lucide-panel-right-close")).not.toBeNull();
-      expect(container.querySelector('[aria-label="Hide side panel"]')).toBeNull();
-
-      toggle!.click();
-      expect(mockSetPanelVisible).toHaveBeenCalledWith(false);
+      expect(container.querySelector('[aria-label="Close side panel"]')).toBeNull();
     });
 
     it("restores a remembered width from localStorage (clamped to the minimum)", async () => {
@@ -160,6 +195,35 @@ describe("PropertiesPanel", () => {
       expect(aside!.style.width).toBe("0px");
       expect(aside!.style.opacity).toBe("0");
       // No grip while hidden.
+      expect(aside!.querySelector('[role="separator"]')).toBeNull();
+    });
+  });
+
+  describe("Streamlined UI off", () => {
+    beforeEach(() => {
+      mockInstanceSettingsApi.getExperimental.mockResolvedValue({
+        enableStreamlinedUi: false,
+        enableClassicTaskInterface: false,
+      });
+    });
+
+    it("restores master's default resizable panel rather than the classic panel", async () => {
+      await renderPanel({ taskDetailLayout: true });
+      const aside = container.querySelector("aside");
+      expect(aside).not.toBeNull();
+      expect(aside!.style.width).toBe("322px");
+      expect(aside!.querySelector('[role="separator"][aria-label="Resize panel"]')).not.toBeNull();
+      expect(container.querySelector('[aria-label="Maximize side panel"]')).not.toBeNull();
+    });
+
+    it("still honors the independent Classic Task Interface preference", async () => {
+      mockInstanceSettingsApi.getExperimental.mockResolvedValue({
+        enableStreamlinedUi: false,
+        enableClassicTaskInterface: true,
+      });
+      await renderPanel({ taskDetailLayout: true });
+      const aside = container.querySelector("aside");
+      expect(aside!.style.width).toBe("320px");
       expect(aside!.querySelector('[role="separator"]')).toBeNull();
     });
   });

--- a/ui/src/components/PropertiesPanel.tsx
+++ b/ui/src/components/PropertiesPanel.tsx
@@ -2,14 +2,17 @@ import { useCallback, useEffect, useRef, useState, type ReactNode } from "react"
 import { X } from "lucide-react";
 import { usePanel } from "../context/PanelContext";
 import { useClassicTaskInterfaceEnabled } from "../hooks/useClassicTaskInterfaceEnabled";
+import { useStreamlinedUiEnabled } from "../hooks/useStreamlinedUiEnabled";
 import { cn } from "../lib/utils";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { SidePanelFrame, SidePanelWindowControls } from "@/components/side-panel";
 
-export function PropertiesPanel() {
+export function PropertiesPanel({ taskDetailLayout = false }: { taskDetailLayout?: boolean }) {
   const { panelContent, panelContentMode, panelVisible, setPanelVisible } = usePanel();
   const { enabled: classicTaskInterfaceEnabled } = useClassicTaskInterfaceEnabled();
+  const { enabled: streamlinedUiEnabled } = useStreamlinedUiEnabled();
+  const streamlinedTaskDetailLayout = streamlinedUiEnabled && taskDetailLayout;
 
   if (!panelContent) return null;
 
@@ -36,23 +39,27 @@ export function PropertiesPanel() {
 
   return (
     <ResizablePropertiesPanel
+      key={streamlinedTaskDetailLayout ? "task-detail" : "default"}
       panelContent={panelContent}
       panelContentMode={panelContentMode}
       panelVisible={panelVisible}
       setPanelVisible={setPanelVisible}
+      taskDetailLayout={streamlinedTaskDetailLayout}
     />
   );
 }
 
 /* ------------------------------------------------------------------------- *
- * Chat-style (default) resizable/maximizable variant. Everything below
- * renders only when the Classic Task Interface flag is OFF.
+ * Production chat-style resizable/maximizable variant. Streamlined UI only
+ * changes its task-detail dimensions; Classic Task Interface selects the
+ * fixed panel above.
  * ------------------------------------------------------------------------- */
 
 /**
  * Portal target in the redesigned pane's header bar: hosted content (the
- * Properties | Plan | Artifacts tab strip) renders here, left of the window
- * controls. See IssueProperties' flag-ON shell.
+ * Properties | Plan | Artifacts tab strip, including the single active
+ * Properties tab) renders here, left of the window controls. See
+ * IssueProperties' flag-ON shell.
  */
 export const PROPERTIES_PANE_HEADER_SLOT_ID = "properties-pane-header-slot";
 /**
@@ -63,7 +70,9 @@ export const PROPERTIES_PANE_HEADER_SLOT_ID = "properties-pane-header-slot";
 export const PROPERTIES_PANE_FOOTER_SLOT_ID = "properties-pane-footer-slot";
 
 const WIDTH_STORAGE_KEY = "taskChatRedesign.propertiesPaneWidth";
+const TASK_DETAIL_WIDTH_STORAGE_KEY = "taskChatRedesign.taskDetailPropertiesPaneWidth";
 const DEFAULT_PANE_WIDTH = 322;
+const TASK_DETAIL_DEFAULT_PANE_WIDTH = 434;
 const MIN_PANE_WIDTH = 260;
 /** ~236px sidebar + ~420px minimum center column stay usable while resizing. */
 const RESERVED_LAYOUT_WIDTH = 656;
@@ -84,30 +93,30 @@ function clampPaneWidth(width: number): number {
   return Math.min(Math.max(Math.round(width), MIN_PANE_WIDTH), max);
 }
 
-function readStoredPaneWidth(): number {
-  if (typeof window === "undefined") return DEFAULT_PANE_WIDTH;
+function readStoredPaneWidth(storageKey: string, defaultWidth: number): number {
+  if (typeof window === "undefined") return defaultWidth;
   try {
-    const raw = window.localStorage.getItem(WIDTH_STORAGE_KEY);
+    const raw = window.localStorage.getItem(storageKey);
     const parsed = raw === null ? Number.NaN : Number(raw);
-    return Number.isFinite(parsed) ? parsed : DEFAULT_PANE_WIDTH;
+    return Number.isFinite(parsed) ? parsed : defaultWidth;
   } catch {
-    return DEFAULT_PANE_WIDTH;
+    return defaultWidth;
   }
 }
 
-function persistPaneWidth(width: number) {
+function persistPaneWidth(storageKey: string, width: number) {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.setItem(WIDTH_STORAGE_KEY, String(width));
+    window.localStorage.setItem(storageKey, String(width));
   } catch {
     // Ignore storage failures.
   }
 }
 
-function clearStoredPaneWidth() {
+function clearStoredPaneWidth(storageKey: string) {
   if (typeof window === "undefined") return;
   try {
-    window.localStorage.removeItem(WIDTH_STORAGE_KEY);
+    window.localStorage.removeItem(storageKey);
   } catch {
     // Ignore storage failures.
   }
@@ -134,6 +143,7 @@ interface ResizablePropertiesPanelProps {
   panelContentMode: "padded" | "prose" | "full-bleed";
   panelVisible: boolean;
   setPanelVisible: (visible: boolean) => void;
+  taskDetailLayout: boolean;
 }
 
 function ResizablePropertiesPanel({
@@ -141,8 +151,17 @@ function ResizablePropertiesPanel({
   panelContentMode,
   panelVisible,
   setPanelVisible,
+  taskDetailLayout,
 }: ResizablePropertiesPanelProps) {
-  const [width, setWidth] = useState(() => clampPaneWidth(readStoredPaneWidth()));
+  const defaultPaneWidth = taskDetailLayout
+    ? TASK_DETAIL_DEFAULT_PANE_WIDTH
+    : DEFAULT_PANE_WIDTH;
+  const widthStorageKey = taskDetailLayout
+    ? TASK_DETAIL_WIDTH_STORAGE_KEY
+    : WIDTH_STORAGE_KEY;
+  const [width, setWidth] = useState(() =>
+    clampPaneWidth(readStoredPaneWidth(widthStorageKey, defaultPaneWidth)),
+  );
   const [dragging, setDragging] = useState(false);
   const [maximized, setMaximized] = useState(false);
   const [fixedPane, setFixedPane] = useState<FixedPane | null>(null);
@@ -192,8 +211,8 @@ function ResizablePropertiesPanel({
     dragStateRef.current = null;
     setDragging(false);
     document.body.style.userSelect = previousBodyUserSelectRef.current;
-    if (persist) persistPaneWidth(widthRef.current);
-  }, []);
+    if (persist) persistPaneWidth(widthStorageKey, widthRef.current);
+  }, [widthStorageKey]);
 
   const handleGripPointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
     // Primary button only (touch/pen report button 0 or -1 for down events).
@@ -231,9 +250,9 @@ function ResizablePropertiesPanel({
   }, [endDrag]);
 
   const handleGripDoubleClick = useCallback(() => {
-    setWidth(DEFAULT_PANE_WIDTH);
-    clearStoredPaneWidth();
-  }, []);
+    setWidth(defaultPaneWidth);
+    clearStoredPaneWidth(widthStorageKey);
+  }, [defaultPaneWidth, widthStorageKey]);
 
   const handleMaximize = useCallback(() => {
     const aside = asideRef.current;
@@ -307,7 +326,8 @@ function ResizablePropertiesPanel({
       <aside
         ref={asideRef}
         className={cn(
-          "hidden md:flex border-l border-border bg-card flex-col",
+          "hidden md:flex bg-card flex-col",
+          !maximized && "border-l border-border",
           isFixed
             ? "tc-pane-glide fixed z-40 overflow-hidden"
             : cn(
@@ -361,6 +381,7 @@ function ResizablePropertiesPanel({
             presentation="docked"
             maximized={maximized}
             contentMode="full-bleed"
+            headerSize={taskDetailLayout ? "task-detail" : "default"}
             className="flex-1 border-l-0"
             header={(
               <div
@@ -371,6 +392,7 @@ function ResizablePropertiesPanel({
             trailingControls={(
               <SidePanelWindowControls
                 maximized={maximized}
+                closeControl={taskDetailLayout ? "close" : "toggle"}
                 onMaximizedChange={(next) => {
                   if (next) handleMaximize();
                   else handleRestore();

--- a/ui/src/components/TaskChatThread.test.tsx
+++ b/ui/src/components/TaskChatThread.test.tsx
@@ -36,6 +36,7 @@ const DIRECT_ADAPTER_TYPES = [
   "http",
   "custom_plugin",
 ] as const;
+const streamlinedState = vi.hoisted(() => ({ enabled: true }));
 
 vi.mock("@/components/transcript/useLiveRunTranscripts", () => ({
   useLiveRunTranscripts: ({ runs }: { runs: unknown[] }) => {
@@ -60,6 +61,9 @@ vi.mock("@/context/SidebarContext", () => ({
 }));
 vi.mock("@/hooks/useIssuePlanDocument", () => ({
   useIssuePlanDocument: () => planState,
+}));
+vi.mock("@/hooks/useStreamlinedUiEnabled", () => ({
+  useStreamlinedUiEnabled: () => ({ enabled: streamlinedState.enabled, loaded: true }),
 }));
 vi.mock("@/lib/router", () => ({
   Link: ({
@@ -101,6 +105,7 @@ beforeEach(() => {
   transcriptHookRuns.native.length = 0;
   sidebarState.isMobile = false;
   planState.data = null;
+  streamlinedState.enabled = true;
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
@@ -269,6 +274,22 @@ function questionInteraction(
   } as IssueThreadInteraction;
 }
 
+function createLongThreadComments() {
+  return Array.from({ length: 4 }, (_, index) => ({
+    id: `comment-${index + 1}`,
+    companyId: "company-1",
+    issueId: "issue-1",
+    authorType: "user" as const,
+    authorAgentId: null,
+    authorUserId: "user-1",
+    body: `Thread message ${index + 1}`,
+    presentation: null,
+    metadata: null,
+    createdAt: new Date(`2026-08-15T12:0${index}:00.000Z`),
+    updatedAt: new Date(`2026-08-15T12:0${index}:00.000Z`),
+  }));
+}
+
 describe("TaskChatThread draft pass-through", () => {
   it("aligns the desktop thread header with the side-panel tab row", () => {
     render(
@@ -325,6 +346,10 @@ describe("TaskChatThread draft pass-through", () => {
     );
     expect(dock?.classList).toContain("px-4");
     expect(dock?.classList).not.toContain("px-1");
+    expect(dock?.classList).toContain("-mt-(--radius-task-composer)");
+    expect(dock?.classList).not.toContain("pt-1");
+    expect(dock?.classList).not.toContain("bg-background/80");
+    expect(dock?.classList).not.toContain("backdrop-blur");
   });
 
   it("forwards draftKey so the composer restores a task's saved draft", () => {
@@ -332,7 +357,7 @@ describe("TaskChatThread draft pass-through", () => {
 
     render(
       <TaskChatThread
-        comments={[]}
+        comments={createLongThreadComments()}
         onAdd={async () => {}}
         draftKey="task-chat-draft:issue-1"
       />,
@@ -1477,6 +1502,25 @@ describe("TaskChatThread composer alignment", () => {
     expect(dock?.className).toContain("max-w-(--tc-shell-max-w)");
     expect(dock?.className).not.toContain("md:w-(--pct-80)");
   });
+
+  it("uses master's production composer and gutters when Streamlined UI is off", () => {
+    streamlinedState.enabled = false;
+    render(<TaskChatThread comments={[]} onAdd={async () => {}} />);
+
+    const dock = container.querySelector('[data-testid="task-chat-composer-dock"]');
+    const composer = container.querySelector(".paperclip-task-chat-composer");
+    const send = container.querySelector('[data-testid="task-chat-composer-send"]');
+
+    expect(dock?.classList).not.toContain("md:px-0");
+    expect(dock?.classList).not.toContain("md:pb-4");
+    expect(dock?.classList).toContain("bg-background/80");
+    expect(dock?.classList).toContain("pt-1");
+    expect(dock?.classList).not.toContain("-mt-(--radius-task-composer)");
+    expect(composer?.classList).not.toContain("border");
+    expect(composer?.classList).toContain("bg-card");
+    expect(send?.classList).toContain("rounded-md");
+    expect(send?.classList).not.toContain("rounded-full");
+  });
 });
 
 describe("TaskChatThread no-live-execution-path recovery", () => {
@@ -1551,7 +1595,7 @@ describe("TaskChatThread blocker links", () => {
 
     render(
       <TaskChatThread
-        comments={[]}
+        comments={createLongThreadComments()}
         onAdd={async () => {}}
         issueStatus="blocked"
         blockedBy={[
@@ -1586,13 +1630,11 @@ describe("TaskChatThread blocker links", () => {
     expect(notices).toHaveLength(2);
     expect(notices[0]?.getAttribute("data-placement")).toBe("top");
     expect(notices[1]?.getAttribute("data-placement")).toBe("bottom");
+    expect(notices[0]?.textContent).toContain("Blocked byPAP-600Waiting in review");
+    expect(notices[0]?.textContent).toContain("Root blockerPAP-777Actual work");
+    expect(notices[1]?.textContent).toContain("Still blocked byPAP-600Waiting in review");
+    expect(notices[1]?.textContent).toContain("Root blocker remainsPAP-777Actual work");
     for (const notice of notices) {
-      expect(notice.textContent).toContain(
-        "Blocked byPAP-600Waiting in review",
-      );
-      expect(notice.textContent).toContain(
-        "Ultimately blocked byPAP-777Actual work",
-      );
       expect(notice.querySelector('a[href="/issues/PAP-600"]')).not.toBeNull();
       expect(notice.querySelector('a[href="/issues/PAP-777"]')).not.toBeNull();
     }
@@ -1615,7 +1657,7 @@ describe("TaskChatThread blocker links", () => {
 
     render(
       <TaskChatThread
-        comments={[]}
+        comments={createLongThreadComments()}
         onAdd={async () => {}}
         issueStatus="blocked"
         liveIssueIds={new Set(["direct-running", "terminal-running"])}
@@ -1672,24 +1714,20 @@ describe("TaskChatThread blocker links", () => {
     expect(notices).toHaveLength(2);
     expect(notices[0]?.getAttribute("data-placement")).toBe("top");
     expect(notices[1]?.getAttribute("data-placement")).toBe("bottom");
+    expect(notices[0]?.textContent).toContain("Waiting on live work");
+    expect(notices[1]?.textContent).toContain("Still waiting on live work");
     for (const notice of notices) {
-      expect(notice.textContent).toContain("Waiting on live work");
-      const orderedLinks = [
-        ...notice.querySelectorAll(
-          '[data-testid="task-chat-live-work-step"] a',
-        ),
-      ].map((link) => link.textContent);
+      const orderedLinks = [...notice.querySelectorAll('[data-testid="task-chat-live-work-step"] a')]
+        .map((link) => link.textContent);
       expect(orderedLinks).toEqual([
         "PAP-17424Run the guarded cutover",
         "PAP-17425Verify the live projection",
         "PAP-17427Verify the completed projection",
       ]);
-      expect(notice.textContent).toContain(
-        "Now runningPAP-17426Restore live alias projection",
-      );
-      expect(
-        notice.querySelector('a[href="/issues/PAP-17426"]'),
-      ).not.toBeNull();
+      expect(notice.textContent).toContain("Now runningPAP-17426Restore live alias projection");
+      expect(notice.querySelector('a[href="/issues/PAP-17426"]')).not.toBeNull();
+      expect(notice.querySelector('[data-testid="task-chat-live-work-step"] > a')).not.toBeNull();
+      expect(notice.querySelector('[data-testid="task-chat-live-work-step"] > span')).toBeNull();
     }
     expect(
       container.querySelector('[data-testid="task-chat-blocker-links"]'),
@@ -1699,7 +1737,7 @@ describe("TaskChatThread blocker links", () => {
   it("keeps the compact blocker rows when covered work is no longer live", () => {
     render(
       <TaskChatThread
-        comments={[]}
+        comments={createLongThreadComments()}
         onAdd={async () => {}}
         issueStatus="blocked"
         liveIssueIds={new Set()}
@@ -1739,7 +1777,7 @@ describe("TaskChatThread blocker links", () => {
   it("shows only the direct row when the blocker has no deeper unresolved leaf", () => {
     render(
       <TaskChatThread
-        comments={[]}
+        comments={createLongThreadComments()}
         onAdd={async () => {}}
         issueStatus="blocked"
         blockedBy={[
@@ -1763,6 +1801,7 @@ describe("TaskChatThread blocker links", () => {
       "Blocked byPAP-500Direct dependency",
     );
     expect(container.textContent).not.toContain("Ultimately blocked by");
+    expect(container.textContent).not.toContain("Root blocker");
   });
 
   it("keeps a server-selected intermediate blocker on its direct chain", () => {
@@ -1794,7 +1833,7 @@ describe("TaskChatThread blocker links", () => {
 
     render(
       <TaskChatThread
-        comments={[]}
+        comments={createLongThreadComments()}
         onAdd={async () => {}}
         issueStatus="blocked"
         blockedBy={[
@@ -1825,34 +1864,16 @@ describe("TaskChatThread blocker links", () => {
       />,
     );
 
-    for (const notice of container.querySelectorAll(
-      '[data-testid="task-chat-blocker-links"]',
-    )) {
-      expect(notice.textContent).toContain(
-        "Blocked byPAP-600Selected dependency",
-      );
-      expect(notice.textContent).toContain(
-        "Ultimately blocked byPAP-650Stalled intermediate review",
-      );
-    }
+    const notices = container.querySelectorAll('[data-testid="task-chat-blocker-links"]');
+    expect(notices[0]?.textContent).toContain("Blocked byPAP-600Selected dependency");
+    expect(notices[0]?.textContent).toContain("Root blockerPAP-650Stalled intermediate review");
+    expect(notices[1]?.textContent).toContain("Still blocked byPAP-600Selected dependency");
+    expect(notices[1]?.textContent).toContain("Root blocker remainsPAP-650Stalled intermediate review");
     expect(container.textContent).not.toContain("Unrelated dependency");
     expect(container.textContent).not.toContain("Deeper structural leaf");
   });
 
   it("auto-follows the new bottom blocker row when a pinned thread becomes blocked", () => {
-    const comment = {
-      id: "comment-1",
-      companyId: "company-1",
-      issueId: "issue-1",
-      authorType: "user" as const,
-      authorAgentId: null,
-      authorUserId: "user-1",
-      body: "Waiting for the dependency.",
-      presentation: null,
-      metadata: null,
-      createdAt: new Date("2026-08-15T12:00:00.000Z"),
-      updatedAt: new Date("2026-08-15T12:00:00.000Z"),
-    };
     const directBlocker = {
       id: "direct-1",
       identifier: "PAP-500",
@@ -1863,7 +1884,7 @@ describe("TaskChatThread blocker links", () => {
       assigneeUserId: null,
     };
     const baseProps = {
-      comments: [comment],
+      comments: createLongThreadComments(),
       onAdd: async () => {},
       blockedBy: [directBlocker],
     };
@@ -1879,10 +1900,33 @@ describe("TaskChatThread blocker links", () => {
     expect(scroller.scrollTop).toBe(scroller.scrollHeight);
   });
 
+  it("keeps a short blocked thread to one top affordance", () => {
+    render(
+      <TaskChatThread
+        comments={createLongThreadComments().slice(0, 1)}
+        onAdd={async () => {}}
+        issueStatus="blocked"
+        blockedBy={[{
+          id: "direct-1",
+          identifier: "PAP-500",
+          title: "Direct dependency",
+          status: "todo",
+          priority: "medium",
+          assigneeAgentId: null,
+          assigneeUserId: null,
+        }]}
+      />,
+    );
+
+    const notices = container.querySelectorAll('[data-testid="task-chat-blocker-links"]');
+    expect(notices).toHaveLength(1);
+    expect(notices[0]?.getAttribute("data-placement")).toBe("top");
+  });
+
   it("does not show blocker rows outside the blocked state", () => {
     render(
       <TaskChatThread
-        comments={[]}
+        comments={createLongThreadComments()}
         onAdd={async () => {}}
         issueStatus="in_progress"
         blockedBy={[

--- a/ui/src/components/TaskChatThread.tsx
+++ b/ui/src/components/TaskChatThread.tsx
@@ -80,6 +80,7 @@ import { TaskChatComposer } from "@/components/task-chat/TaskChatComposer";
 import { TaskChatQueuedMessages } from "@/components/task-chat/TaskChatQueuedMessages";
 import { useWindowAutoFollow } from "@/components/task-chat/useWindowAutoFollow";
 import { useSidebar } from "@/context/SidebarContext";
+import { useStreamlinedUiEnabled } from "@/hooks/useStreamlinedUiEnabled";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { useIssuePlanDocument } from "@/hooks/useIssuePlanDocument";
@@ -98,6 +99,7 @@ import {
   workProductHref,
 } from "@/lib/issue-artifacts";
 import { heartbeatsApi, type RuntimeRequestResolution } from "@/api/heartbeats";
+import { TaskChatPresentationProvider } from "@/components/task-chat/presentation-mode";
 
 function toMs(value: Date | string | null | undefined): number {
   if (!value) return 0;
@@ -212,6 +214,16 @@ function isRunnerResponseComment(params: {
 // well within this as soon as the settled turn/comment lands.
 const SETTLING_TAIL_MAX_MS = 15_000;
 const EMPTY_LIVE_ISSUE_IDS: ReadonlySet<string> = new Set<string>();
+const LONG_THREAD_BLOCKER_REPEAT_COUNT = 4;
+
+export function shouldRepeatTaskChatBlockers(items: TaskChatItem[]): boolean {
+  const conversationItems = items.filter((item) => (
+    item.kind === "brief"
+    || item.kind === "interaction"
+    || (item.kind === "message" && !item.interstitial)
+  ));
+  return conversationItems.length >= LONG_THREAD_BLOCKER_REPEAT_COUNT;
+}
 
 function isNativePaperclipRunnerRun(
   run:
@@ -432,6 +444,7 @@ function durableInputLabel(
  * folded row. flag-OFF remains byte-for-byte IssueChatThread.
  */
 export function TaskChatThread(props: TaskChatThreadProps) {
+  const { enabled: streamlinedUiEnabled } = useStreamlinedUiEnabled();
   const {
     comments,
     interactions,
@@ -651,16 +664,6 @@ export function TaskChatThread(props: TaskChatThreadProps) {
         ) : null}
       </>
     ) : undefined;
-
-  const bottomBlockerLinks = liveWorkLinks ? (
-    <TaskChatLiveWorkLinks liveWork={liveWorkLinks} placement="bottom" />
-  ) : blockerLinks ? (
-    <TaskChatBlockerLinks
-      directBlocker={blockerLinks.directBlocker}
-      ultimateBlocker={blockerLinks.ultimateBlocker}
-      placement="bottom"
-    />
-  ) : null;
 
   const linkedRunMetaById = useMemo(() => {
     const map = new Map<
@@ -1867,6 +1870,18 @@ export function TaskChatThread(props: TaskChatThreadProps) {
     ? `${tailPlanItem.id}:${tailPlanItem.document.body.length}`
     : "";
   const threadContentKey = `${taskChatContentKey(items)}:${tailContentKey}:${tailPlanContentKey}:${blockerContentKey}`;
+  const repeatBlockersAtBottom = !streamlinedUiEnabled || shouldRepeatTaskChatBlockers(items);
+  const bottomBlockerLinks = repeatBlockersAtBottom
+    ? liveWorkLinks ? (
+        <TaskChatLiveWorkLinks liveWork={liveWorkLinks} placement="bottom" />
+      ) : blockerLinks ? (
+        <TaskChatBlockerLinks
+          directBlocker={blockerLinks.directBlocker}
+          ultimateBlocker={blockerLinks.ultimateBlocker}
+          placement="bottom"
+        />
+      ) : null
+    : null;
 
   // Status-pill inputs for the tail (PAP-461, A1): the run's start, its finish
   // (once terminal), and the "called N tools" summary. Memoized on the
@@ -2311,6 +2326,7 @@ export function TaskChatThread(props: TaskChatThreadProps) {
   useWindowAutoFollow(isMobile ? autoFollowContentKey : 0, isMobile);
 
   return (
+    <TaskChatPresentationProvider mode={streamlinedUiEnabled ? "streamlined" : "production"}>
     <div
       className={cn(
         "flex flex-col",
@@ -2328,6 +2344,7 @@ export function TaskChatThread(props: TaskChatThreadProps) {
                 className={cn(
                   "mx-auto flex w-full max-w-(--tc-shell-max-w) flex-col gap-6 px-4",
                   isMobile ? "pt-4" : "pt-3",
+                  streamlinedUiEnabled && "md:px-0",
                 )}
                 data-testid="task-chat-thread-header"
               >
@@ -2338,7 +2355,10 @@ export function TaskChatThread(props: TaskChatThreadProps) {
               {emptyMessage}
             </div>
             {bottomBlockerLinks ? (
-              <div className="mx-auto w-full max-w-(--tc-shell-max-w) px-4 pb-4">
+              <div className={cn(
+                "mx-auto w-full max-w-(--tc-shell-max-w) px-4 pb-4",
+                streamlinedUiEnabled && "md:px-0",
+              )}>
                 {bottomBlockerLinks}
               </div>
             ) : null}
@@ -2446,7 +2466,11 @@ export function TaskChatThread(props: TaskChatThreadProps) {
             isMobile
               ? "bottom-(--tc-composer-bottom) z-20 transition-[bottom] duration-200 ease-out"
               : "bottom-0 z-10",
-            "mx-auto flex w-full max-w-(--tc-shell-max-w) flex-col gap-2 bg-background/80 px-4 pb-2 pt-1 backdrop-blur supports-[backdrop-filter]:bg-background/60",
+            "mx-auto flex w-full max-w-(--tc-shell-max-w) flex-col gap-2 px-4 pb-2",
+            streamlinedUiEnabled && "md:px-0 md:pb-4",
+            streamlinedUiEnabled && !isMobile
+              ? "-mt-(--radius-task-composer)"
+              : "bg-background/80 pt-1 backdrop-blur supports-[backdrop-filter]:bg-background/60",
           )}
         >
           {composerAccessory}
@@ -2517,5 +2541,6 @@ export function TaskChatThread(props: TaskChatThreadProps) {
         </div>
       ) : null}
     </div>
+    </TaskChatPresentationProvider>
   );
 }

--- a/ui/src/components/issue-properties/IssueProperties.tsx
+++ b/ui/src/components/issue-properties/IssueProperties.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ComponentType } from "react";
 import { createPortal } from "react-dom";
 import { PROPERTIES_PANE_HEADER_SLOT_ID } from "../PropertiesPanel";
-import { pickTextColorForPillBg } from "@/lib/color-contrast";
 import { issueStatusText } from "@/lib/status-colors";
 import { copyTextToClipboard } from "@/lib/clipboard";
 import { Link } from "@/lib/router";
@@ -21,6 +20,7 @@ import { instanceSettingsApi } from "../../api/instanceSettings";
 import { issuesApi } from "../../api/issues";
 import { useIssuePlanDocument } from "@/hooks/useIssuePlanDocument";
 import { useIssueDocuments } from "@/hooks/useIssueDocuments";
+import { useStreamlinedUiEnabled } from "@/hooks/useStreamlinedUiEnabled";
 import { selectAgentArtifactAttachments } from "@/lib/issue-artifacts";
 import { projectsApi } from "../../api/projects";
 import { useCompany } from "../../context/CompanyContext";
@@ -55,6 +55,7 @@ import { StatusIcon } from "../StatusIcon";
 import { PriorityIcon } from "../PriorityIcon";
 import { SHOW_TASK_PRIORITY_UI } from "../../lib/ui-flags";
 import { Identity } from "../Identity";
+import { ProjectTile } from "../ProjectTile";
 import { IssueReferencePill } from "../IssueReferencePill";
 import { formatDate, formatDateTime, cn, projectUrl } from "../../lib/utils";
 import type { IssueExternalObjectGroup } from "../../hooks/useIssueExternalObjects";
@@ -67,9 +68,15 @@ import { Textarea } from "@/components/ui/textarea";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { IssuePropertiesPlansTab } from "./IssuePropertiesPlansTab";
 import { IssuePropertiesArtifactsTab } from "./IssuePropertiesArtifactsTab";
-import { User, ArrowUpRight, Plus, GitBranch, FolderOpen, HardDrive, Check, Clock, RotateCcw, Loader2, CheckCircle2, ArchiveRestore, ChevronLeft } from "lucide-react";
+import { User, ArrowUpRight, Plus, X, GitBranch, FolderOpen, HardDrive, Check, Clock, RotateCcw, Loader2, CheckCircle2, ArchiveRestore, ChevronLeft } from "lucide-react";
 import { AgentIcon } from "../AgentIconPicker";
 import { InlineEntitySelector, type InlineEntityOption } from "../InlineEntitySelector";
 import {
@@ -112,6 +119,20 @@ import { issueReviewPolicyBadge } from "../../lib/review-policy";
 import { IssueCasesPanel } from "../IssueCasesPanel";
 import { ExpandRelationListButton, RemovableIssueReferencePill } from "./relation-controls";
 import { Badge } from "@/components/ui/badge";
+import {
+  TaskDetailReferencesPanel,
+  TaskDetailSubtasksPanel,
+  type TaskDetailRelationItem,
+} from "../task-detail/TaskDetailRelationsPanel";
+
+function splitMiddleTruncation(value: string): { prefix: string; suffix: string } | null {
+  const splitAt = Math.max(value.lastIndexOf("/"), value.lastIndexOf("\\"));
+  if (splitAt <= 0 || splitAt >= value.length - 1) return null;
+  return {
+    prefix: value.slice(0, splitAt + 1),
+    suffix: value.slice(splitAt + 1),
+  };
+}
 
 function TruncatedCopyable({ value, icon: Icon }: { value: string; icon: ComponentType<{ className?: string }> }) {
   const [copied, setCopied] = useState(false);
@@ -125,18 +146,30 @@ function TruncatedCopyable({ value, icon: Icon }: { value: string; icon: Compone
       timerRef.current = setTimeout(() => setCopied(false), 1500);
     } catch { /* noop */ }
   }, [value]);
+  const { enabled: streamlinedUiEnabled } = useStreamlinedUiEnabled();
+  const middle = streamlinedUiEnabled ? splitMiddleTruncation(value) : null;
 
   return (
     <div className="flex items-center gap-1.5 min-w-0 flex-1" title={value}>
       <Icon className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
       <button
         type="button"
-        className="text-sm font-mono min-w-0 truncate text-left cursor-pointer hover:text-foreground transition-colors"
+        className={cn(
+          "cursor-pointer text-left font-mono text-sm transition-colors hover:text-foreground",
+          streamlinedUiEnabled ? "min-w-0 flex-1" : "min-w-0 truncate",
+        )}
         onClick={handleCopy}
         title={value}
         aria-label={`Copy ${value} to clipboard`}
       >
-        {value}
+        {!streamlinedUiEnabled ? value : middle ? (
+          <span className="flex min-w-0" data-middle-truncate="true">
+            <span className="min-w-0 truncate">{middle.prefix}</span>
+            <span className="max-w-1/2 shrink-0 truncate">{middle.suffix}</span>
+          </span>
+        ) : (
+          <span className="block truncate">{value}</span>
+        )}
       </button>
       {copied && (
         <span className={cn("inline-flex items-center gap-1 text-xs shrink-0", issueStatusText.done)} role="status">
@@ -151,6 +184,7 @@ function TruncatedCopyable({ value, icon: Icon }: { value: string; icon: Compone
 interface IssuePropertiesProps {
   issue: Issue;
   childIssues?: Issue[];
+  issueLinkState?: unknown;
   onAddSubIssue?: () => void;
   onUpdate: (data: Record<string, unknown>) => void;
   inline?: boolean;
@@ -176,10 +210,22 @@ export interface IssuePropertiesDocumentDeepLink {
 
 const ISSUE_BLOCKER_SEARCH_LIMIT = 50;
 const ISSUE_PROPERTY_RELATION_PREVIEW_COUNT = 5;
+const STREAMLINED_PANE_TAB_CLASS =
+  "task-detail-pane-tab h-7 rounded-md text-sm font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+
+type IssuePaneTab = "properties" | "subtasks" | "references" | "plans" | "artifacts";
+
+interface IssuePaneTabDescriptor {
+  value: IssuePaneTab;
+  label: string;
+  count?: number;
+  closable: boolean;
+}
 
 export function IssueProperties({
   issue,
   childIssues = [],
+  issueLinkState,
   onAddSubIssue,
   onUpdate,
   inline,
@@ -208,12 +254,17 @@ export function IssueProperties({
   // the folder the policy exists to hide.
   const hideHostPaths =
     experimentalSettings === undefined || experimentalSettings.enableManagedSandboxOnly === true;
+  const { enabled: streamlinedUiEnabled } = useStreamlinedUiEnabled();
   // Classic Task Interface: gate the Properties | Plans | Artifacts tab shell.
   // Flag ON renders the legacy stacked sections verbatim (no Tabs wrapper);
   // flag OFF — including while settings load — renders the chat-style tab
   // shell. This pane is always task-scoped, so the flag alone is a sufficient
   // gate.
+  // Classic Task Interface alone controls the production tabbed-vs-stacked
+  // boundary. Streamlined UI layers new relationship tabs and visual treatment
+  // onto master's tabbed task-chat pane without changing that boundary.
   const taskChatShellEnabled = experimentalSettings?.enableClassicTaskInterface !== true;
+  const streamlinedPropertiesEnabled = streamlinedUiEnabled && taskChatShellEnabled;
   // When hosted by the resizable PropertiesPanel, the tab strip portals into
   // the pane's header bar (left of the window controls). The slot only exists
   // once the panel has committed, hence the effect; inline hosts (mobile sheet)
@@ -264,7 +315,8 @@ export function IssueProperties({
     (paneTabWorkProducts?.length ?? 0) > 0
     || paneTabStandaloneDocuments.length > 0
     || selectAgentArtifactAttachments(paneTabAttachments, paneTabWorkProducts).length > 0;
-  const [paneTab, setPaneTab] = useState("properties");
+  const [paneTab, setPaneTab] = useState<IssuePaneTab>("properties");
+  const [closedPaneTabs, setClosedPaneTabs] = useState<Set<IssuePaneTab>>(() => new Set());
   // Once a plan document exists, surface it: switch the pane to the Plan tab so
   // the write-up is exposed alongside the plan-approval card, instead of leaving
   // the user on Properties. Only auto-switch until the user picks a tab by hand —
@@ -272,8 +324,11 @@ export function IssueProperties({
   const paneTabUserChosenRef = useRef(false);
   const handlePaneTabChange = useCallback((value: string) => {
     paneTabUserChosenRef.current = true;
-    setPaneTab(value);
+    setPaneTab(value as IssuePaneTab);
   }, []);
+  useEffect(() => {
+    setClosedPaneTabs(new Set());
+  }, [issue.id]);
   useEffect(() => {
     if (hasPlanTab && !paneTabUserChosenRef.current) {
       setPaneTab("plans");
@@ -281,9 +336,16 @@ export function IssueProperties({
   }, [hasPlanTab]);
   useEffect(() => {
     if (!documentDeepLink) return;
-    if (documentDeepLink.tab === "document") return;
+    const targetTab = documentDeepLink.tab;
+    if (targetTab === "document") return;
     paneTabUserChosenRef.current = true;
-    setPaneTab(documentDeepLink.tab);
+    setPaneTab(targetTab);
+    setClosedPaneTabs((current) => {
+      if (!current.has(targetTab)) return current;
+      const next = new Set(current);
+      next.delete(targetTab);
+      return next;
+    });
   }, [documentDeepLink]);
   const [assigneeOpen, setAssigneeOpen] = useState(false);
   const [assigneeSearch, setAssigneeSearch] = useState("");
@@ -305,6 +367,7 @@ export function IssueProperties({
   const [blockedByExpanded, setBlockedByExpanded] = useState(false);
   const [blockingExpanded, setBlockingExpanded] = useState(false);
   const [subTasksExpanded, setSubTasksExpanded] = useState(false);
+  const [subtasksOpen, setSubtasksOpen] = useState(false);
   const [relatedTasksExpanded, setRelatedTasksExpanded] = useState(false);
   const [parentOpen, setParentOpen] = useState(false);
   const [parentSearch, setParentSearch] = useState("");
@@ -606,6 +669,29 @@ export function IssueProperties({
       .filter((identifier) => !excluded.has(identifier))
       .map((identifier) => ({ id: identifier, identifier, title: identifier }));
   }, [childIssues, issue.blockedBy, issue.blocks, issue.relatedWork?.outbound, referencedIssueIdentifiers]);
+  const panelReferencedTasks = useMemo<TaskDetailRelationItem[]>(() => {
+    const outbound = issue.relatedWork?.outbound.map(({ issue: referenced }) => ({
+      id: referenced.id,
+      identifier: referenced.identifier,
+      title: referenced.title,
+      status: referenced.status,
+    })) ?? [];
+    if (outbound.length > 0) return outbound;
+    return referencedIssueIdentifiers.map((identifier) => ({
+      id: identifier,
+      identifier,
+      title: identifier,
+    }));
+  }, [issue.relatedWork?.outbound, referencedIssueIdentifiers]);
+  const panelMentionedInTasks = useMemo<TaskDetailRelationItem[]>(
+    () => issue.relatedWork?.inbound.map(({ issue: referenced }) => ({
+      id: referenced.id,
+      identifier: referenced.identifier,
+      title: referenced.title,
+      status: referenced.status,
+    })) ?? [],
+    [issue.relatedWork?.inbound],
+  );
   const projectLink = (id: string | null) => {
     if (!id) return null;
     const project = projects?.find((p) => p.id === id) ?? null;
@@ -1046,6 +1132,18 @@ export function IssueProperties({
   ) : (
     <span className="text-sm text-muted-foreground">None</span>
   );
+  const labelsExtra = !streamlinedPropertiesEnabled && (issue.labelIds ?? []).length > 0 ? (
+    <button
+      type="button"
+      className="inline-flex items-center gap-1 rounded-full border border-border px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+      onClick={() => setLabelsOpen(true)}
+      aria-label="Add label"
+      title="Add label"
+    >
+      <Plus className="h-3 w-3" />
+      Add label
+    </button>
+  ) : undefined;
   const watchdogContent = (
     <div className="space-y-3 p-2">
       <div className="space-y-1.5">
@@ -1481,14 +1579,14 @@ export function IssueProperties({
   }, [issue.labelIds, issue.labels, labels]);
 
   const labelsTrigger = selectedIssueLabels.length > 0 ? (
-    <div className="flex items-center gap-1 flex-wrap">
+    <div className="flex min-w-0 flex-col items-start gap-1">
       {selectedIssueLabels.slice(0, 3).map((label) => (
         <PropertyChip
           key={label.id}
+          className="border-0"
           style={{
-            borderColor: label.color,
             backgroundColor: `${label.color}22`,
-            color: pickTextColorForPillBg(label.color, 0.13),
+            color: label.color,
           }}
         >
           {label.name}
@@ -1503,19 +1601,6 @@ export function IssueProperties({
   ) : (
     <span className="text-sm text-muted-foreground">None</span>
   );
-  const labelsExtra = (issue.labelIds ?? []).length > 0 ? (
-    <button
-      type="button"
-      className="inline-flex items-center gap-1 rounded-full border border-border px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
-      onClick={() => setLabelsOpen(true)}
-      aria-label="Add label"
-      title="Add label"
-    >
-      <Plus className="h-3 w-3" />
-      Add label
-    </button>
-  ) : undefined;
-
   const labelsContent = (
     <>
       <input
@@ -1832,9 +1917,10 @@ export function IssueProperties({
 
   const projectTrigger = issue.projectId ? (
     <>
-      <span
-        className="shrink-0 h-3 w-3 rounded-sm"
-        style={{ backgroundColor: orderedProjects.find((p) => p.id === issue.projectId)?.color ?? "var(--project-seed)" }}
+      <ProjectTile
+        color={issueProject?.color ?? null}
+        icon={issueProject?.icon ?? null}
+        size="xs"
       />
       <span className="text-sm truncate min-w-0" title={projectName(issue.projectId)}>{projectName(issue.projectId)}</span>
     </>
@@ -1905,9 +1991,10 @@ export function IssueProperties({
               }}
             >
               {option.kind === "project" ? (
-                <span
-                  className="shrink-0 h-3 w-3 rounded-sm"
-                  style={{ backgroundColor: option.color ?? "var(--project-seed)" }}
+                <ProjectTile
+                  color={option.project.color ?? null}
+                  icon={option.project.icon ?? null}
+                  size="xs"
                 />
               ) : null}
               {option.name}
@@ -1932,6 +2019,38 @@ export function IssueProperties({
     ? blockingIssues
     : blockingIssues.slice(0, ISSUE_PROPERTY_RELATION_PREVIEW_COUNT);
   const hiddenBlockingIssueCount = blockingIssues.length - visibleBlockingIssues.length;
+  const blockedByTrigger = blockedByRelations.length > 0 ? (
+    <div className="flex min-w-0 flex-col items-start gap-1">
+      {blockedByRelations.slice(0, 2).map((relation) => (
+        <PropertyChip key={relation.id}>
+          {relation.identifier ?? relation.title}
+        </PropertyChip>
+      ))}
+      {blockedByRelations.length > 2 ? (
+        <Badge variant="outline" className="border-border text-muted-foreground">
+          +{blockedByRelations.length - 2} more
+        </Badge>
+      ) : null}
+    </div>
+  ) : (
+    <span className="text-sm text-muted-foreground">None</span>
+  );
+  const subtasksTrigger = childIssues.length > 0 ? (
+    <div className="flex min-w-0 flex-col items-start gap-1">
+      {childIssues.slice(0, 2).map((child) => (
+        <PropertyChip key={child.id}>
+          {child.identifier ?? child.title}
+        </PropertyChip>
+      ))}
+      {childIssues.length > 2 ? (
+        <Badge variant="outline" className="border-border text-muted-foreground">
+          +{childIssues.length - 2} more
+        </Badge>
+      ) : null}
+    </div>
+  ) : (
+    <span className="text-sm text-muted-foreground">None</span>
+  );
   const visibleRelatedTasks = relatedTasksExpanded
     ? relatedTasks
     : relatedTasks.slice(0, ISSUE_PROPERTY_RELATION_PREVIEW_COUNT);
@@ -2048,9 +2167,20 @@ export function IssueProperties({
     </>
   );
   const blockerSearchActive = normalizedBlockedBySearch.length > 0;
-  const blockerSourceIssues = blockerSearchActive ? searchedBlockedByIssues : allIssues;
-  const blockerOptions = (blockerSourceIssues ?? [])
-    .filter((candidate) => candidate.id !== issue.id);
+  const blockerSourceIssues = blockerSearchActive
+    ? searchedBlockedByIssues
+    : streamlinedPropertiesEnabled
+      ? [...(issue.blockedBy ?? []), ...(allIssues ?? [])]
+      : allIssues;
+  const blockerOptions = streamlinedPropertiesEnabled
+    ? Array.from(
+        new Map(
+          (blockerSourceIssues ?? [])
+            .filter((candidate) => candidate.id !== issue.id)
+            .map((candidate) => [candidate.id, candidate]),
+        ).values(),
+      )
+    : (blockerSourceIssues ?? []).filter((candidate) => candidate.id !== issue.id);
   if (!blockerSearchActive) {
     blockerOptions.sort((a, b) => {
       const aLabel = `${a.identifier ?? ""} ${a.title}`.trim();
@@ -2073,7 +2203,6 @@ export function IssueProperties({
   const removeBlockedBy = (blockedByIssueId: string) => {
     onUpdate({ blockedByIssueIds: blockedByIds.filter((candidate) => candidate !== blockedByIssueId) });
   };
-
   const blockedByContent = (
     <>
       <input
@@ -2136,10 +2265,52 @@ export function IssueProperties({
       Add blocker
     </button>
   );
+  const subtasksContent = (
+    <>
+      <div className="max-h-48 overflow-y-auto overscroll-contain">
+        {childIssues.length > 0 ? childIssues.map((child) => (
+          <Link
+            key={child.id}
+            to={`/issues/${child.identifier ?? child.id}`}
+            state={issueLinkState}
+            className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs hover:bg-accent/50"
+            onClick={() => setSubtasksOpen(false)}
+          >
+            <StatusIcon status={child.status} className="h-3 w-3" />
+            <span className="min-w-0 truncate">
+              {child.identifier ? `${child.identifier} ` : ""}
+              {child.title}
+            </span>
+          </Link>
+        )) : (
+          <div className="px-2 py-2 text-xs text-muted-foreground">No subtasks yet.</div>
+        )}
+      </div>
+      {onAddSubIssue ? (
+        <div className="mt-2 border-t border-border pt-2">
+          <button
+            type="button"
+            className="flex w-full items-center justify-center gap-1.5 rounded border border-border px-2 py-1.5 text-xs hover:bg-accent/50"
+            onClick={() => {
+              setSubtasksOpen(false);
+              onAddSubIssue();
+            }}
+          >
+            <Plus className="h-3 w-3" />
+            Add subtask
+          </button>
+        </div>
+      ) : null}
+    </>
+  );
 
   const propertiesBody = (
-    <div>
-      <PropertySection title="Triage" first>
+    <div className={cn(streamlinedPropertiesEnabled && "task-detail-properties pl-4")}>
+      <PropertySection
+        title={streamlinedPropertiesEnabled ? "Work" : "Triage"}
+        first
+        streamlined={streamlinedPropertiesEnabled}
+      >
         <PropertyRow label="Status">
           <StatusIcon
             status={issue.status}
@@ -2160,19 +2331,6 @@ export function IssueProperties({
             />
           </PropertyRow>
         )}
-
-        <PropertyPicker
-          inline={inline}
-          label="Labels"
-          open={labelsOpen}
-          onOpenChange={(open) => { setLabelsOpen(open); if (!open) setLabelSearch(""); }}
-          triggerContent={labelsTrigger}
-          triggerClassName="min-w-0 max-w-full"
-          popoverClassName="w-64"
-          extra={labelsExtra}
-        >
-          {labelsContent}
-        </PropertyPicker>
 
         <PropertyPicker
           inline={inline}
@@ -2228,9 +2386,23 @@ export function IssueProperties({
         >
           {projectContent}
         </PropertyPicker>
+
+        <PropertyPicker
+          inline={inline}
+          label="Labels"
+          open={labelsOpen}
+          onOpenChange={(open) => { setLabelsOpen(open); if (!open) setLabelSearch(""); }}
+          triggerContent={labelsTrigger}
+          triggerClassName="min-w-0 max-w-full"
+          popoverClassName="w-64"
+          extra={labelsExtra}
+          stacked
+        >
+          {labelsContent}
+        </PropertyPicker>
       </PropertySection>
 
-      <PropertySection title="Relationships">
+      <PropertySection title="Relationships" streamlined={streamlinedPropertiesEnabled}>
         <PropertyPicker
           inline={inline}
           label="Parent"
@@ -2247,7 +2419,23 @@ export function IssueProperties({
           {parentContent}
         </PropertyPicker>
 
-        {inline ? (
+        {streamlinedPropertiesEnabled ? (
+          <PropertyPicker
+            inline={inline}
+            label="Blocked by"
+            open={blockedByOpen}
+            onOpenChange={(open) => {
+              setBlockedByOpen(open);
+              if (!open) setBlockedBySearch("");
+            }}
+            triggerContent={blockedByTrigger}
+            triggerClassName="min-w-0 max-w-full"
+            popoverClassName="w-72"
+            stacked
+          >
+            {blockedByContent}
+          </PropertyPicker>
+        ) : inline ? (
           <div>
             <PropertyRow label="Blocked by" wrap>
               {visibleBlockedByRelations.map((relation) => (
@@ -2265,11 +2453,11 @@ export function IssueProperties({
               />
               {renderAddBlockedByButton(() => setBlockedByOpen((open) => !open))}
             </PropertyRow>
-            {blockedByOpen && (
+            {blockedByOpen ? (
               <div className="rounded-md border border-border bg-popover p-1 mb-2">
                 {blockedByContent}
               </div>
-            )}
+            ) : null}
           </div>
         ) : (
           <PropertyRow label="Blocked by" wrap>
@@ -2293,9 +2481,7 @@ export function IssueProperties({
                 if (!open) setBlockedBySearch("");
               }}
             >
-              <PopoverTrigger asChild>
-                {renderAddBlockedByButton()}
-              </PopoverTrigger>
+              <PopoverTrigger asChild>{renderAddBlockedByButton()}</PopoverTrigger>
               <PopoverContent className="w-72 p-1" align="end" collisionPadding={16}>
                 {blockedByContent}
               </PopoverContent>
@@ -2305,7 +2491,7 @@ export function IssueProperties({
 
         <PropertyRow label="Blocking" wrap>
           {blockingIssues.length > 0 ? (
-            <div className="flex flex-wrap items-center gap-1.5">
+            <div className="flex flex-col items-start gap-1.5">
               {visibleBlockingIssues.map((relation) => (
                 <IssueReferencePill key={relation.id} issue={relation} />
               ))}
@@ -2320,17 +2506,25 @@ export function IssueProperties({
           )}
         </PropertyRow>
 
-        {/* Chat shell promotes sub-tasks to their own pane tab (the full tree),
-            so the slim pill row here would duplicate that home (PAP-496). Keep
-            the pill row only for the classic center-column layout. */}
-        {taskChatShellEnabled ? null : (
+        {streamlinedPropertiesEnabled ? (
+          <PropertyPicker
+            inline={inline}
+            label="Subtasks"
+            open={subtasksOpen}
+            onOpenChange={setSubtasksOpen}
+            triggerContent={subtasksTrigger}
+            triggerClassName="min-w-0 max-w-full"
+            popoverClassName="w-72"
+            stacked
+          >
+            {subtasksContent}
+          </PropertyPicker>
+        ) : !taskChatShellEnabled ? (
           <PropertyRow label="Sub-tasks" wrap>
-            <div className="flex flex-wrap items-center gap-1.5">
-              {childIssues.length > 0
-                ? visibleChildIssues.map((child) => (
-                  <IssueReferencePill key={child.id} issue={child} />
-                ))
-                : null}
+            <div className="flex flex-col items-start gap-1.5">
+              {visibleChildIssues.map((child) => (
+                <IssueReferencePill key={child.id} issue={child} />
+              ))}
               <ExpandRelationListButton
                 hiddenCount={hiddenChildIssueCount}
                 expanded={subTasksExpanded}
@@ -2348,11 +2542,11 @@ export function IssueProperties({
               ) : null}
             </div>
           </PropertyRow>
-        )}
+        ) : null}
 
-        {relatedTasks.length > 0 ? (
-          <PropertyRow label="Related tasks" wrap>
-            <div className="flex flex-wrap items-center gap-1.5">
+        {(!streamlinedPropertiesEnabled || !taskChatShellEnabled) && relatedTasks.length > 0 ? (
+          <PropertyRow label={streamlinedPropertiesEnabled ? "Referenced" : "Related tasks"} wrap>
+            <div className="flex flex-col items-start gap-1.5">
               {visibleRelatedTasks.map((related) => (
                 <IssueReferencePill key={related.id} issue={related} />
               ))}
@@ -2373,7 +2567,7 @@ export function IssueProperties({
         />
       </PropertySection>
 
-      <PropertySection title="Execution">
+      <PropertySection title="Execution" streamlined={streamlinedPropertiesEnabled}>
         {/* Read-only: agents set the policy, the board does not. */}
         {reviewPolicyBadge ? (
           <PropertyRow label="Approvals">
@@ -2482,7 +2676,7 @@ export function IssueProperties({
       </PropertySection>
 
       {workspacePickerEligible || hasWorkspaceRuntimeControls || issue.currentExecutionWorkspace?.branchName || issue.currentExecutionWorkspace?.cwd || issue.executionWorkspaceId ? (
-        <PropertySection title="Workspace">
+        <PropertySection title="Workspace" streamlined={streamlinedPropertiesEnabled}>
           {workspacePickerEligible ? (
             <PropertyPicker
               inline={inline}
@@ -2651,7 +2845,7 @@ export function IssueProperties({
         </PropertySection>
       ) : null}
 
-      <PropertySection title="About">
+      <PropertySection title="About" streamlined={streamlinedPropertiesEnabled}>
         {originatingActor ? (
           <PropertyRow label="Originating">
             {originatingActor.kind === "agent" ? (
@@ -2683,19 +2877,31 @@ export function IssueProperties({
         ) : null}
         {issue.startedAt && (
           <PropertyRow label="Started">
-            <span className="text-sm">{formatDateTime(issue.startedAt)}</span>
+            <span
+              className={streamlinedPropertiesEnabled ? "min-w-0 truncate whitespace-nowrap text-sm" : "text-sm"}
+              title={streamlinedPropertiesEnabled ? formatDateTime(issue.startedAt) : undefined}
+            >{formatDateTime(issue.startedAt)}</span>
           </PropertyRow>
         )}
         {issue.completedAt && (
           <PropertyRow label="Completed">
-            <span className="text-sm">{formatDateTime(issue.completedAt)}</span>
+            <span
+              className={streamlinedPropertiesEnabled ? "min-w-0 truncate whitespace-nowrap text-sm" : "text-sm"}
+              title={streamlinedPropertiesEnabled ? formatDateTime(issue.completedAt) : undefined}
+            >{formatDateTime(issue.completedAt)}</span>
           </PropertyRow>
         )}
         <PropertyRow label="Created">
-          <span className="text-sm">{formatDateTime(issue.createdAt)}</span>
+          <span
+            className={streamlinedPropertiesEnabled ? "min-w-0 truncate whitespace-nowrap text-sm" : "text-sm"}
+            title={streamlinedPropertiesEnabled ? formatDateTime(issue.createdAt) : undefined}
+          >{formatDateTime(issue.createdAt)}</span>
         </PropertyRow>
         <PropertyRow label="Updated">
-          <span className="text-sm">{timeAgo(issue.updatedAt)}</span>
+          <span
+            className={streamlinedPropertiesEnabled ? "min-w-0 truncate whitespace-nowrap text-sm" : "text-sm"}
+            title={streamlinedPropertiesEnabled ? timeAgo(issue.updatedAt) : undefined}
+          >{timeAgo(issue.updatedAt)}</span>
         </PropertyRow>
         {issue.archivedAt && issue.archivedByActorType === "agent" && issue.archivedByAgentId ? (
           (() => {
@@ -2761,13 +2967,51 @@ export function IssueProperties({
   // Classic Task Interface ON: the legacy stacked pane, byte-for-byte.
   if (!taskChatShellEnabled || sidePanelContentOnly) return propertiesBody;
 
-  // Chat-style with nothing to switch between: no tab strip — the header bar
-  // shows a plain title and the pane body is just the properties stack.
-  if (!hasPlanTab && !hasArtifactsTab) {
+  const hasSubtasksTab = streamlinedPropertiesEnabled && childIssues.length > 0;
+  const hasReferencesTab = streamlinedPropertiesEnabled
+    && (panelReferencedTasks.length > 0 || panelMentionedInTasks.length > 0);
+  const availablePaneTabs: IssuePaneTabDescriptor[] = [
+    { value: "properties", label: "Properties", closable: false },
+    ...(hasSubtasksTab
+      ? [{ value: "subtasks" as const, label: "Subtasks", count: childIssues.length, closable: true }]
+      : []),
+    ...(hasReferencesTab
+      ? [{ value: "references" as const, label: "References", closable: true }]
+      : []),
+    ...(hasPlanTab
+      ? [{ value: "plans" as const, label: "Plan", closable: true }]
+      : []),
+    ...(hasArtifactsTab
+      ? [{ value: "artifacts" as const, label: "Artifacts", closable: true }]
+      : []),
+  ];
+  const visiblePaneTabs = availablePaneTabs.filter(
+    (tab) => tab.value === "properties" || !closedPaneTabs.has(tab.value),
+  );
+  const hiddenPaneTabs = availablePaneTabs.filter((tab) => closedPaneTabs.has(tab.value));
+
+  // Chat-style with nothing to switch between: render one selected tab button
+  // so the header uses the same filled-tab treatment as the multi-tab state.
+  if (!hasSubtasksTab && !hasReferencesTab && !hasPlanTab && !hasArtifactsTab) {
     return (
       <>
         {paneHeaderSlot
-          ? createPortal(<span className="text-sm font-medium">Properties</span>, paneHeaderSlot)
+          ? streamlinedPropertiesEnabled ? createPortal(
+              <div className="flex items-center" role="tablist" aria-label="Properties panel sections">
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected="true"
+                  className={cn(
+                    STREAMLINED_PANE_TAB_CLASS,
+                    "inline-flex flex-none items-center bg-muted px-3",
+                  )}
+                >
+                  Properties
+                </button>
+              </div>,
+              paneHeaderSlot,
+            ) : createPortal(<span className="text-sm font-medium">Properties</span>, paneHeaderSlot)
           : null}
         {propertiesBody}
       </>
@@ -2783,37 +3027,150 @@ export function IssueProperties({
   const activePaneTab =
     (paneTab === "plans" && !hasPlanTab)
     || (paneTab === "artifacts" && !hasArtifactsTab)
+    || (paneTab === "subtasks" && !hasSubtasksTab)
+    || (paneTab === "references" && !hasReferencesTab)
+    || closedPaneTabs.has(paneTab)
       ? "properties"
       : paneTab;
-  // In the pane header the strip stretches to the bar's full height and the
-  // active underline drops to bottom-0, so it hugs the header's border line.
+  const closePaneTab = (value: IssuePaneTab) => {
+    if (value === "properties") return;
+    paneTabUserChosenRef.current = true;
+    setClosedPaneTabs((current) => {
+      const next = new Set(current);
+      next.add(value);
+      return next;
+    });
+    if (activePaneTab !== value) return;
+    const closingIndex = visiblePaneTabs.findIndex((tab) => tab.value === value);
+    const fallback = visiblePaneTabs[closingIndex - 1]
+      ?? visiblePaneTabs[closingIndex + 1]
+      ?? availablePaneTabs[0];
+    setPaneTab(fallback.value);
+  };
+  const reopenPaneTab = (value: IssuePaneTab) => {
+    paneTabUserChosenRef.current = true;
+    setClosedPaneTabs((current) => {
+      if (!current.has(value)) return current;
+      const next = new Set(current);
+      next.delete(value);
+      return next;
+    });
+    setPaneTab(value);
+  };
+  const codexStylePaneTabs = Boolean(paneHeaderSlot && streamlinedPropertiesEnabled);
+  // Production keeps the master underline treatment. Streamlined task detail
+  // uses the compact, truncating Codex-inspired pane-tab treatment instead.
   const paneTabTriggerClass = paneHeaderSlot
-    ? "h-full group-data-[orientation=horizontal]/tabs:after:bottom-0"
+    ? streamlinedPropertiesEnabled
+      ? cn(
+          STREAMLINED_PANE_TAB_CLASS,
+          "min-w-0 flex-1 justify-start overflow-hidden after:hidden",
+        )
+      : "h-full group-data-[orientation=horizontal]/tabs:after:bottom-0"
     : undefined;
-  const tabStrip = (
+  const paneTabs = codexStylePaneTabs ? visiblePaneTabs : availablePaneTabs;
+  const tabList = (
     <TabsList
       variant="line"
       className={
         paneHeaderSlot
-          ? "items-stretch justify-start gap-1 p-0 group-data-[orientation=horizontal]/tabs:h-full"
+          ? streamlinedPropertiesEnabled
+            ? "min-w-0 flex-1 items-center justify-start gap-0 overflow-hidden p-0 group-data-[orientation=horizontal]/tabs:h-full"
+            : "items-stretch justify-start gap-1 p-0 group-data-[orientation=horizontal]/tabs:h-full"
           : "w-full justify-start gap-1"
       }
     >
-      <TabsTrigger value="properties" className={paneTabTriggerClass}>
-        Properties
-      </TabsTrigger>
-      {hasPlanTab ? (
-        <TabsTrigger value="plans" className={paneTabTriggerClass}>
-          Plan
-        </TabsTrigger>
-      ) : null}
-      {hasArtifactsTab ? (
-        <TabsTrigger value="artifacts" className={paneTabTriggerClass}>
-          Artifacts
-        </TabsTrigger>
-      ) : null}
+      {paneTabs.map((tab, index) => {
+        const trigger = (
+          <TabsTrigger
+            key={codexStylePaneTabs ? undefined : tab.value}
+            value={tab.value}
+            className={cn(
+              paneTabTriggerClass,
+              codexStylePaneTabs && "mx-1.5 hover:bg-accent/50 group-focus-within/pane-tab:bg-accent/50",
+              codexStylePaneTabs && "px-3",
+            )}
+          >
+            <span
+              className={cn(
+                codexStylePaneTabs
+                  && "task-detail-pane-tab-label min-w-0 flex-1 overflow-hidden whitespace-nowrap",
+              )}
+              title={tab.label}
+            >
+              {tab.label}
+            </span>
+            {tab.count ? (
+              <span className="shrink-0 font-mono text-(length:--text-nano) text-muted-foreground transition-opacity group-hover/pane-tab:opacity-0 group-focus-within/pane-tab:opacity-0">
+                {tab.count}
+              </span>
+            ) : null}
+          </TabsTrigger>
+        );
+        if (!codexStylePaneTabs) return trigger;
+        return (
+          <div
+            key={tab.value}
+            data-slot="task-detail-pane-tab"
+            className="group/pane-tab relative flex min-w-0 flex-1 basis-0 items-center"
+          >
+            {index > 0 ? (
+              <span
+                data-slot="task-detail-pane-tab-divider"
+                aria-hidden="true"
+                className="absolute left-0 top-1/2 h-4 w-px -translate-y-1/2 bg-border"
+              />
+            ) : null}
+            {trigger}
+            {tab.closable ? (
+              <button
+                type="button"
+                className="absolute right-2.5 top-1/2 z-20 inline-flex size-5 -translate-y-1/2 items-center justify-center rounded-sm text-muted-foreground opacity-0 transition-opacity hover:bg-accent hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-(length:--rad-3) focus-visible:ring-ring group-hover/pane-tab:opacity-100 group-focus-within/pane-tab:opacity-100"
+                aria-label={`Close ${tab.label} tab`}
+                onPointerDown={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                }}
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  closePaneTab(tab.value);
+                }}
+              >
+                <X className="size-3.5" aria-hidden />
+              </button>
+            ) : null}
+          </div>
+        );
+      })}
     </TabsList>
   );
+  const tabStrip = codexStylePaneTabs ? (
+    <div className="flex h-full min-w-0 flex-1 items-center">
+      {tabList}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            className="size-6 shrink-0 text-muted-foreground"
+            disabled={hiddenPaneTabs.length === 0}
+            aria-label="Open closed sidebar tab"
+            title={hiddenPaneTabs.length === 0 ? "All sidebar tabs are open" : "Open closed sidebar tab"}
+          >
+            <Plus className="size-3.5" aria-hidden />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="min-w-(--sz-8rem)">
+          {hiddenPaneTabs.map((tab) => (
+            <DropdownMenuItem key={tab.value} onClick={() => reopenPaneTab(tab.value)}>
+              {tab.label}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  ) : tabList;
   return (
     <Tabs value={activePaneTab} onValueChange={handlePaneTabChange} className="flex min-h-0 flex-col gap-3">
       {paneHeaderSlot
@@ -2829,6 +3186,24 @@ export function IssueProperties({
           )
         : tabStrip}
       <TabsContent value="properties">{propertiesBody}</TabsContent>
+      {hasSubtasksTab ? (
+        <TabsContent value="subtasks">
+          <TaskDetailSubtasksPanel
+            items={childIssues}
+            onAddSubtask={onAddSubIssue}
+            issueLinkState={issueLinkState}
+          />
+        </TabsContent>
+      ) : null}
+      {hasReferencesTab ? (
+        <TabsContent value="references">
+          <TaskDetailReferencesPanel
+            referenced={panelReferencedTasks}
+            mentionedIn={panelMentionedInTasks}
+            issueLinkState={issueLinkState}
+          />
+        </TabsContent>
+      ) : null}
       {hasPlanTab ? (
         <TabsContent value="plans">
           <IssuePropertiesPlansTab issue={issue} inline={inline} />

--- a/ui/src/components/issue-properties/primitives.tsx
+++ b/ui/src/components/issue-properties/primitives.tsx
@@ -7,6 +7,7 @@ export function PropertySection({
   className,
   title,
   first,
+  streamlined,
 }: {
   children: ReactNode;
   className?: string;
@@ -14,13 +15,16 @@ export function PropertySection({
   title?: string;
   /** First section drops the top padding on its header. */
   first?: boolean;
+  streamlined?: boolean;
 }) {
   return (
-    <div className={className}>
+    <div className={className} data-property-section="true">
       {title ? (
         <div
           className={cn(
-            "text-xs font-semibold uppercase tracking-wide text-muted-foreground pb-1",
+            streamlined
+              ? "pb-1 font-mono text-(length:--text-nano) font-normal uppercase tracking-wide text-muted-foreground/70"
+              : "text-xs font-semibold uppercase tracking-wide text-muted-foreground pb-1",
             first ? "pt-0" : "pt-3",
           )}
         >
@@ -60,7 +64,15 @@ export function PropertyRow({
       >
         {label}
       </span>
-      <div className={cn("flex min-w-0 flex-1 items-center gap-1.5", wrap && "flex-wrap")}>{children}</div>
+      <div
+        className={cn(
+          "flex min-w-0 flex-1 items-center gap-1.5",
+          wrap && "flex-col items-start",
+        )}
+        data-property-value="true"
+      >
+        {children}
+      </div>
     </div>
   );
 }

--- a/ui/src/components/issue-properties/property-picker.tsx
+++ b/ui/src/components/issue-properties/property-picker.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ChevronDown } from "lucide-react";
 import { cn } from "../../lib/utils";
+import { useStreamlinedUiEnabled } from "../../hooks/useStreamlinedUiEnabled";
 import { PropertyRow } from "./primitives";
 
 /** Renders a Popover on desktop, or an inline collapsible section on mobile (inline mode). */
@@ -14,6 +16,7 @@ export function PropertyPicker({
   popoverClassName,
   popoverAlign = "end",
   extra,
+  stacked = false,
   children,
 }: {
   inline?: boolean;
@@ -25,19 +28,26 @@ export function PropertyPicker({
   popoverClassName?: string;
   popoverAlign?: "start" | "center" | "end";
   extra?: ReactNode;
+  /** Top-aligns the row and vertically stacks chip collections in the trigger. */
+  stacked?: boolean;
   children: ReactNode;
 }) {
+  const { enabled: streamlinedUiEnabled } = useStreamlinedUiEnabled();
   const btnCn = cn(
     "inline-flex min-h-5 items-center gap-1.5 cursor-pointer hover:bg-accent/50 rounded px-1 -mx-1 py-0.5 transition-colors min-w-0 max-w-full text-left",
+    streamlinedUiEnabled && "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
     triggerClassName,
   );
 
   if (inline) {
     return (
       <div>
-        <PropertyRow label={label}>
-          <button className={btnCn} onClick={() => onOpenChange(!open)}>
+        <PropertyRow label={label} wrap={stacked}>
+          <button className={cn(btnCn, stacked && "items-start")} onClick={() => onOpenChange(!open)} aria-expanded={streamlinedUiEnabled ? open : undefined}>
             {triggerContent}
+            {streamlinedUiEnabled ? (
+              <ChevronDown className={cn("ml-auto h-3 w-3 shrink-0 text-muted-foreground transition-transform", open && "rotate-180")} aria-hidden />
+            ) : null}
           </button>
           {extra}
         </PropertyRow>
@@ -51,10 +61,15 @@ export function PropertyPicker({
   }
 
   return (
-    <PropertyRow label={label}>
+    <PropertyRow label={label} wrap={stacked}>
       <Popover open={open} onOpenChange={onOpenChange}>
         <PopoverTrigger asChild>
-          <button className={btnCn}>{triggerContent}</button>
+          <button className={cn(btnCn, stacked && "items-start")} aria-expanded={streamlinedUiEnabled ? open : undefined}>
+            {triggerContent}
+            {streamlinedUiEnabled ? (
+              <ChevronDown className={cn("ml-auto h-3 w-3 shrink-0 text-muted-foreground transition-transform", open && "rotate-180")} aria-hidden />
+            ) : null}
+          </button>
         </PopoverTrigger>
         <PopoverContent className={cn("p-1", popoverClassName)} align={popoverAlign} collisionPadding={16}>
           {children}

--- a/ui/src/components/side-panel/README.md
+++ b/ui/src/components/side-panel/README.md
@@ -12,6 +12,14 @@ The components exported by `@/components/side-panel` are controlled, domain-free
 
 Never put React nodes or fetched content in a persisted `SidePanelTabRecord`. Project icons and live status into `SidePanelTabItem` at render time.
 
+`SidePanelTabs` also accepts `appearance="streamlined-task"` for the experimental task-detail shell. That appearance preserves the approved pre-rebase Codex-inspired treatment—equal-width text tabs, separated surfaces, edge fades, and hover-revealed close actions—while the default appearance remains master's portable side-panel chrome.
+
+Use `headerSize="task-detail"` on `SidePanelFrame` when the panel shares the 60px task breadcrumb row. It keeps the task-detail footer treatment while matching the default portable header height.
+
+`SidePanelWindowControls` defaults to the production visibility-toggle icon. Streamlined task-detail panels use `closeControl="close"` for an explicit X while retaining the same close behavior and accessible labeling.
+
+The Streamlined task adapter registers a counted Subtasks tab only when the current task has child tasks. Closing it moves the surface back into the `+` launcher for the remainder of the session; tasks without children do not advertise the tab.
+
 ## Registering another page
 
 1. Define a serializable payload union for that page, such as `details | activity | history`.

--- a/ui/src/components/side-panel/SidePanelFrame.test.tsx
+++ b/ui/src/components/side-panel/SidePanelFrame.test.tsx
@@ -67,6 +67,53 @@ describe("side-panel shell controls", () => {
     expect(onWindowToggle).toHaveBeenCalledOnce();
   });
 
+  it("offers an explicit X close control for the task-detail sidebar", async () => {
+    const onToggle = vi.fn();
+    await act(async () => root.render(
+      <TooltipProvider>
+        <SidePanelWindowControls
+          maximized={false}
+          onMaximizedChange={vi.fn()}
+          onToggle={onToggle}
+          closeControl="close"
+        />
+      </TooltipProvider>,
+    ));
+
+    const closeButton = container.querySelector<HTMLButtonElement>('[aria-label="Close side panel"]');
+    expect(closeButton).not.toBeNull();
+    expect(closeButton?.querySelector(".lucide-x")).not.toBeNull();
+    expect(container.querySelector('[aria-label="Toggle side panel"]')).toBeNull();
+    await act(async () => closeButton?.click());
+    expect(onToggle).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the task-detail frame borderless except for its docked left edge", async () => {
+    await act(async () => root.render(
+      <SidePanelFrame header={<div>Tabs</div>} footer={<div>Actions</div>} headerSize="task-detail">
+        Body
+      </SidePanelFrame>,
+    ));
+    const frame = container.querySelector("section")!;
+    const header = container.querySelector("header")!;
+    const footer = container.querySelector("footer")!;
+    expect(frame.className).toContain("border-l");
+    expect(header.className).toContain("h-(--side-panel-header-height)");
+    expect(header.className).not.toContain("h-(--sz-60px)");
+    expect(header.className).not.toContain("border-b");
+    expect(footer.className).not.toContain("border-t");
+  });
+
+  it("preserves the shared default header and footer treatment", async () => {
+    await act(async () => root.render(
+      <SidePanelFrame header={<div>Tabs</div>} footer={<div>Actions</div>}>
+        Body
+      </SidePanelFrame>,
+    ));
+    expect(container.querySelector("header")?.className).toContain("h-(--side-panel-header-height)");
+    expect(container.querySelector("footer")?.className).toContain("border-t");
+  });
+
   it("keeps the prose scrollbar on the full-width viewport while centering its content", async () => {
     await act(async () => root.render(
       <SidePanelFrame contentMode="prose">Document body</SidePanelFrame>,

--- a/ui/src/components/side-panel/SidePanelFrame.tsx
+++ b/ui/src/components/side-panel/SidePanelFrame.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties, ReactNode } from "react";
-import { Maximize2, Minimize2, PanelRightClose, PanelRightOpen } from "lucide-react";
+import { Maximize2, Minimize2, PanelRightClose, PanelRightOpen, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
@@ -17,6 +17,7 @@ export interface SidePanelFrameProps {
   maximized?: boolean;
   resizing?: boolean;
   label?: string;
+  headerSize?: "default" | "task-detail";
   className?: string;
   bodyClassName?: string;
   style?: CSSProperties;
@@ -33,6 +34,7 @@ export function SidePanelFrame({
   maximized = false,
   resizing = false,
   label = "Side panel",
+  headerSize = "default",
   className,
   bodyClassName,
   style,
@@ -57,7 +59,9 @@ export function SidePanelFrame({
       style={style}
     >
       {(header || trailingControls) ? (
-        <header className="flex h-(--side-panel-header-height) min-w-0 shrink-0 items-center gap-1 px-2">
+        <header className={cn(
+          "flex h-(--side-panel-header-height) min-w-0 shrink-0 items-center gap-1 px-2",
+        )}>
           <div className="flex min-w-0 flex-1 self-stretch">{header}</div>
           {trailingControls ? (
             <div className="flex shrink-0 items-center gap-1">{trailingControls}</div>
@@ -81,7 +85,14 @@ export function SidePanelFrame({
           </div>
         ) : children}
       </div>
-      {footer ? <footer className="shrink-0 border-t border-border">{footer}</footer> : null}
+      {footer ? (
+        <footer className={cn(
+          "shrink-0",
+          headerSize !== "task-detail" && "border-t border-border",
+        )}>
+          {footer}
+        </footer>
+      ) : null}
     </section>
   );
 }
@@ -128,10 +139,12 @@ export function SidePanelWindowControls({
   maximized,
   onMaximizedChange,
   onToggle,
+  closeControl = "toggle",
 }: {
   maximized: boolean;
   onMaximizedChange: (maximized: boolean) => void;
   onToggle: () => void;
+  closeControl?: "toggle" | "close";
 }) {
   return (
     <>
@@ -146,7 +159,21 @@ export function SidePanelWindowControls({
       >
         {maximized ? <Minimize2 aria-hidden /> : <Maximize2 aria-hidden />}
       </Button>
-      <SidePanelToggleButton open onToggle={onToggle} />
+      {closeControl === "close" ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="h-(--side-panel-tab-height) w-(--side-panel-tab-height) text-muted-foreground hover:text-foreground focus-visible:text-foreground"
+          onClick={onToggle}
+          aria-label="Close side panel"
+          title="Close side panel"
+        >
+          <X aria-hidden />
+        </Button>
+      ) : (
+        <SidePanelToggleButton open onToggle={onToggle} />
+      )}
     </>
   );
 }

--- a/ui/src/components/side-panel/SidePanelTab.tsx
+++ b/ui/src/components/side-panel/SidePanelTab.tsx
@@ -18,6 +18,7 @@ export interface SidePanelTabProps {
   onClose?: () => void;
   onAuxClick?: (event: MouseEvent<HTMLButtonElement>) => void;
   onKeyDown?: ButtonHTMLAttributes<HTMLButtonElement>["onKeyDown"];
+  appearance?: "default" | "streamlined-task";
   className?: string;
 }
 
@@ -36,17 +37,19 @@ export function SidePanelTab({
   onClose,
   onAuxClick,
   onKeyDown,
+  appearance = "default",
   className,
 }: SidePanelTabProps) {
   const closeLabel = `Close ${label}`;
   const wrapperRef = useRef<HTMLDivElement>(null);
   const labelRef = useRef<HTMLSpanElement>(null);
   const [labelIsTruncated, setLabelIsTruncated] = useState(false);
-  const sizingKey = `${label}:${icon ? "icon" : "no-icon"}:${status ? "status" : "no-status"}:${closable ? "closable" : "fixed"}`;
+  const sizingKey = `${appearance}:${label}:${icon ? "icon" : "no-icon"}:${status ? "status" : "no-status"}:${closable ? "closable" : "fixed"}`;
   const [stableWidth, setStableWidth] = useState<{ key: string; width: number } | null>(null);
   const hasStableWidth = stableWidth?.key === sizingKey;
 
   useLayoutEffect(() => {
+    if (appearance === "streamlined-task") return;
     if (hasStableWidth) return;
     const measuredWidth = wrapperRef.current?.getBoundingClientRect().width ?? 0;
     if (measuredWidth <= 0) return;
@@ -71,18 +74,25 @@ export function SidePanelTab({
       ref={wrapperRef}
       data-side-panel-tab-wrapper={id}
       data-active={active ? "true" : "false"}
-      style={hasStableWidth ? { width: stableWidth.width } : undefined}
+      data-appearance={appearance}
+      style={appearance === "default" && hasStableWidth ? { width: stableWidth.width } : undefined}
       className={cn(
-        "group/side-panel-tab relative flex h-(--side-panel-tab-height) min-w-0 shrink-0 items-center rounded-(--side-panel-tab-radius) border border-transparent",
+        appearance === "streamlined-task"
+          ? "group/side-panel-tab relative mx-1.5 flex h-7 min-w-0 flex-1 basis-0 items-center rounded-md border border-transparent"
+          : "group/side-panel-tab relative flex h-(--side-panel-tab-height) min-w-0 shrink-0 items-center rounded-(--side-panel-tab-radius) border border-transparent",
         "side-panel-tab-motion",
         active
-          ? "bg-(--side-panel-tab-active-bg) text-accent-foreground"
-          : "text-muted-foreground hover:bg-(--side-panel-tab-hover-bg) hover:text-foreground",
+          ? appearance === "streamlined-task"
+            ? "text-foreground hover:bg-accent/50"
+            : "bg-(--side-panel-tab-active-bg) text-accent-foreground"
+          : appearance === "streamlined-task"
+            ? "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+            : "text-muted-foreground hover:bg-(--side-panel-tab-hover-bg) hover:text-foreground",
         disabled && "opacity-50",
         className,
       )}
     >
-      <Tooltip>
+      <Tooltip open={labelIsTruncated ? undefined : false}>
         <TooltipTrigger asChild>
           <button
             {...dragHandleProps}
@@ -90,6 +100,7 @@ export function SidePanelTab({
             type="button"
             role="tab"
             data-side-panel-tab-target={id}
+            data-side-panel-tab-tooltip={labelIsTruncated ? "enabled" : "disabled"}
             id={`side-panel-tab-${id}`}
             aria-controls={`side-panel-content-${id}`}
             aria-selected={active}
@@ -100,43 +111,66 @@ export function SidePanelTab({
             onAuxClick={onAuxClick}
             onKeyDown={onKeyDown}
             className={cn(
-              "flex h-full w-full min-w-0 items-center gap-1.5 rounded-(--side-panel-tab-radius) py-1.5 pl-2 text-xs font-medium outline-none",
-              closable && (!hasStableWidth || active) ? "pr-7" : "pr-2.5",
+              appearance === "streamlined-task"
+                ? "flex h-full w-full min-w-0 items-center justify-start rounded-md px-3 text-sm font-medium outline-none"
+                : "flex h-full w-full min-w-0 items-center gap-1.5 rounded-(--side-panel-tab-radius) py-1.5 pl-2 text-xs font-medium outline-none",
+              appearance === "default" && (closable && (!hasStableWidth || active) ? "pr-7" : "pr-2.5"),
               "focus-visible:ring-2 focus-visible:ring-ring/60",
               dragHandleProps?.className,
             )}
           >
-            {icon ? <span className="flex size-3.5 shrink-0 items-center justify-center [&_svg]:size-3.5">{icon}</span> : null}
+            {icon && appearance === "default" ? <span className="flex size-3.5 shrink-0 items-center justify-center [&_svg]:size-3.5">{icon}</span> : null}
             <span
               ref={labelRef}
               data-truncated={labelIsTruncated ? "true" : undefined}
               className={cn(
-                "overflow-hidden whitespace-nowrap",
-                closable && hasStableWidth && !active
-                  ? "max-w-(--side-panel-tab-label-expanded-max-width)"
-                  : "max-w-(--side-panel-tab-label-max-width)",
-                labelIsTruncated && "side-panel-tab-label-fade",
+                appearance === "streamlined-task"
+                  ? "side-panel-tab-label-close-fade task-detail-pane-tab-label min-w-0 flex-1 overflow-hidden whitespace-nowrap text-center"
+                  : "overflow-hidden whitespace-nowrap",
+                appearance === "default" && (
+                  closable && hasStableWidth && !active
+                    ? "max-w-(--side-panel-tab-label-expanded-max-width)"
+                    : "max-w-(--side-panel-tab-label-max-width)"
+                ),
+                appearance === "default" && labelIsTruncated && "side-panel-tab-label-fade",
               )}
             >
               {label}
             </span>
-            {status ? <span className="flex shrink-0 items-center">{status}</span> : null}
+            {status ? (
+              <span className={cn(
+                "flex shrink-0 items-center",
+                appearance === "streamlined-task" && "transition-opacity group-hover/side-panel-tab:opacity-0 group-focus-within/side-panel-tab:opacity-0",
+              )}>
+                {status}
+              </span>
+            ) : null}
           </button>
         </TooltipTrigger>
-        <TooltipContent side="bottom">{label}</TooltipContent>
+        {labelIsTruncated ? <TooltipContent side="bottom">{label}</TooltipContent> : null}
       </Tooltip>
-      {closable && onClose && active ? (
+      {closable && onClose && (appearance === "streamlined-task" || active) ? (
         <button
           type="button"
           aria-label={closeLabel}
           title={closeLabel}
+          onPointerDown={(event) => {
+            if (appearance !== "streamlined-task") return;
+            event.preventDefault();
+            event.stopPropagation();
+          }}
           onClick={(event) => {
             event.stopPropagation();
             onClose();
           }}
-          className="side-panel-tab-motion absolute right-1 flex size-6 items-center justify-center rounded-lg text-muted-foreground outline-none hover:bg-background/70 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/60"
+          className={cn(
+            "side-panel-tab-close-motion absolute flex items-center justify-center text-muted-foreground outline-none hover:text-foreground",
+            appearance === "streamlined-task"
+              ? "right-0 top-1/2 z-20 size-5 -translate-y-1/2 rounded-sm opacity-0 hover:bg-accent focus-visible:opacity-100 focus-visible:ring-2 focus-visible:ring-ring/60 group-hover/side-panel-tab:opacity-100"
+              : "right-1 size-6 rounded-lg hover:bg-background/70 focus-visible:ring-2 focus-visible:ring-ring/60",
+          )}
         >
-          <X className="size-3" aria-hidden />
+          <X className={appearance === "streamlined-task" ? "size-3.5" : "size-3"} aria-hidden />
         </button>
       ) : null}
     </div>

--- a/ui/src/components/side-panel/SidePanelTabs.test.tsx
+++ b/ui/src/components/side-panel/SidePanelTabs.test.tsx
@@ -101,6 +101,193 @@ describe("SidePanelTabs", () => {
     expect(separators[0]?.parentElement?.querySelector('[data-side-panel-tab-target="inactive-two"]')).not.toBeNull();
   });
 
+  it("restores the pre-rebase Streamlined UI tab treatment", () => {
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <SidePanelTabs
+            tabs={[
+              { id: "properties", type: "view", label: "Properties", icon: <SlidersHorizontal />, closable: true },
+              { id: "document:plan", type: "document", label: "Implementation plan", icon: <FileText />, closable: true },
+            ]}
+            activeTabId="properties"
+            onActiveTabChange={vi.fn()}
+            onCloseTab={vi.fn()}
+            onAddTab={vi.fn()}
+            appearance="streamlined-task"
+          />
+        </TooltipProvider>,
+      );
+    });
+
+    const tabs = container.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+    expect(tabs).toHaveLength(2);
+    expect(tabs[0]?.className).toContain("text-sm");
+    expect(tabs[0]?.querySelector("svg")).toBeNull();
+    expect(container.querySelectorAll('[data-side-panel-tab-separator="true"]')).toHaveLength(1);
+
+    const propertiesWrapper = container.querySelector<HTMLElement>('[data-side-panel-tab-wrapper="properties"]');
+    expect(propertiesWrapper?.className).toContain("mx-1.5");
+    expect(propertiesWrapper?.className).toContain("h-7");
+    expect(propertiesWrapper?.className).toContain("text-foreground");
+    expect(propertiesWrapper?.className).toContain("hover:bg-accent/50");
+    expect(propertiesWrapper?.className).not.toContain("bg-muted");
+    expect(propertiesWrapper?.style.width).toBe("");
+    expect(propertiesWrapper?.parentElement?.className)
+      .toContain("min-w-(--side-panel-streamlined-tab-min-width)");
+    expect(propertiesWrapper?.parentElement?.className)
+      .toContain("max-w-(--side-panel-streamlined-tab-max-width)");
+
+    const planLabel = container.querySelector<HTMLElement>('[data-side-panel-tab-target="document:plan"] span');
+    expect(planLabel?.className).toContain("task-detail-pane-tab-label");
+    expect(planLabel?.className).toContain("side-panel-tab-label-close-fade");
+    expect(planLabel?.className).toContain("text-center");
+    const tabList = container.querySelector<HTMLElement>('[role="tablist"]');
+    expect(tabList?.className).toContain("overflow-x-auto");
+    expect(tabList?.className).not.toContain("overflow-hidden");
+    expect(tabList?.firstElementChild?.className).toContain("w-max");
+    expect(tabList?.firstElementChild?.className).toContain("min-w-full");
+    const planCloseButton = container.querySelector<HTMLButtonElement>('button[aria-label="Close Implementation plan"]');
+    expect(planCloseButton?.className).toContain("opacity-0");
+    expect(planCloseButton?.className).toContain("right-0");
+    expect(planCloseButton?.className).toContain("side-panel-tab-close-motion");
+    expect(planCloseButton?.className).not.toContain("side-panel-tab-motion");
+    expect(planCloseButton?.className).not.toContain("group-focus-within/side-panel-tab:opacity-100");
+    const addButton = container.querySelector<HTMLButtonElement>('button[aria-label="Open a new tab"]');
+    expect(addButton?.className).toContain("h-(--side-panel-tab-height)");
+    expect(addButton?.className).toContain("w-(--side-panel-tab-height)");
+    expect(addButton?.className).toContain("hover:bg-accent");
+  });
+
+  it("lets a lone Streamlined tab fill the space before the add action", () => {
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <SidePanelTabs
+            tabs={[
+              {
+                id: "properties",
+                type: "view",
+                label: "Properties",
+                closable: true,
+              },
+            ]}
+            activeTabId="properties"
+            onActiveTabChange={vi.fn()}
+            onCloseTab={vi.fn()}
+            onAddTab={vi.fn()}
+            appearance="streamlined-task"
+          />
+        </TooltipProvider>,
+      );
+    });
+
+    const tabList = container.querySelector<HTMLElement>('[role="tablist"]');
+    const tabTrack = tabList?.firstElementChild;
+    const propertiesWrapper = container.querySelector<HTMLElement>(
+      '[data-side-panel-tab-wrapper="properties"]',
+    )?.parentElement;
+    expect(tabTrack?.className).toContain("w-full");
+    expect(tabTrack?.className).not.toContain("w-max");
+    expect(propertiesWrapper?.className).toContain("max-w-none");
+    expect(propertiesWrapper?.className).toContain("flex-1");
+    expect(propertiesWrapper?.className).not.toContain(
+      "max-w-(--side-panel-streamlined-tab-max-width)",
+    );
+  });
+
+  it("enables the tab flyout only while its label is truncated", () => {
+    const scrollWidth = vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(72);
+    const clientWidth = vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(96);
+
+    const renderLabel = (label: string) => {
+      act(() => {
+        root.render(
+          <TooltipProvider>
+            <SidePanelTabs
+              tabs={[{ id: "properties", type: "view", label, closable: true }]}
+              activeTabId="properties"
+              onActiveTabChange={vi.fn()}
+              onCloseTab={vi.fn()}
+              appearance="streamlined-task"
+            />
+          </TooltipProvider>,
+        );
+      });
+    };
+
+    renderLabel("Properties");
+    const tab = container.querySelector<HTMLButtonElement>('[data-side-panel-tab-target="properties"]')!;
+    const label = tab.querySelector<HTMLElement>(".task-detail-pane-tab-label")!;
+    expect(tab.dataset.sidePanelTabTooltip).toBe("disabled");
+    expect(label.dataset.truncated).toBeUndefined();
+
+    scrollWidth.mockReturnValue(128);
+    clientWidth.mockReturnValue(72);
+    renderLabel("Properties panel");
+    expect(tab.dataset.sidePanelTabTooltip).toBe("enabled");
+    expect(label.dataset.truncated).toBe("true");
+  });
+
+  it("fades the right edge only while more Streamlined tabs remain", () => {
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <SidePanelTabs
+            tabs={[
+              { id: "properties", type: "view", label: "Properties", closable: true },
+              { id: "subtasks", type: "view", label: "Subtasks", closable: true },
+              { id: "artifacts", type: "view", label: "Artifacts", closable: true },
+            ]}
+            activeTabId="properties"
+            onActiveTabChange={vi.fn()}
+            onCloseTab={vi.fn()}
+            onAddTab={vi.fn()}
+            appearance="streamlined-task"
+          />
+        </TooltipProvider>,
+      );
+    });
+
+    const tabList = container.querySelector<HTMLElement>('[role="tablist"]')!;
+    Object.defineProperties(tabList, {
+      clientWidth: { configurable: true, value: 152 },
+      scrollWidth: { configurable: true, value: 384 },
+      scrollLeft: { configurable: true, value: 0, writable: true },
+    });
+    act(() => tabList.dispatchEvent(new Event("scroll")));
+    expect(tabList.dataset.scrollEndFade).toBe("true");
+
+    tabList.scrollLeft = 232;
+    act(() => tabList.dispatchEvent(new Event("scroll")));
+    expect(tabList.dataset.scrollEndFade).toBeUndefined();
+  });
+
+  it("selects an inactive Streamlined UI tab without closing it", () => {
+    const onActiveTabChange = vi.fn();
+    const onCloseTab = vi.fn();
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <SidePanelTabs
+            tabs={[
+              { id: "properties", type: "view", label: "Properties", closable: true },
+              { id: "subtasks", type: "view", label: "Subtasks", closable: true },
+            ]}
+            activeTabId="properties"
+            onActiveTabChange={onActiveTabChange}
+            onCloseTab={onCloseTab}
+            appearance="streamlined-task"
+          />
+        </TooltipProvider>,
+      );
+    });
+
+    act(() => container.querySelector<HTMLButtonElement>('[data-side-panel-tab-target="subtasks"]')?.click());
+    expect(onActiveTabChange).toHaveBeenCalledWith("subtasks");
+    expect(onCloseTab).not.toHaveBeenCalled();
+  });
+
   it("keeps intrinsic tab width stable while giving inactive labels the close-button space", () => {
     vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
       x: 0,

--- a/ui/src/components/side-panel/SidePanelTabs.tsx
+++ b/ui/src/components/side-panel/SidePanelTabs.tsx
@@ -33,6 +33,8 @@ import type { SidePanelTabItem } from "./types";
 interface SortableSidePanelTabProps {
   tab: SidePanelTabItem;
   active: boolean;
+  appearance: "default" | "streamlined-task";
+  fillAvailableWidth: boolean;
   showLeadingSeparator: boolean;
   onSelect: () => void;
   onClose: () => void;
@@ -40,7 +42,17 @@ interface SortableSidePanelTabProps {
   onKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void;
 }
 
-function SortableSidePanelTab({ tab, active, showLeadingSeparator, onSelect, onClose, onAuxClick, onKeyDown }: SortableSidePanelTabProps) {
+function SortableSidePanelTab({
+  tab,
+  active,
+  appearance,
+  fillAvailableWidth,
+  showLeadingSeparator,
+  onSelect,
+  onClose,
+  onAuxClick,
+  onKeyDown,
+}: SortableSidePanelTabProps) {
   const sortable = useSortable({ id: tab.id, disabled: tab.disabled });
   return (
     <div
@@ -49,13 +61,28 @@ function SortableSidePanelTab({ tab, active, showLeadingSeparator, onSelect, onC
         transform: DndCSS.Transform.toString(sortable.transform),
         transition: sortable.transition,
       }}
-      className={cn("relative", sortable.isDragging && "z-20 opacity-80")}
+      className={cn(
+        appearance === "streamlined-task"
+          ? cn(
+              "relative flex flex-1 items-center",
+              fillAvailableWidth
+                ? "min-w-0 max-w-none basis-auto"
+                : "min-w-(--side-panel-streamlined-tab-min-width) max-w-(--side-panel-streamlined-tab-max-width) basis-0",
+            )
+          : "relative",
+        sortable.isDragging && "z-20 opacity-80",
+      )}
     >
       {showLeadingSeparator ? (
         <span
           aria-hidden
           data-side-panel-tab-separator="true"
-          className="pointer-events-none absolute inset-y-2 -left-0.5 w-px bg-border/60"
+          className={cn(
+            "pointer-events-none absolute w-px bg-border",
+            appearance === "streamlined-task"
+              ? "left-0 top-1/2 h-4 -translate-y-1/2"
+              : "inset-y-2 -left-0.5 bg-border/60",
+          )}
         />
       ) : null}
       <SidePanelTab
@@ -65,6 +92,7 @@ function SortableSidePanelTab({ tab, active, showLeadingSeparator, onSelect, onC
         icon={tab.icon}
         status={tab.status}
         active={active}
+        appearance={appearance}
         closable={tab.closable}
         disabled={tab.disabled}
         tabRef={sortable.setActivatorNodeRef}
@@ -90,6 +118,7 @@ export interface SidePanelTabsProps {
   onAddTab?: () => void;
   addControl?: ReactNode;
   addLabel?: string;
+  appearance?: "default" | "streamlined-task";
   className?: string;
 }
 
@@ -102,9 +131,11 @@ export function SidePanelTabs({
   onAddTab,
   addControl,
   addLabel = "Open a new tab",
+  appearance = "default",
   className,
 }: SidePanelTabsProps) {
   const [announcement, setAnnouncement] = useState("");
+  const [showEndFade, setShowEndFade] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const addButtonRef = useRef<HTMLButtonElement>(null);
   const addControlRef = useRef<HTMLDivElement>(null);
@@ -132,6 +163,27 @@ export function SidePanelTabs({
     // `findTabElement` only reads the committed tab DOM for this active id.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTabId]);
+
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (!element || appearance !== "streamlined-task") {
+      setShowEndFade(false);
+      return;
+    }
+    const updateEndFade = () => {
+      const remainingScroll = element.scrollWidth - element.clientWidth - element.scrollLeft;
+      setShowEndFade(remainingScroll > 1);
+    };
+    updateEndFade();
+    element.addEventListener("scroll", updateEndFade, { passive: true });
+    const observer = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(updateEndFade);
+    observer?.observe(element);
+    if (element.firstElementChild) observer?.observe(element.firstElementChild);
+    return () => {
+      element.removeEventListener("scroll", updateEndFade);
+      observer?.disconnect();
+    };
+  }, [appearance, tabIds]);
 
   function focusTab(tabId: string | null) {
     window.requestAnimationFrame(() => {
@@ -198,25 +250,48 @@ export function SidePanelTabs({
   }
 
   return (
-    <div className={cn("flex min-w-0 flex-1 items-center gap-1", className)}>
+    <div className={cn(
+      "flex min-w-0 flex-1 items-center",
+      appearance === "streamlined-task" ? "gap-0" : "gap-1",
+      className,
+    )}>
       <div
         ref={scrollRef}
         role="tablist"
         aria-orientation="horizontal"
-        className="min-w-0 flex-1 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        data-scroll-end-fade={appearance === "streamlined-task" && showEndFade ? "true" : undefined}
+        className={cn(
+          "side-panel-tabs-scroll min-w-0 flex-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+          appearance === "streamlined-task"
+            ? "overflow-x-auto overscroll-x-contain"
+            : "overflow-x-auto",
+        )}
       >
         <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
           <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
-            <div className="flex min-w-max items-center gap-1 py-1">
+            <div className={cn(
+              "flex items-center",
+              appearance === "streamlined-task"
+                ? tabs.length === 1
+                  ? "w-full gap-0"
+                  : "w-max min-w-full gap-0"
+                : "min-w-max gap-1 py-1",
+            )}>
               {tabs.map((tab, index) => (
                 <SortableSidePanelTab
                   key={tab.id}
                   tab={tab}
                   active={tab.id === activeTabId}
+                  appearance={appearance}
+                  fillAvailableWidth={
+                    appearance === "streamlined-task" && tabs.length === 1
+                  }
                   showLeadingSeparator={
-                    index > 0
-                    && tab.id !== activeTabId
-                    && tabs[index - 1]?.id !== activeTabId
+                    appearance === "streamlined-task"
+                      ? index > 0
+                      : index > 0
+                        && tab.id !== activeTabId
+                        && tabs[index - 1]?.id !== activeTabId
                   }
                   onSelect={() => onActiveTabChange(tab.id)}
                   onClose={() => closeTab(tab.id)}
@@ -241,7 +316,12 @@ export function SidePanelTabs({
           onClick={onAddTab}
           aria-label={addLabel}
           title={addLabel}
-          className="h-(--side-panel-tab-height) w-(--side-panel-tab-height) shrink-0 rounded-(--side-panel-control-radius) text-muted-foreground hover:text-foreground focus-visible:text-foreground"
+          className={cn(
+            "shrink-0 text-muted-foreground hover:text-foreground focus-visible:text-foreground",
+            appearance === "streamlined-task"
+              ? "h-(--side-panel-tab-height) w-(--side-panel-tab-height) rounded-md"
+              : "h-(--side-panel-tab-height) w-(--side-panel-tab-height) rounded-(--side-panel-control-radius)",
+          )}
         >
           <Plus aria-hidden />
         </Button>

--- a/ui/src/components/task-chat/TaskChatBlockerLinks.tsx
+++ b/ui/src/components/task-chat/TaskChatBlockerLinks.tsx
@@ -10,6 +10,7 @@ import {
   type WaitingBlockerStep,
 } from "@/lib/issue-blockers";
 import { Link } from "@/lib/router";
+import { useStreamlinedTaskChatPresentation } from "./presentation-mode";
 
 function isUnresolved(blocker: IssueRelationIssueSummary): boolean {
   return blocker.status !== "done" && blocker.status !== "cancelled";
@@ -100,9 +101,20 @@ function BlockerRow({
   label: string;
   blocker: IssueRelationIssueSummary | IssueBlockerAttentionIssueSummary;
 }) {
+  const streamlined = useStreamlinedTaskChatPresentation();
   const issuePathId = blocker.identifier ?? blocker.id;
 
-  return (
+  return streamlined ? (
+    <Link
+      to={createIssueDetailPath(issuePathId)}
+      className="flex min-w-0 items-baseline gap-1.5 rounded px-1 py-0.5 text-amber-800 underline-offset-2 transition-colors hover:bg-accent/50 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:text-amber-200"
+      title={`${blocker.identifier ?? blocker.id.slice(0, 8)} — ${blocker.title}`}
+    >
+      <span className="shrink-0 font-medium">{label}</span>
+      <span className="shrink-0 font-mono">{blocker.identifier ?? blocker.id.slice(0, 8)}</span>
+      <span className="truncate text-amber-700/80 dark:text-amber-300/80">{blocker.title}</span>
+    </Link>
+  ) : (
     <div className="flex min-w-0 items-baseline gap-1.5 whitespace-nowrap">
       <span className="shrink-0 font-medium">{label}</span>
       <Link
@@ -146,16 +158,25 @@ function LiveWorkGlyph({ status }: { status: WaitingBlockerStatus }) {
 
 function LiveWorkLink({
   blocker,
+  status,
+  label,
 }: {
   blocker: IssueRelationIssueSummary | IssueBlockerAttentionIssueSummary;
+  status: WaitingBlockerStatus;
+  label?: string;
 }) {
+  const streamlined = useStreamlinedTaskChatPresentation();
   const issuePathId = blocker.identifier ?? blocker.id;
   return (
     <Link
       to={createIssueDetailPath(issuePathId)}
-      className="flex min-w-0 items-baseline gap-1 text-blue-800 underline-offset-2 hover:underline dark:text-blue-200"
+      className={streamlined
+        ? "flex min-w-0 items-center gap-1.5 rounded px-1 py-0.5 text-blue-800 underline-offset-2 transition-colors hover:bg-accent/50 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring dark:text-blue-200"
+        : "flex min-w-0 items-baseline gap-1 text-blue-800 underline-offset-2 hover:underline dark:text-blue-200"}
       title={`${blocker.identifier ?? blocker.id.slice(0, 8)} — ${blocker.title}`}
     >
+      {streamlined && label ? <span className="shrink-0 font-medium">{label}</span> : null}
+      {streamlined ? <LiveWorkGlyph status={status} /> : null}
       <span className="shrink-0 font-mono">{blocker.identifier ?? blocker.id.slice(0, 8)}</span>
       <span className="truncate text-blue-700/80 dark:text-blue-300/80">{blocker.title}</span>
     </Link>
@@ -171,6 +192,11 @@ export function TaskChatBlockerLinks({
   ultimateBlocker: IssueRelationIssueSummary | IssueBlockerAttentionIssueSummary | null;
   placement: "top" | "bottom";
 }) {
+  const streamlined = useStreamlinedTaskChatPresentation();
+  const directLabel = streamlined && placement === "bottom" ? "Still blocked by" : "Blocked by";
+  const rootLabel = streamlined
+    ? placement === "bottom" ? "Root blocker remains" : "Root blocker"
+    : "Ultimately blocked by";
   return (
     <div
       aria-label="Task blockers"
@@ -178,9 +204,9 @@ export function TaskChatBlockerLinks({
       data-testid="task-chat-blocker-links"
       className="flex min-w-0 flex-col gap-1 overflow-hidden text-(length:--text-micro) leading-4 text-amber-700 dark:text-amber-300"
     >
-      <BlockerRow label="Blocked by" blocker={directBlocker} />
+      <BlockerRow label={directLabel} blocker={directBlocker} />
       {ultimateBlocker ? (
-        <BlockerRow label="Ultimately blocked by" blocker={ultimateBlocker} />
+        <BlockerRow label={rootLabel} blocker={ultimateBlocker} />
       ) : null}
     </div>
   );
@@ -193,6 +219,8 @@ export function TaskChatLiveWorkLinks({
   liveWork: ResolvedTaskChatLiveWork;
   placement: "top" | "bottom";
 }) {
+  const streamlined = useStreamlinedTaskChatPresentation();
+  const heading = streamlined && placement === "bottom" ? "Still waiting on live work" : "Waiting on live work";
   return (
     <div
       aria-label="Tasks waiting on live work"
@@ -204,27 +232,33 @@ export function TaskChatLiveWorkLinks({
         <span className="flex h-3.5 w-3.5 items-center justify-center" aria-hidden>
           <span className="h-2.5 w-2.5 animate-pulse rounded-full bg-blue-400" />
         </span>
-        Waiting on live work
+        {heading}
       </div>
       <ol className="flex min-w-0 flex-col gap-1">
         {liveWork.steps.map(({ blocker, status }, index) => (
           <li
             key={blocker.id}
             data-testid="task-chat-live-work-step"
-            className="flex min-w-0 items-center gap-1.5 whitespace-nowrap"
+            className={streamlined ? "min-w-0 whitespace-nowrap" : "flex min-w-0 items-center gap-1.5 whitespace-nowrap"}
           >
-            <span className="w-4 shrink-0 text-right font-mono text-blue-500/80" aria-hidden>
-              {index + 1}.
-            </span>
-            <LiveWorkGlyph status={status} />
-            <LiveWorkLink blocker={blocker} />
+            {!streamlined ? (
+              <>
+                <span className="w-4 shrink-0 text-right font-mono text-blue-500/80" aria-hidden>
+                  {index + 1}.
+                </span>
+                <LiveWorkGlyph status={status} />
+              </>
+            ) : null}
+            <LiveWorkLink blocker={blocker} status={status} />
           </li>
         ))}
       </ol>
-      {liveWork.nowRunning.map((blocker) => (
+      {liveWork.nowRunning.map((blocker) => streamlined ? (
+        <LiveWorkLink key={blocker.id} blocker={blocker} status="running" label="Now running" />
+      ) : (
         <div key={blocker.id} className="flex min-w-0 items-center gap-1.5 whitespace-nowrap">
           <span className="shrink-0 font-medium">Now running</span>
-          <LiveWorkLink blocker={blocker} />
+          <LiveWorkLink blocker={blocker} status="running" />
         </div>
       ))}
     </div>

--- a/ui/src/components/task-chat/TaskChatBubble.test.tsx
+++ b/ui/src/components/task-chat/TaskChatBubble.test.tsx
@@ -406,7 +406,7 @@ describe("TaskChatBubble footer actions (PAP-413)", () => {
     expect(slot?.querySelector('[data-testid="fake-actions"]')).toBeNull();
   });
 
-  it("leads a runless agent reply with actions, timestamp trailing", () => {
+  it("keeps runless timestamp left and actions at the stable right edge", () => {
     render(
       { id: "m1", kind: "message", author: "agent", authorName: "CEO", text: "Done.", timestamp: "2:34 PM" },
       { actions },
@@ -414,6 +414,9 @@ describe("TaskChatBubble footer actions (PAP-413)", () => {
     expect(container.querySelector('[data-testid="fake-actions"]')).not.toBeNull();
     const stamp = [...container.querySelectorAll("span")].find((el) => el.textContent === "2:34 PM");
     expect(stamp).not.toBeNull();
+    const actionNode = container.querySelector('[data-testid="fake-actions"]')!;
+    expect(stamp!.compareDocumentPosition(actionNode) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+    expect(actionNode.parentElement?.className).toContain("justify-between");
   });
 
   it("omits the actions row entirely when none are supplied (human bubble)", () => {

--- a/ui/src/components/task-chat/TaskChatBubble.tsx
+++ b/ui/src/components/task-chat/TaskChatBubble.tsx
@@ -1,6 +1,7 @@
 import { useState, type ReactNode } from "react";
 import type { IssueAttachment } from "@paperclipai/shared";
 import { cn } from "@/lib/utils";
+import { useStreamlinedTaskChatPresentation } from "./presentation-mode";
 import { MarkdownBody } from "@/components/MarkdownBody";
 import {
   ImageGalleryModal,
@@ -139,6 +140,7 @@ export function TaskChatBubble({
   onTryAgainNoLiveExecutionPath,
   tryAgainNoLiveExecutionPathPending,
 }: TaskChatBubbleProps) {
+  const streamlined = useStreamlinedTaskChatPresentation();
   // Clicking an embedded image opens the full-screen lightbox (with download);
   // arrow keys walk across the other images in the same bubble.
   const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
@@ -364,16 +366,25 @@ export function TaskChatBubble({
           {attachedTurn}
         </div>
       ) : actions ? (
-        // Agent reply without run activity: the actions still lead the footer,
-        // with the always-visible timestamp trailing (PAP-413).
-        <div className="flex items-center gap-1">
-          {actions}
-          {item.timestamp ? (
-            <span className="px-1 text-(length:--text-micro) text-muted-foreground">
-              {item.timestamp}
-            </span>
-          ) : null}
-        </div>
+        streamlined ? (
+          <div className="flex w-full items-center justify-between gap-2 px-1">
+            {item.timestamp ? (
+              <span className="text-(length:--text-micro) text-muted-foreground">
+                {item.timestamp}
+              </span>
+            ) : null}
+            {actions}
+          </div>
+        ) : (
+          <div className="flex items-center gap-1">
+            {actions}
+            {item.timestamp ? (
+              <span className="px-1 text-(length:--text-micro) text-muted-foreground">
+                {item.timestamp}
+              </span>
+            ) : null}
+          </div>
+        )
       ) : item.timestamp ? (
         // Timestamps are always visible (round 9) — no longer hover-revealed.
         <span className="px-1 text-(length:--text-micro) text-muted-foreground">

--- a/ui/src/components/task-chat/TaskChatComposer.test.tsx
+++ b/ui/src/components/task-chat/TaskChatComposer.test.tsx
@@ -293,7 +293,24 @@ describe("TaskChatComposer", () => {
     expect(composer?.className).not.toContain("p-2");
   });
 
-  it("renders the composer shell and its selectors without outlines", () => {
+  it("leaves an 8px token gap between the editor and action row", () => {
+    render(
+      <TaskChatComposer
+        onAdd={async () => {}}
+        workMode="planning"
+        onWorkModeChange={async () => {}}
+      />,
+    );
+
+    const actions = container.querySelector(
+      '[data-testid="task-chat-composer-actions"]',
+    );
+
+    expect(actions?.classList).toContain("mt-2");
+    expect(actions?.classList).not.toContain("mt-1");
+  });
+
+  it("renders a light card shell while preserving the borderless dark treatment", () => {
     render(
       <TaskChatComposer
         onAdd={async () => {}}
@@ -313,9 +330,14 @@ describe("TaskChatComposer", () => {
       '[data-testid="task-chat-composer-assignee"]',
     )!;
 
-    expect(composer.classList).not.toContain("border");
-    expect(composer.className).not.toContain("shadow-");
-    expect(composer.className).not.toContain("focus-within:ring-");
+    expect(composer.classList).toContain("border");
+    expect(composer.classList).toContain("border-border");
+    expect(composer.classList).toContain("bg-card");
+    expect(composer.classList).toContain("shadow-(--shadow-task-composer)");
+    expect(composer.classList).toContain("dark:border-0");
+    expect(composer.classList).toContain("dark:bg-muted");
+    expect(composer.classList).toContain("dark:shadow-none");
+    expect(composer.className).not.toContain("focus-within:ring");
     expect(mode.classList).not.toContain("border");
     expect(mode.className).not.toContain("ring-");
     expect(runner.classList).toContain("border-0");
@@ -448,6 +470,34 @@ describe("TaskChatComposer", () => {
     expect(chip.getAttribute("data-pending-work-mode")).toBe("standard");
     expect(chip.textContent).toContain("Auto");
     expect(onWorkModeChange).not.toHaveBeenCalled();
+  });
+
+  it("uses the borderless Paper controls and inverse circular send button", () => {
+    render(
+      <TaskChatComposer
+        onAdd={vi.fn()}
+        workMode="standard"
+        onWorkModeChange={vi.fn()}
+        enableReassign
+        reassignOptions={[{ id: "agent:a1", label: "Chief of Staff" }]}
+        currentAssigneeValue="agent:a1"
+      />,
+    );
+
+    const mode = container.querySelector<HTMLButtonElement>('[data-testid="task-chat-composer-mode"]')!;
+    const assignee = container.querySelector<HTMLButtonElement>('[data-testid="task-chat-composer-assignee"]')!;
+    const send = sendButton();
+
+    expect(mode.classList).not.toContain("border");
+    expect(mode.classList).toContain("border-0");
+    expect(mode.classList).toContain("status-chip");
+    expect(mode.style.getPropertyValue("--sc")).toBe("var(--tc-mode-agent)");
+    expect(assignee.classList).toContain("border-0");
+    expect(assignee.classList).toContain("shadow-none");
+    expect(send.classList).toContain("rounded-full");
+    expect(send.classList).toContain("bg-foreground");
+    expect(send.classList).toContain("text-background");
+    expect(send.classList).toContain("disabled:opacity-100");
   });
 
   it("passes reopen=true when the issue resumes-to-todo and the assignee is an agent", async () => {

--- a/ui/src/components/task-chat/TaskChatComposer.tsx
+++ b/ui/src/components/task-chat/TaskChatComposer.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
 } from "react";
 import { cn } from "@/lib/utils";
+import { useStreamlinedTaskChatPresentation } from "./presentation-mode";
 import {
   DRAFT_DEBOUNCE_MS,
   clearDraft,
@@ -269,7 +270,7 @@ function escapeMarkdownLabel(name: string): string {
  * Composer for the redesigned thread (v7 spec): the shared MarkdownEditor
  * (rich lists, @-mentions, /-commands, inline pasted images) over a 32px
  * comp-bar of [attach] [mode chip] … [assignee] [send]. The mode chip is a
- * status-chip rectangle carrying the pending mode's hue; the composer chrome
+ * borderless filled control carrying the pending mode's hue; the composer chrome
  * itself stays neutral. Cmd/Ctrl+. and Shift+Tab cycle modes (captured before
  * Lexical); Cmd/Ctrl+Enter posts via the editor's native onSubmit; plain Enter
  * stays a newline / next list item. Pasted or dropped images upload through
@@ -302,6 +303,7 @@ export function TaskChatComposer({
   takeover = null,
   pendingTakeover = null,
 }: TaskChatComposerProps) {
+  const streamlined = useStreamlinedTaskChatPresentation();
   const [body, setBody] = useState(() => (draftKey ? loadDraft(draftKey) : ""));
   const [submitting, setSubmitting] = useState(false);
   const [takeoverBusy, setTakeoverBusy] = useState(false);
@@ -677,7 +679,9 @@ export function TaskChatComposer({
   return (
     <div
       className={cn(
-        "paperclip-task-chat-composer rounded-xl bg-card p-(--sz-18px)",
+        streamlined
+          ? "paperclip-task-chat-composer rounded-(--radius-task-composer) border border-border bg-card p-(--sz-18px) shadow-(--shadow-task-composer) dark:border-0 dark:bg-muted dark:shadow-none"
+          : "paperclip-task-chat-composer rounded-xl bg-card p-(--sz-18px)",
       )}
       onKeyDownCapture={(e) => {
         // Capture mode shortcuts on the wrapper so they work while the rich
@@ -882,7 +886,10 @@ export function TaskChatComposer({
             </AttachmentGroup>
           ) : null}
 
-          <div className="mt-1 flex items-center gap-2">
+          <div
+            className="mt-2 flex items-center gap-2"
+            data-testid="task-chat-composer-actions"
+          >
             {canAcceptFiles ? (
               <>
                 <input
@@ -918,7 +925,12 @@ export function TaskChatComposer({
                     type="button"
                     disabled={disabled || !onWorkModeChange}
                     aria-keyshortcuts="Meta+Period Control+Period Shift+Tab"
-                    className="status-chip flex h-8 shrink-0 items-center gap-1.5 rounded-md px-2.5 text-xs font-medium transition hover:brightness-110 focus-visible:brightness-110 focus-visible:outline-none disabled:opacity-50"
+                    className={cn(
+                      "flex h-8 shrink-0 items-center gap-1.5 rounded-md px-2.5 text-xs font-medium disabled:opacity-50",
+                      streamlined
+                        ? "status-chip border-0 transition hover:brightness-110 focus-visible:brightness-110 focus-visible:outline-none"
+                        : "status-chip transition hover:brightness-110 focus-visible:brightness-110 focus-visible:outline-none",
+                    )}
                     style={{ "--sc": modeHue(pendingMode) } as CSSProperties}
                     data-testid="task-chat-composer-mode"
                     data-pending-work-mode={pendingMode}
@@ -927,7 +939,11 @@ export function TaskChatComposer({
                     <ChevronDown className="h-3 w-3" aria-hidden />
                   </button>
                 </DropdownMenuTrigger>
-                <DropdownMenuContent align="start" className="w-60">
+                <DropdownMenuContent
+                  align="start"
+                  className="flex w-(--sz-300px) flex-col gap-0.5"
+                  data-testid="task-chat-composer-mode-menu"
+                >
                   {workModeMetaList().map((m) => {
                     const Icon = m.icon;
                     const selected = m.value === pendingMode;
@@ -950,7 +966,7 @@ export function TaskChatComposer({
                         />
                         <span className="flex min-w-0 flex-1 flex-col">
                           <span className="font-medium">{m.label}</span>
-                          <span className="text-xs text-muted-foreground">
+                          <span className="whitespace-nowrap text-xs text-muted-foreground">
                             {MODE_DESCRIPTION[m.value] ?? ""}
                           </span>
                         </span>
@@ -1052,7 +1068,12 @@ export function TaskChatComposer({
                     : "Save queued message"
                   : "Send"
               }
-              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-primary text-primary-foreground transition-transform hover:scale-105 disabled:scale-100 disabled:bg-muted disabled:text-muted-foreground"
+              className={cn(
+                "flex h-8 w-8 shrink-0 items-center justify-center transition-transform hover:scale-105 disabled:scale-100",
+                streamlined
+                  ? "rounded-full bg-foreground text-background disabled:bg-foreground disabled:text-background disabled:opacity-100"
+                  : "rounded-md bg-primary text-primary-foreground disabled:bg-muted disabled:text-muted-foreground",
+              )}
               data-testid="task-chat-composer-send"
             >
               {submitting ? (

--- a/ui/src/components/task-chat/TaskChatDescriptionBubble.test.tsx
+++ b/ui/src/components/task-chat/TaskChatDescriptionBubble.test.tsx
@@ -86,6 +86,7 @@ describe("TaskChatDescriptionBubble (PAP-375)", () => {
     expect(body?.textContent).toContain("Ship the widget by");
     // Markdown renders (bold), not raw asterisks.
     expect(body?.querySelector("strong")?.textContent).toBe("Friday");
+    expect(bubble?.querySelector('[data-testid="task-chat-description-edit"]')).toBeNull();
   });
 
   it("renders an agent-created task as the agent-side bubble with the avatar author header", () => {
@@ -106,8 +107,8 @@ describe("TaskChatDescriptionBubble (PAP-375)", () => {
     expect(container.textContent).not.toContain("Ship the widget");
   });
 
-  it("swaps to the InlineEditor on pencil click and returns to the bubble on Escape", () => {
-    render(makeBrief());
+  it("keeps the agent-side pencil editor and returns to the bubble on Escape", () => {
+    render(makeBrief({ author: "agent", authorName: "CEO" }));
     click(container.querySelector('[data-testid="task-chat-description-edit"]'));
 
     const editorWrap = container.querySelector('[data-testid="task-chat-description-editor"]');

--- a/ui/src/components/task-chat/TaskChatDescriptionBubble.tsx
+++ b/ui/src/components/task-chat/TaskChatDescriptionBubble.tsx
@@ -51,12 +51,11 @@ function initialsForName(name: string) {
  * The task description as the requester's first chat bubble (PAP-375):
  * human-created tasks get the blue user bubble, agent-created tasks the
  * agent-side card with the avatar header — same chrome as TaskChatBubble. The
- * body is the live issue.description; a hover pencil swaps the bubble for the
- * same InlineEditor the pre-redesign page used (mentions, image paste/drop,
- * autosave), restoring the edit surface the redesign had gated off. Long
- * descriptions fold at ~12 lines behind a Show more curtain; an empty
- * description renders a muted ghost row that opens the editor — never an
- * empty bubble.
+ * body is the live issue.description. Human-authored blue bubbles are
+ * presentation-only; agent-authored descriptions retain the hover edit
+ * affordance. Long descriptions fold at ~12 lines behind a Show more curtain;
+ * an empty description renders a muted ghost row that opens the editor — never
+ * an empty bubble.
  */
 export function TaskChatDescriptionBubble({ brief }: TaskChatDescriptionBubbleProps) {
   const [editing, setEditing] = useState(false);
@@ -160,15 +159,17 @@ export function TaskChatDescriptionBubble({ brief }: TaskChatDescriptionBubblePr
             </MarkdownBody>
           </FoldCurtain>
         </div>
-        <button
-          type="button"
-          className="mt-1 shrink-0 rounded-md p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-accent/50 hover:text-foreground focus-visible:opacity-100 group-hover/brief:opacity-100"
-          onClick={() => setEditing(true)}
-          aria-label="Edit description"
-          data-testid="task-chat-description-edit"
-        >
-          <Pencil className="h-3.5 w-3.5" aria-hidden />
-        </button>
+        {!isHuman ? (
+          <button
+            type="button"
+            className="mt-1 shrink-0 rounded-md p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-accent/50 hover:text-foreground focus-visible:opacity-100 group-hover/brief:opacity-100"
+            onClick={() => setEditing(true)}
+            aria-label="Edit description"
+            data-testid="task-chat-description-edit"
+          >
+            <Pencil className="h-3.5 w-3.5" aria-hidden />
+          </button>
+        ) : null}
       </div>
       {timestamp ? (
         <span className="px-1 text-(length:--text-micro) text-muted-foreground">{timestamp}</span>

--- a/ui/src/components/task-chat/TaskChatInteractionCard.test.tsx
+++ b/ui/src/components/task-chat/TaskChatInteractionCard.test.tsx
@@ -879,7 +879,7 @@ describe("TaskChatThreadView interaction items", () => {
     expect(
       container
         .querySelector('[data-testid="task-chat-interaction"]')
-        ?.parentElement?.classList.contains("-mt-3"),
+        ?.parentElement?.classList.contains("mt-3"),
     ).toBe(true);
   });
 

--- a/ui/src/components/task-chat/TaskChatMarker.tsx
+++ b/ui/src/components/task-chat/TaskChatMarker.tsx
@@ -1,6 +1,7 @@
 import { useId, useState } from "react";
 import { cn } from "@/lib/utils";
 import { ChevronDown, CircleDot, OctagonX, Flag } from "lucide-react";
+import { useStreamlinedTaskChatPresentation } from "./presentation-mode";
 import type { TaskChatMarkerItem } from "./task-chat-model";
 import { Button } from "@/components/ui/button";
 import { Link } from "@/lib/router";
@@ -28,6 +29,7 @@ export function TaskChatMarker({
 }) {
   const [open, setOpen] = useState(false);
   const detailsId = useId();
+  const streamlined = useStreamlinedTaskChatPresentation();
   const Icon = VARIANT_ICON[item.variant];
   const interrupted = item.variant === "interrupted";
   const relative = item.createdAtIso ? timeAgo(item.createdAtIso) : undefined;
@@ -117,7 +119,11 @@ export function TaskChatMarker({
   }
 
   return (
-    <div className="tc-enter-marker flex items-center gap-2 py-1 text-xs text-muted-foreground">
+    <div
+      className="tc-enter-marker flex items-center gap-2 py-1 text-xs text-muted-foreground"
+      role={streamlined ? "separator" : undefined}
+      aria-label={streamlined ? item.label : undefined}
+    >
       <span className={cn("h-px flex-1", interrupted ? "border-t border-dashed border-destructive/50" : "bg-border")} />
       <span className={cn("flex items-center gap-1.5", interrupted && "text-destructive")}>
         <Icon className="h-3.5 w-3.5" />

--- a/ui/src/components/task-chat/TaskChatSystemNotice.test.tsx
+++ b/ui/src/components/task-chat/TaskChatSystemNotice.test.tsx
@@ -154,7 +154,7 @@ describe("TaskChatSystemNotice (PAP-443)", () => {
     expect(
       container
         .querySelector('[data-testid="task-chat-system-notice"]')
-        ?.classList.contains("items-start"),
+        ?.classList.contains("items-center"),
     ).toBe(true);
   });
 
@@ -223,5 +223,33 @@ describe("TaskChatSystemNotice (PAP-443)", () => {
     expect(
       container.querySelector('[data-testid="task-chat-no-live-path-try-again"]'),
     ).toBeNull();
+  });
+
+  it("keeps workspace-ready events as a compact expandable notice", () => {
+    renderNotice({
+      text: "Workspace ready. The isolated worktree is available at `/tmp/paperclip/worktrees/PAP-91`.",
+      metadata: null,
+    });
+
+    const button = toggleButton();
+    expect(button.getAttribute("aria-expanded")).toBe("false");
+    expect(button.textContent).toContain("System update");
+    expect(button.textContent).toContain("Workspace ready.");
+    expect(button.querySelector("code")).toBeNull();
+    expect(container.textContent).not.toContain("/tmp/paperclip/worktrees/PAP-91");
+
+    flushSync(() => button.click());
+    expect(container.textContent).toContain("/tmp/paperclip/worktrees/PAP-91");
+  });
+
+  it("ignores malformed metadata while preserving expandable raw detail", () => {
+    renderNotice({
+      text: "Workspace ready. Runtime metadata could not be decoded.",
+      metadata: { version: 1, sections: "malformed" } as unknown as TaskChatMessageItem["metadata"],
+    });
+
+    expect(() => flushSync(() => toggleButton().click())).not.toThrow();
+    expect(container.querySelector('[data-testid="task-chat-system-notice-details"]')).not.toBeNull();
+    expect(container.textContent).toContain("Runtime metadata could not be decoded");
   });
 });

--- a/ui/src/components/task-chat/TaskChatSystemNotice.tsx
+++ b/ui/src/components/task-chat/TaskChatSystemNotice.tsx
@@ -8,6 +8,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useStreamlinedTaskChatPresentation } from "./presentation-mode";
 import { MarkdownBody } from "@/components/MarkdownBody";
 import { Button } from "@/components/ui/button";
 import {
@@ -52,6 +53,7 @@ export function TaskChatSystemNotice({
   onTryAgainNoLiveExecutionPath?: () => Promise<void> | void;
   tryAgainNoLiveExecutionPathPending?: boolean;
 }) {
+  const streamlined = useStreamlinedTaskChatPresentation();
   const [open, setOpen] = useState(Boolean(item.presentation?.detailsDefaultOpen));
   const detailsId = useId();
   const { title, tone, detail } = humanizeSystemNotice({
@@ -75,7 +77,13 @@ export function TaskChatSystemNotice({
   };
 
   return (
-    <div className="tc-enter-bubble flex flex-col items-start py-1" data-testid="task-chat-system-notice">
+    <div
+      className={cn("tc-enter-bubble flex flex-col items-center", streamlined ? "py-0.5" : "py-1")}
+      data-testid="task-chat-system-notice"
+      data-tone={streamlined ? tone : undefined}
+      role={streamlined ? "group" : undefined}
+      aria-label={streamlined ? `System update: ${title}` : undefined}
+    >
       <div className="flex max-w-(--pct-85) items-center gap-1.5">
         <button
           type="button"

--- a/ui/src/components/task-chat/TaskChatThreadView.tsx
+++ b/ui/src/components/task-chat/TaskChatThreadView.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import type { IssueAttachment } from "@paperclipai/shared";
 import { cn } from "@/lib/utils";
+import { useStreamlinedTaskChatPresentation } from "./presentation-mode";
 import type {
   TaskChatInteractionItem,
   TaskChatItem,
@@ -275,6 +276,24 @@ function renderItem(
   }
 }
 
+function isSystemLikeItem(item: TaskChatItem): boolean {
+  return item.kind === "marker" || (item.kind === "message" && item.author === "system");
+}
+
+export function taskChatItemSpacingClass(
+  item: TaskChatItem,
+  previousItem: TaskChatItem | null,
+): string | undefined {
+  if (!previousItem) return undefined;
+  const currentIsSystemLike = isSystemLikeItem(item);
+  const previousIsSystemLike = isSystemLikeItem(previousItem);
+  if (currentIsSystemLike && previousIsSystemLike) return "mt-2";
+  if (currentIsSystemLike || previousIsSystemLike) return "mt-3";
+  if (item.kind === "turn" || previousItem.kind === "turn") return "mt-3";
+  if (item.kind === "interaction" || previousItem.kind === "interaction") return "mt-4";
+  return "mt-6";
+}
+
 /**
  * Presentational render layer for the redesigned task thread. Consumed by both
  * the live thread (adapter over comment/run props) and the dev harness
@@ -300,43 +319,22 @@ export function TaskChatThreadView({
   scroll = true,
   attachments = [],
 }: TaskChatThreadViewProps) {
-  const retryableMarkerId =
-    onRetryFailedRun || onTryAgainNoLiveExecutionPath
-      ? [...items]
-          .reverse()
-          .find(
-            (item) =>
-              item.kind === "marker" &&
-              item.variant === "interrupted" &&
-              item.label === "Run failed",
-          )?.id
+  const streamlined = useStreamlinedTaskChatPresentation();
+  const retryableMarkerId = onRetryFailedRun || onTryAgainNoLiveExecutionPath
+    ? [...items]
+        .reverse()
+        .find(
+          (item) =>
+            item.kind === "marker" &&
+            item.variant === "interrupted" &&
+            item.label === "Run failed",
+        )?.id
       : undefined;
-  const body = (
-    <div
-      className={cn(
-        "mx-auto flex w-full max-w-(--tc-shell-max-w) flex-col gap-5 px-4 py-4",
-        className,
-      )}
-    >
-      {header ? (
-        <div
-          className="flex flex-col gap-6 pb-2"
-          data-testid="task-chat-thread-header"
-        >
-          {header}
-        </div>
-      ) : null}
-      {items.map((item, index) => (
-        <div
-          key={item.id}
-          className={cn(
-            index > 0 &&
-              item.kind === "interaction" &&
-              item.interaction.status !== "pending" &&
-              "-mt-3",
-          )}
-        >
-          {renderItem(
+  const renderedItems = streamlined
+    ? items
+        .map((item) => ({
+          item,
+          content: renderItem(
             item,
             onApprovalDecision,
             renderInteraction,
@@ -351,10 +349,65 @@ export function TaskChatThreadView({
             onRetryFailedRun,
             retryFailedRunId,
             attachments,
-          )}
+          ),
+        }))
+        .filter((entry) => entry.content !== null)
+    : [];
+  const body = (
+    <div
+      className={cn(
+        "mx-auto flex w-full max-w-(--tc-shell-max-w) flex-col px-4 py-4",
+        streamlined ? "md:px-0" : "gap-5",
+        className,
+      )}
+    >
+      {header ? (
+        <div
+          className={cn("flex flex-col gap-6", streamlined ? "pb-4" : "pb-2")}
+          data-testid="task-chat-thread-header"
+          >
+            {header}
         </div>
-      ))}
-      {tail}
+      ) : null}
+      {streamlined
+        ? renderedItems.map(({ item, content }, index) => (
+            <div
+              key={item.id}
+              className={taskChatItemSpacingClass(item, renderedItems[index - 1]?.item ?? null)}
+              data-thread-item-kind={item.kind === "message" ? item.author : item.kind}
+            >
+              {content}
+            </div>
+          ))
+        : items.map((item, index) => (
+            <div
+              key={item.id}
+              className={cn(
+                index > 0 &&
+                  item.kind === "interaction" &&
+                  item.interaction.status !== "pending" &&
+                  "-mt-3",
+              )}
+            >
+              {renderItem(
+                item,
+                onApprovalDecision,
+                renderInteraction,
+                renderBrief,
+                renderMessageActions,
+                renderQueuedAction,
+                onRuntimeRequestDecision,
+                "classic",
+                onTryAgainNoLiveExecutionPath,
+                tryAgainNoLiveExecutionPathPending,
+                retryableMarkerId,
+                onRetryFailedRun,
+                retryFailedRunId,
+                attachments,
+              )}
+            </div>
+          ))}
+      {tail ? (streamlined ? <div className="mt-4">{tail}</div> : tail) : null}
     </div>
   );
 

--- a/ui/src/components/task-chat/TaskChatTurn.test.tsx
+++ b/ui/src/components/task-chat/TaskChatTurn.test.tsx
@@ -476,6 +476,8 @@ describe("TaskChatTurn", () => {
     // expandable fold — so expanding the tool history can't drag it down.
     expect(fold()?.contains(lead!)).toBe(false);
     expect(summaryBtn()).not.toBeNull();
+    expect(summaryBtn()!.compareDocumentPosition(lead!) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+    expect(lead?.parentElement?.parentElement?.className).toContain("justify-between");
     // Expanding still works and the leading slot stays put outside the fold.
     flushSync(() => summaryBtn()!.click());
     expect(fold()?.getAttribute("data-folded")).toBe("false");

--- a/ui/src/components/task-chat/TaskChatTurn.tsx
+++ b/ui/src/components/task-chat/TaskChatTurn.tsx
@@ -1,5 +1,6 @@
 import { useState, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
+import { useStreamlinedTaskChatPresentation } from "./presentation-mode";
 import { Check, ChevronRight, X } from "lucide-react";
 import { MarkdownBody } from "@/components/MarkdownBody";
 import type {
@@ -19,10 +20,9 @@ interface TaskChatTurnProps {
    */
   timestampPrefix?: string;
   /**
-   * Content rendered on the header row, leading the summary line (PAP-413: the
-   * copy/👍/👎 action cluster). It sits beside the summary button — NOT inside
-   * the expandable fold — so it stays anchored to the summary line when the
-   * tool history expands beneath it, instead of drifting to the fold's center.
+   * Content rendered on the header row (PAP-413: the copy/👍/👎 action
+   * cluster). The inspection caret and timestamp stay left; actions sit at the
+   * stable right edge, outside the expandable fold.
    */
   leading?: ReactNode;
 }
@@ -75,6 +75,7 @@ export function TaskChatTurn({
   timestampPrefix,
   leading,
 }: TaskChatTurnProps) {
+  const streamlined = useStreamlinedTaskChatPresentation();
   const parentRow = !item.settled && item.liveStatus != null;
   // The new Paperclip Runner task surface owns one durable chronological
   // timeline. The Worked/Stopped row is its stable header, so it stays directly
@@ -182,6 +183,7 @@ export function TaskChatTurn({
         item.standaloneHeader
           ? "border-b border-border/70 py-2 text-sm"
           : "py-0.5 text-xs",
+        streamlined && "min-w-0",
       )}
       data-testid="task-chat-turn-summary"
     >
@@ -244,13 +246,17 @@ export function TaskChatTurn({
       data-settled={item.settled ? "true" : "false"}
     >
       {leading ? (
-        // Actions ride the header row (items-center matches them to the summary
-        // line), and the fold below is a separate sibling — so expanding the
-        // tool history never moves the actions off the summary line (PAP-413).
-        <div className="flex items-center gap-1">
-          {leading}
-          {header}
-        </div>
+        streamlined ? (
+          <div className="flex w-full items-center justify-between gap-2">
+            <div className="min-w-0">{header}</div>
+            <div className="shrink-0">{leading}</div>
+          </div>
+        ) : (
+          <div className="flex items-center gap-1">
+            {leading}
+            {header}
+          </div>
+        )
       ) : (
         header
       )}

--- a/ui/src/components/task-chat/TaskMessageScroller.test.tsx
+++ b/ui/src/components/task-chat/TaskMessageScroller.test.tsx
@@ -160,6 +160,13 @@ describe("TaskMessageScroller", () => {
     expect(el.getAttribute("data-scroll-active")).toBeNull();
   });
 
+  it("contains horizontal overflow so no scrollbar appears above the composer", () => {
+    render();
+
+    expect(scroller().classList).toContain("overflow-x-hidden");
+    expect(scroller().classList).toContain("overflow-y-auto");
+  });
+
   it("auto-follows content instantly while pinned", async () => {
     render(1);
     const el = scroller();
@@ -181,6 +188,8 @@ describe("TaskMessageScroller", () => {
     expect(btn).not.toBeNull();
     expect(btn!.className).toContain("tc-scroll-pill-in");
     expect(btn!.className).toContain("size-8");
+    expect(btn!.className).toContain("bottom-7");
+    expect(btn!.className).not.toContain("bottom-3");
     expect(btn!.className).not.toContain("-translate-x-1/2");
     // Icon-only: no visible text.
     expect(btn!.textContent).toBe("");

--- a/ui/src/components/task-chat/TaskMessageScroller.tsx
+++ b/ui/src/components/task-chat/TaskMessageScroller.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
+import { useStreamlinedTaskChatPresentation } from "./presentation-mode";
 import { ArrowDown } from "lucide-react";
 import { parseCssTimeMs } from "./motion-tokens";
 
@@ -42,6 +43,7 @@ interface TaskMessageScrollerProps {
  * while pinned stays instant, so no reflow/jump happens during streaming.
  */
 export function TaskMessageScroller({ children, contentKey, className }: TaskMessageScrollerProps) {
+  const streamlined = useStreamlinedTaskChatPresentation();
   const ref = useRef<HTMLDivElement>(null);
   const pinnedRef = useRef(true);
   const easingRef = useRef(false);
@@ -216,7 +218,11 @@ export function TaskMessageScroller({ children, contentKey, className }: TaskMes
         // absolute inset-0 (not h-full): the viewport must equal the flex-sized
         // wrapper exactly — percentage heights don't reliably resolve against
         // flex-determined block heights, which let the thread overflow the page.
-        className={cn("scrollbar-while-scrolling absolute inset-0 overflow-y-auto", className)}
+        className={cn(
+          "scrollbar-while-scrolling absolute inset-0 overflow-y-auto",
+          streamlined && "overflow-x-hidden",
+          className,
+        )}
         data-testid="task-chat-scroller"
       >
         {children}
@@ -232,7 +238,8 @@ export function TaskMessageScroller({ children, contentKey, className }: TaskMes
           // The tc-scroll-pill-* keyframes carry the translate(-50%) X-centering
           // (fill: both keeps it after the animation) — no -translate-x-1/2 here.
           className={cn(
-            "absolute bottom-3 left-1/2 flex size-8 items-center justify-center rounded-full border border-border bg-background shadow-sm hover:bg-muted",
+            "absolute left-1/2 flex size-8 items-center justify-center rounded-full border border-border bg-background shadow-sm hover:bg-muted",
+            streamlined ? "bottom-7" : "bottom-3",
             pillPhase === "out" ? "tc-scroll-pill-out" : "tc-scroll-pill-in",
           )}
         >

--- a/ui/src/components/task-chat/presentation-mode.tsx
+++ b/ui/src/components/task-chat/presentation-mode.tsx
@@ -1,0 +1,25 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+export type TaskChatPresentationMode = "production" | "streamlined";
+
+// Isolated component previews/tests render the new presentation by default.
+// The live TaskChatThread always provides an explicit instance-setting mode.
+const TaskChatPresentationContext = createContext<TaskChatPresentationMode>("streamlined");
+
+export function TaskChatPresentationProvider({
+  mode,
+  children,
+}: {
+  mode: TaskChatPresentationMode;
+  children: ReactNode;
+}) {
+  return (
+    <TaskChatPresentationContext.Provider value={mode}>
+      {children}
+    </TaskChatPresentationContext.Provider>
+  );
+}
+
+export function useStreamlinedTaskChatPresentation(): boolean {
+  return useContext(TaskChatPresentationContext) === "streamlined";
+}

--- a/ui/src/components/task-chat/task-chat-render.test.tsx
+++ b/ui/src/components/task-chat/task-chat-render.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { TASK_CHAT_STATES } from "./task-chat-states";
 import { buildScenario } from "./task-chat-fixtures";
 import { TaskChatThreadView } from "./TaskChatThreadView";
+import type { TaskChatItem } from "./task-chat-model";
 import { TaskChatPlanView } from "./TaskChatPlanView";
 import { ThemeProvider } from "@/context/ThemeContext";
 
@@ -49,4 +50,37 @@ describe("Task chat state inventory renders", () => {
       flushSync(() => root.unmount());
     });
   }
+});
+
+describe("Task chat thread rhythm", () => {
+  it("keeps consecutive system events compact while preserving message separation", () => {
+    const items: TaskChatItem[] = [
+      { id: "human", kind: "message", author: "human", text: "Start", timestamp: "9:00 AM" },
+      { id: "system-1", kind: "message", author: "system", text: "Workspace ready." },
+      { id: "marker", kind: "marker", variant: "turn_boundary", label: "Plan created" },
+      { id: "agent", kind: "message", author: "agent", authorName: "Builder", text: "Done", timestamp: "9:01 AM" },
+    ];
+    const root = createRoot(document.body.appendChild(document.createElement("div")));
+    const host = document.body.lastElementChild as HTMLDivElement;
+
+    flushSync(() => root.render(
+      <ThemeProvider>
+        <TaskChatThreadView items={items} scroll={false} />
+      </ThemeProvider>,
+    ));
+
+    const human = host.querySelector('[data-thread-item-kind="human"]');
+    const system = host.querySelector('[data-thread-item-kind="system"]');
+    const marker = host.querySelector('[data-thread-item-kind="marker"]');
+    const agent = host.querySelector('[data-thread-item-kind="agent"]');
+    expect(human?.className).not.toContain("mt-");
+    expect(system?.className).toContain("mt-3");
+    expect(marker?.className).toContain("mt-2");
+    expect(agent?.className).toContain("mt-3");
+    expect(system?.querySelector('[role="group"]')?.getAttribute("aria-label")).toContain("System update");
+    expect(marker?.querySelector('[role="separator"]')?.getAttribute("aria-label")).toBe("Plan created");
+
+    flushSync(() => root.unmount());
+    host.remove();
+  });
 });

--- a/ui/src/components/task-detail/TaskDetailRelationsPanel.test.tsx
+++ b/ui/src/components/task-detail/TaskDetailRelationsPanel.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+
+import { flushSync } from "react-dom";
+import { createRoot, type Root } from "react-dom/client";
+import type { Issue } from "@paperclipai/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  TaskDetailReferencesPanel,
+  TaskDetailSubtasksPanel,
+  resolveTaskDetailSubtaskState,
+} from "./TaskDetailRelationsPanel";
+
+vi.mock("@/lib/router", () => ({
+  Link: ({
+    to,
+    children,
+    state: _state,
+    disableIssueQuicklook: _disableIssueQuicklook,
+    issuePrefetch: _issuePrefetch,
+    ...props
+  }: { to: string; children: React.ReactNode; state?: unknown; disableIssueQuicklook?: boolean; issuePrefetch?: unknown }) => (
+    <a href={to} {...props}>{children}</a>
+  ),
+}));
+
+function createIssue(overrides: Partial<Issue> & Pick<Issue, "id" | "title" | "status">): Issue {
+  return {
+    companyId: "company-1",
+    identifier: `PAP-${overrides.id}`,
+    priority: "medium",
+    ...overrides,
+  } as Issue;
+}
+
+describe("task-detail relation panels", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    flushSync(() => root.unmount());
+    container.remove();
+  });
+
+  it("puts progress before wholly clickable subtask navigation rows", () => {
+    const onAdd = vi.fn();
+    flushSync(() => root.render(
+      <TaskDetailSubtasksPanel
+        items={[
+          createIssue({ id: "2", identifier: "PAP-2", title: "Completed setup", status: "done" }),
+          createIssue({ id: "3", identifier: "PAP-3", title: "Run verification", status: "in_progress" }),
+        ]}
+        onAddSubtask={onAdd}
+      />,
+    ));
+
+    const progress = container.querySelector('[role="progressbar"]');
+    const firstLink = container.querySelector('a[href="/issues/PAP-2"]');
+    expect(progress).not.toBeNull();
+    expect(firstLink).not.toBeNull();
+    expect(progress?.getAttribute("aria-valuenow")).toBe("50");
+    expect(progress!.compareDocumentPosition(firstLink!) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+    expect(container.textContent).toContain("Next action");
+    expect(container.querySelector('a[href="/issues/PAP-3"]')?.textContent).toContain("Run verification");
+    expect(firstLink?.textContent).toContain("Completed setup");
+    expect(firstLink?.textContent).toContain("PAP-2");
+
+    flushSync(() => container.querySelector<HTMLButtonElement>("button")!.click());
+    expect(onAdd).toHaveBeenCalledOnce();
+  });
+
+  it("puts a blocked subtask's root blocker before the shared task row", () => {
+    const blocked = createIssue({
+      id: "12",
+      identifier: "PAP-12",
+      title: "Ship the integration",
+      status: "blocked",
+      blockerAttention: {
+        state: "needs_attention",
+        reason: "attention_required",
+        unresolvedBlockerCount: 1,
+        coveredBlockerCount: 0,
+        stalledBlockerCount: 0,
+        attentionBlockerCount: 1,
+        sampleBlockerIdentifier: "PAP-11",
+        sampleStalledBlockerIdentifier: null,
+        terminalBlocker: { id: "11", identifier: "PAP-11", title: "Approve the dependency" },
+      },
+    });
+    flushSync(() => root.render(<TaskDetailSubtasksPanel items={[blocked]} />));
+
+    const rootBlocker = container.querySelector('a[href="/issues/PAP-11"]');
+    const blockedSubtask = container.querySelector('a[href="/issues/PAP-12"]');
+    expect(rootBlocker?.textContent).toContain("Approve the dependency");
+    expect(blockedSubtask?.closest('[data-slot="task-row"]')).not.toBeNull();
+    expect(rootBlocker!.compareDocumentPosition(blockedSubtask!) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+  });
+
+  it("chooses active work before queued work and does not repeat it in the remaining list", () => {
+    const todo = createIssue({ id: "21", title: "Queued follow-up", status: "todo" });
+    const active = createIssue({ id: "22", title: "Active verification", status: "in_progress" });
+    const done = createIssue({ id: "23", title: "Finished setup", status: "done" });
+
+    const state = resolveTaskDetailSubtaskState([todo, active, done]);
+    expect(state.nextAction?.id).toBe("22");
+    expect(state.remainingItems.map((item) => item.id)).toEqual(["21", "23"]);
+  });
+
+  it("separates outbound references from inbound mentions", () => {
+    flushSync(() => root.render(
+      <TaskDetailReferencesPanel
+        referenced={[{ id: "out", identifier: "PAP-8", title: "Referenced task", status: "todo" }]}
+        mentionedIn={[{ id: "in", identifier: "PAP-9", title: "Mentions this task", status: "blocked" }]}
+      />,
+    ));
+
+    const sections = container.querySelectorAll("section");
+    expect(sections[0]?.textContent).toContain("Referenced task");
+    expect(sections[0]?.textContent).not.toContain("Mentions this task");
+    expect(sections[1]?.textContent).toContain("Mentions this task");
+    expect(container.querySelector('a[href="/issues/PAP-9"]')).not.toBeNull();
+  });
+});

--- a/ui/src/components/task-detail/TaskDetailRelationsPanel.tsx
+++ b/ui/src/components/task-detail/TaskDetailRelationsPanel.tsx
@@ -1,0 +1,241 @@
+import type { Issue, IssueStatus } from "@paperclipai/shared";
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { IssueRow } from "@/components/IssueRow";
+import { StatusIcon } from "@/components/StatusIcon";
+import {
+  createIssueDetailPath,
+  rememberIssueDetailLocationState,
+} from "@/lib/issueDetailBreadcrumb";
+import { Link } from "@/lib/router";
+
+export interface TaskDetailRelationItem {
+  id: string;
+  identifier?: string | null;
+  title: string;
+  status?: IssueStatus | null;
+}
+
+function RelationNavigationList({
+  items,
+  emptyMessage,
+  ariaLabel,
+  issueLinkState,
+}: {
+  items: TaskDetailRelationItem[];
+  emptyMessage: string;
+  ariaLabel: string;
+  issueLinkState?: unknown;
+}) {
+  if (items.length === 0) {
+    return <p className="py-6 text-center text-sm text-muted-foreground">{emptyMessage}</p>;
+  }
+
+  return (
+    <ul className="flex flex-col gap-0.5" aria-label={ariaLabel}>
+      {items.map((item) => {
+        const pathId = item.identifier ?? item.id;
+        return (
+          <li key={item.id}>
+            <Link
+              to={createIssueDetailPath(pathId)}
+              state={issueLinkState}
+              onClickCapture={() => rememberIssueDetailLocationState(pathId, issueLinkState)}
+              className="flex min-w-0 items-center gap-2 rounded-md px-2 py-2 text-sm transition-colors hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              title={`${item.identifier ? `${item.identifier} — ` : ""}${item.title}`}
+            >
+              {item.status ? (
+                <StatusIcon status={item.status} className="h-3.5 w-3.5 shrink-0" />
+              ) : null}
+              <span className="min-w-0 flex-1 truncate">{item.title}</span>
+              {item.identifier ? (
+                <span className="shrink-0 font-mono text-xs text-muted-foreground">
+                  {item.identifier}
+                </span>
+              ) : null}
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+const NEXT_SUBTASK_STATUS_ORDER: IssueStatus[] = [
+  "in_progress",
+  "in_review",
+  "todo",
+  "backlog",
+  "blocked",
+];
+
+export function resolveTaskDetailSubtaskState(items: Issue[]) {
+  const nextAction = NEXT_SUBTASK_STATUS_ORDER
+    .map((status) => items.find((item) => item.status === status))
+    .find((item): item is Issue => Boolean(item)) ?? null;
+  const rootBlocker = nextAction?.status === "blocked"
+    ? nextAction.blockerAttention?.terminalBlocker ?? null
+    : null;
+
+  return {
+    nextAction,
+    rootBlocker,
+    remainingItems: nextAction
+      ? items.filter((item) => item.id !== nextAction.id)
+      : items,
+  };
+}
+
+function SharedSubtaskList({
+  items,
+  ariaLabel,
+  issueLinkState,
+}: {
+  items: Issue[];
+  ariaLabel: string;
+  issueLinkState?: unknown;
+}) {
+  return (
+    <ul className="flex flex-col gap-0.5" aria-label={ariaLabel}>
+      {items.map((item) => (
+        <li key={item.id}>
+          <IssueRow
+            issue={item}
+            issueLinkState={issueLinkState}
+            presentation="task"
+            className="rounded-md"
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function TaskDetailSubtasksPanel({
+  items,
+  onAddSubtask,
+  issueLinkState,
+}: {
+  items: Issue[];
+  onAddSubtask?: () => void;
+  issueLinkState?: unknown;
+}) {
+  const completed = items.filter((item) => item.status === "done").length;
+  const progress = items.length > 0 ? Math.round((completed / items.length) * 100) : 0;
+  const { nextAction, rootBlocker, remainingItems } = resolveTaskDetailSubtaskState(items);
+  const allCompleted = items.length > 0 && completed === items.length;
+
+  return (
+    <section className="flex flex-col gap-4" aria-label="Subtasks">
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+          <span>Progress</span>
+          <span className="font-mono">{completed} of {items.length} complete</span>
+        </div>
+        <div
+          className="h-1.5 overflow-hidden rounded-full bg-muted"
+          role="progressbar"
+          aria-label="Subtask completion"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={progress}
+        >
+          <div
+            className="h-full rounded-full bg-(--status-task-icon-done) transition-[width]"
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      </div>
+
+      {rootBlocker ? (
+        <section className="flex flex-col gap-1.5" aria-labelledby="task-root-blocker-heading">
+          <h3 id="task-root-blocker-heading" className="text-xs font-medium text-muted-foreground">
+            Root blocker
+          </h3>
+          <RelationNavigationList
+            items={[rootBlocker]}
+            emptyMessage=""
+            ariaLabel="Root blocker"
+            issueLinkState={issueLinkState}
+          />
+        </section>
+      ) : null}
+
+      {nextAction ? (
+        <section className="flex flex-col gap-1.5" aria-labelledby="task-next-action-heading">
+          <h3 id="task-next-action-heading" className="text-xs font-medium text-muted-foreground">
+            {nextAction.status === "blocked" ? "Blocked subtask" : "Next action"}
+          </h3>
+          <SharedSubtaskList
+            items={[nextAction]}
+            ariaLabel="Next subtask action"
+            issueLinkState={issueLinkState}
+          />
+        </section>
+      ) : items.length > 0 ? (
+        <p className="text-xs text-muted-foreground">
+          {allCompleted ? "All subtasks are complete." : "No remaining subtask actions."}
+        </p>
+      ) : (
+        <p className="py-6 text-center text-sm text-muted-foreground">No subtasks yet.</p>
+      )}
+
+      {remainingItems.length > 0 ? (
+        <section className="flex flex-col gap-1.5" aria-labelledby="task-other-subtasks-heading">
+          <h3 id="task-other-subtasks-heading" className="text-xs font-medium text-muted-foreground">
+            {nextAction ? "Other subtasks" : "Subtasks"}
+          </h3>
+          <SharedSubtaskList
+            items={remainingItems}
+            ariaLabel={nextAction ? "Other subtasks" : "Subtasks"}
+            issueLinkState={issueLinkState}
+          />
+        </section>
+      ) : null}
+
+      {onAddSubtask ? (
+        <Button type="button" variant="outline" size="sm" className="self-start" onClick={onAddSubtask}>
+          <Plus className="h-3.5 w-3.5" />
+          Add subtask
+        </Button>
+      ) : null}
+    </section>
+  );
+}
+
+export function TaskDetailReferencesPanel({
+  referenced,
+  mentionedIn,
+  issueLinkState,
+}: {
+  referenced: TaskDetailRelationItem[];
+  mentionedIn: TaskDetailRelationItem[];
+  issueLinkState?: unknown;
+}) {
+  return (
+    <div className="flex flex-col gap-6">
+      <section className="flex flex-col gap-2" aria-labelledby="task-referenced-heading">
+        <h3 id="task-referenced-heading" className="text-xs font-medium text-muted-foreground">
+          Referenced
+        </h3>
+        <RelationNavigationList
+          items={referenced}
+          emptyMessage="This task does not reference another task."
+          ariaLabel="Referenced tasks"
+          issueLinkState={issueLinkState}
+        />
+      </section>
+      <section className="flex flex-col gap-2" aria-labelledby="task-mentioned-in-heading">
+        <h3 id="task-mentioned-in-heading" className="text-xs font-medium text-muted-foreground">
+          Mentioned in
+        </h3>
+        <RelationNavigationList
+          items={mentionedIn}
+          emptyMessage="No other task mentions this task."
+          ariaLabel="Tasks that mention this task"
+          issueLinkState={issueLinkState}
+        />
+      </section>
+    </div>
+  );
+}

--- a/ui/src/components/task-side-panel/TaskSidePanel.test.tsx
+++ b/ui/src/components/task-side-panel/TaskSidePanel.test.tsx
@@ -63,6 +63,12 @@ vi.mock("@/components/issue-properties/IssuePropertiesPlansTab", () => ({
   IssuePropertiesPlansTab: () => <div>Plan content</div>,
 }));
 
+vi.mock("@/components/task-detail/TaskDetailRelationsPanel", () => ({
+  TaskDetailSubtasksPanel: ({ items }: { items: Issue[] }) => (
+    <div>{`Subtasks content: ${items.length}`}</div>
+  ),
+}));
+
 vi.mock("@/components/WorkspaceFileBrowser", () => ({
   WorkspaceFileBrowser: () => <div>Files browser</div>,
 }));
@@ -156,6 +162,80 @@ describe("TaskSidePanel", () => {
     await render(panel());
     expect(container.querySelector('[role="tab"][aria-selected="true"]')?.textContent).toContain("Properties");
     expect(container.textContent).toContain("Properties content");
+  });
+
+  it("uses the approved pre-rebase tab appearance for Streamlined UI", async () => {
+    await render(panel({ streamlinedTabs: true }));
+    const propertiesTab = container.querySelector<HTMLElement>('[data-side-panel-tab-target="properties"]');
+    expect(propertiesTab?.className).toContain("text-sm");
+    expect(propertiesTab?.querySelector("svg")).toBeNull();
+    expect(container.querySelector('[data-side-panel-tab-wrapper="properties"]')?.className).toContain("mx-1.5");
+    expect(container.querySelector<HTMLButtonElement>('button[aria-label="Close Properties"]')?.className)
+      .toContain("opacity-0");
+    const addButton = container.querySelector<HTMLButtonElement>('button[aria-label="Open a new tab"]');
+    expect(addButton?.className).toContain("h-(--side-panel-tab-height)");
+    expect(addButton?.className).toContain("w-(--side-panel-tab-height)");
+    expect(addButton?.className).toContain("hover:bg-accent");
+  });
+
+  it("shows an uncounted Subtasks tab only when Streamlined UI has child tasks", async () => {
+    const children = [
+      issue({ id: "child-1", title: "First child" }),
+      issue({ id: "child-2", title: "Second child" }),
+    ];
+    await render(panel({ childIssues: children, showSubtasksTab: true, streamlinedTabs: true }));
+
+    const propertiesTab = container.querySelector<HTMLElement>('[data-side-panel-tab-target="properties"]');
+    const subtasksTab = container.querySelector<HTMLButtonElement>('[data-side-panel-tab-target="subtasks"]');
+    expect(propertiesTab?.getAttribute("aria-selected")).toBe("true");
+    expect(subtasksTab?.textContent?.trim()).toBe("Subtasks");
+    expect(subtasksTab?.getAttribute("aria-label")).toBe("Subtasks");
+
+    await act(async () => subtasksTab?.click());
+    expect(container.textContent).toContain("Subtasks content: 2");
+  });
+
+  it("inserts Subtasks after Properties when child tasks load later", async () => {
+    await render(panel({ childIssues: [], showSubtasksTab: true, streamlinedTabs: true }));
+    await act(async () => container.querySelector<HTMLButtonElement>('button[aria-label="Open a new tab"]')?.click());
+    const artifactsItem = Array.from(document.body.querySelectorAll<HTMLElement>('[role="option"]'))
+      .find((item) => item.textContent?.includes("Artifacts"));
+    await act(async () => artifactsItem?.click());
+
+    await render(panel({
+      childIssues: [issue({ id: "child-1" })],
+      showSubtasksTab: true,
+      streamlinedTabs: true,
+    }));
+
+    expect(Array.from(container.querySelectorAll('[role="tab"]')).map((tab) => tab.getAttribute("data-side-panel-tab-target")))
+      .toEqual(["properties", "subtasks", "artifacts"]);
+  });
+
+  it("hides Subtasks for tasks without children and when Streamlined UI is off", async () => {
+    await render(panel({ childIssues: [], showSubtasksTab: true }));
+    expect(container.querySelector('[data-side-panel-tab-target="subtasks"]')).toBeNull();
+
+    await render(panel({ childIssues: [issue({ id: "child-1" })], showSubtasksTab: false }));
+    expect(container.querySelector('[data-side-panel-tab-target="subtasks"]')).toBeNull();
+  });
+
+  it("reopens a closed Subtasks tab from the launcher", async () => {
+    await render(panel({
+      childIssues: [issue({ id: "child-1" })],
+      showSubtasksTab: true,
+      streamlinedTabs: true,
+    }));
+
+    await act(async () => container.querySelector<HTMLButtonElement>('button[aria-label="Close Subtasks"]')?.click());
+    expect(container.querySelector('[data-side-panel-tab-target="subtasks"]')).toBeNull();
+
+    await act(async () => container.querySelector<HTMLButtonElement>('button[aria-label="Open a new tab"]')?.click());
+    const launcherItem = Array.from(document.body.querySelectorAll<HTMLElement>('[role="option"]'))
+      .find((item) => item.textContent?.includes("Subtasks"));
+    expect(launcherItem).not.toBeUndefined();
+    await act(async () => launcherItem?.click());
+    expect(container.querySelector('[data-side-panel-tab-target="subtasks"]')).not.toBeNull();
   });
 
   it("does not create a Plan tab for planning mode before a plan exists", async () => {

--- a/ui/src/components/task-side-panel/TaskSidePanel.tsx
+++ b/ui/src/components/task-side-panel/TaskSidePanel.tsx
@@ -19,6 +19,7 @@ import {
   FileText,
   FolderOpen,
   Lightbulb,
+  ListTree,
   Plus,
   SlidersHorizontal,
 } from "lucide-react";
@@ -28,6 +29,7 @@ import { PROPERTIES_PANE_HEADER_SLOT_ID } from "@/components/PropertiesPanel";
 import { WorkspaceFileBrowser } from "@/components/WorkspaceFileBrowser";
 import { IssuePropertiesArtifactsTab } from "@/components/issue-properties/IssuePropertiesArtifactsTab";
 import { IssuePropertiesPlansTab } from "@/components/issue-properties/IssuePropertiesPlansTab";
+import { TaskDetailSubtasksPanel } from "@/components/task-detail/TaskDetailRelationsPanel";
 import {
   SidePanelLauncher,
   SidePanelToggleButton,
@@ -63,6 +65,7 @@ import {
   taskPanelDocumentTab,
   taskPanelFilesTab,
   taskPanelPropertiesTab,
+  taskPanelSubtasksTab,
   taskPanelWorkspaceFileTab,
   writeTaskSidePanelState,
   type TaskSidePanelTabPayload,
@@ -75,6 +78,7 @@ export interface TaskSidePanelProps {
   issue: Issue;
   accountScope: string;
   childIssues?: Issue[];
+  issueLinkState?: unknown;
   onAddSubIssue?: () => void;
   onUpdate: (data: Record<string, unknown>) => void;
   inline?: boolean;
@@ -88,6 +92,8 @@ export interface TaskSidePanelProps {
   fileTabsEnabled: boolean;
   documentDeepLink?: { requestId: number; documentKey: string } | null;
   onRequestClose?: () => void;
+  streamlinedTabs?: boolean;
+  showSubtasksTab?: boolean;
 }
 
 const EMPTY_ISSUE_DOCUMENTS: IssueDocument[] = [];
@@ -95,11 +101,22 @@ const EMPTY_ISSUE_DOCUMENTS: IssueDocument[] = [];
 function tabIcon(tab: SidePanelTabRecord<TaskSidePanelTabPayload>): ReactNode {
   switch (tab.payload.kind) {
     case "properties": return <SlidersHorizontal />;
+    case "subtasks": return <ListTree />;
     case "artifacts": return <Box />;
     case "files-browser": return <FolderOpen />;
     case "workspace-file": return <FileCode2 />;
     case "issue-document": return tab.payload.documentKey === "plan" ? <Lightbulb /> : <FileText />;
   }
+}
+
+function insertSubtasksAfterProperties(
+  tabs: SidePanelTabRecord<TaskSidePanelTabPayload>[],
+) {
+  if (tabs.some((tab) => tab.id === "subtasks")) return tabs;
+  const propertiesIndex = tabs.findIndex((tab) => tab.id === "properties");
+  const next = [...tabs];
+  next.splice(propertiesIndex < 0 ? 0 : propertiesIndex + 1, 0, taskPanelSubtasksTab());
+  return next;
 }
 
 function selectorForWorkspaceKind(kind: "execution_workspace" | "project_workspace") {
@@ -190,6 +207,7 @@ export function TaskSidePanel({
   issue,
   accountScope,
   childIssues = [],
+  issueLinkState,
   onAddSubIssue,
   onUpdate,
   inline = false,
@@ -203,6 +221,8 @@ export function TaskSidePanel({
   fileTabsEnabled,
   documentDeepLink,
   onRequestClose,
+  streamlinedTabs = false,
+  showSubtasksTab = false,
 }: TaskSidePanelProps) {
   const handleScroll = useScrollbarWhileScrolling();
   const viewer = useTaskSidePanelFileRouting();
@@ -212,16 +232,33 @@ export function TaskSidePanel({
   const restoredRef = useRef(
     readTaskSidePanelState(accountScope, issue.companyId, issue.id, fileTabsEnabled),
   );
+  const initialSubtasksAvailableRef = useRef(showSubtasksTab && childIssues.length > 0);
+  const subtasksDismissedRef = useRef(
+    restoredRef.current?.userInteracted === true
+      && restoredRef.current.state.tabs.length === 0,
+  );
   const [launcherOpen, setLauncherOpen] = useState(restoredRef.current?.launcherOpen ?? false);
   const [paneHeaderSlot, setPaneHeaderSlot] = useState<HTMLElement | null>(null);
   const bodyRef = useRef<HTMLDivElement>(null);
   const scrollPositionsRef = useRef(new Map<string, number>());
   const userInteractedRef = useRef(restoredRef.current?.userInteracted ?? false);
   const autoPlanHandledRef = useRef(restoredRef.current?.autoPlanHandled ?? false);
-  const initialState = useMemo(() => restoredRef.current?.state ?? ({
-    tabs: [taskPanelPropertiesTab()],
-    activeTabId: "properties",
-  }), []);
+  const initialState = useMemo(() => {
+    const restored = restoredRef.current?.state;
+    let tabs = restored?.tabs ?? [taskPanelPropertiesTab()];
+    if (!initialSubtasksAvailableRef.current) {
+      tabs = tabs.filter((tab) => tab.payload.kind !== "subtasks");
+    } else if (!subtasksDismissedRef.current) {
+      tabs = insertSubtasksAfterProperties(tabs);
+    }
+    const requestedActive = restored?.activeTabId ?? "properties";
+    return {
+      tabs,
+      activeTabId: tabs.some((tab) => tab.id === requestedActive)
+        ? requestedActive
+        : tabs[0]?.id ?? null,
+    };
+  }, []);
 
   const persist = useCallback((state: { tabs: SidePanelTabRecord<TaskSidePanelTabPayload>[]; activeTabId: string | null }) => {
     writeTaskSidePanelState(accountScope, issue.companyId, issue.id, {
@@ -234,6 +271,29 @@ export function TaskSidePanel({
   }, [accountScope, issue.companyId, issue.id, launcherOpen]);
   const controller = useSidePanelTabs<TaskSidePanelTabPayload>({ initialState, onStateChange: persist });
   const activeTab = controller.tabs.find((tab) => tab.id === controller.activeTabId) ?? null;
+  const subtasksAvailable = showSubtasksTab && childIssues.length > 0;
+  const hasSubtasksTab = controller.tabs.some((tab) => tab.id === "subtasks");
+
+  useEffect(() => {
+    if (!subtasksAvailable) {
+      subtasksDismissedRef.current = false;
+      if (hasSubtasksTab) controller.closeTab("subtasks");
+      return;
+    }
+    if (!hasSubtasksTab && !subtasksDismissedRef.current) {
+      controller.resetTabs({
+        tabs: insertSubtasksAfterProperties(controller.tabs),
+        activeTabId: controller.activeTabId,
+      });
+    }
+  }, [
+    controller.activeTabId,
+    controller.closeTab,
+    controller.resetTabs,
+    controller.tabs,
+    hasSubtasksTab,
+    subtasksAvailable,
+  ]);
 
   useEffect(() => {
     if (inline) {
@@ -353,6 +413,7 @@ export function TaskSidePanel({
 
   function closeTab(tabId: string) {
     markInteracted();
+    if (tabId === "subtasks") subtasksDismissedRef.current = true;
     const tab = controller.tabs.find((candidate) => candidate.id === tabId);
     controller.closeTab(tabId);
     if (tabId === controller.activeTabId && (tab?.payload.kind === "workspace-file" || tab?.payload.kind === "files-browser")) {
@@ -392,7 +453,7 @@ export function TaskSidePanel({
       id: tab.id,
       type: tab.type,
       label: document ? documentDisplayTitle(document) : tab.label,
-      ariaLabel: tab.ariaLabel,
+      ariaLabel: tab.payload.kind === "subtasks" ? "Subtasks" : tab.ariaLabel,
       closable: true,
       contentMode: tab.contentMode,
       icon: tabIcon(tab),
@@ -402,6 +463,7 @@ export function TaskSidePanel({
   const launcherSections = useMemo<SidePanelLauncherSection[]>(() => {
     const primary: SidePanelLauncherItem[] = [
       { id: "properties", label: "Properties", icon: <SlidersHorizontal />, alreadyOpen: controller.tabs.some((tab) => tab.id === "properties") },
+      ...(subtasksAvailable ? [{ id: "subtasks", label: "Subtasks", description: `${childIssues.length} total`, icon: <ListTree />, alreadyOpen: controller.tabs.some((tab) => tab.id === "subtasks") }] : []),
       { id: "artifacts", label: "Artifacts", icon: <Box />, alreadyOpen: controller.tabs.some((tab) => tab.id === "artifacts") },
     ];
     if (fileTabsEnabled) {
@@ -451,11 +513,18 @@ export function TaskSidePanel({
       });
     }
     return sections;
-  }, [controller.tabs, documents, fileTabsEnabled, planDocument, recentFilesQuery.data, recentFilesQuery.isError, recentFilesQuery.isLoading]);
+  }, [childIssues.length, controller.tabs, documents, fileTabsEnabled, planDocument, recentFilesQuery.data, recentFilesQuery.isError, recentFilesQuery.isLoading, subtasksAvailable]);
 
   function selectLauncherItem(item: SidePanelLauncherItem) {
     markInteracted();
     if (item.id === "properties") controller.openTab(taskPanelPropertiesTab());
+    else if (item.id === "subtasks") {
+      subtasksDismissedRef.current = false;
+      controller.resetTabs({
+        tabs: insertSubtasksAfterProperties(controller.tabs),
+        activeTabId: "subtasks",
+      });
+    }
     else if (item.id === "artifacts") controller.openTab(taskPanelArtifactsTab());
     else if (item.id === "files") {
       controller.openTab(taskPanelFilesTab());
@@ -486,7 +555,18 @@ export function TaskSidePanel({
       open={launcherOpen}
       onOpenChange={setLauncherOpen}
       trigger={(
-        <Button type="button" variant="ghost" size="icon-sm" className="h-(--side-panel-tab-height) w-(--side-panel-tab-height) shrink-0 rounded-(--side-panel-control-radius) text-muted-foreground hover:text-foreground focus-visible:text-foreground" aria-label="Open a new tab">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className={cn(
+            "shrink-0 text-muted-foreground hover:text-foreground focus-visible:text-foreground",
+            streamlinedTabs
+              ? "h-(--side-panel-tab-height) w-(--side-panel-tab-height) rounded-md"
+              : "h-(--side-panel-tab-height) w-(--side-panel-tab-height) rounded-(--side-panel-control-radius)",
+          )}
+          aria-label="Open a new tab"
+        >
           <Plus aria-hidden />
         </Button>
       )}
@@ -503,6 +583,7 @@ export function TaskSidePanel({
         controller.reorderTabs(ordered);
       }}
       addControl={launcherControl}
+      appearance={streamlinedTabs ? "streamlined-task" : "default"}
     />
   );
 
@@ -514,6 +595,7 @@ export function TaskSidePanel({
       <IssueProperties
         issue={issue}
         childIssues={childIssues}
+        issueLinkState={issueLinkState}
         onAddSubIssue={onAddSubIssue}
         onUpdate={onUpdate}
         inline={inline}
@@ -525,6 +607,14 @@ export function TaskSidePanel({
         onCheckMonitorNow={onCheckMonitorNow}
         checkingMonitorNow={checkingMonitorNow}
         sidePanelContentOnly
+      />
+    );
+  } else if (activeTab.payload.kind === "subtasks") {
+    content = (
+      <TaskDetailSubtasksPanel
+        items={childIssues}
+        onAddSubtask={onAddSubIssue}
+        issueLinkState={issueLinkState}
       />
     );
   } else if (activeTab.payload.kind === "artifacts") {

--- a/ui/src/hooks/useKeyboardShortcuts.test.tsx
+++ b/ui/src/hooks/useKeyboardShortcuts.test.tsx
@@ -11,19 +11,16 @@ import { useKeyboardShortcuts } from "./useKeyboardShortcuts";
 function TestHarness({
   onNewIssue,
   onSearch,
-  onToggleCollapse,
   onGoToInbox,
 }: {
   onNewIssue: () => void;
   onSearch?: () => void;
-  onToggleCollapse?: () => void;
   onGoToInbox?: () => void;
 }) {
   useKeyboardShortcuts({
     enabled: true,
     onNewIssue,
     onSearch,
-    onToggleCollapse,
     onGoToInbox,
   });
 
@@ -113,29 +110,30 @@ describe("useKeyboardShortcuts", () => {
     });
   });
 
-  it("fires onToggleCollapse on Cmd/Ctrl+B", () => {
+  it("does not intercept the retired Cmd/Ctrl+B collapse shortcut", () => {
     const root = createRoot(container);
-    const onToggleCollapse = vi.fn();
 
     act(() => {
-      root.render(<TestHarness onNewIssue={vi.fn()} onToggleCollapse={onToggleCollapse} />);
+      root.render(<TestHarness onNewIssue={vi.fn()} />);
     });
 
-    document.dispatchEvent(new KeyboardEvent("keydown", {
+    const metaEvent = new KeyboardEvent("keydown", {
       key: "b",
       metaKey: true,
       bubbles: true,
       cancelable: true,
-    }));
-    expect(onToggleCollapse).toHaveBeenCalledTimes(1);
+    });
+    document.dispatchEvent(metaEvent);
+    expect(metaEvent.defaultPrevented).toBe(false);
 
-    document.dispatchEvent(new KeyboardEvent("keydown", {
+    const ctrlEvent = new KeyboardEvent("keydown", {
       key: "b",
       ctrlKey: true,
       bubbles: true,
       cancelable: true,
-    }));
-    expect(onToggleCollapse).toHaveBeenCalledTimes(2);
+    });
+    document.dispatchEvent(ctrlEvent);
+    expect(ctrlEvent.defaultPrevented).toBe(false);
 
     act(() => {
       root.unmount();
@@ -201,23 +199,4 @@ describe("useKeyboardShortcuts", () => {
     });
   });
 
-  it("does not fire onToggleCollapse for a bare 'b' keypress", () => {
-    const root = createRoot(container);
-    const onToggleCollapse = vi.fn();
-
-    act(() => {
-      root.render(<TestHarness onNewIssue={vi.fn()} onToggleCollapse={onToggleCollapse} />);
-    });
-
-    document.dispatchEvent(new KeyboardEvent("keydown", {
-      key: "b",
-      bubbles: true,
-      cancelable: true,
-    }));
-    expect(onToggleCollapse).not.toHaveBeenCalled();
-
-    act(() => {
-      root.unmount();
-    });
-  });
 });

--- a/ui/src/hooks/useKeyboardShortcuts.ts
+++ b/ui/src/hooks/useKeyboardShortcuts.ts
@@ -11,7 +11,6 @@ interface ShortcutHandlers {
   onNewIssue?: () => void;
   onSearch?: () => void;
   onToggleSidebar?: () => void;
-  onToggleCollapse?: () => void;
   onTogglePanel?: () => void;
   onShowShortcuts?: () => void;
   onGoToInbox?: () => void;
@@ -22,7 +21,6 @@ export function useKeyboardShortcuts({
   onNewIssue,
   onSearch,
   onToggleSidebar,
-  onToggleCollapse,
   onTogglePanel,
   onShowShortcuts,
   onGoToInbox,
@@ -128,12 +126,6 @@ export function useKeyboardShortcuts({
         onToggleSidebar?.();
       }
 
-      // Cmd/Ctrl+B → Collapse/expand sidebar (desktop) or toggle drawer (mobile)
-      if ((e.key === "b" || e.key === "B") && (e.metaKey || e.ctrlKey) && !e.altKey) {
-        e.preventDefault();
-        onToggleCollapse?.();
-      }
-
       // ] → Toggle Panel
       if (e.key === "]" && !e.metaKey && !e.ctrlKey) {
         e.preventDefault();
@@ -155,5 +147,5 @@ export function useKeyboardShortcuts({
       document.removeEventListener("focusin", handleFocusIn, true);
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [enabled, onNewIssue, onSearch, onToggleSidebar, onToggleCollapse, onTogglePanel, onShowShortcuts, onGoToInbox]);
+  }, [enabled, onNewIssue, onSearch, onToggleSidebar, onTogglePanel, onShowShortcuts, onGoToInbox]);
 }

--- a/ui/src/lib/issue-filters.test.ts
+++ b/ui/src/lib/issue-filters.test.ts
@@ -7,6 +7,7 @@ import {
   countActiveIssueFilters,
   defaultIssueFilterState,
   resolveIssueFilterWorkspaceId,
+  searchIssueFilterOptions,
   shouldIncludeIssueFilterWorkspaceOption,
 } from "./issue-filters";
 
@@ -68,6 +69,14 @@ function makeExternalObjectSummary(overrides: Partial<ExternalObjectSummary> = {
 }
 
 describe("issue filters", () => {
+  it("searches filter options case-insensitively without mutating the source", () => {
+    const options = [{ name: "Alpha Agent" }, { name: "Release QA" }];
+    expect(searchIssueFilterOptions(options, "  qa ", (option) => option.name)).toEqual([
+      { name: "Release QA" },
+    ]);
+    expect(options).toHaveLength(2);
+  });
+
   it("filters issues by creator across agents and users", () => {
     const issues = [
       makeIssue({ id: "agent-match", createdByAgentId: "agent-1" }),

--- a/ui/src/lib/issue-filters.ts
+++ b/ui/src/lib/issue-filters.ts
@@ -123,6 +123,18 @@ export function toggleIssueFilterValue(values: string[], value: string): string[
   return values.includes(value) ? values.filter((existing) => existing !== value) : [...values, value];
 }
 
+export function searchIssueFilterOptions<T>(
+  options: readonly T[] | undefined,
+  search: string,
+  getSearchText: (option: T) => string,
+): T[] {
+  const normalizedSearch = search.trim().toLocaleLowerCase();
+  if (!normalizedSearch) return [...(options ?? [])];
+  return (options ?? []).filter((option) =>
+    getSearchText(option).toLocaleLowerCase().includes(normalizedSearch),
+  );
+}
+
 export function resolveIssueFilterWorkspaceId(
   issue: Pick<Issue, "executionWorkspaceId" | "projectId" | "projectWorkspaceId">,
   context: IssueFilterWorkspaceContext = {},

--- a/ui/src/lib/task-collection-preferences.test.ts
+++ b/ui/src/lib/task-collection-preferences.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+  loadTaskCollectionPreferences,
+  saveTaskCollectionPreferences,
+  taskCollectionPreferencesStorageKey,
+} from "./task-collection-preferences";
+
+class MemoryStorage {
+  private values = new Map<string, string>();
+  getItem(key: string) { return this.values.get(key) ?? null; }
+  setItem(key: string, value: string) { this.values.set(key, value); }
+}
+
+type ViewState = { sort: "updated" | "created"; filters: string[] };
+type Column = "status" | "id" | "updated";
+
+const defaults: ViewState = { sort: "updated", filters: [] };
+const columns: Column[] = ["status", "id", "updated"];
+const normalizeViewState = (value: unknown): ViewState => {
+  const candidate = value as Partial<ViewState> | null;
+  return {
+    sort: candidate?.sort === "created" ? "created" : "updated",
+    filters: Array.isArray(candidate?.filters)
+      ? candidate.filters.filter((entry): entry is string => typeof entry === "string")
+      : [],
+  };
+};
+const normalizeColumns = (value: unknown): Column[] => Array.isArray(value)
+  ? value.filter((entry): entry is Column => columns.includes(entry as Column))
+  : columns;
+
+describe("task collection preferences", () => {
+  it("migrates legacy view and column keys into a versioned company scope", () => {
+    const storage = new MemoryStorage();
+    storage.setItem("legacy:view", JSON.stringify({ sort: "created", filters: ["active"] }));
+    storage.setItem("legacy:columns", JSON.stringify(["status", "id"]));
+
+    const loaded = loadTaskCollectionPreferences<ViewState, Column>({
+      storage,
+      companyId: "company-a",
+      collectionKey: "tasks",
+      legacyViewStorageKey: "legacy:view",
+      legacyColumnsStorageKey: "legacy:columns",
+      defaultViewState: defaults,
+      defaultColumns: columns,
+      normalizeViewState,
+      normalizeColumns,
+    });
+
+    expect(loaded).toEqual({
+      viewState: { sort: "created", filters: ["active"] },
+      columns: ["status", "id"],
+      migrated: true,
+      source: "legacy",
+    });
+    const current = storage.getItem(taskCollectionPreferencesStorageKey({
+      companyId: "company-a",
+      collectionKey: "tasks",
+    }));
+    expect(JSON.parse(current ?? "{}")).toMatchObject({ version: 1, companyId: "company-a", collectionKey: "tasks" });
+  });
+
+  it("keeps preferences isolated between companies", () => {
+    const storage = new MemoryStorage();
+    saveTaskCollectionPreferences<ViewState, Column>(
+      { companyId: "company-a", collectionKey: "tasks" },
+      { viewState: { sort: "created", filters: [] }, columns: ["id"] },
+      storage,
+    );
+
+    const companyB = loadTaskCollectionPreferences<ViewState, Column>({
+      storage,
+      companyId: "company-b",
+      collectionKey: "tasks",
+      defaultViewState: defaults,
+      defaultColumns: columns,
+      normalizeViewState,
+      normalizeColumns,
+    });
+    expect(companyB.viewState).toEqual(defaults);
+    expect(companyB.columns).toEqual(columns);
+  });
+
+  it("dual-writes legacy keys for compatibility", () => {
+    const storage = new MemoryStorage();
+    saveTaskCollectionPreferences<ViewState, Column>(
+      {
+        companyId: "company-a",
+        collectionKey: "tasks",
+        legacyViewStorageKey: "legacy:view",
+        legacyColumnsStorageKey: "legacy:columns",
+      },
+      { viewState: { sort: "created", filters: ["active"] }, columns: ["status"] },
+      storage,
+    );
+
+    expect(JSON.parse(storage.getItem("legacy:view") ?? "{}")).toEqual({ sort: "created", filters: ["active"] });
+    expect(JSON.parse(storage.getItem("legacy:columns") ?? "[]")).toEqual(["status"]);
+  });
+
+  it("preserves a collection default when only legacy columns existed", () => {
+    const storage = new MemoryStorage();
+    storage.setItem("legacy:columns", JSON.stringify(["id"]));
+    const options = {
+      storage,
+      companyId: "company-a",
+      collectionKey: "tasks",
+      legacyViewStorageKey: "legacy:view",
+      legacyColumnsStorageKey: "legacy:columns",
+      defaultViewState: defaults,
+      defaultColumns: columns,
+      normalizeViewState,
+      normalizeColumns,
+    } as const;
+
+    const migrated = loadTaskCollectionPreferences<ViewState, Column>(options);
+    const reloaded = loadTaskCollectionPreferences<ViewState, Column>(options);
+    expect(migrated.source).toBe("default");
+    expect(reloaded.source).toBe("default");
+    expect(reloaded.columns).toEqual(["id"]);
+  });
+});

--- a/ui/src/lib/task-collection-preferences.ts
+++ b/ui/src/lib/task-collection-preferences.ts
@@ -1,0 +1,141 @@
+export const TASK_COLLECTION_PREFERENCES_VERSION = 1 as const;
+
+type StorageLike = Pick<Storage, "getItem" | "setItem">;
+
+export interface TaskCollectionPreferenceEnvelope<TViewState, TColumn extends string> {
+  version: typeof TASK_COLLECTION_PREFERENCES_VERSION;
+  companyId: string;
+  collectionKey: string;
+  viewState: TViewState;
+  viewStateSource?: "stored" | "default";
+  columns: TColumn[];
+}
+
+export interface TaskCollectionPreferenceLocation {
+  companyId: string;
+  collectionKey: string;
+  legacyViewStorageKey?: string;
+  legacyColumnsStorageKey?: string;
+}
+
+export interface LoadTaskCollectionPreferenceOptions<TViewState, TColumn extends string>
+  extends TaskCollectionPreferenceLocation {
+  storage?: StorageLike | null;
+  defaultViewState: TViewState;
+  defaultColumns: TColumn[];
+  normalizeViewState: (value: unknown) => TViewState;
+  normalizeColumns: (value: unknown) => TColumn[];
+}
+
+function browserStorage(): StorageLike | null {
+  if (typeof localStorage === "undefined") return null;
+  return localStorage;
+}
+
+function parseStoredJson(storage: StorageLike, key: string | undefined): unknown {
+  if (!key) return null;
+  try {
+    const value = storage.getItem(key);
+    return value == null ? null : JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+export function taskCollectionPreferencesStorageKey({
+  companyId,
+  collectionKey,
+}: Pick<TaskCollectionPreferenceLocation, "companyId" | "collectionKey">): string {
+  return `paperclip:task-collection:v${TASK_COLLECTION_PREFERENCES_VERSION}:${encodeURIComponent(companyId)}:${encodeURIComponent(collectionKey)}`;
+}
+
+function isCurrentEnvelope<TViewState, TColumn extends string>(
+  value: unknown,
+  location: TaskCollectionPreferenceLocation,
+): value is TaskCollectionPreferenceEnvelope<TViewState, TColumn> {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<TaskCollectionPreferenceEnvelope<TViewState, TColumn>>;
+  return candidate.version === TASK_COLLECTION_PREFERENCES_VERSION
+    && candidate.companyId === location.companyId
+    && candidate.collectionKey === location.collectionKey
+    && "viewState" in candidate
+    && Array.isArray(candidate.columns);
+}
+
+export function saveTaskCollectionPreferences<TViewState, TColumn extends string>(
+  location: TaskCollectionPreferenceLocation,
+  value: { viewState: TViewState; columns: TColumn[]; viewStateSource?: "stored" | "default" },
+  storage: StorageLike | null = browserStorage(),
+): void {
+  if (!storage) return;
+  const envelope: TaskCollectionPreferenceEnvelope<TViewState, TColumn> = {
+    version: TASK_COLLECTION_PREFERENCES_VERSION,
+    companyId: location.companyId,
+    collectionKey: location.collectionKey,
+    viewState: value.viewState,
+    viewStateSource: value.viewStateSource ?? "stored",
+    columns: value.columns,
+  };
+
+  try {
+    storage.setItem(taskCollectionPreferencesStorageKey(location), JSON.stringify(envelope));
+    // Dual-write during migration so older builds using the same worktree keep
+    // reading the latest presentation state.
+    if (location.legacyViewStorageKey) {
+      storage.setItem(location.legacyViewStorageKey, JSON.stringify(value.viewState));
+    }
+    if (location.legacyColumnsStorageKey) {
+      storage.setItem(location.legacyColumnsStorageKey, JSON.stringify(value.columns));
+    }
+  } catch {
+    // Preferences are an enhancement; storage denial must not break the list.
+  }
+}
+
+export function loadTaskCollectionPreferences<TViewState, TColumn extends string>({
+  storage = browserStorage(),
+  defaultViewState,
+  defaultColumns,
+  normalizeViewState,
+  normalizeColumns,
+  ...location
+}: LoadTaskCollectionPreferenceOptions<TViewState, TColumn>): {
+  viewState: TViewState;
+  columns: TColumn[];
+  migrated: boolean;
+  source: "current" | "legacy" | "default";
+} {
+  if (!storage) {
+    return { viewState: defaultViewState, columns: defaultColumns, migrated: false, source: "default" };
+  }
+
+  const current = parseStoredJson(storage, taskCollectionPreferencesStorageKey(location));
+  if (isCurrentEnvelope<TViewState, TColumn>(current, location)) {
+    return {
+      viewState: normalizeViewState(current.viewState),
+      columns: normalizeColumns(current.columns),
+      migrated: false,
+      source: current.viewStateSource === "default" ? "default" : "current",
+    };
+  }
+
+  const legacyView = parseStoredJson(storage, location.legacyViewStorageKey);
+  const legacyColumns = parseStoredJson(storage, location.legacyColumnsStorageKey);
+  const hasLegacyState = legacyView !== null || legacyColumns !== null;
+  const preferences = {
+    viewState: legacyView === null ? defaultViewState : normalizeViewState(legacyView),
+    columns: legacyColumns === null ? defaultColumns : normalizeColumns(legacyColumns),
+  };
+
+  if (hasLegacyState) {
+    saveTaskCollectionPreferences(location, {
+      ...preferences,
+      viewStateSource: legacyView === null ? "default" : "stored",
+    }, storage);
+  }
+  return {
+    ...preferences,
+    migrated: hasLegacyState,
+    source: legacyView !== null ? "legacy" : "default",
+  };
+}

--- a/ui/src/lib/task-date-groups.test.ts
+++ b/ui/src/lib/task-date-groups.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { taskDateGroup, taskDateGroupSeparator } from "./task-date-groups";
+
+describe("task date groups", () => {
+  const now = new Date(2026, 7, 31, 9, 30);
+
+  it("uses local calendar boundaries instead of rolling 24-hour windows", () => {
+    expect(taskDateGroup(new Date(2026, 7, 31, 0, 1), now)).toBe("today");
+    expect(taskDateGroup(new Date(2026, 7, 30, 23, 59), now)).toBe("yesterday");
+    expect(taskDateGroup(new Date(2026, 7, 29, 23, 59), now)).toBe("earlier");
+  });
+
+  it("does not emit duplicate or leading Earlier separators", () => {
+    expect(taskDateGroupSeparator(null, "earlier")).toBeNull();
+    expect(taskDateGroupSeparator(null, "today")).toBe("Today");
+    expect(taskDateGroupSeparator("today", "today")).toBeNull();
+    expect(taskDateGroupSeparator("today", "yesterday")).toBe("Yesterday");
+    expect(taskDateGroupSeparator("yesterday", "earlier")).toBe("Earlier");
+  });
+});

--- a/ui/src/lib/task-date-groups.ts
+++ b/ui/src/lib/task-date-groups.ts
@@ -1,0 +1,37 @@
+export type TaskDateGroup = "today" | "yesterday" | "earlier";
+
+export const taskDateGroupLabels: Record<TaskDateGroup, string> = {
+  today: "Today",
+  yesterday: "Yesterday",
+  earlier: "Earlier",
+};
+
+function localCalendarOrdinal(date: Date): number {
+  return Date.UTC(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+/** Groups timestamps by the operator's local calendar, including across DST. */
+export function taskDateGroup(value: Date | string | number, now: Date = new Date()): TaskDateGroup {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return "earlier";
+
+  const dayDifference = Math.round(
+    (localCalendarOrdinal(now) - localCalendarOrdinal(date)) / (24 * 60 * 60 * 1000),
+  );
+  if (dayDifference <= 0) return "today";
+  if (dayDifference === 1) return "yesterday";
+  return "earlier";
+}
+
+/**
+ * Returns the label to insert before the current row. A list made entirely of
+ * older work does not begin with a redundant "Earlier" heading.
+ */
+export function taskDateGroupSeparator(
+  previous: TaskDateGroup | null,
+  current: TaskDateGroup,
+): string | null {
+  if (previous === current) return null;
+  if (previous === null && current === "earlier") return null;
+  return taskDateGroupLabels[current];
+}

--- a/ui/src/lib/task-side-panel-state.test.ts
+++ b/ui/src/lib/task-side-panel-state.test.ts
@@ -6,6 +6,7 @@ import {
   taskPanelDocumentTab,
   taskPanelFilesTab,
   taskPanelPropertiesTab,
+  taskPanelSubtasksTab,
   writeTaskSidePanelState,
 } from "./task-side-panel-state";
 
@@ -52,6 +53,23 @@ describe("task side-panel persistence", () => {
     const restored = readTaskSidePanelState("user-1", "company-1", "task-1", false);
     expect(restored?.state.tabs.map((tab) => tab.id)).toEqual(["properties", "document:plan"]);
     expect(restored?.state.activeTabId).toBe("properties");
+  });
+
+  it("round-trips the Streamlined UI subtasks tab", () => {
+    writeTaskSidePanelState("user-1", "company-1", "task-1", {
+      state: {
+        tabs: [taskPanelPropertiesTab(), taskPanelSubtasksTab()],
+        activeTabId: "subtasks",
+      },
+      launcherOpen: false,
+      userInteracted: true,
+      autoPlanHandled: true,
+      updatedAt: 1,
+    });
+
+    const restored = readTaskSidePanelState("user-1", "company-1", "task-1", false);
+    expect(restored?.state.tabs.map((tab) => tab.id)).toEqual(["properties", "subtasks"]);
+    expect(restored?.state.activeTabId).toBe("subtasks");
   });
 
   it("retains only the 50 most recently written tasks", () => {

--- a/ui/src/lib/task-side-panel-state.ts
+++ b/ui/src/lib/task-side-panel-state.ts
@@ -6,6 +6,7 @@ const MAX_TASK_STATES = 50;
 
 export type TaskSidePanelTabPayload =
   | { kind: "properties" }
+  | { kind: "subtasks" }
   | { kind: "artifacts" }
   | { kind: "issue-document"; documentKey: string }
   | {
@@ -62,6 +63,7 @@ function parsePayload(value: unknown): TaskSidePanelTabPayload | null {
   if (!input) return null;
   const kind = input.kind;
   if (kind === "properties") return { kind };
+  if (kind === "subtasks") return { kind };
   if (kind === "artifacts") return { kind };
   if (kind === "issue-document") {
     return typeof input.documentKey === "string" && input.documentKey.length > 0
@@ -182,6 +184,10 @@ export function writeTaskSidePanelState(
 
 export function taskPanelPropertiesTab(): SidePanelTabRecord<TaskSidePanelTabPayload> {
   return { id: "properties", type: "properties", label: "Properties", closable: true, contentMode: "padded", payload: { kind: "properties" } };
+}
+
+export function taskPanelSubtasksTab(): SidePanelTabRecord<TaskSidePanelTabPayload> {
+  return { id: "subtasks", type: "subtasks", label: "Subtasks", closable: true, contentMode: "padded", payload: { kind: "subtasks" } };
 }
 
 export function taskPanelArtifactsTab(): SidePanelTabRecord<TaskSidePanelTabPayload> {

--- a/ui/src/pages/Inbox.test.tsx
+++ b/ui/src/pages/Inbox.test.tsx
@@ -11,6 +11,7 @@ import {
   clearLocalInboxArchive,
   getLocalInboxArchiveIssueIds,
 } from "../lib/inboxArchiveCache";
+import { taskCollectionPreferencesStorageKey } from "../lib/task-collection-preferences";
 
 const routerMock = vi.hoisted(() => ({
   location: { pathname: "/", search: "", hash: "" },
@@ -360,7 +361,10 @@ function resetInboxApiMocks() {
   apiMocks.agentsList.mockResolvedValue([]);
   apiMocks.heartbeatRunsList.mockResolvedValue([]);
   apiMocks.liveRunsForCompany.mockResolvedValue([]);
-  apiMocks.experimentalSettings.mockResolvedValue({ enableIsolatedWorkspaces: false });
+  apiMocks.experimentalSettings.mockResolvedValue({
+    enableIsolatedWorkspaces: false,
+    enableStreamlinedUi: true,
+  });
   apiMocks.projectsList.mockResolvedValue([]);
 }
 
@@ -368,6 +372,7 @@ describe("Inbox toolbar", () => {
   let container: HTMLDivElement;
 
   beforeEach(() => {
+    localStorage.clear();
     resetInboxApiMocks();
     container = document.createElement("div");
     document.body.appendChild(container);
@@ -378,6 +383,52 @@ describe("Inbox toolbar", () => {
       clearLocalInboxArchive("company-1", issueId);
     }
     container.remove();
+  });
+
+  it("restores the legacy toolbar and issue-row presentation when Streamlined UI is off", async () => {
+    routerMock.location.pathname = "/inbox/mine";
+    apiMocks.experimentalSettings.mockResolvedValue({
+      enableIsolatedWorkspaces: false,
+      enableStreamlinedUi: false,
+    });
+    apiMocks.issuesList.mockResolvedValue([
+      createIssue({ id: "legacy-row", identifier: "PAP-1904", title: "Legacy inbox task" }),
+    ]);
+    localStorage.setItem(
+      taskCollectionPreferencesStorageKey({ companyId: "company-1", collectionKey: "inbox" }),
+      JSON.stringify({
+        version: 1,
+        companyId: "company-1",
+        collectionKey: "inbox",
+        viewState: {},
+        columns: [],
+      }),
+    );
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0 } },
+    });
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Inbox />
+        </QueryClientProvider>,
+      );
+    });
+    await vi.waitFor(() => expect(container.textContent).toContain("Legacy inbox task"));
+
+    expect(container.querySelector('[data-slot="collection-toolbar"]')).toBeNull();
+    expect(container.querySelector('[role="toolbar"][aria-label="Inbox controls"]')).toBeNull();
+    expect(container.textContent).toContain("Mine");
+    expect(container.querySelector('[data-slot="task-row"]')).toBeNull();
+    const issueLink = container.querySelector('[data-inbox-issue-link]');
+    // Production reads the legacy Inbox column key and must ignore the
+    // Streamlined collection envelope above when the experiment is disabled.
+    expect(issueLink?.parentElement?.textContent).toContain("PAP-1904");
+
+    act(() => root.unmount());
   });
 
   it("does not render external-object summaries in inbox rows", async () => {
@@ -452,6 +503,16 @@ describe("Inbox toolbar", () => {
       expect(row?.querySelector("[data-inbox-row-surface]")).not.toBeNull();
     }
 
+    const approvalRow = rowFor("Hire Agent: New teammate");
+    const approvalActions = [...(approvalRow?.querySelectorAll("button") ?? [])]
+      .filter((button) => button.textContent === "Approve" || button.textContent === "Reject");
+    expect(approvalActions.length).toBeGreaterThanOrEqual(2);
+    approvalActions.forEach((button) => {
+      expect(button.className).toContain("h-8");
+      expect(button.className).toContain("min-w-(--sz-64px)");
+      expect(button.className).toContain("justify-center");
+    });
+
     act(() => root.unmount());
   });
 
@@ -471,7 +532,13 @@ describe("Inbox toolbar", () => {
       parentId: parent.id,
       title: "Nested inbox task",
     });
-    apiMocks.issuesList.mockResolvedValue([parent, child]);
+    const grandchild = createIssue({
+      id: "grandchild-issue",
+      identifier: "PAP-1003",
+      parentId: child.id,
+      title: "Deeply nested inbox task",
+    });
+    apiMocks.issuesList.mockResolvedValue([parent, child, grandchild]);
 
     const mountInbox = async () => {
       const queryClient = new QueryClient({
@@ -499,12 +566,23 @@ describe("Inbox toolbar", () => {
     let root = await mountInbox();
     try {
       expect(container.textContent).toContain(child.title);
+      expect(container.textContent).toContain(grandchild.title);
+      const taskRowFor = (title: string) =>
+        Array.from(container.querySelectorAll('[data-slot="task-row"]'))
+          .find((row) => row.textContent?.includes(title));
+      const childTaskRow = taskRowFor(child.title);
+      const grandchildTaskRow = taskRowFor(grandchild.title);
+      expect(childTaskRow?.querySelectorAll('[data-slot="task-row-tree-guide"]')).toHaveLength(1);
+      expect(childTaskRow?.querySelector('button[aria-label="Collapse sub-tasks"]')).not.toBeNull();
+      expect(grandchildTaskRow?.querySelectorAll('[data-slot="task-row-tree-guide"]')).toHaveLength(2);
+      expect(grandchildTaskRow?.querySelector('[data-slot="task-row-disclosure-spacer"]')).not.toBeNull();
 
       await act(async () => {
         parentToggle()?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
       });
       await vi.waitFor(() => {
         expect(container.textContent).not.toContain(child.title);
+        expect(container.textContent).not.toContain(grandchild.title);
       });
       expect(JSON.parse(localStorage.getItem(storageKey) ?? "[]")).toEqual([parent.id]);
 
@@ -517,12 +595,14 @@ describe("Inbox toolbar", () => {
       });
       await vi.waitFor(() => {
         expect(container.textContent).toContain(child.title);
+        expect(container.textContent).toContain(grandchild.title);
       });
       expect(JSON.parse(localStorage.getItem(storageKey) ?? "[]")).toEqual([]);
 
       act(() => root.unmount());
       root = await mountInbox();
       expect(container.textContent).toContain(child.title);
+      expect(container.textContent).toContain(grandchild.title);
     } finally {
       localStorage.removeItem(storageKey);
       act(() => root.unmount());
@@ -556,6 +636,191 @@ describe("Inbox toolbar", () => {
     act(() => {
       root.unmount();
     });
+  });
+
+  it("keeps Mine, Recent, Unread, Blocked, and All in the shared toolbar geometry", async () => {
+    for (const tab of ["mine", "recent", "unread", "blocked", "all"] as const) {
+      routerMock.location.pathname = `/inbox/${tab}`;
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0 } },
+      });
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          <QueryClientProvider client={queryClient}>
+            <Inbox />
+          </QueryClientProvider>,
+        );
+      });
+
+      const toolbar = container.querySelector('[data-slot="collection-toolbar"]');
+      expect(toolbar?.getAttribute("aria-label")).toBe("Inbox controls");
+      expect(toolbar?.querySelector('[data-slot="collection-toolbar-context"]')).not.toBeNull();
+      expect(toolbar?.querySelector('[data-slot="collection-toolbar-search"] input[placeholder="Search inbox…"]')).not.toBeNull();
+      expect(toolbar?.querySelector('[data-slot="collection-toolbar-controls"]')).not.toBeNull();
+      expect(container.querySelectorAll('input[placeholder="Search inbox…"]')).toHaveLength(1);
+
+      act(() => root.unmount());
+      container.replaceChildren();
+    }
+  });
+
+  it("explains that live-run filtering is different from active task statuses", async () => {
+    routerMock.location.pathname = "/inbox/mine";
+    localStorage.setItem("paperclip:inbox:filters:company-1", JSON.stringify({
+      allCategoryFilter: "everything",
+      allApprovalFilter: "all",
+      issueFilters: { liveOnly: true },
+    }));
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0 } },
+    });
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Inbox />
+        </QueryClientProvider>,
+      );
+    });
+
+    expect(container.querySelector('[data-testid="inbox-filter-scope-feedback"]')?.textContent)
+      .toBe("Live runs only — tasks currently connected to an agent run.");
+    const migrated = JSON.parse(
+      localStorage.getItem("paperclip:task-collection:v1:company-1:inbox") ?? "null",
+    ) as { companyId?: string; collectionKey?: string } | null;
+    expect(migrated).toMatchObject({ companyId: "company-1", collectionKey: "inbox" });
+
+    act(() => root.unmount());
+  });
+
+  it("groups ungrouped attention items by Today, Yesterday, and Earlier", async () => {
+    routerMock.location.pathname = "/inbox/mine";
+    const now = new Date();
+    const localNoon = (daysAgo: number) =>
+      new Date(now.getFullYear(), now.getMonth(), now.getDate() - daysAgo, 12, 0, 0);
+    apiMocks.issuesList.mockResolvedValue([
+      createIssue({ id: "today", title: "Today task", lastActivityAt: localNoon(0) }),
+      createIssue({ id: "yesterday", title: "Yesterday task", lastActivityAt: localNoon(1) }),
+      createIssue({ id: "earlier", title: "Earlier task", lastActivityAt: localNoon(3) }),
+    ]);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0 } },
+    });
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Inbox />
+        </QueryClientProvider>,
+      );
+    });
+    await vi.waitFor(() => expect(container.textContent).toContain("Earlier task"));
+
+    const separators = [...container.querySelectorAll('[data-testid="inbox-date-group"]')];
+    expect(separators.map((node) => node.textContent?.trim()))
+      .toEqual(["Today", "Yesterday", "Earlier"]);
+    expect(separators.every((separator) => (
+      separator.querySelectorAll("[data-date-group-rule]").length === 2
+    ))).toBe(true);
+    expect(separators.every((separator) => (
+      separator.querySelector("[data-date-group-label]")?.classList.contains("text-muted-foreground/70")
+    ))).toBe(true);
+
+    act(() => root.unmount());
+  });
+
+  it("honors the saved Columns option for hiding date group separators", async () => {
+    routerMock.location.pathname = "/inbox/mine";
+    localStorage.setItem(
+      taskCollectionPreferencesStorageKey({
+        companyId: "company-1",
+        collectionKey: "inbox",
+      }),
+      JSON.stringify({
+        version: 1,
+        companyId: "company-1",
+        collectionKey: "inbox",
+        viewState: { showDateGroupSeparators: false },
+        columns: ["status", "id", "updated"],
+      }),
+    );
+    const now = new Date();
+    const localNoon = (daysAgo: number) =>
+      new Date(now.getFullYear(), now.getMonth(), now.getDate() - daysAgo, 12, 0, 0);
+    apiMocks.issuesList.mockResolvedValue([
+      createIssue({ id: "today", title: "Today task", lastActivityAt: localNoon(0) }),
+      createIssue({ id: "earlier", title: "Earlier task", lastActivityAt: localNoon(3) }),
+    ]);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0 } },
+    });
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Inbox />
+        </QueryClientProvider>,
+      );
+    });
+    await vi.waitFor(() => expect(container.textContent).toContain("Earlier task"));
+
+    expect(container.querySelector('[data-testid="inbox-date-group"]')).toBeNull();
+
+    act(() => root.unmount());
+  });
+
+  it("shows the resolved isolated workspace name in canonical task metadata", async () => {
+    routerMock.location.pathname = "/inbox/mine";
+    localStorage.setItem("paperclip:inbox:issue-columns", JSON.stringify(["status", "id", "workspace", "updated"]));
+    apiMocks.experimentalSettings.mockResolvedValue({ enableIsolatedWorkspaces: true });
+    apiMocks.executionWorkspaceSummaries.mockResolvedValue([{
+      id: "execution-workspace-1",
+      name: "Workspace Aurora",
+      mode: "isolated_workspace",
+      projectWorkspaceId: "project-workspace-1",
+    }]);
+    apiMocks.projectsList.mockResolvedValue([{
+      id: "project-1",
+      name: "Launch",
+      color: null,
+      workspaces: [{ id: "project-workspace-1", name: "Main" }],
+      executionWorkspacePolicy: { defaultProjectWorkspaceId: "project-workspace-1" },
+      primaryWorkspace: null,
+    }]);
+    apiMocks.issuesList.mockResolvedValue([createIssue({
+      projectId: "project-1",
+      executionWorkspaceId: "execution-workspace-1",
+      title: "Workspace-aware task",
+    })]);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 0, gcTime: 0 } },
+    });
+    const root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <Inbox />
+        </QueryClientProvider>,
+      );
+    });
+    await vi.waitFor(() => expect(container.textContent).toContain("Workspace-aware task"));
+
+    const taskRow = container.querySelector('[data-slot="task-row"]');
+    const identifier = taskRow?.querySelector('[data-slot="task-row-identifier"]');
+    const timestamp = taskRow?.querySelector('[data-slot="task-row-timestamp"]');
+    expect(taskRow?.textContent).toContain("Workspace Aurora");
+    expect(identifier?.textContent).toBe("PAP-904");
+    expect(timestamp).not.toBeNull();
+    if (!identifier || !timestamp) throw new Error("Expected canonical identifier and timestamp columns");
+    expect(identifier.compareDocumentPosition(timestamp) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+
+    act(() => root.unmount());
   });
 
   it("hides workspace grouping when isolated workspaces are disabled", async () => {
@@ -678,7 +943,7 @@ describe("Inbox toolbar", () => {
     });
   });
 
-  it("does not indent unread rows: the mark-read dot sits in a reserved leading slot present on every row", async () => {
+  it("does not indent unread rows: the mark-read dot overlays the shared task-row gutter", async () => {
     routerMock.location.pathname = "/inbox/mine";
     // Two sibling leaf rows, one unread and one read, so their leading columns
     // are directly comparable.
@@ -716,29 +981,25 @@ describe("Inbox toolbar", () => {
     const rows = Array.from(container.querySelectorAll("[data-inbox-item]"));
     const rowFor = (text: string) => rows.find((row) => row.textContent?.includes(text));
     const markReadButton = (row: Element) => row.querySelector('button[aria-label="Mark as read"]');
-    // The empty spacer that reserves the chevron column on every leaf row.
-    // Excludes the tree-guide span (`.self-stretch`), which only renders on
-    // nested rows.
+    // The canonical spacer reserves the disclosure column on every leaf row.
     const hasLeadingSpacer = (row: Element) =>
-      !!row.querySelector("span.hidden.w-4.shrink-0.sm\\:block:not(.self-stretch)");
-    // The reserved leading dot slot, present on read AND unread rows.
+      !!row.querySelector('[data-slot="task-row-disclosure-spacer"]');
+    // The overlay anchor is present on read AND unread Inbox rows without
+    // consuming a layout column.
     const dotSlot = (row: Element) =>
       row.querySelector('[data-testid="issue-row-unread-slot"]');
 
     const unreadRow = rowFor("Unread inbox row")!;
     const readRow = rowFor("Read inbox row")!;
 
-    // The dot lives in a fixed leading slot that is reserved on every inbox row
-    // (in flow, NOT an absolute overlay). Because read and unread rows both
-    // reserve it — and both keep the chevron spacer — their status icon + title
-    // land at the same x (the bug this fix addresses: an unread-only dot column
-    // used to push unread rows right).
+    // Both rows share the canonical task-row geometry. The dot is absolutely
+    // positioned in the row gutter, so Inbox does not gain a column that Tasks
+    // lacks and unread state cannot shift status/title alignment.
     const unreadSlot = dotSlot(unreadRow);
     const readSlot = dotSlot(readRow);
     expect(unreadSlot).not.toBeNull();
     expect(readSlot).not.toBeNull();
-    // In flow, not an absolute overlay.
-    expect(unreadSlot?.className).not.toContain("absolute");
+    expect(unreadSlot?.className).toContain("absolute");
     // Only the unread row carries the dot button; the read slot is empty.
     expect(markReadButton(unreadSlot!)).not.toBeNull();
     expect(readSlot?.querySelector('button[aria-label="Mark as read"]')).toBeNull();
@@ -765,13 +1026,13 @@ describe("Inbox toolbar", () => {
     });
     const root = createRoot(container);
 
-    // The keyboard-selected row swaps to `hover:bg-transparent` on its root
-    // band (the overlay link's parent, where the wash now lives); find its index.
+    // Canonical task rows put the selected wash on the root band (the overlay
+    // link's parent); find the row with the standalone selected utility.
     const bandOf = (row: Element): HTMLElement | null =>
       row.querySelector<HTMLAnchorElement>("a[data-inbox-issue-link]")?.parentElement ?? null;
     const selectedRowIndex = () =>
       [...container.querySelectorAll("[data-inbox-item]")].findIndex((row) =>
-        bandOf(row)?.className.includes("hover:bg-transparent"),
+        bandOf(row)?.className.split(/\s+/).includes("bg-accent/50"),
       );
 
     try {

--- a/ui/src/pages/IssueDetail.test.tsx
+++ b/ui/src/pages/IssueDetail.test.tsx
@@ -31,7 +31,11 @@ import {
   shouldScrollIssueDetailToTopOnNavigation,
 } from "./IssueDetail";
 import { queryKeys } from "../lib/queryKeys";
-import { createIssueDetailLocationState } from "../lib/issueDetailBreadcrumb";
+import {
+  armIssueDetailInboxQuickArchive,
+  createIssueDetailLocationState,
+} from "../lib/issueDetailBreadcrumb";
+import { getRecentTasksStorageKey, readRecentTasks } from "../lib/recent-tasks";
 import { ApiError } from "../api/client";
 
 const mockIssuesApi = vi.hoisted(() => ({
@@ -120,6 +124,7 @@ const mockIssuePropertiesRender = vi.hoisted(() => vi.fn());
 const mockTaskSidePanelRender = vi.hoisted(() => vi.fn());
 const mockSetBreadcrumbs = vi.hoisted(() => vi.fn());
 const mockSetBreadcrumbToolbar = vi.hoisted(() => vi.fn());
+const mockSetBreadcrumbPanelControl = vi.hoisted(() => vi.fn());
 const mockSetMobileToolbar = vi.hoisted(() => vi.fn());
 const mockPushToast = vi.hoisted(() => vi.fn());
 const mockIssuesListRender = vi.hoisted(() => vi.fn());
@@ -272,6 +277,7 @@ vi.mock("../context/BreadcrumbContext", () => ({
   useBreadcrumbs: () => ({
     setBreadcrumbs: mockSetBreadcrumbs,
     setBreadcrumbToolbar: mockSetBreadcrumbToolbar,
+    setBreadcrumbPanelControl: mockSetBreadcrumbPanelControl,
     setMobileToolbar: mockSetMobileToolbar,
   }),
 }));
@@ -1250,6 +1256,8 @@ describe("IssueDetail", () => {
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
     mockPanelState.panelVisible = true;
     mockSidebarState.isMobile = false;
     container = document.createElement("div");
@@ -1332,12 +1340,15 @@ describe("IssueDetail", () => {
       enableIssuePlanDecompositions: false,
       enableExperimentalFileViewer: false,
       enableExternalObjects: false,
+      enableStreamlinedUi: true,
     });
     mockIssuesApi.listAcceptedPlanDecompositions.mockResolvedValue([]);
     mockIssuesApi.getDocument.mockResolvedValue(null);
     mockOpenPanel.mockClear();
     mockClosePanel.mockClear();
     mockSetPanelVisible.mockClear();
+    mockSetBreadcrumbPanelControl.mockClear();
+    mockSetMobileToolbar.mockClear();
     mockIssuePropertiesRender.mockClear();
     mockTaskSidePanelRender.mockClear();
     mockIssuesListRender.mockClear();
@@ -1362,6 +1373,8 @@ describe("IssueDetail", () => {
     queryClient.clear();
     container.remove();
     document.body.innerHTML = "";
+    localStorage.clear();
+    sessionStorage.clear();
     vi.restoreAllMocks();
   });
 
@@ -1383,6 +1396,16 @@ describe("IssueDetail", () => {
 
     expect(container.textContent).toContain("Issue detail smoke");
     expect(container.textContent).toContain("Task chat thread");
+    const titleGroup = container.querySelector('[data-slot="task-detail-title"]');
+    const identifier = titleGroup?.querySelector('[data-slot="task-title-identifier"]');
+    const titleRow = titleGroup?.parentElement;
+    const titleActions = container.querySelector('[data-slot="task-title-actions"]');
+    expect(titleGroup?.textContent?.replace(/\s+/g, " ").trim()).toBe("Issue detail smokePAP-1");
+    expect(identifier?.textContent).toBe("PAP-1");
+    expect(titleRow?.className).toContain("pr-8");
+    expect(titleActions?.className).toContain("absolute");
+    expect(titleActions?.className).toContain("top-0");
+    expect(titleActions?.querySelector('button[aria-label="More task actions"]')).not.toBeNull();
     expect(
       consoleErrorSpy.mock.calls.some((call: unknown[]) =>
         String(call[0]).includes(
@@ -1392,7 +1415,94 @@ describe("IssueDetail", () => {
     ).toBe(false);
   });
 
+  it("keeps hierarchy breadcrumbs and label chips out of the Streamlined task header", async () => {
+    mockIssuesApi.get.mockResolvedValue(
+      createIssue({
+        ancestors: [
+          {
+            id: "parent-1",
+            identifier: "PAP-0",
+            title: "Parent task visible in Properties",
+          },
+        ] as Issue["ancestors"],
+        labels: [
+          {
+            id: "label-1",
+            companyId: "company-1",
+            name: "Quick win",
+            color: "#22c55e",
+            createdAt: new Date("2026-04-21T00:00:00.000Z"),
+            updatedAt: new Date("2026-04-21T00:00:00.000Z"),
+          },
+        ],
+        labelIds: ["label-1"],
+      }),
+    );
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    expect(container.textContent).not.toContain("Parent task visible in Properties");
+    expect(container.textContent).not.toContain("Quick win");
+    expect(container.textContent).toContain("Issue detail smoke");
+  });
+
+  it("preserves hierarchy breadcrumbs and label chips when Streamlined UI is off", async () => {
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({
+      enableIssuePlanDecompositions: false,
+      enableExperimentalFileViewer: false,
+      enableExternalObjects: false,
+      enableStreamlinedUi: false,
+    });
+    mockIssuesApi.get.mockResolvedValue(
+      createIssue({
+        ancestors: [
+          {
+            id: "parent-1",
+            identifier: "PAP-0",
+            title: "Parent task breadcrumb",
+          },
+        ] as Issue["ancestors"],
+        labels: [
+          {
+            id: "label-1",
+            companyId: "company-1",
+            name: "Legacy label",
+            color: "#22c55e",
+            createdAt: new Date("2026-04-21T00:00:00.000Z"),
+            updatedAt: new Date("2026-04-21T00:00:00.000Z"),
+          },
+        ],
+        labelIds: ["label-1"],
+      }),
+    );
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+
+    expect(container.textContent).toContain("Parent task breadcrumb");
+    expect(container.textContent).toContain("Legacy label");
+  });
+
   it("lifts the redesigned desktop thread into the side-panel header band", async () => {
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({
+      enableIssuePlanDecompositions: false,
+      enableExperimentalFileViewer: false,
+      enableExternalObjects: false,
+      enableStreamlinedUi: false,
+    });
     mockIssuesApi.get.mockResolvedValue(createIssue());
 
     await act(async () => {
@@ -1412,24 +1522,10 @@ describe("IssueDetail", () => {
     });
   });
 
-  it("registers the persistent breadcrumb side-panel toggle only while the panel is closed", async () => {
+  it("does not register a redundant breadcrumb side-panel toggle in Streamlined UI", async () => {
     mockIssuesApi.get.mockResolvedValue(createIssue());
-
-    await act(async () => {
-      root.render(
-        <QueryClientProvider client={queryClient}>
-          <IssueDetail />
-        </QueryClientProvider>,
-      );
-    });
-    await flushReact();
-    expect(
-      container.querySelector('button[aria-label="Toggle side panel"]'),
-    ).toBeNull();
-    expect(mockSetBreadcrumbToolbar.mock.calls.at(-1)?.[0]).toBeNull();
-
-    mockSetBreadcrumbToolbar.mockClear();
     mockPanelState.panelVisible = false;
+
     await act(async () => {
       root.render(
         <QueryClientProvider client={queryClient}>
@@ -1438,9 +1534,27 @@ describe("IssueDetail", () => {
       );
     });
     await flushReact();
-    expect(
-      container.querySelector('button[aria-label="Toggle side panel"]'),
-    ).toBeNull();
+    expect(mockSetBreadcrumbToolbar.mock.calls.every(([node]) => node === null)).toBe(true);
+  });
+
+  it("retains the production breadcrumb side-panel toggle when Streamlined UI is off", async () => {
+    mockIssuesApi.get.mockResolvedValue(createIssue());
+    mockPanelState.panelVisible = false;
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({
+      enableIssuePlanDecompositions: false,
+      enableExperimentalFileViewer: false,
+      enableExternalObjects: false,
+      enableStreamlinedUi: false,
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
 
     const toolbar = mockSetBreadcrumbToolbar.mock.calls
       .map(([node]) => node)
@@ -1450,6 +1564,80 @@ describe("IssueDetail", () => {
     expect(toolbar).toBeDefined();
     toolbar.props.children.props.onToggle();
     expect(mockSetPanelVisible).toHaveBeenCalledWith(true);
+  });
+
+  it("uses task activity for recency and ignores passive revisits", async () => {
+    const authRequest = createDeferred<{
+      session: { userId: string };
+      user: { id: string };
+    }>();
+    const issue = createIssue({
+      title: "Initial recent title",
+      status: "todo",
+      updatedAt: new Date(100),
+    });
+    mockAuthApi.getSession.mockReturnValue(authRequest.promise);
+    mockIssuesApi.get.mockResolvedValue(issue);
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+
+    expect(
+      readRecentTasks(
+        getRecentTasksStorageKey("company-1", null),
+        "company-1",
+      ),
+    ).toEqual([]);
+
+    await act(async () => {
+      authRequest.resolve({
+        session: { userId: "user-1" },
+        user: { id: "user-1" },
+      });
+    });
+    await waitForAssertion(() => {
+      expect(
+        readRecentTasks(
+          getRecentTasksStorageKey("company-1", "user-1"),
+          "company-1",
+        ),
+      ).toEqual([
+        expect.objectContaining({
+          id: "issue-1",
+          title: "Initial recent title",
+          status: "todo",
+          recordedAt: 100,
+        }),
+      ]);
+    });
+
+    act(() => {
+      queryClient.setQueryData(queryKeys.issues.detail("PAP-1"), {
+        ...issue,
+        title: "Snapshot refresh title",
+        status: "in_progress",
+        updatedAt: new Date(200),
+      });
+    });
+    await flushReact();
+
+    expect(
+      readRecentTasks(
+        getRecentTasksStorageKey("company-1", "user-1"),
+        "company-1",
+      )[0],
+    ).toMatchObject({
+      title: "Snapshot refresh title",
+      status: "in_progress",
+      recordedAt: 200,
+    });
   });
 
   it("opens a closed desktop pane and routes an ordinary document to its own tab on direct load", async () => {
@@ -1675,7 +1863,7 @@ describe("IssueDetail", () => {
     expect(panel?.querySelector('[data-slot="sheet-close"]')).not.toBeNull();
   });
 
-  it("renders the full sub-task tree below the title in the chat center pane", async () => {
+  it("moves subtask data into the properties panel instead of the chat center pane", async () => {
     mockIssuesApi.get.mockResolvedValue(createIssue());
     mockIssuesApi.list.mockResolvedValue([
       createIssue({
@@ -1697,24 +1885,13 @@ describe("IssueDetail", () => {
     await flushReact();
     await flushReact();
 
-    const title = Array.from(container.querySelectorAll("div")).find(
-      (element) => element.textContent === "Issue detail smoke",
-    );
-    const subTasks = Array.from(container.querySelectorAll("div")).find(
-      (element) => element.textContent === "Sub-issues",
-    );
-    expect(title).toBeDefined();
-    expect(subTasks).toBeDefined();
-    expect(
-      title!.compareDocumentPosition(subTasks!) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).not.toBe(0);
-    expect(mockIssuesListRender).toHaveBeenCalledWith(
-      expect.objectContaining({
-        createIssueLabel: "Sub-task",
-        showProgressSummary: true,
-      }),
-    );
+    const panel = mockOpenPanel.mock.calls.at(-1)?.[0] as { props?: Record<string, unknown> } | undefined;
+    expect(panel?.props?.childIssues).toEqual([
+      expect.objectContaining({ id: "child-1", identifier: "PAP-2" }),
+    ]);
+    expect(panel?.props?.onAddSubIssue).toEqual(expect.any(Function));
+    expect(container.textContent).not.toContain("Sub-issues");
+    expect(mockIssuesListRender).not.toHaveBeenCalled();
   });
 
   it("hides the full sub-task tree when the task has no subtasks", async () => {
@@ -1988,9 +2165,10 @@ describe("IssueDetail", () => {
     await flushReact();
     await flushReact();
 
-    const archiveButton = container.querySelector<HTMLButtonElement>(
-      'button[aria-label="Archive from inbox"]',
-    );
+    const moreButton = container.querySelector<HTMLButtonElement>('button[aria-label="More task actions"]');
+    await act(async () => moreButton!.click());
+    const archiveButton = Array.from(document.body.querySelectorAll<HTMLButtonElement>("button"))
+      .find((button) => button.textContent?.trim() === "Archive from inbox") ?? null;
     expect(archiveButton).not.toBeNull();
 
     await act(async () => {
@@ -2112,9 +2290,10 @@ describe("IssueDetail", () => {
     await flushReact();
     await flushReact();
 
-    const archiveButton = container.querySelector<HTMLButtonElement>(
-      'button[aria-label="Archive from inbox"]',
-    );
+    const moreButton = container.querySelector<HTMLButtonElement>('button[aria-label="More task actions"]');
+    await act(async () => moreButton!.click());
+    const archiveButton = Array.from(document.body.querySelectorAll<HTMLButtonElement>("button"))
+      .find((button) => button.textContent?.trim() === "Archive from inbox") ?? null;
     expect(archiveButton).not.toBeNull();
     await act(async () => {
       archiveButton!.dispatchEvent(
@@ -2143,6 +2322,131 @@ describe("IssueDetail", () => {
         tone: "error",
       });
     });
+  });
+
+  it("keeps inbox archive actions scoped to an inbox-origin task", async () => {
+    mockLocation.state = createIssueDetailLocationState("Tasks", "/issues/all", "issues");
+    mockIssuesApi.get.mockResolvedValue(createIssue());
+    mockInstanceSettingsApi.getGeneral.mockResolvedValue({
+      keyboardShortcuts: true,
+      feedbackDataSharingPreference: "prompt",
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+
+    const moreButton = container.querySelector<HTMLButtonElement>('button[aria-label="More task actions"]');
+    await act(async () => moreButton!.click());
+    expect(Array.from(document.body.querySelectorAll("button"))
+      .some((button) => button.textContent?.trim() === "Archive from inbox")).toBe(false);
+
+    mockIssuesApi.archiveFromInbox.mockClear();
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "y", bubbles: true }));
+    expect(mockIssuesApi.archiveFromInbox).not.toHaveBeenCalled();
+  });
+
+  it("arms the inbox archive shortcut only for the selected inbox row", async () => {
+    mockLocation.state = armIssueDetailInboxQuickArchive(
+      createIssueDetailLocationState("Inbox", "/inbox/mine", "inbox"),
+    );
+    mockIssuesApi.get.mockResolvedValue(createIssue());
+    mockInstanceSettingsApi.getGeneral.mockResolvedValue({
+      keyboardShortcuts: true,
+      feedbackDataSharingPreference: "prompt",
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+
+    const panel = mockOpenPanel.mock.calls.at(-1)?.[0] as { props?: Record<string, unknown> } | undefined;
+    expect(panel?.props?.issueLinkState).toEqual(expect.objectContaining({
+      issueDetailSource: "inbox",
+      issueDetailInboxQuickArchiveArmed: false,
+    }));
+
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "y", bubbles: true }));
+    await waitForAssertion(() => {
+      expect(mockIssuesApi.archiveFromInbox).toHaveBeenCalledWith("issue-1");
+    });
+  });
+
+  it("uses history Back for a live inbox origin and a route fallback for direct links", async () => {
+    mockSidebarState.isMobile = true;
+    mockLocation.state = createIssueDetailLocationState("Inbox", "/inbox/mine", "inbox");
+    mockIssuesApi.get.mockResolvedValue(createIssue());
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+
+    const liveToolbar = [...mockSetMobileToolbar.mock.calls]
+      .map(([node]) => node)
+      .filter(Boolean)
+      .at(-1) as ReactNode;
+    const toolbarContainer = document.createElement("div");
+    document.body.appendChild(toolbarContainer);
+    const toolbarRoot = createRoot(toolbarContainer);
+    flushSync(() => toolbarRoot.render(liveToolbar));
+    const historyLengthSpy = vi.spyOn(window.history, "length", "get").mockReturnValue(2);
+    await act(async () => {
+      toolbarContainer.querySelector<HTMLButtonElement>('button[aria-label="Back to inbox"]')!.click();
+    });
+    expect(mockNavigate).toHaveBeenCalledWith(-1);
+    historyLengthSpy.mockRestore();
+
+    flushSync(() => toolbarRoot.unmount());
+    toolbarContainer.remove();
+    mockNavigate.mockClear();
+    mockSetMobileToolbar.mockClear();
+    mockLocation.state = null;
+    mockLocation.search = "?from=inbox&fromHref=%2Finbox%2Fmine";
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+    mockNavigate.mockClear();
+
+    const directToolbar = [...mockSetMobileToolbar.mock.calls]
+      .map(([node]) => node)
+      .filter(Boolean)
+      .at(-1) as ReactNode;
+    const directToolbarContainer = document.createElement("div");
+    document.body.appendChild(directToolbarContainer);
+    const directToolbarRoot = createRoot(directToolbarContainer);
+    flushSync(() => directToolbarRoot.render(directToolbar));
+    await act(async () => {
+      directToolbarContainer.querySelector<HTMLButtonElement>('button[aria-label="Back to inbox"]')!.click();
+    });
+    expect(mockNavigate).toHaveBeenCalledWith("/inbox/mine");
+
+    flushSync(() => directToolbarRoot.unmount());
+    directToolbarContainer.remove();
   });
 
   it("shows assignee and originating avatars in the issue header metadata", async () => {
@@ -2882,10 +3186,25 @@ describe("IssueDetail", () => {
     expect(optimisticComment).toMatchObject({ clientStatus: "pending" });
     expect(optimisticComment?.queueState).toBeUndefined();
 
+    const postedAt = new Date("2026-04-21T00:00:10.000Z");
     await act(async () => {
-      postedComment.resolve(createIssueComment({ body: "Fresh comment" }));
+      postedComment.resolve(createIssueComment({
+        body: "Fresh comment",
+        createdAt: postedAt,
+        updatedAt: postedAt,
+      }));
     });
     await flushReact();
+
+    expect(
+      readRecentTasks(
+        getRecentTasksStorageKey("company-1", null),
+        "company-1",
+      )[0],
+    ).toMatchObject({
+      id: "issue-1",
+      recordedAt: postedAt.getTime(),
+    });
   });
 
   it("hides the plan decomposition panel by default", async () => {
@@ -2979,6 +3298,7 @@ describe("IssueDetail", () => {
 
   it("starts a planning-mode task as chat-only until its plan document exists", async () => {
     mockSetBreadcrumbToolbar.mockClear();
+    mockSetBreadcrumbPanelControl.mockClear();
     mockInstanceSettingsApi.getExperimental.mockResolvedValue({
       enableIssuePlanDecompositions: false,
       enableExperimentalFileViewer: false,
@@ -3010,7 +3330,12 @@ describe("IssueDetail", () => {
       .reverse()
       .map(([node]) => node)
       .find((node) => node !== null);
-    expect(toolbar).toBeDefined();
+    expect(toolbar).toBeUndefined();
+    const panelControl = [...mockSetBreadcrumbPanelControl.mock.calls]
+      .reverse()
+      .map(([control]) => control)
+      .find((control) => control !== null);
+    expect(panelControl).toMatchObject({ open: false });
   });
 
   it("reveals the planning-mode task sidebar when its plan document exists", async () => {
@@ -3040,6 +3365,7 @@ describe("IssueDetail", () => {
 
   it("keeps the Show properties button clickable on the first task and reveals the sidebar on demand", async () => {
     mockSetBreadcrumbToolbar.mockClear();
+    mockSetBreadcrumbPanelControl.mockClear();
     mockInstanceSettingsApi.getExperimental.mockResolvedValue({
       enableIssuePlanDecompositions: false,
       enableExperimentalFileViewer: false,
@@ -3063,18 +3389,20 @@ describe("IssueDetail", () => {
     await flushReact();
     expect(mockOpenPanel).not.toHaveBeenCalled();
 
-    // Even though panelVisible is true, the suppressed first task registers
-    // the persistent top-row opt-in launcher.
-    const toolbar = [...mockSetBreadcrumbToolbar.mock.calls]
+    // Even though panelVisible is true, the suppressed first task routes the
+    // single breadcrumb panel control through its per-task opt-in behavior.
+    const panelControl = [...mockSetBreadcrumbPanelControl.mock.calls]
       .reverse()
-      .map(([node]) => node)
-      .find((node) => node !== null) as ReactElement<{
-      children: ReactElement<{ onToggle: () => void }>;
-    }>;
-    expect(toolbar).toBeDefined();
+      .map(([control]) => control)
+      .find((control) => control !== null) as {
+      open: boolean;
+      onToggle: () => void;
+    };
+    expect(panelControl).toMatchObject({ open: false });
+    expect(mockSetBreadcrumbToolbar.mock.calls.every(([node]) => node === null)).toBe(true);
 
     await act(async () => {
-      toolbar.props.children.props.onToggle();
+      panelControl.onToggle();
     });
     await flushReact();
 
@@ -3655,9 +3983,13 @@ describe("IssueDetail", () => {
       });
       await flushReact();
 
-      const copyButton = Array.from(container.querySelectorAll("button")).find(
-        (button) => button.getAttribute("title") === "Copy task as markdown",
+      const moreButton = container.querySelector<HTMLButtonElement>(
+        'button[aria-label="More task actions"]',
       );
+      await act(async () => moreButton!.click());
+      const copyButton = Array.from(
+        document.body.querySelectorAll<HTMLButtonElement>("button"),
+      ).find((button) => button.textContent?.trim() === "Copy as markdown");
       expect(copyButton).toBeTruthy();
 
       await act(async () => {
@@ -3718,6 +4050,7 @@ describe("IssueDetail", () => {
       enableIssuePlanDecompositions: false,
       enableExperimentalFileViewer: false,
       enableExternalObjects: false,
+      enableStreamlinedUi: true,
       enableClassicTaskInterface: true,
     });
     mockIssuesApi.get.mockResolvedValue(createIssue());
@@ -3776,6 +4109,54 @@ describe("IssueDetail", () => {
         (comment) => comment.id === "interaction-response:classic-question",
       ),
     ).toBe(false);
+  });
+
+  it("restores master's task chat thread when Streamlined UI is off", async () => {
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({
+      enableIssuePlanDecompositions: false,
+      enableExperimentalFileViewer: false,
+      enableExternalObjects: false,
+      enableStreamlinedUi: false,
+      enableClassicTaskInterface: false,
+    });
+    mockIssuesApi.get.mockResolvedValue(createIssue());
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+
+    expect(container.querySelector('[data-testid="issue-chat-thread"]')).toBeNull();
+    expect(container.querySelector('[data-testid="task-chat-thread"]')).not.toBeNull();
+  });
+
+  it("still honors Classic Task Interface when Streamlined UI is off", async () => {
+    mockInstanceSettingsApi.getExperimental.mockResolvedValue({
+      enableIssuePlanDecompositions: false,
+      enableExperimentalFileViewer: false,
+      enableExternalObjects: false,
+      enableStreamlinedUi: false,
+      enableClassicTaskInterface: true,
+    });
+    mockIssuesApi.get.mockResolvedValue(createIssue());
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <IssueDetail />
+        </QueryClientProvider>,
+      );
+    });
+    await flushReact();
+    await flushReact();
+
+    expect(container.querySelector('[data-testid="issue-chat-thread"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="task-chat-thread"]')).toBeNull();
   });
 
   it("passes @task mention options to the thread by default", async () => {

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -84,6 +84,7 @@ import {
   readIssueDetailBreadcrumb,
   readIssueDetailHeaderSeed,
   rememberIssueDetailLocationState,
+  shouldArmIssueDetailInboxQuickArchive,
 } from "../lib/issueDetailBreadcrumb";
 import {
   resolveIssueActiveRun,
@@ -143,6 +144,7 @@ import {
   upsertInterruptedRun,
 } from "../lib/optimistic-issue-runs";
 import { useProjectOrder } from "../hooks/useProjectOrder";
+import { recordRecentTask } from "../lib/recent-tasks";
 import {
   relativeTime,
   cn,
@@ -162,6 +164,7 @@ import {
 import { TaskChatThread } from "../components/TaskChatThread";
 import type { TaskChatIssueBrief } from "../components/task-chat/TaskChatDescriptionBubble";
 import { useClassicTaskInterfaceEnabled } from "../hooks/useClassicTaskInterfaceEnabled";
+import { useStreamlinedUiEnabled } from "../hooks/useStreamlinedUiEnabled";
 import { workModeMetaFor } from "../lib/work-mode-meta";
 import { IssueContinuationHandoff } from "../components/IssueContinuationHandoff";
 import { IssueAttachmentsSection } from "../components/IssueAttachmentsSection";
@@ -962,16 +965,34 @@ function IssueChatSkeleton() {
   );
 }
 
+function useTaskDetailInterfaceMode() {
+  const {
+    enabled: classicTaskInterfacePreferenceEnabled,
+    loaded: classicTaskInterfaceLoaded,
+  } = useClassicTaskInterfaceEnabled();
+  const {
+    enabled: streamlinedUiEnabled,
+    loaded: streamlinedUiLoaded,
+  } = useStreamlinedUiEnabled();
+  const classicTaskInterfaceEnabled = classicTaskInterfacePreferenceEnabled;
+  const taskChatShellEnabled = !classicTaskInterfaceEnabled;
+
+  return {
+    classicTaskInterfaceEnabled,
+    taskChatShellEnabled,
+    streamlinedTaskDetailEnabled: streamlinedUiEnabled && taskChatShellEnabled,
+    streamlinedUiEnabled,
+    loaded: classicTaskInterfaceLoaded && streamlinedUiLoaded,
+  };
+}
+
 function IssueDetailLoadingState({
   headerSeed,
 }: {
   headerSeed: ReturnType<typeof readIssueDetailHeaderSeed>;
 }) {
-  const identifier =
-    headerSeed?.identifier ?? headerSeed?.id.slice(0, 8) ?? null;
-  const { enabled: classicTaskInterfaceEnabled } =
-    useClassicTaskInterfaceEnabled();
-  const taskChatShellEnabled = !classicTaskInterfaceEnabled;
+  const identifier = headerSeed?.identifier ?? headerSeed?.id.slice(0, 8) ?? null;
+  const { taskChatShellEnabled } = useTaskDetailInterfaceMode();
 
   return (
     <div
@@ -1084,6 +1105,7 @@ function IssueDetailLoadingState({
 
 interface InboxMobileToolbarProps {
   backHref: string;
+  preferHistoryBack: boolean;
   issueId: string | undefined;
   issueHidden: boolean;
   onArchive: () => void;
@@ -1095,6 +1117,7 @@ interface InboxMobileToolbarProps {
 
 function InboxMobileToolbar({
   backHref,
+  preferHistoryBack,
   issueId: issueIdProp,
   issueHidden,
   onArchive,
@@ -1115,7 +1138,7 @@ function InboxMobileToolbar({
           // Use browser back when we have real history so the inbox
           // restores its scroll position. Fall back to a PUSH to
           // backHref when there's no prior entry (e.g. deep-link).
-          if (window.history.length > 1) {
+          if (preferHistoryBack && window.history.length > 1) {
             navigate(-1);
           } else {
             navigate(backHref);
@@ -1405,15 +1428,10 @@ const IssueDetailChatTab = memo(function IssueDetailChatTab({
   externalReferences,
   linkCaseReferences,
 }: IssueDetailChatTabProps) {
-  // Seam for the Classic Task Interface (flag: enableClassicTaskInterface).
-  // Flag ON renders the legacy IssueChatThread verbatim; flag OFF (the
-  // default) renders the chat-style TaskChatThread. Both components share one
-  // prop type, so no cast is needed.
-  const { enabled: classicTaskInterfaceEnabled } =
-    useClassicTaskInterfaceEnabled();
-  const ThreadComponent = classicTaskInterfaceEnabled
-    ? IssueChatThread
-    : TaskChatThread;
+  // Preserve master's Classic Task Interface seam: Streamlined UI changes the
+  // TaskChatThread presentation but never swaps it for IssueChatThread.
+  const { classicTaskInterfaceEnabled, streamlinedTaskDetailEnabled } = useTaskDetailInterfaceMode();
+  const ThreadComponent = classicTaskInterfaceEnabled ? IssueChatThread : TaskChatThread;
   const queryClient = useQueryClient();
   const { pushToast } = useToastActions();
   const { data: activity } = useQuery({
@@ -2132,7 +2150,10 @@ const IssueDetailChatTab = memo(function IssueDetailChatTab({
         ) : (
           // Chat shell: center the bubbles at the thread cap (mirrors
           // TaskChatThreadView) and dock a composer placeholder beneath them.
-          <div className="mx-auto flex w-full max-w-(--tc-shell-max-w) flex-col gap-3 px-4 py-4">
+          <div className={cn(
+            "mx-auto flex w-full max-w-(--tc-shell-max-w) flex-col gap-3 px-4 py-4",
+            streamlinedTaskDetailEnabled && "md:px-0",
+          )}>
             <IssueChatSkeleton />
             <IssueChatComposerSkeleton className="mt-3" />
           </div>
@@ -2632,16 +2653,16 @@ function IssueDetailActivityTab({
 export function IssueDetail() {
   const { issueId } = useParams<{ issueId: string }>();
   const { selectedCompanyId } = useCompany();
-  // Classic Task Interface (flag: enableClassicTaskInterface): with the flag
-  // OFF (the default) the chat-style thread owns the center column — the
-  // legacy title/description block, sub-tasks table, plan decompositions and
-  // Documents section are gated off (plan lives in the properties-pane Plan
-  // tab). Flag ON restores the legacy page.
+  // Classic Task Interface remains the sole task-chat-vs-pre-chat switch from
+  // master. Streamlined UI only layers the new task-detail presentation onto
+  // master's default task-chat shell.
   const {
-    enabled: classicTaskInterfaceEnabled,
-    loaded: classicTaskInterfaceLoaded,
-  } = useClassicTaskInterfaceEnabled();
-  const taskChatShellEnabled = !classicTaskInterfaceEnabled;
+    classicTaskInterfaceEnabled,
+    taskChatShellEnabled,
+    streamlinedTaskDetailEnabled,
+    streamlinedUiEnabled,
+    loaded: taskInterfaceSettingsLoaded,
+  } = useTaskDetailInterfaceMode();
   // Chat-style: the page wrapper spans the full center pane so the thread's
   // scroll viewport (and its scrollbar) reaches the properties-pane border;
   // every non-thread section re-centers itself at the 60rem shell cap instead.
@@ -2650,8 +2671,12 @@ export function IssueDetail() {
     : undefined;
   const { openNewIssue } = useDialogActions();
   const { openPanel, closePanel, panelVisible, setPanelVisible } = usePanel();
-  const { setBreadcrumbs, setBreadcrumbToolbar, setMobileToolbar } =
-    useBreadcrumbs();
+  const {
+    setBreadcrumbs,
+    setBreadcrumbToolbar,
+    setBreadcrumbPanelControl,
+    setMobileToolbar,
+  } = useBreadcrumbs();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const navigationType = useNavigationType();
@@ -2703,6 +2728,22 @@ export function IssueDetail() {
     () =>
       readIssueDetailLocationState(issueId, location.state, location.search),
     [issueId, location.state, location.search],
+  );
+  const relationIssueLinkState = useMemo(() => {
+    const sourceState = resolvedIssueDetailState ?? location.state;
+    if (!streamlinedTaskDetailEnabled) return sourceState;
+    if (typeof sourceState !== "object" || sourceState === null) return sourceState;
+    return {
+      ...sourceState,
+      // The inbox `y` shortcut is intentionally armed only for the selected
+      // inbox row. Preserve the origin/breadcrumb when opening a related task,
+      // but do not let that one-row archive affordance leak to the relation.
+      issueDetailInboxQuickArchiveArmed: false,
+    };
+  }, [location.state, resolvedIssueDetailState, streamlinedTaskDetailEnabled]);
+  const preferInboxHistoryBack = useMemo(
+    () => readIssueDetailLocationState(null, location.state)?.issueDetailSource === "inbox",
+    [location.state],
   );
   const issueHeaderSeed = useMemo(
     () =>
@@ -2974,7 +3015,7 @@ export function IssueDetail() {
     ),
   });
 
-  const { data: session } = useQuery({
+  const { data: session, isFetched: sessionResolved } = useQuery({
     queryKey: queryKeys.auth.session,
     queryFn: () => authApi.getSession(),
   });
@@ -2985,6 +3026,10 @@ export function IssueDetail() {
     enabled: !!selectedCompanyId,
   });
   const currentUserId = session?.user?.id ?? session?.session?.userId ?? null;
+  useEffect(() => {
+    if (!streamlinedUiEnabled || !issue || !sessionResolved) return;
+    recordRecentTask(issue, currentUserId);
+  }, [issue, currentUserId, sessionResolved, streamlinedUiEnabled]);
   const { data: boardAccess } = useQuery({
     queryKey: queryKeys.access.currentBoardAccess,
     queryFn: () => accessApi.getCurrentBoardAccess(),
@@ -3193,6 +3238,13 @@ export function IssueDetail() {
     }
     setPanelVisible(true);
   }, [issue?.id, setPanelVisible, suppressPanelUntilPlan]);
+  const toggleTaskSidePanel = useCallback(() => {
+    if (!panelVisible || suppressPanelUntilPlan) {
+      openTaskSidePanel();
+      return;
+    }
+    setPanelVisible(false);
+  }, [openTaskSidePanel, panelVisible, setPanelVisible, suppressPanelUntilPlan]);
   const showRichSubIssuesSection = shouldRenderRichSubIssuesSection(
     childIssuesLoading,
     childIssues.length,
@@ -3576,6 +3628,9 @@ export function IssueDetail() {
       const issueRefs = new Set<string>([issueId!, nextIssue.id]);
       if (nextIssue.identifier) issueRefs.add(nextIssue.identifier);
       mergeIssueResponseIntoCaches(issueRefs, nextIssue);
+      if (streamlinedUiEnabled && sessionResolved) {
+        recordRecentTask(nextIssue, currentUserId);
+      }
       queryClient.invalidateQueries({
         queryKey: queryKeys.issues.activity(issueId!),
       });
@@ -3944,13 +3999,9 @@ export function IssueDetail() {
     [updateChildIssue.mutate],
   );
 
-  // PAP-496: the chat shell keeps the full sub-task tree directly below the
-  // title in the center column. This is the tree's single chat-shell home; the
-  // Properties pane does not duplicate it. Classic mode keeps its existing
-  // center-column section below the header.
   const subTasksTree = useMemo(
     () =>
-      taskChatShellEnabled && issue && showRichSubIssuesSection ? (
+      taskChatShellEnabled && !streamlinedTaskDetailEnabled && issue && showRichSubIssuesSection ? (
         <IssuesList
           issues={childIssues}
           isLoading={childIssuesLoading}
@@ -3975,6 +4026,7 @@ export function IssueDetail() {
       ) : null,
     [
       taskChatShellEnabled,
+      streamlinedTaskDetailEnabled,
       issue,
       showRichSubIssuesSection,
       childIssues,
@@ -4180,6 +4232,13 @@ export function IssueDetail() {
           current.filter(
             (entry) => entry.clientId !== context.optimisticCommentId,
           ),
+        );
+      }
+      if (streamlinedUiEnabled && issue && sessionResolved) {
+        recordRecentTask(
+          issue,
+          currentUserId,
+          new Date(comment.createdAt).getTime(),
         );
       }
     },
@@ -5016,8 +5075,31 @@ export function IssueDetail() {
   ]);
 
   useEffect(() => {
+    if (!streamlinedTaskDetailEnabled || !taskChatShellEnabled || !issue?.id) {
+      setBreadcrumbPanelControl(null);
+      return;
+    }
+
+    setBreadcrumbPanelControl({
+      open: panelVisible && !suppressPanelUntilPlan,
+      onToggle: toggleTaskSidePanel,
+    });
+
+    return () => setBreadcrumbPanelControl(null);
+  }, [
+    issue?.id,
+    panelVisible,
+    setBreadcrumbPanelControl,
+    streamlinedTaskDetailEnabled,
+    suppressPanelUntilPlan,
+    taskChatShellEnabled,
+    toggleTaskSidePanel,
+  ]);
+
+  useEffect(() => {
     const showTaskPanelLauncher =
       taskChatShellEnabled &&
+      !streamlinedTaskDetailEnabled &&
       !isMobile &&
       Boolean(issue?.id) &&
       (!panelVisible || suppressPanelUntilPlan);
@@ -5042,6 +5124,7 @@ export function IssueDetail() {
     openTaskSidePanel,
     panelVisible,
     setBreadcrumbToolbar,
+    streamlinedTaskDetailEnabled,
     suppressPanelUntilPlan,
     taskChatShellEnabled,
   ]);
@@ -5113,6 +5196,7 @@ export function IssueDetail() {
     const sharedProps = {
       issue: panelIssue,
       childIssues: panelChildIssues,
+      issueLinkState: streamlinedTaskDetailEnabled ? relationIssueLinkState : undefined,
       onAddSubIssue: openNewSubIssue,
       onUpdate: handleIssuePropertiesUpdate,
       hasActiveRun: resolvedHasActiveRun,
@@ -5140,6 +5224,8 @@ export function IssueDetail() {
           {...sharedProps}
           accountScope={currentUserId ?? "anonymous"}
           fileTabsEnabled={fileViewerEnabled}
+          streamlinedTabs={streamlinedTaskDetailEnabled}
+          showSubtasksTab={streamlinedTaskDetailEnabled}
         />,
         { contentMode: "full-bleed" },
       );
@@ -5156,6 +5242,8 @@ export function IssueDetail() {
     panelChildIssues,
     panelIssue,
     suppressPanelUntilPlan,
+    relationIssueLinkState,
+    streamlinedTaskDetailEnabled,
     resolvedHasActiveRun,
     checkIssueMonitorNow.isPending,
     checkIssueMonitorNow.mutate,
@@ -5172,7 +5260,12 @@ export function IssueDetail() {
 
   const goToInboxShortcutArmedRef = useRef(false);
   const goToInboxShortcutTimeoutRef = useRef<number | null>(null);
-  const canQuickArchiveFromInbox = keyboardShortcutsEnabled && !issue?.hiddenAt;
+  const canQuickArchiveFromInbox =
+    keyboardShortcutsEnabled &&
+    (!streamlinedUiEnabled || (
+      isFromInbox && shouldArmIssueDetailInboxQuickArchive(location.state)
+    )) &&
+    !issue?.hiddenAt;
 
   useEffect(() => {
     if (!issue?.id || !canQuickArchiveFromInbox) return;
@@ -5319,7 +5412,7 @@ export function IssueDetail() {
 
       // The classic interface owns document links in its center-column
       // Documents section. Do not open its tab-less properties panel.
-      if (!classicTaskInterfaceLoaded || !taskChatShellEnabled) return false;
+      if (!taskInterfaceSettingsLoaded || !taskChatShellEnabled) return false;
 
       if (isMobile) {
         setMobilePropsOpen(true);
@@ -5340,7 +5433,7 @@ export function IssueDetail() {
       return true;
     },
     [
-      classicTaskInterfaceLoaded,
+      taskInterfaceSettingsLoaded,
       isMobile,
       issue?.id,
       issueId,
@@ -5619,6 +5712,7 @@ export function IssueDetail() {
     setMobileToolbar(
       <InboxMobileToolbar
         backHref={backHref}
+        preferHistoryBack={streamlinedUiEnabled ? preferInboxHistoryBack : true}
         issueId={issue?.id}
         issueHidden={issueHidden}
         archivePending={archivePending}
@@ -5633,6 +5727,8 @@ export function IssueDetail() {
   }, [
     showInboxToolbar,
     backHref,
+    preferInboxHistoryBack,
+    streamlinedUiEnabled,
     issue?.id,
     issueHidden,
     archivePending,
@@ -6365,75 +6461,103 @@ export function IssueDetail() {
   // scroll viewport, so they scroll away with the messages and the composer
   // stays near the viewport bottom. Flag OFF renders the same nodes in the
   // page flow, in their original order relative to the alert banners.
-  const ancestorsNav = ancestors.length > 0 && (
-    <nav
-      className={cn(
-        "flex items-center gap-1 text-xs text-muted-foreground flex-wrap",
-        shellSectionClass,
-      )}
-    >
-      {[...ancestors].reverse().map((ancestor, i) => (
-        <span key={ancestor.id} className="flex items-center gap-1">
-          {i > 0 && <ChevronRight className="h-3 w-3 shrink-0" />}
-          <Link
-            to={createIssueDetailPath(ancestor.identifier ?? ancestor.id)}
-            state={resolvedIssueDetailState ?? location.state}
-            onClickCapture={() =>
-              rememberIssueDetailLocationState(
-                ancestor.identifier ?? ancestor.id,
-                resolvedIssueDetailState ?? location.state,
-                location.search,
-              )
-            }
-            className="hover:text-foreground transition-colors truncate max-w-(--sz-200px)"
-            title={ancestor.title}
-          >
-            {ancestor.title}
-          </Link>
+  const ancestorsNav =
+    !streamlinedTaskDetailEnabled && ancestors.length > 0 ? (
+      <nav
+        className={cn(
+          "flex items-center gap-1 text-xs text-muted-foreground flex-wrap",
+          shellSectionClass,
+        )}
+      >
+        {[...ancestors].reverse().map((ancestor, i) => (
+          <span key={ancestor.id} className="flex items-center gap-1">
+            {i > 0 && <ChevronRight className="h-3 w-3 shrink-0" />}
+            <Link
+              to={createIssueDetailPath(ancestor.identifier ?? ancestor.id)}
+              state={resolvedIssueDetailState ?? location.state}
+              onClickCapture={() =>
+                rememberIssueDetailLocationState(
+                  ancestor.identifier ?? ancestor.id,
+                  resolvedIssueDetailState ?? location.state,
+                  location.search,
+                )
+              }
+              className="hover:text-foreground transition-colors truncate max-w-(--sz-200px)"
+              title={ancestor.title}
+            >
+              {ancestor.title}
+            </Link>
+          </span>
+        ))}
+        <ChevronRight className="h-3 w-3 shrink-0" />
+        <span className="text-foreground/60 truncate max-w-(--sz-200px)">
+          {issue.title}
         </span>
-      ))}
-      <ChevronRight className="h-3 w-3 shrink-0" />
-      <span className="text-foreground/60 truncate max-w-(--sz-200px)">
-        {issue.title}
-      </span>
-    </nav>
+      </nav>
+    ) : null;
+
+  const issueStatusControl = (
+    <StatusIcon
+      status={issue.status}
+      size="lg"
+      blockerAttention={issue.blockerAttention}
+      onChange={(status) => updateIssue.mutate({ status })}
+    />
   );
 
   const issueHeaderBlock = (
-    <div
-      data-testid="issue-detail-header"
-      className={cn("space-y-3", shellSectionClass)}
-    >
-      <div className="flex items-center gap-2 min-w-0 flex-wrap">
-        <StatusIcon
-          status={issue.status}
-          size="lg"
-          blockerAttention={issue.blockerAttention}
-          onChange={(status) => updateIssue.mutate({ status })}
-        />
-        {/* PAP-411: priority UI hidden behind SHOW_TASK_PRIORITY_UI. */}
-        {SHOW_TASK_PRIORITY_UI && (
-          <PriorityIcon
-            priority={issue.priority}
-            onChange={(priority) => updateIssue.mutate({ priority })}
-          />
-        )}
-        <span className="text-sm font-mono text-muted-foreground shrink-0">
-          {issue.identifier ?? issue.id.slice(0, 8)}
-        </span>
+      <div
+        data-testid="issue-detail-header"
+        className={cn(streamlinedTaskDetailEnabled ? "relative space-y-2" : "space-y-3", shellSectionClass)}
+      >
+        {streamlinedTaskDetailEnabled ? (
+          <div className="flex min-w-0 items-center gap-2 pr-8">
+            {issueStatusControl}
+            <div data-slot="task-detail-title" className="flex min-w-0 flex-1 items-baseline gap-2">
+              <InlineEditor
+                value={issue.title}
+                onSave={(title) => updateIssue.mutateAsync({ title })}
+                as="h2"
+                className="min-w-0 text-xl font-semibold leading-normal text-balance"
+              />
+              <span
+                data-slot="task-title-identifier"
+                className="shrink-0 font-mono text-sm text-muted-foreground"
+              >
+                {issue.identifier ?? issue.id.slice(0, 8)}
+              </span>
+            </div>
+          </div>
+        ) : null}
 
-        {hasLiveRuns && (
-          <Badge
-            variant="outline"
-            className={cn("gap-1.5 text-(length:--text-nano)", liveBlueBadge)}
-          >
-            <span className="relative flex h-1.5 w-1.5">
-              <span className="animate-pulse absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75" />
-              <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-blue-500" />
+        <div
+          className={cn(
+            "flex min-w-0 flex-wrap items-center gap-2",
+            streamlinedTaskDetailEnabled && "gap-x-6 gap-y-2 pl-7",
+          )}
+        >
+          {!streamlinedTaskDetailEnabled ? issueStatusControl : null}
+          {/* PAP-411: priority UI hidden behind SHOW_TASK_PRIORITY_UI. */}
+          {SHOW_TASK_PRIORITY_UI && (
+            <PriorityIcon
+              priority={issue.priority}
+              onChange={(priority) => updateIssue.mutate({ priority })}
+            />
+          )}
+          {!streamlinedTaskDetailEnabled ? (
+            <span className="shrink-0 font-mono text-sm text-muted-foreground">
+              {issue.identifier ?? issue.id.slice(0, 8)}
             </span>
-            Live
-          </Badge>
-        )}
+          ) : null}
+          {hasLiveRuns && (
+            <Badge variant="outline" className={cn("gap-1.5 text-(length:--text-nano)", liveBlueBadge)}>
+              <span className="relative flex h-1.5 w-1.5">
+                <span className="animate-pulse absolute inline-flex h-full w-full rounded-full bg-blue-400 opacity-75" />
+                <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-blue-500" />
+              </span>
+              Live
+            </Badge>
+          )}
 
         {issue.originKind === "routine_execution" && issue.originId && (
           <Link
@@ -6545,7 +6669,7 @@ export function IssueDetail() {
           userLabelMap={userLabelMap}
         />
 
-        {(issue.labels ?? []).length > 0 && (
+        {!streamlinedTaskDetailEnabled && (issue.labels ?? []).length > 0 && (
           <div className="hidden sm:flex items-center gap-1">
             {(issue.labels ?? []).slice(0, 4).map((label) => (
               <Badge
@@ -6569,7 +6693,7 @@ export function IssueDetail() {
           </div>
         )}
 
-        {!(isMobile && isFromInbox) && (
+        {!streamlinedTaskDetailEnabled && !(isMobile && isFromInbox) && (
           <div className="ml-auto flex items-center gap-0.5 md:hidden shrink-0">
             <Button
               variant="ghost"
@@ -6595,7 +6719,7 @@ export function IssueDetail() {
         )}
 
         <div className="hidden md:flex items-center md:ml-auto shrink-0">
-          {canArchiveFromInbox && (
+          {!streamlinedTaskDetailEnabled && canArchiveFromInbox && (
             <Button
               variant="ghost"
               size="icon-xs"
@@ -6621,20 +6745,23 @@ export function IssueDetail() {
               <FileCode2 className="h-4 w-4" />
             </Button>
           ) : null}
-          <Button
-            variant="ghost"
-            size="icon-xs"
-            onClick={copyIssueToClipboard}
-            title="Copy task as markdown"
-          >
-            {copied ? (
-              <Check className="h-4 w-4 text-green-500" />
-            ) : (
-              <Copy className="h-4 w-4" />
-            )}
-          </Button>
-          {taskChatShellEnabled ||
-          (panelVisible && !suppressPanelUntilPlan) ? null : (
+          {!streamlinedTaskDetailEnabled ? (
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              onClick={copyIssueToClipboard}
+              title="Copy task as markdown"
+            >
+              {copied ? (
+                <Check className="h-4 w-4 text-green-500" />
+              ) : (
+                <Copy className="h-4 w-4" />
+              )}
+            </Button>
+          ) : null}
+          {!streamlinedTaskDetailEnabled &&
+          !taskChatShellEnabled &&
+          (!panelVisible || suppressPanelUntilPlan) ? (
             <TooltipProvider>
               <SidePanelToggleButton
                 open={false}
@@ -6643,27 +6770,69 @@ export function IssueDetail() {
                 className="shrink-0"
               />
             </TooltipProvider>
-          )}
-
-          <Popover open={moreOpen} onOpenChange={setMoreOpen}>
-            <PopoverTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                className="shrink-0"
-                aria-label="More task actions"
-                title="More task actions"
-                onKeyDown={(event) => {
-                  if (event.key === "Enter" || event.key === " ") {
-                    event.preventDefault();
-                    setMoreOpen(true);
-                  }
-                }}
-              >
-                <MoreHorizontal className="h-4 w-4" />
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent className="w-52 p-1" align="end">
+          ) : null}
+          <div
+            data-slot="task-title-actions"
+            className={cn(
+              streamlinedTaskDetailEnabled && "absolute right-0 top-0 flex h-7 items-center",
+            )}
+          >
+            <Popover open={moreOpen} onOpenChange={setMoreOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  className="shrink-0"
+                  aria-label="More task actions"
+                  title="More task actions"
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      setMoreOpen(true);
+                    }
+                  }}
+                >
+                  <MoreHorizontal className="h-4 w-4" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-52 p-1" align="end">
+              {streamlinedTaskDetailEnabled ? (
+                <>
+                  <button
+                    className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-accent/50"
+                    onClick={() => {
+                      openNewSubIssue();
+                      setMoreOpen(false);
+                    }}
+                  >
+                    <Plus className="h-3 w-3" />
+                    Add subtask
+                  </button>
+                  <button
+                    className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-accent/50"
+                    onClick={() => {
+                      void copyIssueToClipboard();
+                      setMoreOpen(false);
+                    }}
+                  >
+                    {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+                    Copy as markdown
+                  </button>
+                  {canArchiveFromInbox ? (
+                    <button
+                      className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-xs hover:bg-accent/50 disabled:opacity-50"
+                      disabled={archivePending}
+                      onClick={() => {
+                        if (!archivePending && issue?.id) archiveFromInbox.mutate(issue.id);
+                        setMoreOpen(false);
+                      }}
+                    >
+                      <Archive className="h-3 w-3" />
+                      Archive from inbox
+                    </button>
+                  ) : null}
+                </>
+              ) : null}
               {canPauseLeafWork ? (
                 <button
                   className="flex items-center gap-2 w-full px-2 py-1.5 text-xs rounded hover:bg-accent/50"
@@ -6764,21 +6933,24 @@ export function IssueDetail() {
                 <EyeOff className="h-3 w-3" />
                 Hide this task
               </button>
-            </PopoverContent>
-          </Popover>
+              </PopoverContent>
+            </Popover>
+          </div>
         </div>
       </div>
 
-      <InlineEditor
-        value={issue.title}
-        onSave={(title) => updateIssue.mutateAsync({ title })}
-        as="h2"
-        className={
-          taskChatShellEnabled ? "text-base font-semibold" : "text-xl font-bold"
-        }
-      />
+      {!streamlinedTaskDetailEnabled ? (
+        <InlineEditor
+          value={issue.title}
+          onSave={(title) => updateIssue.mutateAsync({ title })}
+          as="h2"
+          className={
+            taskChatShellEnabled ? "text-base font-semibold" : "text-xl font-bold"
+          }
+        />
+      ) : null}
 
-      {taskChatShellEnabled ? subTasksTree : null}
+      {taskChatShellEnabled && !streamlinedTaskDetailEnabled ? subTasksTree : null}
 
       <IssueMonitorBanner
         issue={issue}
@@ -6975,548 +7147,433 @@ export function IssueDetail() {
                 ) : null}
               </div>
             ) : (
-              <div className="text-xs">
-                This task is paused by ancestor{" "}
-                {activePauseHoldRoot?.identifier ? (
-                  <Link
-                    to={createIssueDetailPath(activePauseHoldRoot.identifier)}
-                    className="underline"
-                  >
-                    {activePauseHoldRoot.identifier}
-                  </Link>
-                ) : (
-                  activePauseHold.rootIssueId.slice(0, 8)
-                )}
-                . Resume from the root task to deliver deferred work.
-              </div>
-            )}
+            <div className="text-xs">
+              This task is paused by ancestor{" "}
+              {activePauseHoldRoot?.identifier ? (
+                <Link to={createIssueDetailPath(activePauseHoldRoot.identifier)} className="underline">
+                  {activePauseHoldRoot.identifier}
+                </Link>
+              ) : (
+                activePauseHold.rootIssueId.slice(0, 8)
+              )}
+              . Resume from the root task to deliver deferred work.
+            </div>
+          )}
+        </div>
+      )}
+
+      {taskChatShellEnabled ? null : issueHeaderBlock}
+
+      {taskChatShellEnabled ? null : pluginOutletsBlock}
+
+      {taskChatShellEnabled ? null : showRichSubIssuesSection ? (
+        <div className="space-y-3">
+          <div className="flex items-center justify-between gap-2">
+            <h3 className="text-sm font-medium text-muted-foreground">Sub-tasks</h3>
           </div>
-        )}
+          <IssuesList
+            issues={childIssues}
+            isLoading={childIssuesLoading}
+            agents={agents}
+            projects={projects}
+            liveIssueIds={liveIssueIds}
+            mutedIssueIds={mutedChildIssueIds}
+            issueBadgeById={childPauseBadgeById}
+            projectId={issue.projectId ?? undefined}
+            viewStateKey={`paperclip:issue-detail:${issue.id}:subissues-view`}
+            issueLinkState={resolvedIssueDetailState ?? location.state}
+            searchFilters={{ descendantOf: issue.id, includeBlockedBy: true }}
+            searchWithinLoadedIssues
+            baseCreateIssueDefaults={buildSubIssueDefaultsForViewer(issue, currentUserId)}
+            createIssueLabel="Sub-task"
+            defaultSortField="workflow"
+            showProgressSummary
+            parentIssueIdForCostSummary={issue.id}
+            onUpdateIssue={handleChildIssueUpdate}
+          />
+        </div>
+      ) : (
+        <div className="flex flex-wrap items-center justify-end gap-2 min-w-0">
+          <Button variant="outline" size="sm" onClick={openNewSubIssue} className="shrink-0 shadow-none">
+            <Plus className="mr-1.5 h-3.5 w-3.5" />
+            New Sub-task
+          </Button>
+        </div>
+      )}
 
-        {taskChatShellEnabled ? null : issueHeaderBlock}
+      {!taskChatShellEnabled && showPlanDecompositionsSection ? (
+        <IssuePlanDecompositionsSection
+          issueId={issue.id}
+          issueIdentifier={issue.identifier}
+          agentMap={agentMap}
+        />
+      ) : null}
 
-        {taskChatShellEnabled ? null : pluginOutletsBlock}
+      {/* Flag ON: attachments/work products/workspace live in the properties
+          pane (Artifacts tab) — the center column belongs to the thread. */}
+      {taskChatShellEnabled ? null : (
+      <IssueDocumentsSection
+        issue={issue}
+        canDeleteDocuments={Boolean(session?.user?.id)}
+        canManageDocumentLocks={Boolean(session?.user?.id)}
+        feedbackVotes={feedbackVotes}
+        feedbackDataSharingPreference={feedbackDataSharingPreference}
+        feedbackTermsUrl={FEEDBACK_TERMS_URL}
+        mentions={mentionOptions}
+        externalReferences={externalObjectsState.isEnabled ? externalObjectsState.markdownReferences : undefined}
+        imageUploadHandler={async (file) => {
+          const attachment = await uploadAttachment.mutateAsync(file);
+          return attachment.contentPath;
+        }}
+        onVote={async (revisionId, vote, options) => {
+          await feedbackVoteMutation.mutateAsync({
+            targetType: "issue_document_revision",
+            targetId: revisionId,
+            vote,
+            reason: options?.reason,
+            allowSharing: options?.allowSharing,
+            sharingPreferenceAtSubmit: feedbackDataSharingPreference,
+          });
+        }}
+        extraActions={!hasAttachments ? attachmentUploadButton : null}
+        agentMap={agentMap}
+        userProfileMap={userProfileMap}
+      />
+      )}
 
-        {taskChatShellEnabled ? null : showRichSubIssuesSection ? (
+      {taskChatShellEnabled ? null : (
+      <IssueOutputSection
+        workProducts={workProducts}
+        onMediaClick={(item) => {
+          const meta = item.metadata;
+          if (!meta) return;
+          const idx = mediaGalleryItems.findIndex((galleryItem) => (
+            galleryItem.contentPath === meta.contentPath ||
+            galleryItem.id === `work-product-${item.id}` ||
+            galleryItem.id === meta.attachmentId
+          ));
+          setGalleryIndex(idx >= 0 ? idx : 0);
+          setGalleryOpen(true);
+        }}
+      />
+      )}
+
+      {taskChatShellEnabled ? null : attachmentsInitialLoading ? (
+        <IssueSectionSkeleton titleWidth="w-24" rows={2} />
+      ) : hasAttachments ? (
+        <IssueAttachmentsSection
+          attachments={attachmentList}
+          uploadButton={attachmentUploadButton}
+          error={attachmentError}
+          dragActive={attachmentDragActive}
+          deletePending={deleteAttachment.isPending}
+          onDelete={(attachmentId) => deleteAttachment.mutate(attachmentId)}
+          onImageClick={(attachment) => {
+            const idx = mediaGalleryItems.findIndex((a) => a.id === attachment.id);
+            setGalleryIndex(idx >= 0 ? idx : 0);
+            setGalleryOpen(true);
+          }}
+          onDragEnter={(evt) => {
+            evt.preventDefault();
+            setAttachmentDragActive(true);
+          }}
+          onDragOver={(evt) => {
+            evt.preventDefault();
+            setAttachmentDragActive(true);
+          }}
+          onDragLeave={(evt) => {
+            if (evt.currentTarget.contains(evt.relatedTarget as Node | null)) return;
+            setAttachmentDragActive(false);
+          }}
+          onDrop={(evt) => void handleAttachmentDrop(evt)}
+        />
+      ) : null}
+
+      <ImageGalleryModal
+        items={mediaGalleryItems}
+        initialIndex={galleryIndex}
+        open={galleryOpen}
+        onOpenChange={setGalleryOpen}
+      />
+
+      {taskChatShellEnabled ? null : (
+      <IssueWorkspaceCard
+        issue={issue}
+        project={resolvedProject}
+        onUpdate={(data) => updateIssue.mutate(data)}
+        onBrowseFiles={fileViewerEnabled ? () => setFileViewerPromptOpen(true) : undefined}
+        onOpenFileByPath={fileViewerEnabled ? () => setFileViewerPromptOpen(true) : undefined}
+      />
+      )}
+
+      {!taskChatShellEnabled && fileViewerEnabled && issue.workProducts && issue.workProducts.length > 0 && (() => {
+        const workProductsWithFileRefs = issue.workProducts
+          .map((product) => ({ product, fileRef: extractWorkspaceFileRefFromWorkProduct(product) }))
+          .filter(({ fileRef }) => fileRef !== null);
+
+        if (workProductsWithFileRefs.length === 0) return null;
+
+        return (
           <div className="space-y-3">
             <div className="flex items-center justify-between gap-2">
-              <h3 className="text-sm font-medium text-muted-foreground">
-                Sub-tasks
-              </h3>
+              <h3 className="text-sm font-medium text-muted-foreground">Artifacts</h3>
             </div>
-            <IssuesList
-              issues={childIssues}
-              isLoading={childIssuesLoading}
-              agents={agents}
-              projects={projects}
-              liveIssueIds={liveIssueIds}
-              mutedIssueIds={mutedChildIssueIds}
-              issueBadgeById={childPauseBadgeById}
-              projectId={issue.projectId ?? undefined}
-              viewStateKey={`paperclip:issue-detail:${issue.id}:subissues-view`}
-              issueLinkState={resolvedIssueDetailState ?? location.state}
-              searchFilters={{ descendantOf: issue.id, includeBlockedBy: true }}
-              searchWithinLoadedIssues
-              baseCreateIssueDefaults={buildSubIssueDefaultsForViewer(
-                issue,
-                currentUserId,
-              )}
-              createIssueLabel="Sub-task"
-              defaultSortField="workflow"
-              showProgressSummary
-              parentIssueIdForCostSummary={issue.id}
-              onUpdateIssue={handleChildIssueUpdate}
-            />
+            <div className="flex flex-wrap gap-2">
+              {workProductsWithFileRefs.map(({ product, fileRef }) => (
+                <ArtifactFileChip
+                  key={product.id}
+                  workspaceFileRef={fileRef!}
+                  title={product.title}
+                />
+              ))}
+            </div>
           </div>
-        ) : (
-          <div className="flex flex-wrap items-center justify-end gap-2 min-w-0">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={openNewSubIssue}
-              className="shrink-0 shadow-none"
-            >
-              <Plus className="mr-1.5 h-3.5 w-3.5" />
-              New Sub-task
-            </Button>
-          </div>
-        )}
+        );
+      })()}
 
-        {!taskChatShellEnabled && showPlanDecompositionsSection ? (
-          <IssuePlanDecompositionsSection
-            issueId={issue.id}
-            issueIdentifier={issue.identifier}
-            agentMap={agentMap}
-          />
-        ) : null}
+      {taskChatShellEnabled ? null : <Separator className={shellSectionClass} />}
 
-        {/* Flag ON: attachments/work products/workspace live in the properties
-          pane (Artifacts tab) — the center column belongs to the thread. */}
+      <Tabs
+        value={resolvedDetailTab}
+        onValueChange={setDetailTab}
+        className={taskChatShellEnabled ? (isMobile ? undefined : "min-h-0 flex-1") : "space-y-3"}
+      >
+        {/* Redesign: the chat IS the page — the Chat/Activity/Related-work tab
+            strip is hidden and the thread renders as the only surface. */}
         {taskChatShellEnabled ? null : (
-          <IssueDocumentsSection
-            issue={issue}
-            canDeleteDocuments={Boolean(session?.user?.id)}
-            canManageDocumentLocks={Boolean(session?.user?.id)}
-            feedbackVotes={feedbackVotes}
-            feedbackDataSharingPreference={feedbackDataSharingPreference}
-            feedbackTermsUrl={FEEDBACK_TERMS_URL}
-            mentions={mentionOptions}
-            externalReferences={
-              externalObjectsState.isEnabled
-                ? externalObjectsState.markdownReferences
-                : undefined
-            }
-            imageUploadHandler={async (file) => {
-              const attachment = await uploadAttachment.mutateAsync(file);
-              return attachment.contentPath;
-            }}
-            onVote={async (revisionId, vote, options) => {
-              await feedbackVoteMutation.mutateAsync({
-                targetType: "issue_document_revision",
-                targetId: revisionId,
-                vote,
-                reason: options?.reason,
-                allowSharing: options?.allowSharing,
-                sharingPreferenceAtSubmit: feedbackDataSharingPreference,
-              });
-            }}
-            extraActions={!hasAttachments ? attachmentUploadButton : null}
-            agentMap={agentMap}
-            userProfileMap={userProfileMap}
-          />
+        <TabsList variant="line" className={cn("w-full justify-start gap-1", shellSectionClass)}>
+          <TabsTrigger value="chat" className="gap-1.5">
+            <MessageSquare className="h-3.5 w-3.5" />
+            Chat
+          </TabsTrigger>
+          <TabsTrigger value="activity" className="gap-1.5">
+            <ActivityIcon className="h-3.5 w-3.5" />
+            Activity
+          </TabsTrigger>
+          <TabsTrigger value="related-work" className="gap-1.5">
+            <ListTree className="h-3.5 w-3.5" />
+            Related work
+          </TabsTrigger>
+          {issuePluginTabItems.map((item) => (
+            <TabsTrigger key={item.value} value={item.value}>
+              {item.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
         )}
 
-        {taskChatShellEnabled ? null : (
-          <IssueOutputSection
-            workProducts={workProducts}
-            onMediaClick={(item) => {
-              const meta = item.metadata;
-              if (!meta) return;
-              const idx = mediaGalleryItems.findIndex(
-                (galleryItem) =>
-                  galleryItem.contentPath === meta.contentPath ||
-                  galleryItem.id === `work-product-${item.id}` ||
-                  galleryItem.id === meta.attachmentId,
-              );
-              setGalleryIndex(idx >= 0 ? idx : 0);
-              setGalleryOpen(true);
-            }}
-          />
-        )}
-
-        {taskChatShellEnabled ? null : attachmentsInitialLoading ? (
-          <IssueSectionSkeleton titleWidth="w-24" rows={2} />
-        ) : hasAttachments ? (
-          <IssueAttachmentsSection
-            attachments={attachmentList}
-            uploadButton={attachmentUploadButton}
-            error={attachmentError}
-            dragActive={attachmentDragActive}
-            deletePending={deleteAttachment.isPending}
-            onDelete={(attachmentId) => deleteAttachment.mutate(attachmentId)}
-            onImageClick={(attachment) => {
-              const idx = mediaGalleryItems.findIndex(
-                (a) => a.id === attachment.id,
-              );
-              setGalleryIndex(idx >= 0 ? idx : 0);
-              setGalleryOpen(true);
-            }}
-            onDragEnter={(evt) => {
-              evt.preventDefault();
-              setAttachmentDragActive(true);
-            }}
-            onDragOver={(evt) => {
-              evt.preventDefault();
-              setAttachmentDragActive(true);
-            }}
-            onDragLeave={(evt) => {
-              if (evt.currentTarget.contains(evt.relatedTarget as Node | null))
-                return;
-              setAttachmentDragActive(false);
-            }}
-            onDrop={(evt) => void handleAttachmentDrop(evt)}
-          />
-        ) : null}
-
-        <ImageGalleryModal
-          items={mediaGalleryItems}
-          initialIndex={galleryIndex}
-          open={galleryOpen}
-          onOpenChange={setGalleryOpen}
-        />
-
-        {taskChatShellEnabled ? null : (
-          <IssueWorkspaceCard
-            issue={issue}
-            project={resolvedProject}
-            onUpdate={(data) => updateIssue.mutate(data)}
-            onBrowseFiles={
-              fileViewerEnabled
-                ? () => setFileViewerPromptOpen(true)
-                : undefined
-            }
-            onOpenFileByPath={
-              fileViewerEnabled
-                ? () => setFileViewerPromptOpen(true)
-                : undefined
-            }
-          />
-        )}
-
-        {!taskChatShellEnabled &&
-          fileViewerEnabled &&
-          issue.workProducts &&
-          issue.workProducts.length > 0 &&
-          (() => {
-            const workProductsWithFileRefs = issue.workProducts
-              .map((product) => ({
-                product,
-                fileRef: extractWorkspaceFileRefFromWorkProduct(product),
-              }))
-              .filter(({ fileRef }) => fileRef !== null);
-
-            if (workProductsWithFileRefs.length === 0) return null;
-
-            return (
-              <div className="space-y-3">
-                <div className="flex items-center justify-between gap-2">
-                  <h3 className="text-sm font-medium text-muted-foreground">
-                    Artifacts
-                  </h3>
-                </div>
-                <div className="flex flex-wrap gap-2">
-                  {workProductsWithFileRefs.map(({ product, fileRef }) => (
-                    <ArtifactFileChip
-                      key={product.id}
-                      workspaceFileRef={fileRef!}
-                      title={product.title}
-                    />
-                  ))}
-                </div>
-              </div>
-            );
-          })()}
-
-        {taskChatShellEnabled ? null : (
-          <Separator className={shellSectionClass} />
-        )}
-
-        <Tabs
-          value={resolvedDetailTab}
-          onValueChange={setDetailTab}
+        {/* The chat shell keeps the page's responsive 16px/24px gutters so
+            thread content and the composer do not touch either sidebar. */}
+        <TabsContent
+          data-testid="issue-detail-content"
+          value="chat"
           className={
             taskChatShellEnabled
               ? isMobile
-                ? undefined
-                : "min-h-0 flex-1"
-              : "space-y-3"
+                ? streamlinedTaskDetailEnabled ? undefined : "-mx-4"
+                : streamlinedTaskDetailEnabled
+                  ? "flex min-h-0 flex-col"
+                  : "-mx-4 -mt-4 md:-mx-6 md:-mt-6 flex min-h-0 flex-col"
+              : undefined
           }
         >
-          {/* Redesign: the chat IS the page — the Chat/Activity/Related-work tab
-            strip is hidden and the thread renders as the only surface. */}
-          {taskChatShellEnabled ? null : (
-            <TabsList
-              variant="line"
-              className={cn("w-full justify-start gap-1", shellSectionClass)}
-            >
-              <TabsTrigger value="chat" className="gap-1.5">
-                <MessageSquare className="h-3.5 w-3.5" />
-                Chat
-              </TabsTrigger>
-              <TabsTrigger value="activity" className="gap-1.5">
-                <ActivityIcon className="h-3.5 w-3.5" />
-                Activity
-              </TabsTrigger>
-              <TabsTrigger value="related-work" className="gap-1.5">
-                <ListTree className="h-3.5 w-3.5" />
-                Related work
-              </TabsTrigger>
-              {issuePluginTabItems.map((item) => (
-                <TabsTrigger key={item.value} value={item.value}>
-                  {item.label}
-                </TabsTrigger>
-              ))}
-            </TabsList>
-          )}
+          {resolvedDetailTab === "chat" ? (
+            <IssueDetailChatTab
+              threadHeader={taskChatThreadHeader}
+              issueBrief={
+                // Suppress the seeded-description bubble for the onboarding first
+                // task: its description is agent instructions, not something the
+                // user typed. The user lands on a seeded agent greeting instead.
+                taskChatShellEnabled &&
+                issue.originKind !== ONBOARDING_FIRST_TASK_ORIGIN_KIND
+                  ? {
+                      description: issue.description ?? "",
+                      author: issue.createdByAgentId ? "agent" : "human",
+                      authorName: issue.createdByAgentId
+                        ? agentMap.get(issue.createdByAgentId)?.name ?? "Agent"
+                        : undefined,
+                      agentIcon: issue.createdByAgentId
+                        ? agentMap.get(issue.createdByAgentId)?.icon
+                        : undefined,
+                      createdAt: issue.createdAt,
+                      onSave: (description) => updateIssue.mutateAsync({ description }),
+                      mentions: mentionOptions,
+                      externalReferences: externalObjectsState.isEnabled
+                        ? externalObjectsState.markdownReferences
+                        : undefined,
+                      imageUploadHandler: async (file) => {
+                        const attachment = await uploadAttachment.mutateAsync(file);
+                        return attachment.contentPath;
+                      },
+                      onDropFile: async (file) => {
+                        await uploadAttachment.mutateAsync(file);
+                      },
+                    }
+                  : undefined
+              }
+              issueId={issue.id}
+              companyId={issue.companyId}
+              projectId={issue.projectId ?? null}
+              issueStatus={issue.status}
+              issueAssigneeAgentId={issue.assigneeAgentId}
+              issueWorkMode={issue.workMode ?? "standard"}
+              executionRunId={issue.executionRunId ?? null}
+              blockedBy={issue.blockedBy ?? []}
+              liveIssueIds={liveIssueIds}
+              blockerAttention={issue.blockerAttention ?? null}
+              successfulRunHandoff={issue.successfulRunHandoff ?? null}
+              scheduledRetry={issue.scheduledRetry ?? null}
+              recoveryAction={issue.activeRecoveryAction ?? null}
+              onResolveRecoveryAction={handleResolveRecoveryAction}
+              onReissueIsolatedRecoveryAction={handleReissueIsolatedRecoveryAction}
+              reissueIsolatedRecoveryActionPending={reissueIsolatedRecoveryAction.isPending}
+              onReconcileForwardRecoveryAction={handleReconcileForwardRecoveryAction}
+              onBreakGlassOverrideRecoveryAction={handleBreakGlassOverrideRecoveryAction}
+              onQuarantineRestoreRecoveryAction={handleQuarantineRestoreRecoveryAction}
+              quarantineRestoreRecoveryActionPending={reconcileRecoveryAction.isPending}
+              canBreakGlassRecoveryAction={canManageBoardRuntime}
+              reconcileRecoveryActionPending={reconcileRecoveryAction.isPending}
+              canFalsePositiveRecoveryAction={canResolveBoardRecoveryAction}
+              legacyRecoverySourceIssue={legacyRecoverySourceIssue}
+              comments={threadComments}
+              commentsInitialLoading={commentsLoading}
+              locallyQueuedCommentRunIds={locallyQueuedCommentRunIds}
+              interactions={interactions}
+              documents={issue.documentSummaries ?? []}
+              workProducts={workProducts ?? []}
+              attachments={attachments ?? []}
+              hasOlderComments={hasOlderComments}
+              commentsLoadingOlder={commentsLoadingOlder}
+              onLoadOlderComments={loadOlderComments}
+              onRefreshLatestComments={refetchLatestComments}
+              composerRef={commentComposerRef}
+              composerAccessory={
+                hasVisibleMonitorSurface(issue) ? (
+                  <IssueMonitorComposerStrip
+                    issue={issue}
+                    onCheckNow={() => checkIssueMonitorNow.mutate()}
+                    checkingNow={checkIssueMonitorNow.isPending}
+                  />
+                ) : null
+              }
+              footer={
+                !taskChatShellEnabled && siblingNavigation ? (
+                  <IssueSiblingNavigation
+                    navigation={siblingNavigation}
+                    linkState={resolvedIssueDetailState ?? location.state}
+                  />
+                ) : null
+              }
+              feedbackVotes={feedbackVotes}
+              feedbackDataSharingPreference={feedbackDataSharingPreference}
+              feedbackTermsUrl={FEEDBACK_TERMS_URL}
+              agentMap={agentMap}
+              currentUserId={currentUserId}
+              userLabelMap={userLabelMap}
+              userProfileMap={userProfileMap}
+              draftKey={`paperclip:issue-comment-draft:${issue.id}`}
+              reassignOptions={commentReassignOptions}
+              currentAssigneeValue={actualAssigneeValue}
+              suggestedAssigneeValue={suggestedAssigneeValue}
+              mentions={mentionOptions}
+              composerDisabledReason={null}
+              composerHint={composerHint}
+              queuedCommentReason={queuedCommentReason}
+              onVote={handleCommentVote}
+              onAdd={handleChatAdd}
+              onImageUpload={handleCommentImageUpload}
+              onAttachImage={handleCommentAttachImage}
+              onInterruptQueued={handleInterruptQueuedRun}
+              onDeleteComment={(commentId) => deleteComment.mutateAsync({ commentId }).then(() => undefined)}
+              onPauseWorkRun={canManageTreeControl
+                ? (runId) => pauseIssueWorkRun.mutateAsync({ runId, scope: treeControlScope }).then(() => undefined)
+                : undefined}
+              runFinalizationActions={runFinalizationActions}
+              onWorkModeChange={(nextMode) => {
+                const currentMode: IssueWorkMode = issue.workMode ?? "standard";
+                if (currentMode === nextMode) return;
+                return updateIssue.mutateAsync({ workMode: nextMode }).then(() => undefined);
+              }}
+              onCancelQueued={handleCancelQueuedComment}
+              interruptingQueuedRunId={interruptQueuedComment.isPending ? interruptQueuedComment.variables ?? null : null}
+              pausingWorkRunId={pauseIssueWorkRun.isPending ? pauseIssueWorkRun.variables?.runId ?? null : null}
+              onImageClick={handleChatImageClick}
+              onAcceptInteraction={handleAcceptInteraction}
+              onRejectInteraction={handleRejectInteraction}
+              onSubmitInteractionAnswers={handleSubmitInteractionAnswers}
+              onCancelInteraction={handleCancelInteraction}
+              onSkipInteraction={handleSkipInteraction}
+              onSubmitInteractionVerdicts={handleSubmitInteractionVerdicts}
+              assigneeUserId={issue.assigneeUserId ?? null}
+              onResumeFromBacklog={canResumeFromBacklog ? handleResumeFromBacklog : undefined}
+              resumeFromBacklogPending={
+                updateIssue.isPending && updateIssue.variables?.status === "todo"
+              }
+              onResumeAssignee={issue.assigneeAgentId ? handleResumeAssignee : undefined}
+              resumeAssigneePending={resumeAssigneeAgent.isPending}
+              onTryAgainNoLiveExecutionPath={
+                issue.status === "blocked" && issue.activeRecoveryAction
+                  ? handleTryAgainNoLiveExecutionPath
+                  : undefined
+              }
+              tryAgainNoLiveExecutionPathPending={
+                resolveRecoveryAction.isPending &&
+                resolveRecoveryAction.variables?.sourceIssueStatus === "todo"
+              }
+              externalReferences={externalObjectsState.isEnabled ? externalObjectsState.markdownReferences : undefined}
+              linkCaseReferences={casesChipsEnabled}
+            />
+          ) : null}
+        </TabsContent>
 
-          {/* Flag ON the thread viewport extends under main's horizontal padding
-            (symmetric, so the centered column keeps the same axis) and its top
-            padding, placing task metadata in the side-panel tab header band. */}
-          <TabsContent
-            data-testid="issue-detail-content"
-            value="chat"
-            className={
-              taskChatShellEnabled
-                ? isMobile
-                  ? "-mx-4"
-                  : "-mx-4 -mt-4 md:-mx-6 md:-mt-6 flex min-h-0 flex-col"
-                : undefined
-            }
-          >
-            {resolvedDetailTab === "chat" ? (
-              <IssueDetailChatTab
-                threadHeader={taskChatThreadHeader}
-                issueBrief={
-                  // Suppress the seeded-description bubble for the onboarding first
-                  // task: its description is agent instructions, not something the
-                  // user typed. The user lands on a seeded agent greeting instead.
-                  taskChatShellEnabled &&
-                  issue.originKind !== ONBOARDING_FIRST_TASK_ORIGIN_KIND
-                    ? {
-                        description: issue.description ?? "",
-                        author: issue.createdByAgentId ? "agent" : "human",
-                        authorName: issue.createdByAgentId
-                          ? (agentMap.get(issue.createdByAgentId)?.name ??
-                            "Agent")
-                          : undefined,
-                        agentIcon: issue.createdByAgentId
-                          ? agentMap.get(issue.createdByAgentId)?.icon
-                          : undefined,
-                        createdAt: issue.createdAt,
-                        onSave: (description) =>
-                          updateIssue.mutateAsync({ description }),
-                        mentions: mentionOptions,
-                        externalReferences: externalObjectsState.isEnabled
-                          ? externalObjectsState.markdownReferences
-                          : undefined,
-                        imageUploadHandler: async (file) => {
-                          const attachment =
-                            await uploadAttachment.mutateAsync(file);
-                          return attachment.contentPath;
-                        },
-                        onDropFile: async (file) => {
-                          await uploadAttachment.mutateAsync(file);
-                        },
-                      }
-                    : undefined
-                }
-                issueId={issue.id}
-                companyId={issue.companyId}
-                projectId={issue.projectId ?? null}
-                issueStatus={issue.status}
-                issueAssigneeAgentId={issue.assigneeAgentId}
-                issueWorkMode={issue.workMode ?? "standard"}
-                executionRunId={issue.executionRunId ?? null}
-                blockedBy={issue.blockedBy ?? []}
-                liveIssueIds={liveIssueIds}
-                blockerAttention={issue.blockerAttention ?? null}
-                successfulRunHandoff={issue.successfulRunHandoff ?? null}
-                scheduledRetry={issue.scheduledRetry ?? null}
-                recoveryAction={issue.activeRecoveryAction ?? null}
-                onResolveRecoveryAction={handleResolveRecoveryAction}
-                onReissueIsolatedRecoveryAction={
-                  handleReissueIsolatedRecoveryAction
-                }
-                reissueIsolatedRecoveryActionPending={
-                  reissueIsolatedRecoveryAction.isPending
-                }
-                onReconcileForwardRecoveryAction={
-                  handleReconcileForwardRecoveryAction
-                }
-                onBreakGlassOverrideRecoveryAction={
-                  handleBreakGlassOverrideRecoveryAction
-                }
-                onQuarantineRestoreRecoveryAction={
-                  handleQuarantineRestoreRecoveryAction
-                }
-                quarantineRestoreRecoveryActionPending={
-                  reconcileRecoveryAction.isPending
-                }
-                canBreakGlassRecoveryAction={canManageBoardRuntime}
-                reconcileRecoveryActionPending={
-                  reconcileRecoveryAction.isPending
-                }
-                canFalsePositiveRecoveryAction={canResolveBoardRecoveryAction}
-                legacyRecoverySourceIssue={legacyRecoverySourceIssue}
-                comments={threadComments}
-                commentsInitialLoading={commentsLoading}
-                locallyQueuedCommentRunIds={locallyQueuedCommentRunIds}
-                interactions={interactions}
-                documents={issue.documentSummaries ?? []}
-                workProducts={workProducts ?? []}
-                attachments={attachments ?? []}
-                hasOlderComments={hasOlderComments}
-                commentsLoadingOlder={commentsLoadingOlder}
-                onLoadOlderComments={loadOlderComments}
-                onRefreshLatestComments={refetchLatestComments}
-                composerRef={commentComposerRef}
-                composerAccessory={
-                  hasVisibleMonitorSurface(issue) ? (
-                    <IssueMonitorComposerStrip
-                      issue={issue}
-                      onCheckNow={() => checkIssueMonitorNow.mutate()}
-                      checkingNow={checkIssueMonitorNow.isPending}
-                    />
-                  ) : null
-                }
-                footer={
-                  !taskChatShellEnabled && siblingNavigation ? (
-                    <IssueSiblingNavigation
-                      navigation={siblingNavigation}
-                      linkState={resolvedIssueDetailState ?? location.state}
-                    />
-                  ) : null
-                }
-                feedbackVotes={feedbackVotes}
-                feedbackDataSharingPreference={feedbackDataSharingPreference}
-                feedbackTermsUrl={FEEDBACK_TERMS_URL}
-                agentMap={agentMap}
-                currentUserId={currentUserId}
-                userLabelMap={userLabelMap}
-                userProfileMap={userProfileMap}
-                draftKey={`paperclip:issue-comment-draft:${issue.id}`}
-                reassignOptions={commentReassignOptions}
-                currentAssigneeValue={actualAssigneeValue}
-                suggestedAssigneeValue={suggestedAssigneeValue}
-                mentions={mentionOptions}
-                composerDisabledReason={null}
-                composerHint={composerHint}
-                queuedCommentReason={queuedCommentReason}
-                onVote={handleCommentVote}
-                onAdd={handleChatAdd}
-                onImageUpload={handleCommentImageUpload}
-                onAttachImage={handleCommentAttachImage}
-                onInterruptQueued={handleInterruptQueuedRun}
-                onDeleteComment={(commentId) =>
-                  deleteComment.mutateAsync({ commentId }).then(() => undefined)
-                }
-                onPauseWorkRun={
-                  canManageTreeControl
-                    ? (runId) =>
-                        pauseIssueWorkRun
-                          .mutateAsync({ runId, scope: treeControlScope })
-                          .then(() => undefined)
-                    : undefined
-                }
-                runFinalizationActions={runFinalizationActions}
-                onWorkModeChange={(nextMode) => {
-                  const currentMode: IssueWorkMode =
-                    issue.workMode ?? "standard";
-                  if (currentMode === nextMode) return;
-                  return updateIssue
-                    .mutateAsync({ workMode: nextMode })
-                    .then(() => undefined);
-                }}
-                onCancelQueued={handleCancelQueuedComment}
-                interruptingQueuedRunId={
-                  interruptQueuedComment.isPending
-                    ? (interruptQueuedComment.variables ?? null)
-                    : null
-                }
-                pausingWorkRunId={
-                  pauseIssueWorkRun.isPending
-                    ? (pauseIssueWorkRun.variables?.runId ?? null)
-                    : null
-                }
-                onImageClick={handleChatImageClick}
-                onAcceptInteraction={handleAcceptInteraction}
-                onRejectInteraction={handleRejectInteraction}
-                onSubmitInteractionAnswers={handleSubmitInteractionAnswers}
-                onCancelInteraction={handleCancelInteraction}
-                onSkipInteraction={handleSkipInteraction}
-                onSubmitInteractionVerdicts={handleSubmitInteractionVerdicts}
-                assigneeUserId={issue.assigneeUserId ?? null}
-                onResumeFromBacklog={
-                  canResumeFromBacklog ? handleResumeFromBacklog : undefined
-                }
-                resumeFromBacklogPending={
-                  updateIssue.isPending &&
-                  updateIssue.variables?.status === "todo"
-                }
-                onResumeAssignee={
-                  issue.assigneeAgentId ? handleResumeAssignee : undefined
-                }
-                resumeAssigneePending={resumeAssigneeAgent.isPending}
-                onTryAgainNoLiveExecutionPath={
-                  issue.status === "blocked" && issue.activeRecoveryAction
-                    ? handleTryAgainNoLiveExecutionPath
-                    : undefined
-                }
-                tryAgainNoLiveExecutionPathPending={
-                  resolveRecoveryAction.isPending &&
-                  resolveRecoveryAction.variables?.sourceIssueStatus === "todo"
-                }
-                externalReferences={
-                  externalObjectsState.isEnabled
-                    ? externalObjectsState.markdownReferences
-                    : undefined
-                }
-                linkCaseReferences={casesChipsEnabled}
-              />
-            ) : null}
-          </TabsContent>
+        <TabsContent value="activity" className={shellSectionClass}>
+          {detailTab === "activity" ? (
+            <IssueDetailActivityTab
+              issue={issue}
+              issueId={issue.id}
+              companyId={issue.companyId}
+              issueStatus={issue.status}
+              childIssues={childIssues}
+              agentMap={agentMap}
+              hasLiveRuns={hasLiveRuns}
+              currentUserId={currentUserId}
+              userProfileMap={userProfileMap}
+              pendingApprovalAction={pendingApprovalAction}
+              handoffFocusSignal={handoffFocusSignal}
+              onApprovalAction={(approvalId, action) => {
+                approvalDecision.mutate({ approvalId, action });
+              }}
+              externalReferences={externalObjectsState.isEnabled ? externalObjectsState.markdownReferences : undefined}
+            />
+          ) : null}
+        </TabsContent>
 
-          <TabsContent value="activity" className={shellSectionClass}>
-            {detailTab === "activity" ? (
-              <IssueDetailActivityTab
-                issue={issue}
-                issueId={issue.id}
-                companyId={issue.companyId}
-                issueStatus={issue.status}
-                childIssues={childIssues}
-                agentMap={agentMap}
-                hasLiveRuns={hasLiveRuns}
-                currentUserId={currentUserId}
-                userProfileMap={userProfileMap}
-                pendingApprovalAction={pendingApprovalAction}
-                handoffFocusSignal={handoffFocusSignal}
-                onApprovalAction={(approvalId, action) => {
-                  approvalDecision.mutate({ approvalId, action });
-                }}
-                externalReferences={
-                  externalObjectsState.isEnabled
-                    ? externalObjectsState.markdownReferences
-                    : undefined
-                }
-              />
-            ) : null}
-          </TabsContent>
+        <TabsContent value="related-work" className={shellSectionClass}>
+          <IssueRelatedWorkPanel
+            relatedWork={issue.relatedWork}
+            externalObjectsEnabled={externalObjectsState.isEnabled}
+            externalObjects={externalObjectsState.isEnabled ? externalObjectsState.groups : undefined}
+            externalObjectsLoading={externalObjectsState.isEnabled ? externalObjectsState.isLoading : undefined}
+            externalObjectsError={externalObjectsState.isEnabled ? externalObjectsState.isError : undefined}
+            onRetryExternalObjects={externalObjectsState.isEnabled ? externalObjectsState.refetch : undefined}
+          />
+        </TabsContent>
 
-          <TabsContent value="related-work" className={shellSectionClass}>
-            <IssueRelatedWorkPanel
-              relatedWork={issue.relatedWork}
-              externalObjectsEnabled={externalObjectsState.isEnabled}
-              externalObjects={
-                externalObjectsState.isEnabled
-                  ? externalObjectsState.groups
-                  : undefined
-              }
-              externalObjectsLoading={
-                externalObjectsState.isEnabled
-                  ? externalObjectsState.isLoading
-                  : undefined
-              }
-              externalObjectsError={
-                externalObjectsState.isEnabled
-                  ? externalObjectsState.isError
-                  : undefined
-              }
-              onRetryExternalObjects={
-                externalObjectsState.isEnabled
-                  ? externalObjectsState.refetch
-                  : undefined
-              }
+        {activePluginTab && (
+          <TabsContent value={activePluginTab.value} className={shellSectionClass}>
+            <PluginSlotMount
+              slot={activePluginTab.slot}
+              context={{
+                companyId: issue.companyId,
+                projectId: issue.projectId ?? null,
+                entityId: issue.id,
+                entityType: "issue",
+              }}
+              missingBehavior="placeholder"
             />
           </TabsContent>
-
-          {activePluginTab && (
-            <TabsContent
-              value={activePluginTab.value}
-              className={shellSectionClass}
-            >
-              <PluginSlotMount
-                slot={activePluginTab.slot}
-                context={{
-                  companyId: issue.companyId,
-                  projectId: issue.projectId ?? null,
-                  entityId: issue.id,
-                  entityType: "issue",
-                }}
-                missingBehavior="placeholder"
-              />
-            </TabsContent>
-          )}
-        </Tabs>
+        )}
+      </Tabs>
 
         <Dialog open={treeControlOpen} onOpenChange={setTreeControlOpen}>
           <DialogContent className="flex max-h-(--sz-calc-18) flex-col gap-0 overflow-hidden p-0 sm:max-w-(--sz-560px)">
@@ -7766,6 +7823,11 @@ export function IssueDetail() {
                   issue={issue}
                   accountScope={currentUserId ?? "anonymous"}
                   childIssues={childIssues}
+                  issueLinkState={
+                    streamlinedTaskDetailEnabled
+                      ? relationIssueLinkState
+                      : undefined
+                  }
                   onAddSubIssue={openNewSubIssue}
                   onUpdate={(data) => updateIssue.mutate(data)}
                   inline
@@ -7793,6 +7855,8 @@ export function IssueDetail() {
                   onCheckMonitorNow={() => checkIssueMonitorNow.mutate()}
                   checkingMonitorNow={checkIssueMonitorNow.isPending}
                   fileTabsEnabled={fileViewerEnabled}
+                  streamlinedTabs={streamlinedTaskDetailEnabled}
+                  showSubtasksTab={streamlinedTaskDetailEnabled}
                   documentDeepLink={
                     documentDeepLink?.issueId === issue.id
                       ? documentDeepLink
@@ -7815,6 +7879,11 @@ export function IssueDetail() {
                     <IssueProperties
                       issue={issue}
                       childIssues={childIssues}
+                      issueLinkState={
+                        streamlinedTaskDetailEnabled
+                          ? relationIssueLinkState
+                          : undefined
+                      }
                       onAddSubIssue={openNewSubIssue}
                       onUpdate={(data) => updateIssue.mutate(data)}
                       inline

--- a/ui/src/pages/Issues.test.tsx
+++ b/ui/src/pages/Issues.test.tsx
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 import type { Issue } from "@paperclipai/shared";
-import { buildIssuesSearchUrl, getNextIssuesPageOffset, mergeIssuePagesStable } from "./Issues";
+import {
+  ISSUES_ROW_PRESENTATION,
+  ISSUES_TOOLBAR_PRESENTATION,
+  buildIssuesSearchUrl,
+  getNextIssuesPageOffset,
+  mergeIssuePagesStable,
+  resolveIssuesPresentation,
+} from "./Issues";
 
 function createIssue(id: string, title: string): Issue {
   return { id, title } as Issue;
@@ -21,6 +28,25 @@ describe("buildIssuesSearchUrl", () => {
 });
 
 describe("issues page pagination helpers", () => {
+  it("opts the Tasks route into the canonical shared task-row presentation", () => {
+    expect(ISSUES_ROW_PRESENTATION).toBe("task");
+  });
+
+  it("opts the Tasks route into the shared collection toolbar", () => {
+    expect(ISSUES_TOOLBAR_PRESENTATION).toBe("collection");
+  });
+
+  it("restores the retained legacy list and toolbar when Streamlined UI is off", () => {
+    expect(resolveIssuesPresentation(false)).toEqual({
+      rowPresentation: "legacy",
+      toolbarPresentation: "legacy",
+    });
+    expect(resolveIssuesPresentation(true)).toEqual({
+      rowPresentation: "task",
+      toolbarPresentation: "collection",
+    });
+  });
+
   it("advances to the next offset when the current page is full", () => {
     expect(getNextIssuesPageOffset(100, 0)).toBe(100);
     expect(getNextIssuesPageOffset(100, 100)).toBe(200);

--- a/ui/src/pages/Issues.tsx
+++ b/ui/src/pages/Issues.tsx
@@ -15,9 +15,18 @@ import { EmptyState } from "../components/EmptyState";
 import { IssuesList } from "../components/IssuesList";
 import { CircleDot } from "lucide-react";
 import type { Issue } from "@paperclipai/shared";
+import { useStreamlinedUiEnabled } from "../hooks/useStreamlinedUiEnabled";
 
 const WORKSPACE_FILTER_ISSUE_LIMIT = 1000;
 const ISSUES_PAGE_SIZE = 100;
+export const ISSUES_ROW_PRESENTATION = "task" as const;
+export const ISSUES_TOOLBAR_PRESENTATION = "collection" as const;
+
+export function resolveIssuesPresentation(streamlinedUiEnabled: boolean) {
+  return streamlinedUiEnabled
+    ? { rowPresentation: ISSUES_ROW_PRESENTATION, toolbarPresentation: ISSUES_TOOLBAR_PRESENTATION }
+    : { rowPresentation: "legacy" as const, toolbarPresentation: "legacy" as const };
+}
 
 export function getNextIssuesPageOffset(
   loadedPageSize: number,
@@ -57,6 +66,8 @@ export function buildIssuesSearchUrl(currentHref: string, search: string): strin
 }
 
 export function Issues() {
+  const { enabled: streamlinedUiEnabled } = useStreamlinedUiEnabled();
+  const issuesPresentation = resolveIssuesPresentation(streamlinedUiEnabled);
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
   const location = useLocation();
@@ -187,7 +198,14 @@ export function Issues() {
   });
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={CircleDot} message="Select an organization to view tasks." />;
+    return (
+      <EmptyState
+        icon={CircleDot}
+        message={streamlinedUiEnabled
+          ? "Select an organization to view tasks."
+          : "Select a company to view tasks."}
+      />
+    );
   }
 
   return (
@@ -200,6 +218,8 @@ export function Issues() {
       projects={projects}
       liveIssueIds={liveIssueIds}
       viewStateKey="paperclip:issues-view"
+      rowPresentation={issuesPresentation.rowPresentation}
+      toolbarPresentation={issuesPresentation.toolbarPresentation}
       issueLinkState={issueLinkState}
       initialAssignees={searchParams.get("assignee") ? [searchParams.get("assignee")!] : undefined}
       initialWorkspaces={initialWorkspaces.length > 0 ? initialWorkspaces : undefined}

--- a/ui/src/pages/LegacyInbox.tsx
+++ b/ui/src/pages/LegacyInbox.tsx
@@ -330,13 +330,13 @@ export function FailedRunInboxRow({
                 onClick={onMarkRead}
                 className={cn(
                   "inline-flex h-4 w-4 items-center justify-center rounded-full transition-colors",
-                  "hover:bg-blue-500/20",
+                  "hover:bg-(--status-task-in_progress)/20",
                 )}
                 aria-label="Mark as read"
               >
                 <span className={cn(
                   "block h-2 w-2 rounded-full transition-opacity duration-300",
-                  "bg-blue-600 dark:bg-blue-400",
+                  "bg-(--status-task-in_progress)",
                   unreadState === "fading" ? "opacity-0" : "opacity-100",
                 )} />
               </button>
@@ -479,13 +479,13 @@ function ApprovalInboxRow({
                 onClick={onMarkRead}
                 className={cn(
                   "inline-flex h-4 w-4 items-center justify-center rounded-full transition-colors",
-                  "hover:bg-blue-500/20",
+                  "hover:bg-(--status-task-in_progress)/20",
                 )}
                 aria-label="Mark as read"
               >
                 <span className={cn(
                   "block h-2 w-2 rounded-full transition-opacity duration-300",
-                  "bg-blue-600 dark:bg-blue-400",
+                  "bg-(--status-task-in_progress)",
                   unreadState === "fading" ? "opacity-0" : "opacity-100",
                 )} />
               </button>
@@ -526,7 +526,7 @@ function ApprovalInboxRow({
               <>
                 <Button
                   size="sm"
-                  className="h-8 bg-green-700 px-3 text-white hover:bg-green-600"
+                  className="h-8 bg-(--status-task-icon-done) px-3 text-white hover:bg-(--status-task-done)"
                   onClick={onApprove}
                   disabled={isPending}
                 >
@@ -550,7 +550,7 @@ function ApprovalInboxRow({
         <div className="mt-3 flex gap-2 sm:hidden">
           <Button
             size="sm"
-            className="h-8 bg-green-700 px-3 text-white hover:bg-green-600"
+            className="h-8 bg-(--status-task-icon-done) px-3 text-white hover:bg-(--status-task-done)"
             onClick={onApprove}
             disabled={isPending}
           >
@@ -612,13 +612,13 @@ function JoinRequestInboxRow({
                 onClick={onMarkRead}
                 className={cn(
                   "inline-flex h-4 w-4 items-center justify-center rounded-full transition-colors",
-                  "hover:bg-blue-500/20",
+                  "hover:bg-(--status-task-in_progress)/20",
                 )}
                 aria-label="Mark as read"
               >
                 <span className={cn(
                   "block h-2 w-2 rounded-full transition-opacity duration-300",
-                  "bg-blue-600 dark:bg-blue-400",
+                  "bg-(--status-task-in_progress)",
                   unreadState === "fading" ? "opacity-0" : "opacity-100",
                 )} />
               </button>
@@ -649,7 +649,7 @@ function JoinRequestInboxRow({
           ) : null}
           <Button
             size="sm"
-            className="h-8 bg-green-700 px-3 text-white hover:bg-green-600"
+            className="h-8 bg-(--status-task-icon-done) px-3 text-white hover:bg-(--status-task-done)"
             onClick={onApprove}
             disabled={isPending}
           >
@@ -669,7 +669,7 @@ function JoinRequestInboxRow({
       <div className="mt-3 flex gap-2 sm:hidden">
         <Button
           size="sm"
-          className="h-8 bg-green-700 px-3 text-white hover:bg-green-600"
+          className="h-8 bg-(--status-task-icon-done) px-3 text-white hover:bg-(--status-task-done)"
           onClick={onApprove}
           disabled={isPending}
         >

--- a/ui/src/pages/LegacyInbox.tsx
+++ b/ui/src/pages/LegacyInbox.tsx
@@ -30,8 +30,6 @@ import { useIssueExternalObjectSummaries } from "../hooks/useIssueExternalObject
 import {
   applyIssueFilters,
   countActiveIssueFilters,
-  defaultIssueFilterState,
-  normalizeIssueFilterState,
   type IssueFilterState,
 } from "../lib/issue-filters";
 import { collectLiveIssueIds, collectSubtreeLiveCounts } from "../lib/liveIssueIds";
@@ -71,7 +69,6 @@ import {
   useLocalInboxArchiveIssueIds,
 } from "../lib/inboxArchiveCache";
 import { EmptyState } from "../components/EmptyState";
-import { CollectionToolbar, type CollectionToolbarProps } from "../components/CollectionToolbar";
 import { IssueGroupHeader } from "../components/IssueGroupHeader";
 import { PageSkeleton } from "../components/PageSkeleton";
 import {
@@ -79,15 +76,12 @@ import {
   InboxIssueTrailingColumns,
   IssueColumnPicker,
   issueActivityText,
-  issueActivityTimestamp,
   issueTrailingColumns,
 } from "../components/IssueColumns";
 import { IssueFiltersPopover } from "../components/IssueFiltersPopover";
 import { InboxArchiveButton, IssueRow } from "../components/IssueRow";
 import { BlockedInboxView } from "../components/BlockedInboxView";
 import { SwipeToArchive } from "../components/SwipeToArchive";
-import { useStreamlinedUiEnabled } from "../hooks/useStreamlinedUiEnabled";
-import { Inbox as LegacyInbox } from "./LegacyInbox";
 
 import { StatusIcon } from "../components/StatusIcon";
 import { cn } from "../lib/utils";
@@ -105,6 +99,13 @@ import {
 } from "@/components/ui/dialog";
 import { Separator } from "@/components/ui/separator";
 import { Tabs } from "@/components/ui/tabs";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   Inbox as InboxIcon,
@@ -144,6 +145,8 @@ import {
   isMineInboxTab,
   loadCollapsedInboxGroupKeys,
   loadCollapsedInboxParentIds,
+  loadInboxFilterPreferences,
+  loadInboxIssueColumns,
   loadInboxNesting,
   loadInboxWorkItemGroupBy,
   normalizeInboxIssueColumns,
@@ -151,8 +154,10 @@ import {
   shouldResetInboxWorkspaceGrouping,
   resolveIssueWorkspaceName,
   resolveInboxSelectionIndex,
+  saveInboxFilterPreferences,
   saveCollapsedInboxGroupKeys,
   saveCollapsedInboxParentIds,
+  saveInboxIssueColumns,
   saveInboxNesting,
   saveInboxWorkItemGroupBy,
   type InboxWorkspaceGroupingOptions,
@@ -168,8 +173,6 @@ import {
   type InboxTab,
   type InboxWorkItem,
   type InboxWorkItemGroupBy,
-  INBOX_FILTER_PREFERENCES_KEY_PREFIX,
-  INBOX_ISSUE_COLUMNS_KEY,
 } from "../lib/inbox";
 import { useDismissedInboxAlerts, useInboxDismissals, useReadInboxItems } from "../hooks/useInboxBadge";
 import { useInboxSortAttention } from "../hooks/useInboxSortAttention";
@@ -178,78 +181,10 @@ import {
   reconcileInboxOrderPin,
   type InboxOrderPin,
 } from "../lib/inboxOrderPin";
-import {
-  loadTaskCollectionPreferences,
-  saveTaskCollectionPreferences,
-  type TaskCollectionPreferenceLocation,
-} from "../lib/task-collection-preferences";
-import {
-  taskDateGroup,
-  taskDateGroupSeparator,
-  type TaskDateGroup,
-} from "../lib/task-date-groups";
 
 const INBOX_HEARTBEAT_RUN_LIMIT = 200;
 const INBOX_ISSUE_LIST_LIMIT = 500;
 const INBOX_HOT_PATH_STALE_MS = 30_000;
-const INBOX_COLLECTION_KEY = "inbox";
-
-type StreamlinedInboxViewState = InboxFilterPreferences & {
-  showDateGroupSeparators: boolean;
-};
-
-const DEFAULT_INBOX_FILTER_PREFERENCES: StreamlinedInboxViewState = {
-  allCategoryFilter: "everything",
-  allApprovalFilter: "all",
-  issueFilters: { ...defaultIssueFilterState },
-  showDateGroupSeparators: true,
-};
-
-function normalizeInboxCollectionViewState(value: unknown): StreamlinedInboxViewState {
-  const candidate = value && typeof value === "object"
-    ? value as Partial<StreamlinedInboxViewState>
-    : {};
-  const category = candidate.allCategoryFilter;
-  const approval = candidate.allApprovalFilter;
-  return {
-    allCategoryFilter:
-      category === "issues_i_touched"
-      || category === "join_requests"
-      || category === "approvals"
-      || category === "failed_runs"
-      || category === "alerts"
-        ? category
-        : "everything",
-    allApprovalFilter: approval === "actionable" || approval === "resolved" ? approval : "all",
-    issueFilters: normalizeIssueFilterState(candidate.issueFilters),
-    showDateGroupSeparators: candidate.showDateGroupSeparators !== false,
-  };
-}
-
-function inboxCollectionPreferenceLocation(
-  companyId: string | null | undefined,
-): TaskCollectionPreferenceLocation {
-  return {
-    companyId: companyId ?? "__unscoped__",
-    collectionKey: INBOX_COLLECTION_KEY,
-    legacyViewStorageKey: companyId
-      ? `${INBOX_FILTER_PREFERENCES_KEY_PREFIX}:${companyId}`
-      : undefined,
-    legacyColumnsStorageKey: INBOX_ISSUE_COLUMNS_KEY,
-  };
-}
-
-function loadInboxCollectionPreferences(companyId: string | null | undefined) {
-  return loadTaskCollectionPreferences({
-    ...inboxCollectionPreferenceLocation(companyId),
-    defaultViewState: DEFAULT_INBOX_FILTER_PREFERENCES,
-    defaultColumns: DEFAULT_INBOX_ISSUE_COLUMNS,
-    normalizeViewState: normalizeInboxCollectionViewState,
-    normalizeColumns: (value) => Array.isArray(value)
-      ? normalizeInboxIssueColumns(value)
-      : DEFAULT_INBOX_ISSUE_COLUMNS,
-  });
-}
 
 export { InboxIssueMetaLeading, InboxIssueTrailingColumns } from "../components/IssueColumns";
 export { IssueGroupHeader as InboxGroupHeader } from "../components/IssueGroupHeader";
@@ -383,7 +318,7 @@ export function FailedRunInboxRow({
 
   return (
     <div className={cn(
-      "group py-2.5 pl-4 pr-2 sm:py-2",
+      "group border-b border-border px-2 py-2.5 last:border-b-0 sm:px-1 sm:pr-3 sm:py-2",
       className,
     )}>
       <div className="flex items-start gap-2 sm:items-center">
@@ -532,7 +467,7 @@ function ApprovalInboxRow({
 
   return (
     <div className={cn(
-      "group py-2.5 pl-4 pr-2 sm:py-2",
+      "group border-b border-border px-2 py-2.5 last:border-b-0 sm:px-1 sm:pr-3 sm:py-2",
       className,
     )}>
       <div className="flex items-start gap-2 sm:items-center">
@@ -591,7 +526,7 @@ function ApprovalInboxRow({
               <>
                 <Button
                   size="sm"
-                  className="h-8 min-w-(--sz-64px) justify-center bg-green-700 px-3 text-white hover:bg-green-600"
+                  className="h-8 bg-green-700 px-3 text-white hover:bg-green-600"
                   onClick={onApprove}
                   disabled={isPending}
                 >
@@ -600,7 +535,7 @@ function ApprovalInboxRow({
                 <Button
                   variant="destructive"
                   size="sm"
-                  className="h-8 min-w-(--sz-64px) justify-center px-3"
+                  className="h-8 px-3"
                   onClick={onReject}
                   disabled={isPending}
                 >
@@ -615,7 +550,7 @@ function ApprovalInboxRow({
         <div className="mt-3 flex gap-2 sm:hidden">
           <Button
             size="sm"
-            className="h-8 min-w-(--sz-64px) justify-center bg-green-700 px-3 text-white hover:bg-green-600"
+            className="h-8 bg-green-700 px-3 text-white hover:bg-green-600"
             onClick={onApprove}
             disabled={isPending}
           >
@@ -624,7 +559,7 @@ function ApprovalInboxRow({
           <Button
             variant="destructive"
             size="sm"
-            className="h-8 min-w-(--sz-64px) justify-center px-3"
+            className="h-8 px-3"
             onClick={onReject}
             disabled={isPending}
           >
@@ -665,7 +600,7 @@ function JoinRequestInboxRow({
 
   return (
     <div className={cn(
-      "group py-2.5 pl-4 pr-2 sm:py-2",
+      "group border-b border-border px-2 py-2.5 last:border-b-0 sm:px-1 sm:pr-3 sm:py-2",
       className,
     )}>
       <div className="flex items-start gap-2 sm:items-center">
@@ -754,48 +689,7 @@ function JoinRequestInboxRow({
   );
 }
 
-function InboxCollectionToolbar({
-  streamlined,
-  context,
-  search,
-  controls,
-  feedback,
-  ariaLabel,
-}: CollectionToolbarProps & { streamlined: boolean }) {
-  if (streamlined) {
-    return (
-      <CollectionToolbar
-        ariaLabel={ariaLabel}
-        context={context}
-        search={search}
-        controls={controls}
-        feedback={feedback}
-      />
-    );
-  }
-
-  return (
-    <div role="toolbar" aria-label={ariaLabel} className="space-y-2">
-      {search ? <div className="sm:hidden">{search}</div> : null}
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        {context}
-        <div className="flex items-center gap-2">
-          {search ? <div className="hidden sm:block">{search}</div> : null}
-          {controls}
-        </div>
-      </div>
-      {feedback}
-    </div>
-  );
-}
-
 export function Inbox() {
-  const { enabled: streamlinedUiEnabled } = useStreamlinedUiEnabled();
-  return streamlinedUiEnabled ? <StreamlinedInbox /> : <LegacyInbox />;
-}
-
-function StreamlinedInbox() {
-  const streamlinedUiEnabled = true;
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
   const { openNewIssue } = useDialogActions();
@@ -813,15 +707,13 @@ function StreamlinedInbox() {
   const experimentalSettingsLoaded = experimentalSettings !== undefined;
   const [searchQuery, setSearchQuery] = useState("");
   const normalizedSearchQuery = searchQuery.trim();
-  const [filterPreferences, setFilterPreferences] = useState<StreamlinedInboxViewState>(
-    () => loadInboxCollectionPreferences(selectedCompanyId).viewState,
+  const [filterPreferences, setFilterPreferences] = useState<InboxFilterPreferences>(
+    () => loadInboxFilterPreferences(selectedCompanyId),
   );
   const [groupBy, setGroupBy] = useState<InboxWorkItemGroupBy>(() => loadInboxWorkItemGroupBy());
   const [blockedGroupBy, setBlockedGroupBy] = useState<BlockedInboxGroupBy>("none");
   const [blockedSortBy, setBlockedSortBy] = useState<BlockedInboxSort>("most_recent");
-  const [visibleIssueColumns, setVisibleIssueColumns] = useState<InboxIssueColumn[]>(
-    () => loadInboxCollectionPreferences(selectedCompanyId).columns,
-  );
+  const [visibleIssueColumns, setVisibleIssueColumns] = useState<InboxIssueColumn[]>(loadInboxIssueColumns);
   const { dismissed: dismissedAlerts, dismiss: dismissAlert } = useDismissedInboxAlerts();
   const { dismissedAtByKey, dismiss: dismissInboxItem } = useInboxDismissals(selectedCompanyId);
   const { readItems, markRead: markItemRead, markUnread: markItemUnread } = useReadInboxItems();
@@ -892,9 +784,7 @@ function StreamlinedInbox() {
   useEffect(() => {
     if (previousSelectedCompanyIdRef.current !== selectedCompanyId) {
       previousSelectedCompanyIdRef.current = selectedCompanyId;
-      const preferences = loadInboxCollectionPreferences(selectedCompanyId);
-      setFilterPreferences(preferences.viewState);
-      setVisibleIssueColumns(preferences.columns);
+      setFilterPreferences(loadInboxFilterPreferences(selectedCompanyId));
       setCollapsedGroupKeys(loadCollapsedInboxGroupKeys(selectedCompanyId));
       setCollapsedInboxParents(loadCollapsedInboxParentIds(selectedCompanyId));
     }
@@ -1293,11 +1183,6 @@ function StreamlinedInbox() {
     () => issueTrailingColumns.filter((column) => visibleIssueColumnSet.has(column) && availableIssueColumnSet.has(column)),
     [availableIssueColumnSet, visibleIssueColumnSet],
   );
-  const visibleTaskDataColumns = useMemo(
-    () => visibleTrailingIssueColumns.filter((column) => column !== "updated"),
-    [visibleTrailingIssueColumns],
-  );
-  const showTaskTimestamp = visibleIssueColumnSet.has("updated") && availableIssueColumnSet.has("updated");
 
   const failedRuns = useMemo(
     () =>
@@ -1683,11 +1568,8 @@ function StreamlinedInbox() {
   const setIssueColumns = useCallback((next: InboxIssueColumn[]) => {
     const normalized = normalizeInboxIssueColumns(next);
     setVisibleIssueColumns(normalized);
-    saveTaskCollectionPreferences(inboxCollectionPreferenceLocation(selectedCompanyId), {
-      viewState: filterPreferences,
-      columns: normalized,
-    });
-  }, [filterPreferences, selectedCompanyId]);
+    saveInboxIssueColumns(normalized);
+  }, []);
   const toggleIssueColumn = useCallback((column: InboxIssueColumn, enabled: boolean) => {
     if (enabled) {
       setIssueColumns([...visibleIssueColumns, column]);
@@ -1696,17 +1578,14 @@ function StreamlinedInbox() {
     setIssueColumns(visibleIssueColumns.filter((value) => value !== column));
   }, [setIssueColumns, visibleIssueColumns]);
   const updateFilterPreferences = useCallback(
-    (updater: (previous: StreamlinedInboxViewState) => StreamlinedInboxViewState) => {
+    (updater: (previous: InboxFilterPreferences) => InboxFilterPreferences) => {
       setFilterPreferences((previous) => {
         const next = updater(previous);
-        saveTaskCollectionPreferences(inboxCollectionPreferenceLocation(selectedCompanyId), {
-          viewState: next,
-          columns: visibleIssueColumns,
-        });
+        saveInboxFilterPreferences(selectedCompanyId, next);
         return next;
       });
     },
-    [selectedCompanyId, visibleIssueColumns],
+    [selectedCompanyId],
   );
   const updateIssueFilters = useCallback((patch: Partial<IssueFilterState>) => {
     updateFilterPreferences((previous) => ({
@@ -2331,7 +2210,7 @@ function StreamlinedInbox() {
   }, [selectedIndex]);
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={InboxIcon} message="Select an organization to view inbox." />;
+    return <EmptyState icon={InboxIcon} message="Select a company to view inbox." />;
   }
 
   const hasRunFailures = failedRuns.length > 0;
@@ -2380,42 +2259,60 @@ function StreamlinedInbox() {
     .map((issue) => issue.id);
   const canMarkAllRead = unreadIssueIds.length > 0;
   const activeIssueFilterCount = countActiveIssueFilters(issueFilters, true);
-  const activeInboxScopeFilterCount = tab === "all"
-    ? Number(allCategoryFilter !== "everything")
-      + Number(showApprovalsCategory && allApprovalFilter !== "all")
-    : 0;
-  const activeFilterCount = activeIssueFilterCount + activeInboxScopeFilterCount;
   const showGeneralIssueToolbarControls = tab !== "blocked";
-  const activeStatusFilterApplied =
-    issueFilters.statuses.length === 4
-    && ["todo", "in_progress", "in_review", "blocked"].every((status) =>
-      issueFilters.statuses.includes(status as IssueFilterState["statuses"][number]),
-    );
-  const issueFilterFeedback = issueFilters.liveOnly
-    ? "Live runs only — tasks currently connected to an agent run."
-    : activeStatusFilterApplied
-      ? "Active statuses — open tasks, whether or not an agent is running."
-      : null;
   return (
     <div className="space-y-6">
-      <InboxCollectionToolbar
-        streamlined={streamlinedUiEnabled}
-        ariaLabel="Inbox controls"
-        context={(
-          <Tabs value={tab} onValueChange={(value) => navigate(`/inbox/${value}`)}>
-            <PageTabBar
-              items={[
-                { value: "mine", label: "Mine" },
-                { value: "recent", label: "Recent" },
-                { value: "unread", label: "Unread" },
-                { value: "blocked", label: "Blocked" },
-                { value: "all", label: "All" },
-              ]}
-            />
-          </Tabs>
-        )}
-        search={(
-          <div className="relative ml-auto w-full sm:w-(--sz-220px)">
+      <div className="space-y-2">
+        {/* Search — full-width row on mobile, inline on desktop */}
+        <div className="relative sm:hidden">
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            type="search"
+            placeholder="Search inbox…"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (shouldBlurPageSearchOnEnter({
+                key: e.key,
+                isComposing: e.nativeEvent.isComposing,
+              })) {
+                e.currentTarget.blur();
+                return;
+              }
+
+              if (shouldBlurPageSearchOnEscape({
+                key: e.key,
+                isComposing: e.nativeEvent.isComposing,
+                currentValue: e.currentTarget.value,
+              })) {
+                e.currentTarget.blur();
+              }
+            }}
+            className="h-8 w-full pl-8 text-xs"
+            data-page-search-target="true"
+          />
+        </div>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+        <Tabs value={tab} onValueChange={(value) => navigate(`/inbox/${value}`)}>
+          <PageTabBar
+            items={[
+              {
+                value: "mine",
+                label: "Mine",
+              },
+              {
+                value: "recent",
+                label: "Recent",
+              },
+              { value: "unread", label: "Unread" },
+              { value: "blocked", label: "Blocked" },
+              { value: "all", label: "All" },
+            ]}
+          />
+        </Tabs>
+
+        <div className="flex items-center gap-2">
+          <div className="relative hidden sm:block">
             <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
             <Input
               type="search"
@@ -2439,16 +2336,14 @@ function StreamlinedInbox() {
                   e.currentTarget.blur();
                 }
               }}
-              className="h-8 w-full pl-8 text-xs"
+              className="h-8 w-(--sz-220px) pl-8 text-xs"
               data-page-search-target="true"
             />
           </div>
-        )}
-        controls={(
-          <>
           {tab === "blocked" ? (
             <>
               <IssueFiltersPopover
+                presentation="legacy"
                 state={issueFilters}
                 onChange={updateIssueFilters}
                 activeFilterCount={activeIssueFilterCount}
@@ -2462,7 +2357,6 @@ function StreamlinedInbox() {
                 buttonVariant="outline"
                 iconOnly
                 workspaces={isolatedWorkspacesEnabled ? executionWorkspaces.filter((w) => w.mode === "isolated_workspace").map((w) => ({ id: w.id, name: w.name })) : undefined}
-                presentation={streamlinedUiEnabled ? "streamlined" : "legacy"}
               />
               <Popover>
                 <PopoverTrigger asChild>
@@ -2499,13 +2393,6 @@ function StreamlinedInbox() {
                 availableColumns={availableIssueColumns}
                 visibleColumnSet={visibleIssueColumnSet}
                 onToggleColumn={toggleIssueColumn}
-                showDateGroupSeparators={filterPreferences.showDateGroupSeparators}
-                onToggleDateGroupSeparators={(enabled) => {
-                  updateFilterPreferences((previous) => ({
-                    ...previous,
-                    showDateGroupSeparators: enabled,
-                  }));
-                }}
                 onResetColumns={() => setIssueColumns(DEFAULT_INBOX_ISSUE_COLUMNS)}
                 title="Choose which inbox columns stay visible"
                 iconOnly
@@ -2555,9 +2442,10 @@ function StreamlinedInbox() {
                 <ListTree className="h-3.5 w-3.5" />
               </Button>
               <IssueFiltersPopover
+                presentation="legacy"
                 state={issueFilters}
                 onChange={updateIssueFilters}
-                activeFilterCount={activeFilterCount}
+                activeFilterCount={activeIssueFilterCount}
                 agents={agents}
                 creators={creatorOptions}
                 projects={projects?.map((project) => ({ id: project.id, name: project.name }))}
@@ -2568,21 +2456,6 @@ function StreamlinedInbox() {
                 buttonVariant="outline"
                 iconOnly
                 workspaces={isolatedWorkspacesEnabled ? executionWorkspaces.filter((w) => w.mode === "isolated_workspace").map((w) => ({ id: w.id, name: w.name })) : undefined}
-                presentation={streamlinedUiEnabled ? "streamlined" : "legacy"}
-                inboxScopeFilters={tab === "all" ? {
-                  category: allCategoryFilter,
-                  approvalStatus: allApprovalFilter,
-                  showApprovalStatus: showApprovalsCategory,
-                  onCategoryChange: updateAllCategoryFilter,
-                  onApprovalStatusChange: updateAllApprovalFilter,
-                  onClear: () => {
-                    updateFilterPreferences((previous) => ({
-                      ...previous,
-                      allCategoryFilter: "everything",
-                      allApprovalFilter: "all",
-                    }));
-                  },
-                } : undefined}
               />
               <Popover>
                 <PopoverTrigger asChild>
@@ -2625,17 +2498,9 @@ function StreamlinedInbox() {
                 availableColumns={availableIssueColumns}
                 visibleColumnSet={visibleIssueColumnSet}
                 onToggleColumn={toggleIssueColumn}
-                showDateGroupSeparators={filterPreferences.showDateGroupSeparators}
-                onToggleDateGroupSeparators={(enabled) => {
-                  updateFilterPreferences((previous) => ({
-                    ...previous,
-                    showDateGroupSeparators: enabled,
-                  }));
-                }}
                 onResetColumns={() => setIssueColumns(DEFAULT_INBOX_ISSUE_COLUMNS)}
                 title="Choose which inbox columns stay visible"
                 iconOnly
-                rowPresentation={streamlinedUiEnabled ? "task" : "legacy"}
               />
               {canMarkAllRead && (
                 <>
@@ -2676,20 +2541,53 @@ function StreamlinedInbox() {
               )}
             </>
           ) : null}
-          </>
-        )}
-        feedback={issueFilterFeedback ? (
-          <p className="text-xs text-muted-foreground" data-testid="inbox-filter-scope-feedback">
-            {issueFilterFeedback}
-          </p>
-        ) : null}
-      />
+        </div>
+        </div>
+      </div>
+
+      {tab === "all" && (
+        <div className="flex flex-wrap items-center gap-2">
+          <Select
+            value={allCategoryFilter}
+            onValueChange={(value) => updateAllCategoryFilter(value as InboxCategoryFilter)}
+          >
+            <SelectTrigger className="h-8 w-(--sz-170px) text-xs">
+              <SelectValue placeholder="Category" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="everything">All categories</SelectItem>
+              <SelectItem value="issues_i_touched">My recent tasks</SelectItem>
+              <SelectItem value="join_requests">Join requests</SelectItem>
+              <SelectItem value="approvals">Approvals</SelectItem>
+              <SelectItem value="failed_runs">Failed runs</SelectItem>
+              <SelectItem value="alerts">Alerts</SelectItem>
+            </SelectContent>
+          </Select>
+
+          {showApprovalsCategory && (
+            <Select
+              value={allApprovalFilter}
+              onValueChange={(value) => updateAllApprovalFilter(value as InboxApprovalFilter)}
+            >
+              <SelectTrigger className="h-8 w-(--sz-170px) text-xs">
+                <SelectValue placeholder="Approval status" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All approval statuses</SelectItem>
+                <SelectItem value="actionable">Needs action</SelectItem>
+                <SelectItem value="resolved">Resolved</SelectItem>
+              </SelectContent>
+            </Select>
+          )}
+        </div>
+      )}
 
       {approvalsError && <p className="text-sm text-destructive">{approvalsError.message}</p>}
       {actionError && <p className="text-sm text-destructive">{actionError}</p>}
 
       {tab === "blocked" ? (
         <BlockedInboxView
+          presentation="legacy"
           companyId={selectedCompanyId!}
           searchQuery={searchQuery}
           agentNameById={agentById}
@@ -2705,7 +2603,6 @@ function StreamlinedInbox() {
           showStatusColumn={visibleIssueColumnSet.has("status") && availableIssueColumnSet.has("status")}
           showIdentifierColumn={visibleIssueColumnSet.has("id") && availableIssueColumnSet.has("id")}
           showUpdatedColumn={visibleIssueColumnSet.has("updated") && availableIssueColumnSet.has("updated")}
-          presentation={streamlinedUiEnabled ? "task" : "legacy"}
         />
       ) : null}
 
@@ -2791,48 +2688,15 @@ function StreamlinedInbox() {
                     <IssueRow
                       key={`issue:${issue.id}`}
                       issue={issue}
-                      presentation={streamlinedUiEnabled ? "task" : "legacy"}
                       issueLinkState={issueLinkState}
                       treeGuides={depth}
-                      chevronInGuide={streamlinedUiEnabled && depth > 0 && hasChildren}
                       selected={selected}
                       className={
                         isArchiving
                           ? "pointer-events-none -translate-x-4 scale-(--s-0_98) opacity-0 transition-all duration-200 ease-out"
                           : "transition-all duration-200 ease-out"
                       }
-                      leadingControl={streamlinedUiEnabled && nestingEnabled && hasChildren && collapseParentId ? (
-                        <button
-                          type="button"
-                          data-slot="icon-button"
-                          className="inline-flex h-4 w-4 shrink-0 items-center justify-center"
-                          aria-label={isExpanded ? "Collapse sub-tasks" : "Expand sub-tasks"}
-                          onClick={(event) => {
-                            event.preventDefault();
-                            event.stopPropagation();
-                            toggleInboxParentCollapse(collapseParentId);
-                          }}
-                        >
-                          <ChevronRight className={cn("h-3.5 w-3.5 transition-transform", isExpanded && "rotate-90")} />
-                        </button>
-                      ) : streamlinedUiEnabled ? (
-                        <span data-slot="task-row-disclosure-spacer" className="h-4 w-4 shrink-0" aria-hidden="true" />
-                      ) : undefined}
-                      statusSlot={streamlinedUiEnabled ? rowStatusIcon : undefined}
-                      metadata={streamlinedUiEnabled ? (
-                        <InboxIssueMetaLeading
-                          issue={issue}
-                          isLive={isLive}
-                          subtreeLiveCount={liveDescendantCount}
-                          showSubtreeLiveChip={showSubtreeLiveChip}
-                          showStatus={false}
-                          showIdentifier={false}
-                        />
-                      ) : undefined}
-                      showIdentifier={streamlinedUiEnabled
-                        ? visibleIssueColumnSet.has("id") && availableIssueColumnSet.has("id")
-                        : undefined}
-                      desktopMetaLeading={!streamlinedUiEnabled ? (
+                      desktopMetaLeading={
                         <>
                           {nestingEnabled ? (
                             depth === 0 && hasChildren && collapseParentId ? (
@@ -2849,6 +2713,11 @@ function StreamlinedInbox() {
                                 <ChevronRight className={cn("h-3.5 w-3.5 transition-transform", isExpanded && "rotate-90")} />
                               </button>
                             ) : (
+                              // Every non-chevron row reserves this spacer so the
+                              // status column lines up under the parent rows'
+                              // collapse chevron. (The unread mark-read dot has
+                              // its own reserved leading slot in IssueRow, to the
+                              // left of this spacer.)
                               <span className="hidden w-4 shrink-0 sm:block" />
                             )
                           ) : null}
@@ -2862,14 +2731,14 @@ function StreamlinedInbox() {
                             statusSlot={rowStatusIcon}
                           />
                         </>
-                      ) : undefined}
-                      titleSuffix={hasChildren && !isExpanded ? (
+                      }
+                      titleSuffix={hasChildren && !isExpanded && depth === 0 ? (
                         <span className="ml-1.5 text-xs text-muted-foreground">
                           ({childCount} sub-task{childCount !== 1 ? "s" : ""})
                         </span>
                       ) : undefined}
                       mobileMeta={issueActivityText(issue).toLowerCase()}
-                      mobileLeading={!streamlinedUiEnabled ? (
+                      mobileLeading={
                         depth === 0 && hasChildren && collapseParentId ? (
                           <button
                             type="button"
@@ -2885,16 +2754,16 @@ function StreamlinedInbox() {
                         ) : (
                           <StatusIcon status={issue.status} blockerAttention={blockerAttention} size="md" />
                         )
-                      ) : undefined}
+                      }
                       unreadState={isUnread ? "visible" : isFading ? "fading" : "hidden"}
                       onMarkRead={() => markReadMutation.mutate(issue.id)}
                       onArchive={allowArchive ? () => archiveIssueMutation.mutate(issue.id) : undefined}
                       archiveDisabled={isArchiving}
                       desktopTrailing={
-                        (streamlinedUiEnabled ? visibleTaskDataColumns : visibleTrailingIssueColumns).length > 0 ? (
+                        visibleTrailingIssueColumns.length > 0 ? (
                           <InboxIssueTrailingColumns
                             issue={issue}
-                            columns={streamlinedUiEnabled ? visibleTaskDataColumns : visibleTrailingIssueColumns}
+                            columns={visibleTrailingIssueColumns}
                             projectName={project?.name ?? null}
                             projectColor={project?.color ?? null}
                             workspaceName={resolveIssueWorkspaceName(issue, {
@@ -2919,14 +2788,11 @@ function StreamlinedInbox() {
                           />
                         ) : undefined
                       }
-                      trailingMeta={streamlinedUiEnabled && showTaskTimestamp ? issueActivityTimestamp(issue) : null}
                     />
                   );
                 };
 
-                let previousDateGroup: TaskDateGroup | null = null;
                 let previousTimestamp = Number.POSITIVE_INFINITY;
-                const legacyTodayCutoff = Date.now() - 24 * 60 * 60 * 1000;
                 return groupedSections.flatMap((group, groupIndex) => {
                   const elements: ReactNode[] = [];
                   const isGroupCollapsed = collapsedGroupKeys.has(group.key);
@@ -3009,46 +2875,18 @@ function StreamlinedInbox() {
                         {child}
                       </div>
                     );
-                    const currentDateGroup = taskDateGroup(item.timestamp);
-                    const dateGroupLabel = streamlinedUiEnabled
-                      && filterPreferences.showDateGroupSeparators
-                      && groupBy === "none"
-                      ? taskDateGroupSeparator(previousDateGroup, currentDateGroup)
-                      : null;
-                    previousDateGroup = currentDateGroup;
-                    const showLegacyEarlierDivider = !streamlinedUiEnabled
-                      && groupBy === "none"
-                      && item.timestamp > 0
-                      && item.timestamp < legacyTodayCutoff
-                      && previousTimestamp >= legacyTodayCutoff;
+                    const todayCutoff = Date.now() - 24 * 60 * 60 * 1000;
+                    const showTodayDivider =
+                      groupBy === "none" &&
+                      item.timestamp > 0 &&
+                      item.timestamp < todayCutoff &&
+                      previousTimestamp >= todayCutoff;
                     previousTimestamp = item.timestamp > 0 ? item.timestamp : previousTimestamp;
-                    if (dateGroupLabel) {
+                    if (showTodayDivider) {
                       elements.push(
-                        <div
-                          key={`date-divider-${group.key}-${currentDateGroup}-${index}`}
-                          className="flex items-center gap-3 px-3 py-1.5 sm:pl-0 sm:pr-4"
-                          data-testid="inbox-date-group"
-                          role="separator"
-                          aria-label={dateGroupLabel}
-                        >
-                          <span className="h-px min-w-0 flex-1 bg-border/80" aria-hidden="true" data-date-group-rule="" />
-                          <span
-                            className="shrink-0 text-(length:--text-nano) font-medium uppercase tracking-wider text-muted-foreground/70"
-                            data-date-group-label=""
-                          >
-                            {dateGroupLabel}
-                          </span>
-                          <span className="h-px min-w-0 flex-1 bg-border/80" aria-hidden="true" data-date-group-rule="" />
-                        </div>,
-                      );
-                    } else if (showLegacyEarlierDivider) {
-                      elements.push(
-                        <div key={`earlier-divider-${group.key}-${index}`} className="my-2 flex items-center gap-3 px-4">
-                          <div className="flex-1 border-t border-border" />
-                          <span
-                            className="shrink-0 text-(length:--text-micro) font-medium uppercase tracking-wider text-muted-foreground/70"
-                            data-date-group-label=""
-                          >
+                        <div key={`today-divider-${group.key}-${index}`} className="my-2 flex items-center gap-3 px-4">
+                          <div className="flex-1 border-t border-zinc-600" />
+                          <span className="shrink-0 text-(length:--text-micro) font-medium uppercase tracking-wider text-zinc-500">
                             Earlier
                           </span>
                         </div>,

--- a/ui/src/pages/MyIssues.tsx
+++ b/ui/src/pages/MyIssues.tsx
@@ -11,8 +11,10 @@ import { EmptyState } from "../components/EmptyState";
 import { PageSkeleton } from "../components/PageSkeleton";
 import { formatDate } from "../lib/utils";
 import { ListTodo } from "lucide-react";
+import { useStreamlinedUiEnabled } from "../hooks/useStreamlinedUiEnabled";
 
 export function MyIssues() {
+  const { enabled: streamlinedUiEnabled } = useStreamlinedUiEnabled();
   const { selectedCompanyId } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
 
@@ -27,7 +29,14 @@ export function MyIssues() {
   });
 
   if (!selectedCompanyId) {
-    return <EmptyState icon={ListTodo} message="Select an organization to view your tasks." />;
+    return (
+      <EmptyState
+        icon={ListTodo}
+        message={streamlinedUiEnabled
+          ? "Select an organization to view your tasks."
+          : "Select a company to view your tasks."}
+      />
+    );
   }
 
   if (isLoading) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Tasks are the main work objects in the control plane.
> - Task lists, task details, chat, and properties currently use different visual and interaction rules.
> - These differences make task state and navigation harder to scan.
> - This pull request applies the streamlined presentation to the full task experience.
> - The benefit is one clear path from a task list into task work and metadata.

## Linked Issues or Issue Description

**What existing behavior does this improve?**

Task and inbox lists, task detail navigation, task chat, the composer, and the properties panel.

**Subsystem affected**

ui/ — React + Vite board UI.

**Current behavior**

Task list rows and detail pages use inconsistent spacing and metadata placement. The chat composer and properties panel also differ from the streamlined shell.

**Proposed behavior**

Use shared task collection controls and consistent detail navigation. Refine chat, composer, properties, side-panel, and responsive behavior.

**Reason and benefit**

Operators can scan task state faster. The detail view also preserves the context established by the task list.

**Breaking changes**

None. The legacy presentation remains available when the experiment is disabled.

## What Changed

- Unify task and inbox collection controls, grouping, filtering, and row presentation.
- Align the task breadcrumb with the task-list root header.
- Refine task chat bubbles, notices, composer modes, scrolling, and interaction cards.
- Refine properties, relations, and side-panel layout and add focused tests.

## Verification

- Run `pnpm --filter ./ui typecheck`.
- Run `pnpm check:token-gates`.
- Run the focused task-list, task-detail, task-chat, properties, and side-panel Vitest suites.
- Test the task list and detail views in both light and dark themes.

## Risks

- The change affects dense task workflows, so overflow and responsive layout are the main risks.
- Focused tests cover legacy and streamlined presentation modes.
- This is the third PR in a four-PR stack. It depends on the surface PR.

> I checked `ROADMAP.md`. This work is UI polish for shipped capabilities. It does not duplicate a planned core feature.

## Model Used

- OpenAI Codex with GPT-5.6 Sol. The model used agentic reasoning, code execution, browser inspection, and image analysis. This environment does not expose the context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

