### PR TITLE
fix(kubernetes): distinguish exec setup failures

### DIFF
--- a/packages/adapter-utils/src/execution-target-sandbox.test.ts
+++ b/packages/adapter-utils/src/execution-target-sandbox.test.ts
@@ -1907,7 +1907,7 @@ describe("sandbox adapter execution targets", () => {
         pid: null,
         startedAt: new Date().toISOString(),
         metadata: {
-          provider: "kubernetes",
+          provider: "kubernetes Authorization: Bearer secret-value",
           backend: "sandbox-cr",
           execFailure: "setup_or_transport",
           statusCode: 403,
@@ -1926,7 +1926,7 @@ describe("sandbox adapter execution targets", () => {
     await expect(
       ensureAdapterExecutionTargetCommandResolvable("agent-cli", target, "/local/workspace", {}),
     ).rejects.toThrow(
-      'Command "agent-cli" is not installed or not on PATH in the sandbox environment. probe stderr: Kubernetes exec failed during setup with HTTP 403. Authorization: Bearer ***REDACTED*** runner metadata: provider=kubernetes, backend=sandbox-cr, execFailure=setup_or_transport, statusCode=403',
+      'Command "agent-cli" is not installed or not on PATH in the sandbox environment. probe stderr: Kubernetes exec failed during setup with HTTP 403. Authorization: Bearer ***REDACTED*** runner metadata: provider=kubernetes Authorization: Bearer ***REDACTED***, backend=sandbox-cr, execFailure=setup_or_transport, statusCode=403',
     );
   });
 

--- a/packages/adapter-utils/src/execution-target-sandbox.test.ts
+++ b/packages/adapter-utils/src/execution-target-sandbox.test.ts
@@ -1896,6 +1896,64 @@ describe("sandbox adapter execution targets", () => {
     }));
   });
 
