### PR TITLE
feat(ui): keyless i18n of the navigation, browser language detection, language picker

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1092,9 +1092,6 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      i18n-keyless-react:
-        specifier: 3.5.0
-        version: 3.5.0(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
       i18next:
         specifier: ^26.3.6
         version: 26.3.6(typescript@7.0.2)
@@ -6449,14 +6446,6 @@ packages:
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
-
-  i18n-keyless-core@3.5.0:
-    resolution: {integrity: sha512-KW375fgdBzUnUeJVvO5gHUf57xFQcxQLPdD3xmb+WRduCO4T9hntbt9enKKYFn44bIlf2xCNBDMhPolwNJpBcg==}
-
-  i18n-keyless-react@3.5.0:
-    resolution: {integrity: sha512-4gSP5h2aiw8UQOWmL0aKgWRwj+xC6TGE4JVEf5KGG6G7T8TjqB68Cp+itUZn31Y1O5t01emgYDV7jXf+wqhRrw==}
-    peerDependencies:
-      react: ^19.2.8
 
   i18next@26.3.6:
     resolution: {integrity: sha512-Bu5Z2nAXgfVyM8xvW3jk9EKRIuX37PudsrBViThNFx7CR7aaYTpP01cxNB/E4c4UUzTDiAZRstEhsRfPOL/8xA==}
@@ -13792,18 +13781,6 @@ snapshots:
       - supports-color
 
   human-signals@2.1.0: {}
-
-  i18n-keyless-core@3.5.0: {}
-
-  i18n-keyless-react@3.5.0(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)):
-    dependencies:
-      i18n-keyless-core: 3.5.0
-      react: 19.2.8
-      zustand: 5.0.15(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - use-sync-external-store
 
   i18next@26.3.6(typescript@7.0.2):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1092,6 +1092,9 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      i18n-keyless-react:
+        specifier: 3.5.0
+        version: 3.5.0(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
       i18next:
         specifier: ^26.3.6
         version: 26.3.6(typescript@7.0.2)
@@ -6446,6 +6449,14 @@ packages:
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
+
+  i18n-keyless-core@3.5.0:
+    resolution: {integrity: sha512-KW375fgdBzUnUeJVvO5gHUf57xFQcxQLPdD3xmb+WRduCO4T9hntbt9enKKYFn44bIlf2xCNBDMhPolwNJpBcg==}
+
+  i18n-keyless-react@3.5.0:
+    resolution: {integrity: sha512-4gSP5h2aiw8UQOWmL0aKgWRwj+xC6TGE4JVEf5KGG6G7T8TjqB68Cp+itUZn31Y1O5t01emgYDV7jXf+wqhRrw==}
+    peerDependencies:
+      react: ^19.2.8
 
   i18next@26.3.6:
     resolution: {integrity: sha512-Bu5Z2nAXgfVyM8xvW3jk9EKRIuX37PudsrBViThNFx7CR7aaYTpP01cxNB/E4c4UUzTDiAZRstEhsRfPOL/8xA==}
@@ -13781,6 +13792,18 @@ snapshots:
       - supports-color
 
   human-signals@2.1.0: {}
+
+  i18n-keyless-core@3.5.0: {}
+
+  i18n-keyless-react@3.5.0(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)):
+    dependencies:
+      i18n-keyless-core: 3.5.0
+      react: 19.2.8
+      zustand: 5.0.15(@types/react@19.2.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - use-sync-external-store
 
   i18next@26.3.6(typescript@7.0.2):
     optionalDependencies:

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -1,0 +1,3 @@
+# Keyless UI translation (ui/src/i18n-keyless.ts). Leave unset to keep the UI English only.
+# VITE_I18N_KEYLESS_API_KEY=
+# VITE_I18N_KEYLESS_API_URL=https://your-i18n-keyless-instance.example.com

--- a/ui/package.json
+++ b/ui/package.json
@@ -57,7 +57,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "i18n-keyless-react": "3.5.0",
+    "i18n-keyless-react": "3.6.0",
     "i18next": "^26.3.6",
     "lexical": "0.48.0",
     "lucide-react": "^1.32.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -57,6 +57,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "i18n-keyless-react": "3.5.0",
     "i18next": "^26.3.6",
     "lexical": "0.48.0",
     "lucide-react": "^1.32.0",

--- a/ui/src/components/LanguageMenuAction.tsx
+++ b/ui/src/components/LanguageMenuAction.tsx
@@ -1,5 +1,5 @@
 import { Languages } from "lucide-react";
-import { setCurrentLanguage, useCurrentLanguage, type Lang } from "i18n-keyless-react";
+import { setCurrentLanguage, useCurrentLanguage, useI18nKeyless, type Lang } from "i18n-keyless-react";
 
 import { cn } from "@/lib/utils";
 import { languageDisplayName, PRIMARY_LANGUAGE, SUPPORTED_LANGUAGES, useT } from "@/i18n-keyless";
@@ -13,12 +13,16 @@ interface LanguageMenuActionProps {
 /**
  * Language picker row for `SidebarAccountMenu`, styled like the `MenuAction`
  * rows around it. The choice persists in `localStorage` through the SDK and
- * is applied on the next boot before the first render.
+ * is applied on the next boot before the first render. Renders nothing when
+ * no translation server is configured (see `ui/src/i18n-keyless.ts`).
  */
 export function LanguageMenuAction({ className, onAfterChange }: LanguageMenuActionProps) {
   const t = useT();
   const current = useCurrentLanguage() ?? PRIMARY_LANGUAGE;
+  const enabled = useI18nKeyless((state) => Boolean(state.config.API_KEY));
   const label = t("Language");
+
+  if (!enabled) return null;
 
   return (
     <label

--- a/ui/src/components/LanguageMenuAction.tsx
+++ b/ui/src/components/LanguageMenuAction.tsx
@@ -1,8 +1,8 @@
 import { Languages } from "lucide-react";
-import { setCurrentLanguage, useCurrentLanguage, useI18nKeyless, type Lang } from "i18n-keyless-react";
+import { setCurrentLanguage, useCurrentLanguage, useI18nKeyless, useTranslation, type Lang } from "i18n-keyless-react";
 
 import { cn } from "@/lib/utils";
-import { languageDisplayName, PRIMARY_LANGUAGE, SUPPORTED_LANGUAGES, useT } from "@/i18n-keyless";
+import { languageDisplayName, PRIMARY_LANGUAGE, SUPPORTED_LANGUAGES } from "@/i18n-keyless";
 
 interface LanguageMenuActionProps {
   className?: string;
@@ -17,7 +17,7 @@ interface LanguageMenuActionProps {
  * no translation server is configured (see `ui/src/i18n-keyless.ts`).
  */
 export function LanguageMenuAction({ className, onAfterChange }: LanguageMenuActionProps) {
-  const t = useT();
+  const t = useTranslation();
   const current = useCurrentLanguage() ?? PRIMARY_LANGUAGE;
   const enabled = useI18nKeyless((state) => Boolean(state.config.API_KEY));
   const label = t("Language");

--- a/ui/src/components/LanguageMenuAction.tsx
+++ b/ui/src/components/LanguageMenuAction.tsx
@@ -1,0 +1,56 @@
+import { Languages } from "lucide-react";
+import { setCurrentLanguage, useCurrentLanguage, type Lang } from "i18n-keyless-react";
+
+import { cn } from "@/lib/utils";
+import { languageDisplayName, PRIMARY_LANGUAGE, SUPPORTED_LANGUAGES, useT } from "@/i18n-keyless";
+
+interface LanguageMenuActionProps {
+  className?: string;
+  /** Called after the language changes; a popover menu uses it to dismiss itself. */
+  onAfterChange?: () => void;
+}
+
+/**
+ * Language picker row for `SidebarAccountMenu`, styled like the `MenuAction`
+ * rows around it. The choice persists in `localStorage` through the SDK and
+ * is applied on the next boot before the first render.
+ */
+export function LanguageMenuAction({ className, onAfterChange }: LanguageMenuActionProps) {
+  const t = useT();
+  const current = useCurrentLanguage() ?? PRIMARY_LANGUAGE;
+  const label = t("Language");
+
+  return (
+    <label
+      className={cn(
+        "flex w-full items-start gap-3 rounded-xl px-3 py-3 text-left transition-colors hover:bg-accent/60",
+        className,
+      )}
+    >
+      <span className="mt-0.5 rounded-lg border border-border bg-background/70 p-2 text-muted-foreground">
+        <Languages className="size-4" />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-sm font-medium text-foreground">{label}</span>
+        <span className="block text-xs text-muted-foreground">
+          {t("Translate the interface into your language.")}
+        </span>
+        <select
+          aria-label={label}
+          value={current}
+          onChange={(event) => {
+            setCurrentLanguage(event.target.value as Lang);
+            onAfterChange?.();
+          }}
+          className="mt-2 w-full rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground"
+        >
+          {SUPPORTED_LANGUAGES.map((lang) => (
+            <option key={lang} value={lang}>
+              {languageDisplayName(lang)}
+            </option>
+          ))}
+        </select>
+      </span>
+    </label>
+  );
+}

--- a/ui/src/components/MobileBottomNav.tsx
+++ b/ui/src/components/MobileBottomNav.tsx
@@ -13,6 +13,7 @@ import { SIDEBAR_SCROLL_RESET_STATE } from "../lib/navigation-scroll";
 import { cn } from "../lib/utils";
 import { useInboxBadge } from "../hooks/useInboxBadge";
 import { Badge } from "@/components/ui/badge";
+import { NAVIGATION_CONTEXT, useT } from "@/i18n-keyless";
 
 interface MobileBottomNavProps {
   visible: boolean;
@@ -40,22 +41,23 @@ export function MobileBottomNav({ visible }: MobileBottomNavProps) {
   const { selectedCompanyId } = useCompany();
   const { openNewIssue } = useDialogActions();
   const inboxBadge = useInboxBadge(selectedCompanyId);
+  const t = useT(NAVIGATION_CONTEXT);
 
   const items = useMemo<MobileNavItem[]>(
     () => [
-      { type: "link", to: "/dashboard", label: "Home", icon: House },
-      { type: "link", to: "/issues", label: "Tasks", icon: CircleDot },
-      { type: "action", label: "Create", icon: SquarePen, onClick: () => openNewIssue() },
-      { type: "link", to: "/agents/all", label: "Agents", icon: Users },
+      { type: "link", to: "/dashboard", label: t("Home"), icon: House },
+      { type: "link", to: "/issues", label: t("Tasks"), icon: CircleDot },
+      { type: "action", label: t("Create"), icon: SquarePen, onClick: () => openNewIssue() },
+      { type: "link", to: "/agents/all", label: t("Agents"), icon: Users },
       {
         type: "link",
         to: "/inbox",
-        label: "Inbox",
+        label: t("Inbox"),
         icon: Inbox,
         badge: inboxBadge.inbox,
       },
     ],
-    [openNewIssue, inboxBadge.inbox],
+    [openNewIssue, inboxBadge.inbox, t],
   );
 
   return (

--- a/ui/src/components/MobileBottomNav.tsx
+++ b/ui/src/components/MobileBottomNav.tsx
@@ -13,7 +13,8 @@ import { SIDEBAR_SCROLL_RESET_STATE } from "../lib/navigation-scroll";
 import { cn } from "../lib/utils";
 import { useInboxBadge } from "../hooks/useInboxBadge";
 import { Badge } from "@/components/ui/badge";
-import { NAVIGATION_CONTEXT, useT } from "@/i18n-keyless";
+import { useTranslation } from "i18n-keyless-react";
+import { NAVIGATION_CONTEXT } from "@/i18n-keyless";
 
 interface MobileBottomNavProps {
   visible: boolean;
@@ -41,7 +42,7 @@ export function MobileBottomNav({ visible }: MobileBottomNavProps) {
   const { selectedCompanyId } = useCompany();
   const { openNewIssue } = useDialogActions();
   const inboxBadge = useInboxBadge(selectedCompanyId);
-  const t = useT(NAVIGATION_CONTEXT);
+  const t = useTranslation(NAVIGATION_CONTEXT);
 
   const items = useMemo<MobileNavItem[]>(
     () => [

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -46,11 +46,12 @@ import { cn, SIDEBAR_RAIL_HIDDEN_LABEL } from "../lib/utils";
 import { PluginSlotOutlet } from "@/plugins/slots";
 import { PluginLauncherOutlet } from "@/plugins/launchers";
 import { SidebarCompanyMenu } from "./SidebarCompanyMenu";
-import { NAVIGATION_CONTEXT, useT } from "@/i18n-keyless";
+import { useTranslation } from "i18n-keyless-react";
+import { NAVIGATION_CONTEXT } from "@/i18n-keyless";
 
 export function Sidebar() {
   const { openNewIssue } = useDialogActions();
-  const t = useT(NAVIGATION_CONTEXT);
+  const t = useTranslation(NAVIGATION_CONTEXT);
   // Every labeled section is collapsible (session-scoped, default open) —
   // one policy across static nav groups and the data-driven sections.
   const [workOpen, setWorkOpen] = useState(true);

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -46,9 +46,11 @@ import { cn, SIDEBAR_RAIL_HIDDEN_LABEL } from "../lib/utils";
 import { PluginSlotOutlet } from "@/plugins/slots";
 import { PluginLauncherOutlet } from "@/plugins/launchers";
 import { SidebarCompanyMenu } from "./SidebarCompanyMenu";
+import { NAVIGATION_CONTEXT, useT } from "@/i18n-keyless";
 
 export function Sidebar() {
   const { openNewIssue } = useDialogActions();
+  const t = useT(NAVIGATION_CONTEXT);
   // Every labeled section is collapsible (session-scoped, default open) —
   // one policy across static nav groups and the data-driven sections.
   const [workOpen, setWorkOpen] = useState(true);
@@ -138,20 +140,20 @@ export function Sidebar() {
               <button
                 onClick={() => openNewIssue()}
                 data-slot="icon-button"
-                aria-label={rail ? "New Task" : undefined}
+                aria-label={rail ? t("New Task") : undefined}
                 className={cn(
                   "flex items-center gap-2.5 mx-2 rounded-lg px-2 py-1.5 pointer-coarse:py-1 text-(length:--text-compact) font-medium text-foreground/80 hover:text-foreground transition-colors",
                   streamlinedUiEnabled ? "hover:bg-background" : "hover:bg-accent/50",
                 )}
               >
                 <SquarePen className="h-4 w-4 shrink-0" />
-                <span className={rail ? SIDEBAR_RAIL_HIDDEN_LABEL : "truncate"}>New Task</span>
+                <span className={rail ? SIDEBAR_RAIL_HIDDEN_LABEL : "truncate"}>{t("New Task")}</span>
               </button>
             );
             return rail ? (
               <Tooltip>
                 <TooltipTrigger asChild>{newTaskButton}</TooltipTrigger>
-                <TooltipContent side="right">New Task</TooltipContent>
+                <TooltipContent side="right">{t("New Task")}</TooltipContent>
               </Tooltip>
             ) : (
               newTaskButton
@@ -161,11 +163,11 @@ export function Sidebar() {
               width; a nav row also keeps search reachable from the
               collapsed rail, where the old header icon was dropped entirely.
               Cmd/Ctrl+K remains the keyboard path (command palette). */}
-          <SidebarNavItem to="/search" label="Search" icon={Search} />
-          <SidebarNavItem to="/dashboard" label="Dashboard" icon={LayoutDashboard} liveCount={liveRunCount} />
+          <SidebarNavItem to="/search" label={t("Search")} icon={Search} />
+          <SidebarNavItem to="/dashboard" label={t("Dashboard")} icon={LayoutDashboard} liveCount={liveRunCount} />
           <SidebarNavItem
             to="/inbox"
-            label="Inbox"
+            label={t("Inbox")}
             icon={Inbox}
             badge={inboxBadge.inbox}
             badgeLabel="unread"
@@ -175,38 +177,38 @@ export function Sidebar() {
           {showDecisions ? (
             <SidebarNavItem
               to="/decisions"
-              label="Decisions"
+              label={t("Decisions")}
               icon={ListChecks}
               badge={attentionCount}
               badgeLabel="decisions"
             />
           ) : null}
           {showStatusCards ? (
-            <SidebarNavItem to="/status" label="Status" icon={LayoutGrid} textBadge="beta" />
+            <SidebarNavItem to="/status" label={t("Status")} icon={LayoutGrid} textBadge="beta" />
           ) : null}
           {conferenceRoomChatEnabled ? (
-            <SidebarNavItem to="/board-chat" label="Conference Room" icon={MessagesSquare} />
+            <SidebarNavItem to="/board-chat" label={t("Conference Room")} icon={MessagesSquare} />
           ) : null}
         </div>
 
-        <SidebarSection label="Work" collapsible={{ open: workOpen, onOpenChange: setWorkOpen }}>
-          <SidebarNavItem to="/issues" label="Tasks" icon={CircleCheck} />
+        <SidebarSection label={t("Work")} collapsible={{ open: workOpen, onOpenChange: setWorkOpen }}>
+          <SidebarNavItem to="/issues" label={t("Tasks")} icon={CircleCheck} />
           {streamlinedUiEnabled ? (
             <>
-              <SidebarNavItem to="/projects" label="Projects" icon={FolderOpen} />
+              <SidebarNavItem to="/projects" label={t("Projects")} icon={FolderOpen} />
               <SidebarStarredProjects />
             </>
           ) : null}
-          <SidebarNavItem to="/routines" label="Routines" icon={Repeat} />
-          <SidebarNavItem to="/artifacts" label="Artifacts" icon={Package} />
+          <SidebarNavItem to="/routines" label={t("Routines")} icon={Repeat} />
+          <SidebarNavItem to="/artifacts" label={t("Artifacts")} icon={Package} />
           {showCases ? (
-            <SidebarNavItem to="/cases" label="Cases" icon={Layers} textBadge="beta" />
+            <SidebarNavItem to="/cases" label={t("Cases")} icon={Layers} textBadge="beta" />
           ) : null}
           {showPipelines ? (
-            <SidebarNavItem to="/pipelines" label="Pipelines" icon={GitBranch} />
+            <SidebarNavItem to="/pipelines" label={t("Pipelines")} icon={GitBranch} />
           ) : null}
           {showGoalsLink ? (
-            <SidebarNavItem to="/goals" label="Goals" icon={Target} />
+            <SidebarNavItem to="/goals" label={t("Goals")} icon={Target} />
           ) : goalsLinkPending ? (
             <div
               data-testid="sidebar-goals-placeholder"
@@ -215,7 +217,7 @@ export function Sidebar() {
             />
           ) : null}
           {showWorkspacesLink ? (
-            <SidebarNavItem to="/workspaces" label="Workspaces" icon={GitBranch} />
+            <SidebarNavItem to="/workspaces" label={t("Workspaces")} icon={GitBranch} />
           ) : null}
           <PluginSlotOutlet
             slotTypes={["sidebar"]}
@@ -234,13 +236,13 @@ export function Sidebar() {
 
         {streamlinedUiEnabled ? (
           <SidebarSection
-            label="Org"
+            label={t("Org")}
             collapsible={{ open: organizationOpen, onOpenChange: setOrganizationOpen }}
           >
-            <SidebarNavItem to="/agents" label="Agents" icon={Users} />
-            <SidebarNavItem to="/skills" label="Skills" icon={Boxes} />
-            <SidebarNavItem to="/apps" label="Apps" icon={AppWindow} />
-            <SidebarNavItem to="/activity" label="Audit" icon={History} />
+            <SidebarNavItem to="/agents" label={t("Agents")} icon={Users} />
+            <SidebarNavItem to="/skills" label={t("Skills")} icon={Boxes} />
+            <SidebarNavItem to="/apps" label={t("Apps")} icon={AppWindow} />
+            <SidebarNavItem to="/activity" label={t("Audit")} icon={History} />
           </SidebarSection>
         ) : null}
 
@@ -251,15 +253,15 @@ export function Sidebar() {
             <SidebarProjects />
             <SidebarAgents />
             <SidebarSection
-              label="Organization"
+              label={t("Organization")}
               collapsible={{ open: organizationOpen, onOpenChange: setOrganizationOpen }}
             >
-              <SidebarNavItem to="/org" label="Org" icon={Network} />
-              <SidebarNavItem to="/apps" label="Apps" icon={AppWindow} />
-              <SidebarNavItem to="/timeline" label="Timeline" icon={GanttChartSquare} />
-              <SidebarNavItem to="/costs" label="Costs" icon={DollarSign} />
-              <SidebarNavItem to="/activity" label="Activity" icon={History} />
-              <SidebarNavItem to="/company/settings" label="Settings" icon={Settings} />
+              <SidebarNavItem to="/org" label={t("Org")} icon={Network} />
+              <SidebarNavItem to="/apps" label={t("Apps")} icon={AppWindow} />
+              <SidebarNavItem to="/timeline" label={t("Timeline")} icon={GanttChartSquare} />
+              <SidebarNavItem to="/costs" label={t("Costs")} icon={DollarSign} />
+              <SidebarNavItem to="/activity" label={t("Activity")} icon={History} />
+              <SidebarNavItem to="/company/settings" label={t("Settings")} icon={Settings} />
             </SidebarSection>
           </>
         )}

--- a/ui/src/components/SidebarAccountMenu.tsx
+++ b/ui/src/components/SidebarAccountMenu.tsx
@@ -20,7 +20,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { cn, SIDEBAR_RAIL_HIDDEN_LABEL } from "../lib/utils";
 import { ThemeToggle } from "./ThemeToggle";
 import { LanguageMenuAction } from "./LanguageMenuAction";
-import { useT } from "@/i18n-keyless";
+import { useTranslation } from "i18n-keyless-react";
 import { SidebarServerInfo } from "./SidebarServerInfo";
 import { Badge } from "@/components/ui/badge";
 
@@ -77,7 +77,7 @@ function sourceVersionSha(version: string): string | null {
 }
 
 function MenuAction({ label, description, icon: Icon, onClick, href, external = false }: MenuActionProps) {
-  const t = useT();
+  const t = useTranslation();
   const className =
     "flex w-full items-start gap-3 rounded-xl px-3 py-3 text-left transition-colors hover:bg-accent/60";
 

--- a/ui/src/components/SidebarAccountMenu.tsx
+++ b/ui/src/components/SidebarAccountMenu.tsx
@@ -19,6 +19,8 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { cn, SIDEBAR_RAIL_HIDDEN_LABEL } from "../lib/utils";
 import { ThemeToggle } from "./ThemeToggle";
+import { LanguageMenuAction } from "./LanguageMenuAction";
+import { useT } from "@/i18n-keyless";
 import { SidebarServerInfo } from "./SidebarServerInfo";
 import { Badge } from "@/components/ui/badge";
 
@@ -75,6 +77,7 @@ function sourceVersionSha(version: string): string | null {
 }
 
 function MenuAction({ label, description, icon: Icon, onClick, href, external = false }: MenuActionProps) {
+  const t = useT();
   const className =
     "flex w-full items-start gap-3 rounded-xl px-3 py-3 text-left transition-colors hover:bg-accent/60";
 
@@ -84,8 +87,8 @@ function MenuAction({ label, description, icon: Icon, onClick, href, external = 
         <Icon className="size-4" />
       </span>
       <span className="min-w-0 flex-1">
-        <span className="block text-sm font-medium text-foreground">{label}</span>
-        <span className="block text-xs text-muted-foreground">{description}</span>
+        <span className="block text-sm font-medium text-foreground">{t(label)}</span>
+        <span className="block text-xs text-muted-foreground">{t(description)}</span>
       </span>
     </>
   );
@@ -264,6 +267,7 @@ export function SidebarAccountMenu({
                 onClick={() => setOpen(false)}
               />
               <ThemeToggle variant="menu-action" onAfterToggle={() => setOpen(false)} />
+              <LanguageMenuAction onAfterChange={() => setOpen(false)} />
               {deploymentMode === "authenticated" ? (
                 <button
                   type="button"

--- a/ui/src/components/SidebarRecentTasks.tsx
+++ b/ui/src/components/SidebarRecentTasks.tsx
@@ -5,6 +5,7 @@ import { useRecentTasks } from "@/hooks/useRecentTasks";
 import { useSidebar } from "@/context/SidebarContext";
 import { SidebarSection } from "./SidebarSection";
 import { SidebarNavItem } from "./SidebarNavItem";
+import { NAVIGATION_CONTEXT, useT } from "@/i18n-keyless";
 
 export function SidebarRecentTasks({
   companyId,
@@ -46,15 +47,16 @@ function RecentTasksList({
   liveIssueIds: ReadonlySet<string>;
   rail: boolean;
 }) {
+  const t = useT(NAVIGATION_CONTEXT);
   const { entries } = useRecentTasks({ companyId, userId });
 
   if (rail && entries.length === 0) return null;
 
   return (
-    <SidebarSection label="Recent Tasks">
+    <SidebarSection label={t("Recent Tasks")}>
       {entries.length === 0 ? (
         <p className="mx-3 px-2 py-1 text-(length:--text-micro) leading-snug text-muted-foreground/70">
-          Open or create a task to keep it close at hand.
+          {t("Open or create a task to keep it close at hand.")}
         </p>
       ) : entries.map((entry) => (
         <SidebarNavItem

--- a/ui/src/components/SidebarRecentTasks.tsx
+++ b/ui/src/components/SidebarRecentTasks.tsx
@@ -5,7 +5,8 @@ import { useRecentTasks } from "@/hooks/useRecentTasks";
 import { useSidebar } from "@/context/SidebarContext";
 import { SidebarSection } from "./SidebarSection";
 import { SidebarNavItem } from "./SidebarNavItem";
-import { NAVIGATION_CONTEXT, useT } from "@/i18n-keyless";
+import { useTranslation } from "i18n-keyless-react";
+import { NAVIGATION_CONTEXT } from "@/i18n-keyless";
 
 export function SidebarRecentTasks({
   companyId,
@@ -47,7 +48,7 @@ function RecentTasksList({
   liveIssueIds: ReadonlySet<string>;
   rail: boolean;
 }) {
-  const t = useT(NAVIGATION_CONTEXT);
+  const t = useTranslation(NAVIGATION_CONTEXT);
   const { entries } = useRecentTasks({ companyId, userId });
 
   if (rail && entries.length === 0) return null;

--- a/ui/src/i18n-keyless.test.ts
+++ b/ui/src/i18n-keyless.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { detectBrowserLanguage, languageDisplayName, SUPPORTED_LANGUAGES } from "./i18n-keyless";
+
+describe("detectBrowserLanguage", () => {
+  it("returns the first supported language, most preferred first", () => {
+    expect(detectBrowserLanguage(["th-TH", "en-US"])).toBe("th");
+    expect(detectBrowserLanguage(["de-AT", "en"])).toBe("de");
+  });
+
+  it("maps regional Chinese tags to the script the server supports", () => {
+    expect(detectBrowserLanguage(["zh-CN"])).toBe("zh-Hans");
+    expect(detectBrowserLanguage(["zh-TW"])).toBe("zh-Hant");
+  });
+
+  it("keeps the regional variant when it is supported", () => {
+    expect(detectBrowserLanguage(["pt-BR"])).toBe("pt-BR");
+    expect(detectBrowserLanguage(["en-GB"])).toBe("en-GB");
+  });
+
+  it("falls back to English for unknown or empty preferences", () => {
+    expect(detectBrowserLanguage(["tlh"])).toBe("en");
+    expect(detectBrowserLanguage([])).toBe("en");
+  });
+});
+
+describe("languageDisplayName", () => {
+  it("names every supported language in that language", () => {
+    for (const lang of SUPPORTED_LANGUAGES) {
+      expect(languageDisplayName(lang)).not.toBe("");
+    }
+    expect(languageDisplayName("de")).toBe("Deutsch");
+    expect(languageDisplayName("th")).toBe("ไทย");
+  });
+});

--- a/ui/src/i18n-keyless.test.ts
+++ b/ui/src/i18n-keyless.test.ts
@@ -1,6 +1,48 @@
 import { describe, expect, it } from "vitest";
 
-import { detectBrowserLanguage, languageDisplayName, SUPPORTED_LANGUAGES } from "./i18n-keyless";
+import {
+  detectBrowserLanguage,
+  languageDisplayName,
+  resolveStorage,
+  SUPPORTED_LANGUAGES,
+} from "./i18n-keyless";
+
+describe("resolveStorage", () => {
+  it("keeps a working storage", () => {
+    const store = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => void store.set(key, value),
+      removeItem: (key: string) => void store.delete(key),
+      clear: () => store.clear(),
+    };
+    expect(resolveStorage(() => storage)).toBe(storage);
+  });
+
+  it("falls back to memory when reading the storage property throws", () => {
+    const storage = resolveStorage(() => {
+      throw new DOMException("The operation is insecure.", "SecurityError");
+    });
+    storage.setItem("k", "v");
+    expect(storage.getItem("k")).toBe("v");
+  });
+
+  it("falls back to memory when the storage throws on first use", () => {
+    const storage = resolveStorage(() => ({
+      getItem: () => {
+        throw new DOMException("QuotaExceededError");
+      },
+      setItem: () => {},
+      removeItem: () => {},
+      clear: () => {},
+    }));
+    expect(storage.getItem("k")).toBeNull();
+  });
+
+  it("falls back to memory when no storage is available", () => {
+    expect(resolveStorage(() => undefined).getItem("k")).toBeNull();
+  });
+});
 
 describe("detectBrowserLanguage", () => {
   it("returns the first supported language, most preferred first", () => {

--- a/ui/src/i18n-keyless.ts
+++ b/ui/src/i18n-keyless.ts
@@ -1,0 +1,133 @@
+import {
+  getTranslation,
+  init,
+  resolveLang,
+  useCurrentLanguage,
+  useI18nKeyless,
+  type Lang,
+  type TranslationOptions,
+} from "i18n-keyless-react";
+
+/**
+ * Keyless UI translation.
+ *
+ * The English string in the JSX is the key. There is no locale file and no key
+ * name to invent: the first render of a string in a new language asks the
+ * translation server for it, the server translates it once with an LLM and
+ * stores it, and every later client gets it from the cache. Reviewers fix a
+ * translation on the server dashboard instead of in a 40-file JSON diff.
+ *
+ * Only `English` ships in the bundle, so an offline or air-gapped instance
+ * still renders every string in the primary language.
+ */
+
+export const PRIMARY_LANGUAGE: Lang = "en";
+
+/** Every language the translation server can answer for. */
+export const SUPPORTED_LANGUAGES: readonly Lang[] = [
+  "en",
+  "ar",
+  "bn",
+  "ca",
+  "zh-Hans",
+  "zh-Hant",
+  "hr",
+  "cs",
+  "da",
+  "nl",
+  "en-GB",
+  "fi",
+  "fr",
+  "fr-CA",
+  "de",
+  "el",
+  "gu",
+  "he",
+  "hi",
+  "hu",
+  "id",
+  "it",
+  "ja",
+  "kn",
+  "ko",
+  "ms",
+  "ml",
+  "mr",
+  "no",
+  "or",
+  "pl",
+  "pt",
+  "pt-BR",
+  "pa",
+  "ro",
+  "ru",
+  "sk",
+  "sl",
+  "es",
+  "es-MX",
+  "sv",
+  "ta",
+  "te",
+  "th",
+  "tr",
+  "uk",
+  "ur",
+  "vi",
+];
+
+/**
+ * Picks the first browser language Paperclip supports, most preferred first.
+ * `zh-CN` resolves to `zh-Hans`, `de-AT` to `de`, an unknown tag to English.
+ */
+export function detectBrowserLanguage(preferred: readonly string[]): Lang {
+  for (const tag of preferred) {
+    const lang = resolveLang(tag, { supported: SUPPORTED_LANGUAGES });
+    if (lang) return lang;
+  }
+  return PRIMARY_LANGUAGE;
+}
+
+/** Native display name of a language, in that language ("Deutsch", "ไทย"). */
+export function languageDisplayName(lang: Lang): string {
+  try {
+    return new Intl.DisplayNames([lang], { type: "language" }).of(lang) ?? lang;
+  } catch {
+    return lang;
+  }
+}
+
+export function initI18nKeyless() {
+  void init({
+    API_KEY: "TXgf8PpHp3zxLJcc",
+    API_URL: "https://i18n-keyless.ambroselli.io",
+    storage: window.localStorage,
+    languages: {
+      primary: PRIMARY_LANGUAGE,
+      supported: [...SUPPORTED_LANGUAGES],
+      fallback: PRIMARY_LANGUAGE,
+      initWithDefault: detectBrowserLanguage(navigator.languages ?? [navigator.language]),
+    },
+  });
+}
+
+/** Disambiguates one-word labels for the translator ("Audit" is a log, not an exam). */
+export const NAVIGATION_CONTEXT: TranslationOptions = {
+  context: "Navigation menu item in an app that manages AI agents, tasks and projects",
+};
+
+/**
+ * Reactive translator for string props (`label`, `aria-label`, `placeholder`).
+ * Re-renders the caller when the language changes or a translation arrives.
+ * `options` applies to every call (`context`, `namespace`, ...).
+ * For JSX text prefer `<I18nKeylessText>` from `i18n-keyless-react`.
+ *
+ * Storybook and unit tests render components without the app entry, so the
+ * SDK is not initialized there; the identity function keeps English in that
+ * case instead of throwing.
+ */
+export function useT(options?: TranslationOptions): (text: string) => string {
+  useCurrentLanguage();
+  useI18nKeyless((state) => state.translations);
+  const initialized = useI18nKeyless((state) => Boolean(state.config.API_KEY));
+  return initialized ? (text) => getTranslation(text, options) : (text) => text;
+}

--- a/ui/src/i18n-keyless.ts
+++ b/ui/src/i18n-keyless.ts
@@ -1,14 +1,4 @@
-import {
-  createMemoryStorage,
-  getTranslation,
-  init,
-  resolveLang,
-  useCurrentLanguage,
-  useI18nKeyless,
-  type I18nConfig,
-  type Lang,
-  type TranslationOptions,
-} from "i18n-keyless-react";
+import { createMemoryStorage, init, resolveLang, type I18nConfig, type Lang, type TranslationOptions } from "i18n-keyless-react";
 
 /**
  * Keyless UI translation.
@@ -155,19 +145,3 @@ export function initI18nKeyless() {
 export const NAVIGATION_CONTEXT: TranslationOptions = {
   context: "Navigation menu item in an app that manages AI agents, tasks and projects",
 };
-
-/**
- * Reactive translator for string props (`label`, `aria-label`, `placeholder`).
- * Re-renders the caller when the language changes or a translation arrives.
- * `options` applies to every call (`context`, `namespace`, ...).
- * For JSX text prefer `<I18nKeylessText>` from `i18n-keyless-react`.
- *
- * When the SDK is not initialized (no key configured, Storybook, unit tests)
- * the identity function keeps English instead of throwing.
- */
-export function useT(options?: TranslationOptions): (text: string) => string {
-  useCurrentLanguage();
-  useI18nKeyless((state) => state.translations);
-  const initialized = useI18nKeyless((state) => Boolean(state.config.API_KEY));
-  return initialized ? (text) => getTranslation(text, options) : (text) => text;
-}

--- a/ui/src/i18n-keyless.ts
+++ b/ui/src/i18n-keyless.ts
@@ -1,9 +1,11 @@
 import {
+  createMemoryStorage,
   getTranslation,
   init,
   resolveLang,
   useCurrentLanguage,
   useI18nKeyless,
+  type I18nConfig,
   type Lang,
   type TranslationOptions,
 } from "i18n-keyless-react";
@@ -17,8 +19,14 @@ import {
  * stores it, and every later client gets it from the cache. Reviewers fix a
  * translation on the server dashboard instead of in a 40-file JSON diff.
  *
- * Only `English` ships in the bundle, so an offline or air-gapped instance
- * still renders every string in the primary language.
+ * The translation server is deployment configuration, read at build time:
+ *
+ *   VITE_I18N_KEYLESS_API_KEY  the project's public key (required to enable)
+ *   VITE_I18N_KEYLESS_API_URL  a self-hosted server; omit for the hosted one
+ *
+ * Without a key the UI stays English and makes no network request. Only
+ * English ships in the bundle, so an offline or air-gapped instance still
+ * renders every string in the primary language.
  */
 
 export const PRIMARY_LANGUAGE: Lang = "en";
@@ -96,18 +104,51 @@ export function languageDisplayName(lang: Lang): string {
   }
 }
 
+type Storage = NonNullable<I18nConfig["storage"]>;
+/** A storage adapter with the three methods the SDK reads and writes through. */
+export type KeyValueStorage = Storage & Required<Pick<Storage, "getItem" | "setItem" | "removeItem">>;
+
+/**
+ * The persistent cache for translations and the chosen language. A browser
+ * can deny `localStorage` (privacy mode, blocked site data): reading the
+ * property itself throws. In that case the SDK runs on an in-memory store,
+ * so the language choice lasts for the session and nothing aborts startup.
+ */
+export function resolveStorage(read: () => KeyValueStorage | undefined): KeyValueStorage {
+  try {
+    const storage = read();
+    if (!storage) return createMemoryStorage() as KeyValueStorage;
+    // Some browsers expose the object and throw on first use.
+    storage.getItem("i18n-keyless:probe");
+    return storage;
+  } catch {
+    return createMemoryStorage() as KeyValueStorage;
+  }
+}
+
 export function initI18nKeyless() {
-  void init({
-    API_KEY: "TXgf8PpHp3zxLJcc",
-    API_URL: "https://i18n-keyless.ambroselli.io",
-    storage: window.localStorage,
-    languages: {
-      primary: PRIMARY_LANGUAGE,
-      supported: [...SUPPORTED_LANGUAGES],
-      fallback: PRIMARY_LANGUAGE,
-      initWithDefault: detectBrowserLanguage(navigator.languages ?? [navigator.language]),
-    },
-  });
+  const apiKey = import.meta.env.VITE_I18N_KEYLESS_API_KEY as string | undefined;
+  if (!apiKey) return;
+  const apiUrl = import.meta.env.VITE_I18N_KEYLESS_API_URL as string | undefined;
+
+  try {
+    init({
+      API_KEY: apiKey,
+      ...(apiUrl ? { API_URL: apiUrl } : {}),
+      storage: resolveStorage(() => window.localStorage),
+      languages: {
+        primary: PRIMARY_LANGUAGE,
+        supported: [...SUPPORTED_LANGUAGES],
+        fallback: PRIMARY_LANGUAGE,
+        initWithDefault: detectBrowserLanguage(navigator.languages ?? [navigator.language]),
+      },
+    }).catch((error: unknown) => {
+      console.warn("i18n-keyless: translations unavailable, the UI stays in English", error);
+    });
+  } catch (error) {
+    // Translation is a progressive enhancement: never block the first render.
+    console.warn("i18n-keyless: initialization failed, the UI stays in English", error);
+  }
 }
 
 /** Disambiguates one-word labels for the translator ("Audit" is a log, not an exam). */
@@ -121,9 +162,8 @@ export const NAVIGATION_CONTEXT: TranslationOptions = {
  * `options` applies to every call (`context`, `namespace`, ...).
  * For JSX text prefer `<I18nKeylessText>` from `i18n-keyless-react`.
  *
- * Storybook and unit tests render components without the app entry, so the
- * SDK is not initialized there; the identity function keeps English in that
- * case instead of throwing.
+ * When the SDK is not initialized (no key configured, Storybook, unit tests)
+ * the identity function keeps English instead of throwing.
  */
 export function useT(options?: TranslationOptions): (text: string) => string {
   useCurrentLanguage();

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -23,8 +23,12 @@ import { getOrCreatePaperclipReactRoot } from "./lib/react-root";
 import { startServiceWorkerUpdates } from "./lib/service-worker-updates";
 import "@mdxeditor/editor/style.css";
 import "./index.css";
+import { initI18nKeyless } from "./i18n-keyless";
 
 initPluginBridge(React, ReactDOM);
+
+// Keyless UI translation: the English strings are the keys. Must run before the first render.
+initI18nKeyless();
 
 // React 19.2 emits an unbounded stream of performance.measure() entries for its
 // DevTools performance tracks and never clears them; on a long-lived tab they


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The board UI is English only. Two open issues ask for a localized UI, in Thai (#5924) and in German (#1171).
> - An i18next foundation exists (`ui/src/i18n/`), but it holds 3 keys and 40 locale files. About 25 community PRs try to extract the other strings. None is merged. Each one adds thousands of keys across 40 JSON files, and the review tool stops at 100 files.
> - This pull request removes the key files from the loop. The English string in the JSX is the key. A translation server translates each string once, stores it, and serves it to every client. Reviewers correct a translation on a dashboard, not in a JSON diff.
> - It applies this to one surface, the navigation, so the approach is easy to review: the sidebar, the mobile bottom nav, and the account menu, plus browser language detection and a language picker.
> - The benefit is a localized navigation in 48 languages today, and a migration path for the other strings that adds no file per language.

## Linked Issues or Issue Description

Refs #5924
Refs #1171

Related PRs that extract strings into i18next locale files: #4431, #6075, #8641, #11125, #11251, #3669, #10362, #11361. This PR does not conflict with them at the framework level. i18next stays in place. It offers a different way to feed the strings.

**Disclosure:** I am the author of i18n-keyless. The translation server is deployment configuration, not a default: without `VITE_I18N_KEYLESS_API_KEY` the UI stays English and makes no network request. To try the PR, point it at the demo instance I run (values in Verification). Paperclip can run its own instance with the self-hosted image (https://i18n-keyless.com/self-hosted), or use the hosted service. The SDK is MIT.

## What Changed

- `ui/src/i18n-keyless.ts` (new): the SDK init, read from `VITE_I18N_KEYLESS_API_KEY` and `VITE_I18N_KEYLESS_API_URL` (off when unset), `resolveStorage()` (falls back to an in-memory store when the browser denies `localStorage`, so startup never aborts), the list of 48 supported languages, `detectBrowserLanguage()` (`zh-CN` resolves to `zh-Hans`, `de-AT` to `de`, unknown to English), `languageDisplayName()` (native names through `Intl.DisplayNames`, no data file), and `NAVIGATION_CONTEXT`, a translation context that tells the translator a one-word label is a menu item ("Audit" is a log, not an exam).
- `ui/src/main.tsx`: calls the init before the first render.
- `ui/src/components/Sidebar.tsx`: `const t = useTranslation(NAVIGATION_CONTEXT)` from the SDK, and the navigation labels go through it. `label="Dashboard"` becomes `label={t("Dashboard")}`. No key name, no locale entry.
- `ui/src/components/MobileBottomNav.tsx`: same change for the five mobile items.
- `ui/src/components/SidebarRecentTasks.tsx`: same change for the section header and the empty state.
- `ui/src/components/SidebarAccountMenu.tsx`: the menu rows go through `t()`, and a new `LanguageMenuAction` row lets the user pick a language.
- `ui/src/components/LanguageMenuAction.tsx` (new): the picker, styled like the `ThemeToggle` menu row. The choice persists in `localStorage` and applies on the next boot. Renders nothing when no server is configured.
- `ui/.env.example` (new): documents the two variables.
- `ui/src/i18n-keyless.test.ts` (new): language detection, display names, and the storage fallback.
- `ui/package.json`: adds `i18n-keyless-react@3.6.0`. The lockfile is not in the PR; CI refreshes it.

Out of scope, on purpose: the other pages. The same one-line change applies to each string. Removing the i18next foundation is a separate decision.

## Verification

Automated:

```bash
pnpm --filter @paperclipai/ui typecheck
pnpm --filter @paperclipai/ui exec vitest run
node scripts/check-forbidden-tokens.mjs
```

Manual, in the browser:

1. Create `ui/.env` with the demo instance, then run `pnpm dev` and open the board:

   ```
   VITE_I18N_KEYLESS_API_KEY=TXgf8PpHp3zxLJcc
   VITE_I18N_KEYLESS_API_URL=https://i18n-keyless.ambroselli.io
   ```

2. Open the account menu at the bottom of the sidebar. A `Language` row shows a picker with each language in its own name.
3. Pick `Deutsch` or `ไทย`. The sidebar, the section headers, the `New Task` button, the mobile bottom nav, and the account menu rows switch language. The first switch to a new language can show English for about one second while the server translates; every later load reads the cache.
4. Reload the page. The language persists.
5. Clear `localStorage` and set the browser language to `th-TH`. The board boots in Thai.
6. Block `i18n-keyless.ambroselli.io` in DevTools. The UI renders in English and logs no error. English ships in the bundle; only the other languages come from the server.
7. Remove `ui/.env` and rebuild. The `Language` row is gone, the UI is English, and no request leaves the browser.

## Risks

- **Runtime dependency for non-English languages, opt-in.** Nothing is configured by default. A deployment that sets the two variables sends the English UI strings to the server it names, and a client that cannot reach that server renders English. An air-gapped instance keeps working in English. The self-hosted image runs next to Paperclip with the same Docker model.
- **The public API key is in the bundle when configured.** It is a read-and-translate key scoped to one project, like an analytics key. It cannot read or change anything else.
- **AI translations are the first pass.** They are corrected on the server dashboard by anyone the project owner invites. The translations are stored on the server, not in the repo, so a fork with a different server starts from English.
- **Nothing removed.** The i18next foundation and the 40 locale files stay in place. The two systems do not touch the same strings.
- A browser that denies `localStorage` gets an in-memory store: the language choice lasts for the session. Startup never throws.
- Storybook and unit tests render components without the app entry. The SDK renders the English string in that case and sends nothing.

## Model Used

Claude Fable 5.1 (`claude-fable-5-1`), Anthropic, through Claude Code. Extended thinking and tool use. The author reviewed and tested every change.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

