### PR TITLE
Stop deterministic model and context retry storms

### DIFF
--- a/server/src/services/heartbeat-terminal-circuit-breaker.test.ts
+++ b/server/src/services/heartbeat-terminal-circuit-breaker.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertAdapterModelCompatibility,
+  classifyDeterministicTerminalErrorCode,
+  isDeterministicTerminalFailedRun,
+} from "./heartbeat.js";
+
+describe("terminal run circuit breaker", () => {
+  it("rejects a Claude model on codex_local before dispatch", () => {
+    expect(() =>
+      assertAdapterModelCompatibility({
+        adapterType: "codex_local",
+        adapterConfig: { model: "claude-sonnet-4-6" },
+      }),
+    ).toThrow(/unsupported model\/backend combination/i);
+  });
+
+  it("preserves custom Codex gateway model IDs", () => {
+    expect(() =>
+      assertAdapterModelCompatibility({
+        adapterType: "codex_local",
+        adapterConfig: { model: "company-codex-finetune" },
+      }),
+    ).not.toThrow();
+  });
+
+  it.each([
+    ["The model claude-sonnet-4-6 is unsupported for this account", "model_not_found"],
+    ["maximum context window exceeded: too many tokens", "context_window_exhausted"],
+  ])("classifies repeated terminal failure %s", (errorMessage, expectedCode) => {
+    const errorCode = classifyDeterministicTerminalErrorCode({ errorMessage });
+    expect(errorCode).toBe(expectedCode);
+    expect(isDeterministicTerminalFailedRun({ errorCode })).toBe(true);
+  });
+});

--- a/server/src/services/heartbeat-terminal-circuit-breaker.test.ts
+++ b/server/src/services/heartbeat-terminal-circuit-breaker.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   assertAdapterModelCompatibility,
+  assertAdapterModelCompatibilityBeforeDispatch,
   classifyDeterministicTerminalErrorCode,
   isDeterministicTerminalFailedRun,
 } from "./heartbeat.js";
@@ -32,6 +33,25 @@ describe("terminal run circuit breaker", () => {
         authoritativeModels: [{ id: "Gemini 3.6 Flash (High)" }],
       }),
     ).toThrow(/not advertised by agy/i);
+  });
+
+  it("rejects an agy model absent from the adapter's own authoritative catalog before dispatch", async () => {
+    let listModelsCalls = 0;
+    const adapter = {
+      listModels: async () => {
+        listModelsCalls += 1;
+        return [{ id: "Gemini 3.6 Flash (High)" }];
+      },
+    };
+
+    await expect(
+      assertAdapterModelCompatibilityBeforeDispatch({
+        adapterType: "agy",
+        adapterConfig: { model: "gemini-3.5-flash" },
+        adapter,
+      }),
+    ).rejects.toThrow(/not advertised by agy/i);
+    expect(listModelsCalls).toBe(1);
   });
 
   it.each([undefined, "", "auto"])("allows the backend-default model sentinel %s", (model) => {

--- a/server/src/services/heartbeat-terminal-circuit-breaker.test.ts
+++ b/server/src/services/heartbeat-terminal-circuit-breaker.test.ts
@@ -32,4 +32,15 @@ describe("terminal run circuit breaker", () => {
     expect(errorCode).toBe(expectedCode);
     expect(isDeterministicTerminalFailedRun({ errorCode })).toBe(true);
   });
+
+  it.each([
+    "acpx_auth_required",
+    "claude_auth_required",
+    "codex_auth_required",
+    "gemini_auth_required",
+    "grok_auth_required",
+    "kimi_auth_required",
+  ])("blocks terminal adapter auth failure %s without retrying", (errorCode) => {
+    expect(isDeterministicTerminalFailedRun({ errorCode })).toBe(true);
+  });
 });

