### PR TITLE
fix(server): reduce heartbeat control-plane load

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -1466,6 +1466,53 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .where(eq(heartbeatRuns.agentId, agentId));
     expect(runs).toHaveLength(0);
   });
+  it("treats dependency-blocked assignments as non-actionable timer work", async () => {
+    const { companyId, agentId } = await seedIdleTimerAgentFixture();
+    const blockerIssueId = randomUUID();
+    const blockedIssueId = randomUUID();
+    await db.insert(issues).values([
+      {
+        id: blockerIssueId,
+        companyId,
+        title: "Finish prerequisite work",
+        status: "in_progress",
+        priority: "medium",
+      },
+      {
+        id: blockedIssueId,
+        companyId,
+        title: "Blocked assigned work",
+        status: "todo",
+        priority: "high",
+        assigneeAgentId: agentId,
+      },
+    ]);
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: blockedIssueId,
+      type: "blocks",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "timer",
+      triggerDetail: "system",
+      reason: "heartbeat_timer",
+      requestedByActorType: "system",
+      requestedByActorId: "heartbeat_scheduler",
+    });
+
+    expect(run).toBeNull();
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+    const requests = await db
+      .select({ reason: agentWakeupRequests.reason })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, agentId));
+    expect(requests).toEqual([
+      expect.objectContaining({ reason: "heartbeat.timer.no_actionable_work" }),
+    ]);
+  });
 
   it("queues exactly one retry when the recorded local pid is dead", async () => {
     const { agentId, runId, issueId } = await seedRunFixture({
@@ -5960,6 +6007,43 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     if (runs[0]?.id) {
       await waitForRunToSettle(heartbeat, runs[0].id);
     }
+  });
+  it("batch-skips dependency-blocked assigned todo work before creating wakeups", async () => {
+    const blocked = await seedAssignedTodoNoRunFixture();
+    const blockerIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: blockerIssueId,
+      companyId: blocked.companyId,
+      title: "Finish prerequisite work",
+      status: "in_progress",
+      priority: "medium",
+      issueNumber: 2,
+      identifier: `T${blocked.companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}-2`,
+    });
+    await db.insert(issueRelations).values({
+      companyId: blocked.companyId,
+      issueId: blockerIssueId,
+      relatedIssueId: blocked.issueId,
+      type: "blocks",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+    expect(result.assignmentDispatched).toBe(0);
+    expect(result.dependencyBlockedSkipped).toBe(1);
+    expect(result.skipped).toBe(1);
+    expect(result.issueIds).toEqual([]);
+
+    const blockedWakeups = await db
+      .select()
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.agentId, blocked.agentId));
+    expect(blockedWakeups).toHaveLength(0);
+    const blockedRuns = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, blocked.agentId));
+    expect(blockedRuns).toHaveLength(0);
   });
 
   it("does not duplicate initial assigned todo dispatch when a queued wake already exists", async () => {

--- a/server/src/__tests__/inbox-dismissals.test.ts
+++ b/server/src/__tests__/inbox-dismissals.test.ts
@@ -7,6 +7,7 @@ import {
   agents,
   approvals,
   companies,
+  costEvents,
   createDb,
   heartbeatRuns,
   inboxDismissals,
@@ -49,6 +50,7 @@ describeEmbeddedPostgres("inbox dismissals", () => {
     await db.delete(joinRequests);
     await db.delete(invites);
     await db.delete(activityLog);
+    await db.delete(costEvents);
     await db.delete(heartbeatRuns);
     await db.delete(approvals);
     await db.delete(agents);
@@ -265,6 +267,64 @@ describeEmbeddedPostgres("inbox dismissals", () => {
     expect(badges).toEqual({
       inbox: 3,
       approvals: 1,
+      failedRuns: 1,
+      joinRequests: 0,
+    });
+  });
+
+  it("adds agent and budget alerts without loading the dashboard run chart", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: "PAP",
+      budgetMonthlyCents: 100,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "ErroredAgent",
+      role: "engineer",
+      status: "error",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(costEvents).values({
+      companyId,
+      agentId,
+      provider: "test",
+      biller: "test",
+      billingType: "tokens",
+      model: "test-model",
+      costCents: 80,
+      occurredAt: new Date(),
+    });
+
+    const alertsOnly = await badgesSvc.get(companyId);
+    expect(alertsOnly).toEqual({
+      inbox: 2,
+      approvals: 0,
+      failedRuns: 0,
+      joinRequests: 0,
+    });
+
+    await db.insert(heartbeatRuns).values({
+      companyId,
+      agentId,
+      invocationSource: "assignment",
+      status: "failed",
+      createdAt: new Date(),
+    });
+
+    const failedRunDeduplicated = await badgesSvc.get(companyId);
+    expect(failedRunDeduplicated).toEqual({
+      inbox: 2,
+      approvals: 0,
       failedRuns: 1,
       joinRequests: 0,
     });

--- a/server/src/routes/sidebar-badges.ts
+++ b/server/src/routes/sidebar-badges.ts
@@ -4,7 +4,6 @@ import { and, eq } from "drizzle-orm";
 import { inboxDismissals, joinRequests } from "@paperclipai/db";
 import { sidebarBadgeService } from "../services/sidebar-badges.js";
 import { accessService } from "../services/access.js";
-import { dashboardService } from "../services/dashboard.js";
 import { collapseDuplicatePendingHumanJoinRequests } from "../lib/join-request-dedupe.js";
 import { assertCompanyAccess } from "./authz.js";
 
@@ -28,7 +27,6 @@ export function sidebarBadgeRoutes(db: Db) {
   const router = Router();
   const svc = sidebarBadgeService(db);
   const access = accessService(db);
-  const dashboard = dashboardService(db);
 
   router.get("/companies/:companyId/sidebar-badges", async (req, res) => {
     const companyId = req.params.companyId as string;
@@ -82,12 +80,6 @@ export function sidebarBadgeRoutes(db: Db) {
       dismissals: dismissedAtByKey,
       joinRequests: visibleJoinRequests,
     });
-    const summary = await dashboard.summary(companyId);
-    const hasFailedRuns = badges.failedRuns > 0;
-    const alertsCount =
-      (summary.agents.error > 0 && !hasFailedRuns ? 1 : 0) +
-      (summary.costs.monthBudgetCents > 0 && summary.costs.monthUtilizationPercent >= 80 ? 1 : 0);
-    badges.inbox = badges.failedRuns + alertsCount + badges.joinRequests + badges.approvals;
 
     res.json(badges);
   });

--- a/server/src/services/dashboard.ts
+++ b/server/src/services/dashboard.ts
@@ -105,7 +105,7 @@ export function dashboardService(db: Db) {
       // Both recursive arms are bounded to the chart window: a retry is always
       // created after the run it retries, so ancestors of an out-of-window
       // child are themselves out of window and invisible to the membership
-      // test below. Unbounded, the seed walks every run the company ever had.
+      // join below. Unbounded, the seed walks every run the company ever had.
       const runActivityRows = (await db.execute(sql`
         WITH RECURSIVE recovered_runs(id) AS (
           SELECT parent.id
@@ -125,12 +125,13 @@ export function dashboardService(db: Db) {
           to_char(run.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD') AS date,
           run.status AS status,
           run.error_code AS error_code,
-          (run.id IN (SELECT id FROM recovered_runs)) AS recovered,
+          (recovered_run.id IS NOT NULL) AS recovered,
           count(*)::double precision AS count
         FROM ${heartbeatRuns} AS run
+        LEFT JOIN recovered_runs AS recovered_run ON recovered_run.id = run.id
         WHERE run.company_id = ${companyId}
           AND run.created_at >= ${runActivityStart.toISOString()}::timestamptz
-        GROUP BY date, run.status, run.error_code, recovered
+        GROUP BY date, run.status, run.error_code, (recovered_run.id IS NOT NULL)
       `)) as unknown as Iterable<{
         date: string;
         status: string;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -14858,8 +14858,8 @@ export function heartbeatService(
   }
 
   async function hasActionableTimerWork(agent: typeof agents.$inferSelect) {
-    const row = await db
-      .select({ id: issues.id })
+    const assignedIssues = await db
+      .select({ id: issues.id, status: issues.status })
       .from(issues)
       .where(
         and(
@@ -14870,9 +14870,16 @@ export function heartbeatService(
           inArray(issues.status, [...TIMER_ACTIONABLE_ISSUE_STATUSES]),
         ),
       )
-      .limit(1)
-      .then((rows) => rows[0] ?? null);
-    return Boolean(row);
+      .then((rows) => rows);
+    if (assignedIssues.some((issue) => issue.status === "in_progress")) return true;
+
+    const todoIssueIds = assignedIssues
+      .filter((issue) => issue.status === "todo")
+      .map((issue) => issue.id);
+    if (todoIssueIds.length === 0) return false;
+
+    const dependencyReadiness = await issuesSvc.listDependencyReadiness(agent.companyId, todoIssueIds);
+    return todoIssueIds.some((issueId) => dependencyReadiness.get(issueId)?.isDependencyReady !== false);
   }
 
   async function markTimerHeartbeatChecked(

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3453,6 +3453,23 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
           opts?.issueCreatedAtGte ? gte(issues.createdAt, opts.issueCreatedAtGte) : undefined,
         ),
       );
+    const todoIssueIdsByCompany = new Map<string, string[]>();
+    for (const issue of candidates) {
+      if (issue.status !== "todo") continue;
+      const issueIds = todoIssueIdsByCompany.get(issue.companyId) ?? [];
+      issueIds.push(issue.id);
+      todoIssueIdsByCompany.set(issue.companyId, issueIds);
+    }
+    const dependencyReadinessByCompany = new Map<
+      string,
+      Awaited<ReturnType<typeof issuesSvc.listDependencyReadiness>>
+    >();
+    await Promise.all([...todoIssueIdsByCompany].map(async ([companyId, issueIds]) => {
+      dependencyReadinessByCompany.set(
+        companyId,
+        await issuesSvc.listDependencyReadiness(companyId, issueIds),
+      );
+    }));
 
     const result = {
       assignmentDispatched: 0,
@@ -3470,10 +3487,20 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       recentProgressExempted: 0,
       operatorCancelExempted: 0,
       skipped: 0,
+      dependencyBlockedSkipped: 0,
       issueIds: [] as string[],
     };
 
     for (const issue of candidates) {
+      const dependencyReadiness = dependencyReadinessByCompany
+        .get(issue.companyId)
+        ?.get(issue.id);
+      if (issue.status === "todo" && dependencyReadiness?.isDependencyReady === false) {
+        result.dependencyBlockedSkipped += 1;
+        result.skipped += 1;
+        continue;
+      }
+
       const executionState = issue.status === "in_review"
         ? parseIssueExecutionState(issue.executionState)
         : null;

--- a/server/src/services/sidebar-badges.ts
+++ b/server/src/services/sidebar-badges.ts
@@ -1,6 +1,6 @@
-import { and, desc, eq, inArray, not } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, not, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { agents, approvals, heartbeatRuns } from "@paperclipai/db";
+import { agents, approvals, companies, costEvents, heartbeatRuns } from "@paperclipai/db";
 import type { SidebarBadges } from "@paperclipai/shared";
 
 const ACTIONABLE_APPROVAL_STATUSES = ["pending", "revision_requested"];
@@ -66,6 +66,35 @@ export function sidebarBadgeService(db: Db) {
         FAILED_HEARTBEAT_STATUSES.includes(row.runStatus)
         && !isDismissed(extra?.dismissals ?? new Map(), `run:${row.id}`, row.createdAt),
       ).length;
+      // Sidebar badges poll frequently, so collect only the two alert inputs
+      // instead of loading the full dashboard summary and its 14-day run chart.
+      const monthStart = new Date();
+      monthStart.setUTCDate(1);
+      monthStart.setUTCHours(0, 0, 0, 0);
+      const [errorAgentCount, monthBudgetCents, monthSpendCents] = await Promise.all([
+        db
+          .select({ count: sql<number>`count(*)` })
+          .from(agents)
+          .where(and(eq(agents.companyId, companyId), eq(agents.status, "error")))
+          .then((rows) => Number(rows[0]?.count ?? 0)),
+        db
+          .select({ monthBudgetCents: companies.budgetMonthlyCents })
+          .from(companies)
+          .where(eq(companies.id, companyId))
+          .then((rows) => Number(rows[0]?.monthBudgetCents ?? 0)),
+        db
+          .select({
+            monthSpendCents: sql<number>`coalesce(sum(${costEvents.costCents}), 0)::double precision`,
+          })
+          .from(costEvents)
+          .where(and(eq(costEvents.companyId, companyId), gte(costEvents.occurredAt, monthStart)))
+          .then((rows) => Number(rows[0]?.monthSpendCents ?? 0)),
+      ]);
+      const monthUtilizationPercent =
+        monthBudgetCents > 0 ? Number(((monthSpendCents / monthBudgetCents) * 100).toFixed(2)) : 0;
+      const alertsCount =
+        (errorAgentCount > 0 && failedRuns === 0 ? 1 : 0) +
+        (monthBudgetCents > 0 && monthUtilizationPercent >= 80 ? 1 : 0);
 
       const joinRequests = (extra?.joinRequests ?? []).filter((row) =>
         !isDismissed(
@@ -76,7 +105,7 @@ export function sidebarBadgeService(db: Db) {
       ).length;
       const unreadTouchedIssues = extra?.unreadTouchedIssues ?? 0;
       return {
-        inbox: actionableApprovals + failedRuns + joinRequests + unreadTouchedIssues,
+        inbox: actionableApprovals + failedRuns + joinRequests + unreadTouchedIssues + alertsCount,
         approvals: actionableApprovals,
         failedRuns,
         joinRequests,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The heartbeat scheduler and dashboard share the same server and database resources
> - Fixed-interval recovery work can overlap when one pass takes longer than its interval
> - Dependency-blocked work can create repeated timer and recovery checks even when it cannot run
> - The sidebar badge endpoint polls often and currently loads the full dashboard summary
> - The dashboard run chart uses a correlated recursive-CTE membership test for every recent run
> - This pull request removes these avoidable sources of control-plane load
> - The benefit is faster UI reads and bounded recovery work under load

## Linked Issues or Issue Description

Refs #11699
Refs #8102

**What happened?**

A self-hosted server stayed CPU-bound even after every agent was paused. Several database sessions ran the same dashboard run-activity query at the same time. The sidebar badge endpoint loaded the full dashboard summary on each poll. The recovery scheduler also inspected dependency-blocked assigned work on each pass, and timer wakes treated that work as actionable.

On a database with about 26,000 heartbeat runs, the 14-day run-activity query examined about 8,100 recent runs. The old plan took about 2.0 seconds. A join-based plan with the same result took about 0.19 seconds.

**Expected behavior**

Sidebar badge polls should read only badge inputs. The dashboard should classify recovered runs without a correlated membership scan for each run. Timer and recovery paths should skip assigned todo work until its dependencies are ready. Work that is already in progress must remain actionable.

**Steps to reproduce**

1. Use external Postgres with a large heartbeat run history.
2. Open a page that polls the sidebar badge endpoint.
3. Inspect active Postgres queries and server CPU.
4. Assign several todo issues to agents while those issues still have unresolved blockers.
5. Run the timer and stranded-assignment recovery paths.
6. Observe repeated dashboard run-activity queries and blocked-work checks.

**Paperclip version or commit**

Reproduced on a source build before commit 480630041. The change is rebased on 480630041.

**Deployment mode**

Self-hosted server.

**Installation method**

Built from source.

**Agent adapter(s) involved**

Not adapter-specific. This is a core scheduler and query issue.

**Database mode**

External Postgres.

**Node.js version**

The supported CI toolchain uses Node 24.11 or later. The focused tests also passed on Node 22.22.1.

**Operating system**

Linux.

**Relevant logs or output**

The old dashboard plan took about 1,996 ms for about 8,100 recent rows. The join rewrite took about 186 ms with the same recovered-run semantics. During the incident, several copies of the old query were active at the same time.

**Additional context**

PR #11699 adds the single-flight guard for periodic recovery. This pull request contains the remaining query and dependency-readiness changes. PR #8102 is related but has a wider wake-coalescing scope.

## What Changed

- Replace the per-row recursive-CTE membership subplan with a left join to the unique recovered-run set.
- Move agent-error and monthly-budget alert reads into the lightweight sidebar badge service.
- Remove the full dashboard summary call from the 15-second sidebar badge endpoint.
- Batch dependency-readiness checks by company before stranded todo recovery.
- Skip dependency-blocked todo assignments before per-issue recovery queries or wake creation.
- Treat blocked todo assignments as non-actionable timer work.
- Keep in-progress assignments actionable even when dependency relations exist.
- Add regression tests for timer wakes, recovery scans, alert counts, and failed-run alert deduplication.

## Verification

- `pnpm exec vitest run server/src/lib/single-flight.test.ts server/src/__tests__/dashboard-service.test.ts server/src/__tests__/inbox-dismissals.test.ts`
  - 12 tests passed.
- `pnpm exec vitest run server/src/__tests__/heartbeat-process-recovery.test.ts -t dependency-blocked`
  - 2 tests passed.
- `cd server && pnpm exec tsc --noEmit`
  - Passed.
- `pnpm --filter @paperclipai/server typecheck`
  - The server TypeScript phase was checked separately. The wrapper cannot finish on the diagnostic host because the host does not have `cargo`, which the new runner build requires.

## Risks

- Low migration risk. This pull request has no schema or data migration.
- The recovered-run CTE uses `UNION`, so each recovered run id is unique and the left join does not change counts.
- A missing dependency-readiness entry remains fail-open and actionable.
- The recovery optimization applies only to todo issues. In-progress and in-review recovery behavior is unchanged.
- Sidebar alert thresholds and failed-run deduplication remain unchanged.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected ΓÇö check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5, with reasoning, tool use, code execution, database plan analysis, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge