### PR TITLE
fix(ui): drop the "Open invite" action from the invites section

### DIFF
--- a/ui/src/components/access/InvitesSection.test.tsx
+++ b/ui/src/components/access/InvitesSection.test.tsx
@@ -207,7 +207,9 @@ describe("InvitesSection", () => {
       "https://paperclip.local/invite/new-token",
     );
     expect(container.textContent).toContain("Copy link");
-    expect(container.textContent).toContain("Open invite");
+    // The inviter opening their own single-use link is never what they
+    // mean, so the section deliberately offers no "Open invite" action.
+    expect(container.textContent).not.toContain("Open invite");
     expect(pushToastMock).toHaveBeenCalledWith({
       title: "Invite created",
       body: "Invite ready below and copied to clipboard.",

--- a/ui/src/components/access/InvitesSection.tsx
+++ b/ui/src/components/access/InvitesSection.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Check, Copy, ExternalLink } from "lucide-react";
+import { Check, Copy } from "lucide-react";
 import { accessApi } from "@/api/access";
 import { ApiError } from "@/api/client";
 import { Button } from "@/components/ui/button";
@@ -270,12 +270,6 @@ export function InvitesSection() {
               >
                 <Copy className="h-4 w-4" />
                 Copy link
-              </Button>
-              <Button size="sm" variant="outline" asChild>
-                <a href={latestInviteUrl} target="_blank" rel="noreferrer">
-                  <ExternalLink className="h-4 w-4" />
-                  Open invite
-                </a>
               </Button>
             </div>
           </div>


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The Members page has an Invites tab where an admin mints single-use invite links for people
> - After a link is created, the section offers two actions: "Copy link" and "Open invite"
> - "Open invite" opens the inviter's own single-use link in a new tab, which is never what the inviter means — the link is for the invitee
> - This pull request removes the "Open invite" button and keeps "Copy link" as the only action
> - The benefit is that the section no longer invites a mistake, and the one remaining action matches the section's purpose

## Linked Issues or Issue Description

No existing issue. Description follows the enhancement template:

**What existing behavior does this improve?**
The latest-invite panel on the Members page Invites tab.

**Subsystem affected**
UI — `ui/src/components/access/InvitesSection.tsx`.

**Current behavior**
After an invite is created, the panel shows a "Copy link" button and an "Open invite" button. "Open invite" opens the invite URL in a new tab as the inviter.

**Proposed behavior**
The panel shows only "Copy link". The invite URL field itself stays visible and selectable.

**Reason and benefit**
Invite links are single-use and addressed to the invitee. The inviter opening their own link at best shows them their own landing page and at worst walks the link toward consumption. Removing the button removes the trap.

**Breaking changes**
None. No API or data change.

## What Changed

- Removed the "Open invite" anchor button from `InvitesSection`.
- Removed the now-unused `ExternalLink` icon import.
- The component test now asserts the action is absent.

## Verification

- `cd ui && npx vitest run src/components/access/InvitesSection.test.tsx` — 3 tests pass.
- `cd ui && npx tsc -p tsconfig.json --noEmit` — clean.
- Manual: create an invite on the Members page Invites tab; the latest-invite panel shows the URL field and "Copy link" only.

## Risks

Low risk. UI-only removal of one button; the invite URL remains fully visible and copyable.

## Model Used

Claude Fable 5 (`claude-fable-5`, Anthropic), extended thinking, agentic tool use via Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge