### PR TITLE
fix(issues): make a pre-rollout blocked stamp eligible when an unblock owner is attached

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import { asc, eq } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { ROUTABLE_BLOCKED_ROLLOUT_AT } from "../services/routable-blocked.js";
 import { sql } from "drizzle-orm";
 import {
   activityLog,
@@ -3828,6 +3829,84 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
 
   afterAll(async () => {
     await tempDb?.cleanup();
+  });
+
+  async function seedCompanyWithAgent() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `B${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Unblock owner",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    return { companyId, agentId };
+  }
+
+  // A blocked row can carry a blockedTransitionAt from before routable
+  // blocking existed -- imported historical data, or a restore. That stamp
+  // fails isProspectiveBlockedTransition's cutoff, so attaching an
+  // unblockDescriptor to such a row used to achieve nothing: the owner was
+  // never routed and no self-heal path repaired it, because a stamped row
+  // looks healthy to all of them.
+  it("advances a pre-rollout stamp when an unblockDescriptor is attached to an already-blocked issue", async () => {
+    const { companyId, agentId } = await seedCompanyWithAgent();
+    const issue = await svc.create(companyId, {
+      title: "Imported from the old system, blocked ever since",
+      description: null,
+      status: "blocked",
+      priority: "medium",
+    });
+    const preRollout = new Date(ROUTABLE_BLOCKED_ROLLOUT_AT.getTime() - 90 * 24 * 60 * 60 * 1000);
+    await db.update(issues)
+      .set({ blockedTransitionAt: preRollout, blockedOwnerNotifiedAt: null, unblockDescriptor: null })
+      .where(eq(issues.id, issue.id));
+
+    const updated = await svc.update(issue.id, {
+      unblockDescriptor: { owner: { agentId }, action: "Confirm the migrated figures" },
+    });
+
+    expect(updated?.status).toBe("blocked");
+    expect(updated?.blockedTransitionAt).not.toBeNull();
+    expect(updated!.blockedTransitionAt!.getTime()).toBeGreaterThanOrEqual(
+      ROUTABLE_BLOCKED_ROLLOUT_AT.getTime(),
+    );
+    expect(updated!.blockedTransitionAt!.getTime()).toBeGreaterThan(preRollout.getTime());
+    expect(updated?.blockedOwnerNotifiedAt).toBeNull();
+  });
+
+  it("leaves a post-rollout stamp alone when an unblockDescriptor is attached", async () => {
+    const { companyId, agentId } = await seedCompanyWithAgent();
+    const issue = await svc.create(companyId, {
+      title: "Blocked after the rollout",
+      description: null,
+      status: "blocked",
+      priority: "medium",
+    });
+    const postRollout = new Date(ROUTABLE_BLOCKED_ROLLOUT_AT.getTime() + 60_000);
+    await db.update(issues)
+      .set({ blockedTransitionAt: postRollout, blockedOwnerNotifiedAt: null, unblockDescriptor: null })
+      .where(eq(issues.id, issue.id));
+
+    const updated = await svc.update(issue.id, {
+      unblockDescriptor: { owner: { agentId }, action: "Confirm the figures" },
+    });
+
+    // The stamp is the block's own cycle key. It must not be advanced just
+    // because a descriptor arrived, or every descriptor edit would reopen the
+    // dependency-wake decision for the issue's dependents.
+    expect(updated!.blockedTransitionAt!.toISOString()).toBe(postRollout.toISOString());
   });
 
   async function seedSharedWorkspaceDependency() {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -125,6 +125,7 @@ import {
   type IssueLivenessFinding,
 } from "./recovery/issue-graph-liveness.js";
 import { visibleIssueCondition } from "./issue-visibility.js";
+import { ROUTABLE_BLOCKED_ROLLOUT_AT } from "./routable-blocked.js";
 import { finalizeStatusCardsForStalledGeneration } from "./status-card-finalization.js";
 import { finalizeSummarySlotsForTerminalIssue } from "./summary-slot-finalization.js";
 import {
@@ -7812,6 +7813,29 @@ export function issueService(db: Db) {
       } else if (existing.status === "blocked" && issueData.status && issueData.status !== "blocked") {
         patch.unblockDescriptor = null;
         patch.blockedTransitionAt = null;
+        patch.blockedOwnerNotifiedAt = null;
+      } else if (
+        existing.status === "blocked"
+        && issueData.unblockDescriptor
+        && existing.blockedTransitionAt
+        && existing.blockedTransitionAt < ROUTABLE_BLOCKED_ROLLOUT_AT
+      ) {
+        // The row is already blocked and carries a stamp from before routable
+        // blocking existed -- an import of historical data, or a restore. That
+        // stamp fails isProspectiveBlockedTransition's cutoff, so attaching an
+        // unblockDescriptor to the row achieves nothing: the owner is never
+        // routed, never notified, and no later write repairs it, because the
+        // row is stamped and so looks healthy to every self-heal path.
+        //
+        // Attaching the descriptor is the moment the routable request is
+        // actually made, whatever the underlying block has been sitting there
+        // since, so the stamp advances to now and eligibility follows the
+        // request rather than the history. This fires at most once per row:
+        // afterwards the stamp is past the cutoff and this branch cannot match
+        // again. Advancing the stamp also starts a fresh dependency-wake cycle
+        // key, which is correct here -- any cycle belonging to a pre-cutoff
+        // stamp predates the feature that reads it.
+        patch.blockedTransitionAt = patch.updatedAt;
         patch.blockedOwnerNotifiedAt = null;
       }
       if (issueData.requestDepth !== undefined) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - A blocked issue can name an unblock owner in its `unblockDescriptor`. That owner gets a wake so somebody is asked to unblock it
> - Eligibility for that wake is `isProspectiveBlockedTransition`, which requires `blockedTransitionAt` to be at or after `ROUTABLE_BLOCKED_ROLLOUT_AT`
> - A blocked row can carry a stamp from before that cutoff: imported historical data, or a restore from backup
> - Attaching an unblock owner to such a row achieves nothing. The cutoff rejects it, and no self-heal path repairs it, because every one of them keys off a *missing* stamp and this row has one
> - The row is therefore permanently unnotifiable while looking completely healthy
> - This pull request advances the stamp at the moment the descriptor is attached, and only then
> - The benefit is that attaching an unblock owner always reaches that owner, whatever the row's history

## Linked Issues or Issue Description

No existing issue. The problem is described below.

**Bug: what happened?**

An issue that is already `blocked` with a `blockedTransitionAt` earlier than
`ROUTABLE_BLOCKED_ROLLOUT_AT` does not notify its unblock owner when an
`unblockDescriptor` is attached. `isProspectiveBlockedTransition` returns false for the
historical stamp, so the edge-triggered notification path does not fire. No later write
repairs the row, because the self-heal paths only act on a row with no stamp.

**Expected behavior**

Attaching an `unblockDescriptor` to a blocked issue notifies the named owner, whenever the
underlying block started.

**Version**

Reproduced on `master`.

## What Changed

- `issueService.update()` advances `blockedTransitionAt` to the write time, and clears
  `blockedOwnerNotifiedAt`, when an `unblockDescriptor` is attached to a row that is
  already `blocked` and whose stamp is earlier than `ROUTABLE_BLOCKED_ROLLOUT_AT`
- Added a test for the pre-cutoff case, and a test pinning that a post-cutoff stamp is
  left alone

## Verification

    ./node_modules/.bin/vitest run \
      server/src/__tests__/issues-service.test.ts \
      server/src/__tests__/routable-blocked.test.ts \
      server/src/__tests__/attention-service.test.ts

Result on 3 September 2026: 3 files passed, 152 tests passed. Server typecheck is clean.

## Risks

- The branch fires at most once per row. After it runs, the stamp is past the cutoff and
  the condition cannot match again
- `blockedTransitionAt` is also the dependency-wake cycle key. Advancing it starts a fresh
  cycle. That is correct for a pre-cutoff stamp, because any cycle belonging to such a
  stamp predates the feature that reads the key. It is *not* correct for a post-cutoff
  stamp, which is why the branch is restricted to pre-cutoff rows and a test pins that
- Behavioural shift: owners of affected historical rows are notified once, on the next
  descriptor attach. This is the intended repair
- Related: #12734 restructures the same `if`/`else` chain in `update()`. Expect a small
  textual conflict. This pull request is independent of it and does not depend on it

## Model Used

Claude Opus (claude-opus-5), extended thinking, with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no user-facing documentation changes are needed
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — not known until CI runs
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — not known until Greptile runs
- [x] I will address all Greptile and reviewer comments before requesting merge