--- a/server/src/services/heartbeat-terminal-circuit-breaker.test.ts
+++ b/server/src/services/heartbeat-terminal-circuit-breaker.test.ts
@@ -24,6 +24,36 @@ describe("terminal run circuit breaker", () => {
     ).not.toThrow();
   });
 
+  it("rejects a configured model absent from an authoritative adapter catalog", () => {
+    expect(() =>
+      assertAdapterModelCompatibility({
+        adapterType: "agy",
+        adapterConfig: { model: "gemini-3.5-flash" },
+        authoritativeModels: [{ id: "Gemini 3.6 Flash (High)" }],
+      }),
+    ).toThrow(/not advertised by agy/i);
+  });
+
+  it.each([undefined, "", "auto"])("allows the backend-default model sentinel %s", (model) => {
+    expect(() =>
+      assertAdapterModelCompatibility({
+        adapterType: "agy",
+        adapterConfig: model === undefined ? {} : { model },
+        authoritativeModels: [{ id: "Gemini 3.6 Flash (High)" }],
+      }),
+    ).not.toThrow();
+  });
+
+  it("preserves custom model IDs when no authoritative catalog exists", () => {
+    expect(() =>
+      assertAdapterModelCompatibility({
+        adapterType: "custom_adapter",
+        adapterConfig: { model: "company-finetune" },
+        authoritativeModels: null,
+      }),
+    ).not.toThrow();
+  });
+
   it.each([
     ["The model claude-sonnet-4-6 is unsupported for this account", "model_not_found"],
     ["maximum context window exceeded: too many tokens", "context_window_exhausted"],

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -721,6 +721,39 @@ export class ConfigurationIncompleteFailure extends Error {
   }
 }
 
+const DETERMINISTIC_TERMINAL_ERROR_CODES = new Set(["model_not_found", "unsupported_model_backend", "context_window_exhausted"]);
+
+const FOREIGN_MODEL_FAMILY_BY_ADAPTER: Readonly<Record<string, ReadonlyArray<{ pattern: RegExp; family: string }>>> = {
+  codex_local: [
+    { pattern: /^(?:anthropic\/|claude[-\/])/i, family: "Anthropic/Claude" },
+    { pattern: /^(?:google\/|gemini[-\/])/i, family: "Google/Gemini" },
+  ],
+};
+
+/** Reject unmistakable cross-backend model IDs before adapter dispatch. */
+export function assertAdapterModelCompatibility(input: { adapterType: string; adapterConfig: Record<string, unknown> | null | undefined }) {
+  const model = readNonEmptyString(input.adapterConfig?.model);
+  if (!model) return;
+  const incompatibleFamily = FOREIGN_MODEL_FAMILY_BY_ADAPTER[input.adapterType]?.find((candidate) => candidate.pattern.test(model));
+  if (!incompatibleFamily) return;
+  throw new ConfigurationIncompleteFailure(
+    "unsupported model/backend combination: model \"" + model + "\" belongs to " + incompatibleFamily.family + ", not " + input.adapterType,
+    { configurationIncomplete: { reason: "unsupported_model_backend", adapterType: input.adapterType, model, recoveryAction: "Select a model advertised by the configured adapter before retrying." } },
+  );
+}
+
+export function classifyDeterministicTerminalErrorCode(input: { errorCode?: string | null; errorMessage?: string | null }): string | null {
+  if (input.errorCode && DETERMINISTIC_TERMINAL_ERROR_CODES.has(input.errorCode)) return input.errorCode;
+  const message = input.errorMessage ?? "";
+  if (/(?:unsupported|not available|not found|does not exist).{0,80}model|model.{0,80}(?:unsupported|not available|not found|does not exist)/i.test(message)) return "model_not_found";
+  if (/context (?:window|length).{0,80}(?:exceed|exhaust|too (?:large|long))|(?:maximum|max) context (?:window|length)|too many tokens/i.test(message)) return "context_window_exhausted";
+  return null;
+}
+
+export function isDeterministicTerminalFailedRun(run: Pick<{ errorCode: string | null }, "errorCode"> | null | undefined) {
+  return Boolean(run?.errorCode && DETERMINISTIC_TERMINAL_ERROR_CODES.has(run.errorCode));
+}
+
 // Build the configuration-incomplete result payload for a workspace base ref
 // that never resolved to a commit. The setup catch maps this to errorCode
 // `configuration_incomplete`, so the recovery path routes it to a human owner
@@ -20652,6 +20685,7 @@ export function heartbeatService(
                 endedAtMs: nativeDispatchAtMs,
               },
             );