+  it("surfaces sanitized non-timeout runner diagnostics and allowlisted metadata", async () => {
+    const runner = {
+      execute: vi.fn().mockResolvedValue({
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        stdout: "",
+        stderr: 'Kubernetes exec failed during setup with HTTP 403. Authorization: Bearer secret-value',
+        pid: null,
+        startedAt: new Date().toISOString(),
+        metadata: {
+          provider: "kubernetes",
+          backend: "sandbox-cr",
+          execFailure: "setup_or_transport",
+          statusCode: 403,
+          namespace: "private-namespace",
+          authorization: "secret-value",
+        },
+      }),
+    };
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      remoteCwd: "/workspace",
+      runner,
+    };
+
+    await expect(
+      ensureAdapterExecutionTargetCommandResolvable("agent-cli", target, "/local/workspace", {}),
+    ).rejects.toThrow(
+      'Command "agent-cli" is not installed or not on PATH in the sandbox environment. probe stderr: Kubernetes exec failed during setup with HTTP 403. Authorization: Bearer ***REDACTED*** runner metadata: provider=kubernetes, backend=sandbox-cr, execFailure=setup_or_transport, statusCode=403',
+    );
+  });
+
+  it("keeps a genuine runner timeout mapped to the command timeout message", async () => {
+    const runner = {
+      execute: vi.fn().mockResolvedValue({
+        exitCode: null,
+        signal: null,
+        timedOut: true,
+        stdout: "",
+        stderr: "execInPod timed out after 1000ms (pod=pod-1, container=agent, cmd0=sh).",
+        pid: null,
+        startedAt: new Date().toISOString(),
+      }),
+    };
+    const target: AdapterSandboxExecutionTarget = {
+      kind: "remote",
+      transport: "sandbox",
+      remoteCwd: "/workspace",
+      runner,
+    };
+
+    await expect(
+      ensureAdapterExecutionTargetCommandResolvable("agent-cli", target, "/local/workspace", {}),
+    ).rejects.toThrow('Timed out checking command "agent-cli" on sandbox target.');
+  });
+
   it("runs shell commands through the same runner", async () => {
     const runner = {
       execute: vi.fn(async () => ({

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -73,6 +73,7 @@ import {
 } from "./server-utils.js";
 import { sanitizeRemoteExecutionEnv } from "./remote-execution-env.js";
 import { preferredShellForSandbox, shellCommandArgs } from "./sandbox-shell.js";
+import { redactDiagnosticText } from "./command-redaction.js";
 import {
   runWithRuntimeParent,
   type RuntimeSpanRunner,
@@ -684,7 +685,7 @@ export async function ensureAdapterExecutionTargetCommandResolvable(
 async function probeSandboxCommandResolvable(
   command: string,
   target: AdapterSandboxExecutionTarget,
-): Promise<{ resolved: boolean; timedOut: boolean; stderr: string }> {
+): Promise<{ resolved: boolean; timedOut: boolean; stderr: string; metadata?: Record<string, unknown> }> {
   const runner = requireSandboxRunner(target);
   const probeScript = `command -v ${shellQuote(command)}`;
   const result = await runner.execute({
@@ -696,8 +697,22 @@ async function probeSandboxCommandResolvable(
   return {
     resolved: !result.timedOut && (result.exitCode ?? 1) === 0,
     timedOut: result.timedOut,
-    stderr: result.stderr.trim(),
+    stderr: redactDiagnosticText(result.stderr.trim()).slice(0, 800),
+    metadata: result.metadata,
   };
+}
+
+const SANDBOX_PROBE_METADATA_KEYS = ["provider", "backend", "execFailure", "statusCode"] as const;
+
+function formatSandboxProbeMetadata(metadata: Record<string, unknown> | undefined): string {
+  if (!metadata) return "";
+  const entries = SANDBOX_PROBE_METADATA_KEYS.flatMap((key) => {
+    const value = metadata[key];
+    return typeof value === "string" || typeof value === "number" || typeof value === "boolean"
+      ? [`${key}=${String(value).slice(0, 120)}`]
+      : [];
+  });
+  return entries.length > 0 ? ` runner metadata: ${entries.join(", ")}` : "";
 }
 
 async function ensureSandboxCommandResolvable(
@@ -756,9 +771,10 @@ async function ensureSandboxCommandResolvable(
   }
 
   const probeStderr = probe.stderr.length > 0 ? ` probe stderr: ${probe.stderr}` : "";
+  const probeMetadata = formatSandboxProbeMetadata(probe.metadata);
   const installDetail = installFailureDetail ? `; ${installFailureDetail}` : "";
   throw new Error(
-    `Command "${command}" is not installed or not on PATH in the sandbox environment${installDetail}.${probeStderr}`,
+    `Command "${command}" is not installed or not on PATH in the sandbox environment${installDetail}.${probeStderr}${probeMetadata}`,
   );
 }
 

--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -709,7 +709,7 @@ function formatSandboxProbeMetadata(metadata: Record<string, unknown> | undefine
   const entries = SANDBOX_PROBE_METADATA_KEYS.flatMap((key) => {
     const value = metadata[key];
     return typeof value === "string" || typeof value === "number" || typeof value === "boolean"
-      ? [`${key}=${String(value).slice(0, 120)}`]
+      ? [`${key}=${redactDiagnosticText(String(value)).slice(0, 120)}`]
       : [];
   });
   return entries.length > 0 ? ` runner metadata: ${entries.join(", ")}` : "";

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -50,6 +50,7 @@ export interface RunProcessResult {
   // The sandbox runner sets them, so the exec span records a true wall time.
   finishedAt?: string | null;
   durationMs?: number | null;
+  metadata?: Record<string, unknown>;
   // The typed error code of a transport-level failure, or absent when the
   // process result carries no such code. It follows the same additive-optional
   // convention as the timing fields: a producer that names no code leaves it

--- a/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/plugin.ts
@@ -36,7 +36,12 @@ import {
   sandboxCrOrchestrator,
   SandboxCrTimeoutError,
 } from "./sandbox-cr-orchestrator.js";
-import { execInPod, execInPodStreaming, wrapCommandWithEnv } from "./pod-exec.js";
+import {
+  ExecInPodTimeoutError,
+  execInPod,
+  execInPodStreaming,
+  wrapCommandWithEnv,
+} from "./pod-exec.js";
 import { performSyncIn, performSyncOut, type PodStreamExec } from "./file-sync.js";
 import { checkLeaseResumable, destroyLeaseResources } from "./lease-lifecycle.js";
 import {
@@ -110,6 +115,45 @@ function getOrCreateUploadInterceptor(leaseId: string): FastUploadInterceptor {
 // On worker restart this resets, which is fine: the first exec on each
 // lease then re-confirms readiness from scratch.
 const readySandboxesByLease = new Set<string>();
+
+function getKubernetesExecStatusCode(error: unknown): number | null {
+  if (!error || typeof error !== "object") return null;
+  const record = error as { statusCode?: unknown; response?: { statusCode?: unknown } };
+  const statusCode = record.statusCode ?? record.response?.statusCode;
+  return typeof statusCode === "number" && Number.isInteger(statusCode) && statusCode >= 100 && statusCode <= 599
+    ? statusCode
+    : null;
+}
+
+export function mapKubernetesExecError(
+  error: unknown,
+  metadata: Record<string, unknown> = {},
+): PluginEnvironmentExecuteResult {
+  if (error instanceof ExecInPodTimeoutError) {
+    return {
+      exitCode: null,
+      timedOut: true,
+      stdout: "",
+      stderr: error.message,
+      metadata: { ...metadata, execFailure: "timeout" },
+    };
+  }
+
+  const statusCode = getKubernetesExecStatusCode(error);
+  return {
+    exitCode: 1,
+    timedOut: false,
+    stdout: "",
+    stderr: statusCode === null
+      ? "Kubernetes exec failed before command completion."
+      : `Kubernetes exec failed during setup with HTTP ${statusCode}.`,
+    metadata: {
+      ...metadata,
+      execFailure: "setup_or_transport",
+      ...(statusCode === null ? {} : { statusCode }),
+    },
+  };
+}
 
 // How long onEnvironmentResumeLease waits for an existing Sandbox pod to
 // report Ready before declaring the lease non-resumable. Deliberately short:
@@ -832,20 +876,11 @@ const plugin = definePlugin({
               flushTimeoutMs,
             );
           } catch (err) {
-            return {
-              exitCode: null,
-              timedOut: true,
-              stdout: "",
-              stderr: `fast-upload flush failed: ${err instanceof Error ? err.message : String(err)}`,
-              metadata: {
-                provider: "kubernetes",
-                backend: "sandbox-cr",
-                namespace,
-                sandboxName: lease.providerLeaseId,
-                podName,
-                fastUpload: "flush",
-              },
-            };
+            return mapKubernetesExecError(err, {
+              provider: "kubernetes",
+              backend: "sandbox-cr",
+              fastUpload: "flush",
+            });
           }
           return {
             exitCode: flushResult.exitCode,
@@ -900,21 +935,10 @@ const plugin = definePlugin({
           remainingTimeoutMs,
         );
       } catch (err) {
-        // Watchdog-fired or WebSocket-setup error. Surface as a timeout so
-        // the caller can retry instead of hanging forever.
-        return {
-          exitCode: null,
-          timedOut: true,
-          stdout: "",
-          stderr: appendNetworkEgressDenyHint(err instanceof Error ? err.message : String(err), scopedNetworkEgress),
-          metadata: {
-            provider: "kubernetes",
-            backend: "sandbox-cr",
-            namespace,
-            sandboxName: lease.providerLeaseId,
-            podName,
-          },
-        };
+        return mapKubernetesExecError(err, {
+          provider: "kubernetes",
+          backend: "sandbox-cr",
+        });
       }
 
       return {

--- a/packages/plugins/sandbox-providers/kubernetes/src/pod-exec.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/src/pod-exec.ts
@@ -28,6 +28,13 @@ import type { KubeConfig } from "@kubernetes/client-node";
 // importing it directly couples this file to that internal choice.
 type WebSocketLike = { close(): void };
 
+export class ExecInPodTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ExecInPodTimeoutError";
+  }
+}
+
 // Single-quote a string for safe interpolation into a sh -c script. Wraps in
 // '...' and escapes any embedded single quotes via '\'' (close, escape, reopen).
 export function shQuote(segment: string): string {
@@ -140,7 +147,7 @@ export async function execInPod(
           if (resolved) return;
           resolved = true;
           try { ws?.close(); } catch { /* ignore */ }
-          reject(new Error(
+          reject(new ExecInPodTimeoutError(
             `execInPod timed out after ${timeoutMs}ms (pod=${podName}, container=${containerName}, cmd0=${effectiveCommand[0] ?? ""}). The WebSocket likely dropped before the command produced a status frame.`,
           ));
         }, timeoutMs);

--- a/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin.test.ts
+++ b/packages/plugins/sandbox-providers/kubernetes/test/unit/plugin.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import plugin from "../../src/plugin.js";
+import { ExecInPodTimeoutError } from "../../src/pod-exec.js";
+import plugin, { mapKubernetesExecError } from "../../src/plugin.js";
 
 describe("plugin", () => {
   it("exports the kubernetes driver", () => {
@@ -71,6 +72,41 @@ describe("plugin", () => {
   it("onHealth returns ok", async () => {
     const result = await plugin.definition.onHealth!();
     expect(result.status).toBe("ok");
+  });
+
+  it("maps an exec setup exception to a failed non-timeout result without exposing its message", () => {
+    const result = mapKubernetesExecError(
+      new Error("websocket upgrade failed: Authorization: Bearer secret-value"),
+      { provider: "kubernetes", backend: "sandbox-cr" },
+    );
+
+    expect(result).toEqual({
+      exitCode: 1,
+      timedOut: false,
+      stdout: "",
+      stderr: "Kubernetes exec failed before command completion.",
+      metadata: {
+        provider: "kubernetes",
+        backend: "sandbox-cr",
+        execFailure: "setup_or_transport",
+      },
+    });
+  });
+
+  it("keeps an exec watchdog timeout as a timeout result", () => {
+    const error = new ExecInPodTimeoutError("execInPod timed out after 1000ms (pod=pod-1, container=agent, cmd0=sh).");
+
+    expect(mapKubernetesExecError(error, { provider: "kubernetes", backend: "sandbox-cr" })).toEqual({
+      exitCode: null,
+      timedOut: true,
+      stdout: "",
+      stderr: error.message,
+      metadata: {
+        provider: "kubernetes",
+        backend: "sandbox-cr",
+        execFailure: "timeout",
+      },
+    });
   });
 
   it("validateConfig warns about FQDN limitation in standard mode", async () => {

--- a/server/src/__tests__/environment-execution-target.test.ts
+++ b/server/src/__tests__/environment-execution-target.test.ts
@@ -1227,6 +1227,32 @@ describe("resolveEnvironmentExecutionTarget", () => {
     expect(result).toMatchObject({ stdout: "final-out", stderr: "final-err" });
   });
 
+  it("preserves provider result metadata for the sandbox runner", async () => {
+    const { tracer } = createRecordingExecTracer();
+    const runner = await runnerWithExecute({
+      provider: "kubernetes",
+      tracer,
+      execute: vi.fn().mockResolvedValue({
+        exitCode: 1,
+        signal: null,
+        timedOut: false,
+        stdout: "",
+        stderr: "Kubernetes exec failed before command completion.",
+        metadata: { provider: "kubernetes", backend: "sandbox-cr", execFailure: "setup_or_transport" },
+      }),
+    });
+
+    const result = await (runner as {
+      execute(input: unknown): Promise<{ metadata?: Record<string, unknown> }>;
+    }).execute({ command: "sh" });
+
+    expect(result.metadata).toEqual({
+      provider: "kubernetes",
+      backend: "sandbox-cr",
+      execFailure: "setup_or_transport",
+    });
+  });
+
   it("creates exactly one sandbox.exec span for one streamed provider call", async () => {
     const { tracer, spans } = createRecordingExecTracer();
     const runner = await runnerWithExecute({

--- a/server/src/services/environment-execution-target.ts
+++ b/server/src/services/environment-execution-target.ts
@@ -571,6 +571,7 @@ export async function resolveEnvironmentExecutionTarget(input: {
                   startedAt,
                   finishedAt,
                   durationMs,
+                  metadata: result.metadata,
                 };
               } finally {
                 if (span) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents for work.
> - The Kubernetes sandbox provider runs commands in remote Sandbox pods.
> - The provider uses `execInPod()` for command probes.
> - Its generic exception path reports every error as a timeout.
> - This hides setup and transport failures behind a misleading command timeout.
> - This pull request keeps real watchdog timeouts and classifies other failures safely.
> - The benefit is actionable command-probe diagnostics without leaking exception text.

## Linked Issues or Issue Description

No public issue exists for this bug. Related PRs: Refs #10215 and Refs #10263.

**What happened?**

A Kubernetes `execInPod()` setup or transport exception is returned as `timedOut: true`. The command-resolvability layer then reports a command timeout even when the command did not run.

**Expected behavior**

A watchdog timeout remains a timeout. A setup or transport exception returns a non-timeout failure with sanitized diagnostics.

**Steps to reproduce**

1. Use the Kubernetes sandbox provider.
2. Cause `execInPod()` to reject before command completion.
3. Run a sandbox command resolvability probe.
4. Observe a timeout message instead of a setup or transport failure.

**Paperclip version or commit**

`master` commit `865b4854fb44d3689f1c0ff17e3e715d52aaea73`.

**Deployment mode**

Self-hosted server.

**Agent adapter(s) involved**

Not adapter-specific. The failure occurs in the Kubernetes sandbox provider result contract.

**Relevant logs or output**

No raw logs are included. The regression tests model a generic setup failure and assert that its original exception text is not exposed.

## What Changed

- Add a typed `ExecInPodTimeoutError` for the provider watchdog path.
- Map other Kubernetes exec setup and transport errors to a failed, non-timeout result with fixed sanitized diagnostics.
- Preserve allowlisted provider metadata through the sandbox runner.
- Render bounded, redacted probe diagnostics and allowlisted metadata in command-resolvability errors.
- Add provider, adapter-utils, and server regression tests.

## Verification

- `npx --yes pnpm@9.15.4 exec vitest run test/unit/plugin.test.ts` — 15 passed.
- `npx --yes pnpm@9.15.4 exec vitest run packages/adapter-utils/src/execution-target-sandbox.test.ts` — 127 passed.
- `npx --yes pnpm@9.15.4 exec vitest run server/src/__tests__/environment-execution-target.test.ts` — 39 passed.
- Kubernetes, adapter-utils, and server typecheck and build commands passed.
- The full Kubernetes package suite has unrelated macOS-only `/proc/self/fd/*` file-sync harness failures.

## Risks

Low risk. Genuine watchdog timeouts keep their existing timeout result. Other exception text is replaced with fixed diagnostics. The metadata display uses an explicit allowlist and bounds values.

## Model Used

OpenAI GPT-5.6 Terra (`openai/gpt-5.6-terra`). I used tool-assisted source inspection, test execution, and GitHub CLI operations.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no documentation change is required for this internal error classification)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