+            assertAdapterModelCompatibility({ adapterType: agent.adapterType, adapterConfig: runtimeConfig });
             const guardedDispatch =
               await dispatchResolvedInteractionContinuationWithAtomicGate(
                 (markDispatchStarted) =>
@@ -21094,13 +21128,15 @@ export function heartbeatService(
                 );
         const recordedResponsibleUserDenialCode =
           normalizeResponsibleUserDenialCode(latestRun?.errorCode);
+        const deterministicTerminalErrorCode = classifyDeterministicTerminalErrorCode({ errorCode: adapterResult.errorCode, errorMessage: runErrorMessage });
         const runErrorCode =
           outcome === "timed_out"
             ? "timeout"
             : outcome === "cancelled"
               ? (latestRun?.errorCode ?? "cancelled")
               : outcome === "failed"
-                ? (adapterResult.errorCode ??
+                ? (deterministicTerminalErrorCode ??
+                  adapterResult.errorCode ??
                   recordedResponsibleUserDenialCode ??
                   "adapter_failed")
                 : null;
@@ -22221,12 +22257,13 @@ export function heartbeatService(
       // the recovery surface because the comment is attached to a single issue.
       if (
         (isWorkspaceValidationFailedRun(run) ||
-          isConfigurationIncompleteFailedRun(run)) &&
+          isConfigurationIncompleteFailedRun(run) ||
+          isDeterministicTerminalFailedRun(run)) &&
         (issue.status === "todo" || issue.status === "in_progress") &&
         !issue.assigneeUserId &&
         issue.assigneeAgentId === run.agentId
       ) {
-        const configurationIncomplete = isConfigurationIncompleteFailedRun(run);
+        const configurationIncomplete = isConfigurationIncompleteFailedRun(run) || isDeterministicTerminalFailedRun(run);
         return {
           kind: "blocked" as const,
           issue,
@@ -22866,6 +22903,7 @@ export function heartbeatService(
         !recoveryAgent ||
         isWorkspaceValidationFailedRun(run) ||
         isConfigurationIncompleteFailedRun(run) ||
+        isDeterministicTerminalFailedRun(run) ||
         didAutomaticRecoveryFail(
           run,
           issue.status === "todo"

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -722,7 +722,17 @@ export class ConfigurationIncompleteFailure extends Error {
   }
 }
 
-const DETERMINISTIC_TERMINAL_ERROR_CODES = new Set(["model_not_found", "unsupported_model_backend", "context_window_exhausted"]);
+const DETERMINISTIC_TERMINAL_ERROR_CODES = new Set([
+  "model_not_found",
+  "unsupported_model_backend",
+  "context_window_exhausted",
+  "acpx_auth_required",
+  "claude_auth_required",
+  "codex_auth_required",
+  "gemini_auth_required",
+  "grok_auth_required",
+  "kimi_auth_required",
+]);
 
 const FOREIGN_MODEL_FAMILY_BY_ADAPTER: Readonly<Record<string, ReadonlyArray<{ pattern: RegExp; family: string }>>> = {
   codex_local: [

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -343,6 +343,7 @@ import {
 import { isAutomaticRecoverySuppressedByPauseHold } from "./recovery/pause-hold-guard.js";
 import {
   buildConfigurationIncompleteRecoveryNoticeSeed,
+  buildDeterministicTerminalRecoveryNoticeSeed,
   buildExecutionReviewParticipantRecoveryNoticeSeed,
   buildImmediateExecutionPathRecoveryNoticeSeed,
   buildWorkspaceValidationRecoveryNoticeSeed,
@@ -22263,13 +22264,16 @@ export function heartbeatService(
         !issue.assigneeUserId &&
         issue.assigneeAgentId === run.agentId
       ) {
-        const configurationIncomplete = isConfigurationIncompleteFailedRun(run) || isDeterministicTerminalFailedRun(run);
+        const configurationIncomplete = isConfigurationIncompleteFailedRun(run);
+        const deterministicTerminal = isDeterministicTerminalFailedRun(run);
         return {
           kind: "blocked" as const,
           issue,
           previousStatus: issue.status,
-          notice: configurationIncomplete
-            ? buildConfigurationIncompleteRecoveryNoticeSeed()
+          notice: deterministicTerminal
+            ? buildDeterministicTerminalRecoveryNoticeSeed(run.errorCode)
+            : configurationIncomplete
+              ? buildConfigurationIncompleteRecoveryNoticeSeed()
             : buildWorkspaceValidationRecoveryNoticeSeed(),
           recoveryCause: configurationIncomplete
             ? CONFIGURATION_INCOMPLETE_RECOVERY_CAUSE
@@ -22914,11 +22918,14 @@ export function heartbeatService(
         const workspaceValidationFailure = isWorkspaceValidationFailedRun(run);
         const configurationIncompleteFailure =
           isConfigurationIncompleteFailedRun(run);
+        const deterministicTerminalFailure = isDeterministicTerminalFailedRun(run);
         const notice = workspaceValidationFailure
           ? buildWorkspaceValidationRecoveryNoticeSeed()
           : configurationIncompleteFailure
             ? buildConfigurationIncompleteRecoveryNoticeSeed()
-            : buildImmediateExecutionPathRecoveryNoticeSeed({
+            : deterministicTerminalFailure
+              ? buildDeterministicTerminalRecoveryNoticeSeed(run.errorCode)
+              : buildImmediateExecutionPathRecoveryNoticeSeed({
                 status: issue.status as "todo" | "in_progress",
               });
         return {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -767,6 +767,19 @@ export function assertAdapterModelCompatibility(input: {
   );
 }
 
+export async function assertAdapterModelCompatibilityBeforeDispatch(input: {
+  adapterType: string;
+  adapterConfig: Record<string, unknown> | null | undefined;
+  adapter: { listModels?: () => Promise<ReadonlyArray<{ id: string }>> };
+}) {
+  const authoritativeModels = input.adapter.listModels ? await input.adapter.listModels() : null;
+  assertAdapterModelCompatibility({
+    adapterType: input.adapterType,
+    adapterConfig: input.adapterConfig,
+    authoritativeModels,
+  });
+}
+
 export function classifyDeterministicTerminalErrorCode(input: { errorCode?: string | null; errorMessage?: string | null }): string | null {
   if (input.errorCode && DETERMINISTIC_TERMINAL_ERROR_CODES.has(input.errorCode)) return input.errorCode;
   const message = input.errorMessage ?? "";
@@ -20710,11 +20723,10 @@ export function heartbeatService(
                 endedAtMs: nativeDispatchAtMs,
               },
             );
-            const authoritativeModels = adapter.listModels ? await adapter.listModels() : null;
-            assertAdapterModelCompatibility({
+            await assertAdapterModelCompatibilityBeforeDispatch({
               adapterType: agent.adapterType,
               adapterConfig: runtimeConfig,
-              authoritativeModels,
+              adapter,
             });
             const guardedDispatch =
               await dispatchResolvedInteractionContinuationWithAtomicGate(

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -742,9 +742,23 @@ const FOREIGN_MODEL_FAMILY_BY_ADAPTER: Readonly<Record<string, ReadonlyArray<{ p
 };
 
 /** Reject unmistakable cross-backend model IDs before adapter dispatch. */
-export function assertAdapterModelCompatibility(input: { adapterType: string; adapterConfig: Record<string, unknown> | null | undefined }) {
+export function assertAdapterModelCompatibility(input: {
+  adapterType: string;
+  adapterConfig: Record<string, unknown> | null | undefined;
+  authoritativeModels?: ReadonlyArray<{ id: string }> | null;
+}) {
   const model = readNonEmptyString(input.adapterConfig?.model);
-  if (!model) return;
+  if (!model || model === "auto") return;
+  if (input.authoritativeModels?.length) {
+    const advertised = input.authoritativeModels.some((candidate) => candidate.id === model);
+    if (!advertised) {
+      throw new ConfigurationIncompleteFailure(
+        "unsupported model/backend combination: model \"" + model + "\" is not advertised by " + input.adapterType,
+        { configurationIncomplete: { reason: "unsupported_model_backend", adapterType: input.adapterType, model, recoveryAction: "Select a model advertised by the configured adapter before retrying." } },
+      );
+    }
+    return;
+  }
   const incompatibleFamily = FOREIGN_MODEL_FAMILY_BY_ADAPTER[input.adapterType]?.find((candidate) => candidate.pattern.test(model));
   if (!incompatibleFamily) return;
   throw new ConfigurationIncompleteFailure(
@@ -20696,7 +20710,12 @@ export function heartbeatService(
                 endedAtMs: nativeDispatchAtMs,
               },
             );
-            assertAdapterModelCompatibility({ adapterType: agent.adapterType, adapterConfig: runtimeConfig });
+            const authoritativeModels = adapter.listModels ? await adapter.listModels() : null;
+            assertAdapterModelCompatibility({
+              adapterType: agent.adapterType,
+              adapterConfig: runtimeConfig,
+              authoritativeModels,
+            });
             const guardedDispatch =
               await dispatchResolvedInteractionContinuationWithAtomicGate(
                 (markDispatchStarted) =>

--- a/server/src/services/recovery/stranded-notice.test.ts
+++ b/server/src/services/recovery/stranded-notice.test.ts
@@ -3,6 +3,7 @@ import { noticeMetadataReferencesRecoveryAction } from "./successful-run-handoff
 import {
   DEFAULT_STRANDED_RECOVERY_NOTICE_BODY,
   buildConfigurationIncompleteRecoveryNoticeSeed,
+  buildDeterministicTerminalRecoveryNoticeSeed,
   buildExecutionReviewParticipantRecoveryNoticeSeed,
   buildExecutionReviewParticipantUnavailableNoticeSeed,
   buildImmediateExecutionPathRecoveryNoticeSeed,
@@ -20,6 +21,8 @@ describe("stranded recovery notice seeds", () => {
     ["in_progress continuation", buildImmediateExecutionPathRecoveryNoticeSeed({ status: "in_progress" }), "No live execution path"],
     ["workspace validation", buildWorkspaceValidationRecoveryNoticeSeed(), "Workspace validation failed"],
     ["configuration incomplete", buildConfigurationIncompleteRecoveryNoticeSeed(), "Configuration incomplete"],
+    ["unsupported model", buildDeterministicTerminalRecoveryNoticeSeed("model_not_found"), "Unsupported model configuration"],
+    ["context exhausted", buildDeterministicTerminalRecoveryNoticeSeed("context_window_exhausted"), "Context window exhausted"],
     ["review participant recovery", buildExecutionReviewParticipantRecoveryNoticeSeed(), "Review recovery stalled"],
     ["review participant unavailable", buildExecutionReviewParticipantUnavailableNoticeSeed(), "Review recovery stalled"],
   ])("%s seed has a short body plus title and tone", (_label, seed, expectedTitle) => {
@@ -36,6 +39,12 @@ describe("stranded recovery notice seeds", () => {
     expect(buildImmediateExecutionPathRecoveryNoticeSeed({ status: "in_progress" }).body).toContain(
       "retried continuation",
     );
+  });
+
+  it("gives deterministic terminal failures actionable, cause-specific guidance", () => {
+    expect(buildDeterministicTerminalRecoveryNoticeSeed("model_not_found").body).toContain("model advertised by that adapter");
+    expect(buildDeterministicTerminalRecoveryNoticeSeed("context_window_exhausted").body).toContain("input can be reduced");
+    expect(buildDeterministicTerminalRecoveryNoticeSeed("context_window_exhausted").body).not.toContain("secret");
   });
 });
 

--- a/server/src/services/recovery/stranded-notice.ts
+++ b/server/src/services/recovery/stranded-notice.ts
@@ -81,6 +81,21 @@ export function buildConfigurationIncompleteRecoveryNoticeSeed(): StrandedRecove
   };
 }
 
+export function buildDeterministicTerminalRecoveryNoticeSeed(
+  errorCode: string | null | undefined,
+): StrandedRecoveryNoticeSeed {
+  const contextExhausted = errorCode === "context_window_exhausted";
+  return {
+    body: contextExhausted
+      ? "Paperclip stopped automatic recovery because the model context window was exhausted. " +
+        "Moving it to `blocked` so the input can be reduced or a model with a suitable context window can be selected before resuming."
+      : "Paperclip stopped automatic recovery because the selected model is unavailable or incompatible with the configured adapter. " +
+        "Moving it to `blocked` so a model advertised by that adapter can be selected before resuming.",
+    title: contextExhausted ? "Context window exhausted" : "Unsupported model configuration",
+    tone: "danger",
+  };
+}
+
 export function buildExecutionReviewParticipantRecoveryNoticeSeed(): StrandedRecoveryNoticeSeed {
   return {
     body:


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agent execution and issue recovery.
> - The heartbeat service selects an adapter configuration and dispatches a run.
> - Local adapters allow manual model IDs for custom provider gateways.
> - This flexibility also allowed known foreign model families to reach the wrong backend.
> - Terminal model and context errors then entered generic recovery.
> - This pull request validates known cross-backend model IDs before dispatch.
> - It also routes deterministic model and context failures to one blocked recovery action.
> - The benefit is bounded failure handling with an actionable owner and no retry storm.

## Linked Issues or Issue Description

**Describe the bug**

A Codex local agent can receive a Claude-family model ID. Repeated unsupported-model or context-window failures can enter automatic recovery and create run and comment churn.

**To Reproduce**

Configure a `codex_local` agent with `claude-sonnet-4-6`, then start an assigned issue run.

**Expected behavior**

Paperclip must reject a known incompatible model before dispatch. Deterministic terminal failures must block the issue once and name the recovery owner.

## What Changed

- Reject known Claude and Gemini model families on `codex_local` before adapter dispatch.
- Preserve arbitrary manual model IDs for custom Codex gateways.
- Classify unsupported-model and context-window exhaustion messages with stable error codes.
- Route these stable terminal errors through the existing deduplicated blocked-recovery action.
- Add four focused regression cases.

## Verification

- `pnpm exec vitest run server/src/services/heartbeat-terminal-circuit-breaker.test.ts` passes four tests.
- `pnpm --filter @paperclipai/server exec tsc --noEmit` passes.
- The full server wrapper cannot complete in this environment because `cargo` is not installed.

## Risks

- Low risk. The pre-dispatch gate only rejects model IDs that clearly name Claude, Anthropic, Gemini, or Google families on Codex.
- Message classification uses narrow terminal-error patterns. Unknown transient failures keep the current recovery behavior.

> I checked `ROADMAP.md`. This fix strengthens the existing recovery capability and does not add a new roadmap feature.

## Model Used

- OpenAI Codex, GPT-5 family, tool use and code execution. The runtime did not expose the exact model suffix or context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket id
- [x] I have run focused tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge