### PR TITLE
ci(runner): skip bootstrap registry telemetry

### DIFF
--- a/.github/workflows/pr-trusted.yml
+++ b/.github/workflows/pr-trusted.yml
@@ -282,6 +282,10 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        env:
+          NPM_CONFIG_AUDIT: "false"
+          NPM_CONFIG_FUND: "false"
+          NPM_CONFIG_UPDATE_NOTIFIER: "false"
         with:
           version: 9.15.4
           run_install: false
@@ -371,6 +375,10 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        env:
+          NPM_CONFIG_AUDIT: "false"
+          NPM_CONFIG_FUND: "false"
+          NPM_CONFIG_UPDATE_NOTIFIER: "false"
         with:
           version: 9.15.4
 
@@ -458,6 +466,10 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        env:
+          NPM_CONFIG_AUDIT: "false"
+          NPM_CONFIG_FUND: "false"
+          NPM_CONFIG_UPDATE_NOTIFIER: "false"
         with:
           version: 9.15.4
 
@@ -536,6 +548,10 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        env:
+          NPM_CONFIG_AUDIT: "false"
+          NPM_CONFIG_FUND: "false"
+          NPM_CONFIG_UPDATE_NOTIFIER: "false"
         with:
           version: 9.15.4
 
@@ -601,6 +617,10 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        env:
+          NPM_CONFIG_AUDIT: "false"
+          NPM_CONFIG_FUND: "false"
+          NPM_CONFIG_UPDATE_NOTIFIER: "false"
         with:
           version: 9.15.4
 
@@ -638,6 +658,10 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        env:
+          NPM_CONFIG_AUDIT: "false"
+          NPM_CONFIG_FUND: "false"
+          NPM_CONFIG_UPDATE_NOTIFIER: "false"
         with:
           version: 9.15.4
 
@@ -716,6 +740,10 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        env:
+          NPM_CONFIG_AUDIT: "false"
+          NPM_CONFIG_FUND: "false"
+          NPM_CONFIG_UPDATE_NOTIFIER: "false"
         with:
           version: 9.15.4
 

--- a/.github/workflows/runner-full-stack-e2e.yml
+++ b/.github/workflows/runner-full-stack-e2e.yml
@@ -157,6 +157,10 @@ jobs:
           persist-credentials: false
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        env:
+          NPM_CONFIG_AUDIT: "false"
+          NPM_CONFIG_FUND: "false"
+          NPM_CONFIG_UPDATE_NOTIFIER: "false"
         with:
           version: 9.15.4
 
@@ -231,6 +235,10 @@ jobs:
           test "$(sha256sum pnpm-lock.yaml | cut -d ' ' -f 1)" = "$EXPECTED_LOCK_SHA256"
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        env:
+          NPM_CONFIG_AUDIT: "false"
+          NPM_CONFIG_FUND: "false"
+          NPM_CONFIG_UPDATE_NOTIFIER: "false"
         with:
           version: 9.15.4
 
@@ -487,6 +495,10 @@ jobs:
           test "$(sha256sum pnpm-lock.yaml | cut -d ' ' -f 1)" = "$EXPECTED_LOCK_SHA256"
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        env:
+          NPM_CONFIG_AUDIT: "false"
+          NPM_CONFIG_FUND: "false"
+          NPM_CONFIG_UPDATE_NOTIFIER: "false"
         with:
           version: 9.15.4
 
@@ -607,6 +619,10 @@ jobs:
 
       - if: needs.catalog.outputs.needs_remote_provider_pack == 'true'
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        env:
+          NPM_CONFIG_AUDIT: "false"
+          NPM_CONFIG_FUND: "false"
+          NPM_CONFIG_UPDATE_NOTIFIER: "false"
         with:
           version: 9.15.4
 
@@ -754,6 +770,10 @@ jobs:
           test "$(sha256sum pnpm-lock.yaml | cut -d ' ' -f 1)" = "$EXPECTED_LOCK_SHA256"
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        env:
+          NPM_CONFIG_AUDIT: "false"
+          NPM_CONFIG_FUND: "false"
+          NPM_CONFIG_UPDATE_NOTIFIER: "false"
         with:
           version: 9.15.4
 
@@ -910,6 +930,10 @@ jobs:
           persist-credentials: false
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        env:
+          NPM_CONFIG_AUDIT: "false"
+          NPM_CONFIG_FUND: "false"
+          NPM_CONFIG_UPDATE_NOTIFIER: "false"
         with:
           version: 9.15.4
 
@@ -1014,6 +1038,10 @@ jobs:
           persist-credentials: false
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        env:
+          NPM_CONFIG_AUDIT: "false"
+          NPM_CONFIG_FUND: "false"
+          NPM_CONFIG_UPDATE_NOTIFIER: "false"
         with:
           version: 9.15.4
 

--- a/tests/runner-e2e/workflow-security.test.ts
+++ b/tests/runner-e2e/workflow-security.test.ts
@@ -11,29 +11,37 @@ const buildRemoteProviderPackNeeds =
   /needs:\s*\[\s*authorize,\s*target_lock,\s*catalog,\s*daytona_image,\s*build_runner_artifacts,?\s*\]/u;
 
 describe("public repository paid workflow security", () => {
-  it("keeps pnpm bootstrap registry telemetry out of paid workflow setup", async () => {
-    const workflow = await readFile(
-      path.join(repositoryRoot, ".github/workflows/runner-full-stack-e2e.yml"),
-      "utf8",
-    );
-    const pnpmSetupSteps = workflow
-      .split(/\n(?= {6}- )/u)
-      .filter((step) => step.includes("uses: pnpm/action-setup@"));
-
-    expect(pnpmSetupSteps).toHaveLength(7);
-    for (const step of pnpmSetupSteps) {
-      expect(step).toContain('NPM_CONFIG_AUDIT: "false"');
-      expect(step).toContain('NPM_CONFIG_FUND: "false"');
-      expect(step).toContain('NPM_CONFIG_UPDATE_NOTIFIER: "false"');
-    }
-    for (const variable of [
-      "NPM_CONFIG_AUDIT",
-      "NPM_CONFIG_FUND",
-      "NPM_CONFIG_UPDATE_NOTIFIER",
+  it("keeps pnpm bootstrap registry telemetry out of trusted workflow setup", async () => {
+    for (const workflowName of [
+      "runner-full-stack-e2e.yml",
+      "pr-trusted.yml",
     ]) {
-      expect(workflow.match(new RegExp(`${variable}:`, "gu"))).toHaveLength(
-        pnpmSetupSteps.length,
+      const workflow = await readFile(
+        path.join(repositoryRoot, ".github/workflows", workflowName),
+        "utf8",
       );
+      const pnpmSetupSteps = workflow
+        .split(/\n(?= {6}- )/u)
+        .filter((step) => step.includes("uses: pnpm/action-setup@"));
+
+      expect(pnpmSetupSteps, workflowName).toHaveLength(7);
+      for (const step of pnpmSetupSteps) {
+        expect(step, workflowName).toContain('NPM_CONFIG_AUDIT: "false"');
+        expect(step, workflowName).toContain('NPM_CONFIG_FUND: "false"');
+        expect(step, workflowName).toContain(
+          'NPM_CONFIG_UPDATE_NOTIFIER: "false"',
+        );
+      }
+      for (const variable of [
+        "NPM_CONFIG_AUDIT",
+        "NPM_CONFIG_FUND",
+        "NPM_CONFIG_UPDATE_NOTIFIER",
+      ]) {
+        expect(
+          workflow.match(new RegExp(`${variable}:`, "gu")),
+          workflowName,
+        ).toHaveLength(pnpmSetupSteps.length);
+      }
     }
   });
 

--- a/tests/runner-e2e/workflow-security.test.ts
+++ b/tests/runner-e2e/workflow-security.test.ts
@@ -11,6 +11,32 @@ const buildRemoteProviderPackNeeds =
   /needs:\s*\[\s*authorize,\s*target_lock,\s*catalog,\s*daytona_image,\s*build_runner_artifacts,?\s*\]/u;
 
 describe("public repository paid workflow security", () => {
+  it("keeps pnpm bootstrap registry telemetry out of paid workflow setup", async () => {
+    const workflow = await readFile(
+      path.join(repositoryRoot, ".github/workflows/runner-full-stack-e2e.yml"),
+      "utf8",
+    );
+    const pnpmSetupSteps = workflow
+      .split(/\n(?= {6}- )/u)
+      .filter((step) => step.includes("uses: pnpm/action-setup@"));
+
+    expect(pnpmSetupSteps).toHaveLength(7);
+    for (const step of pnpmSetupSteps) {
+      expect(step).toContain('NPM_CONFIG_AUDIT: "false"');
+      expect(step).toContain('NPM_CONFIG_FUND: "false"');
+      expect(step).toContain('NPM_CONFIG_UPDATE_NOTIFIER: "false"');
+    }
+    for (const variable of [
+      "NPM_CONFIG_AUDIT",
+      "NPM_CONFIG_FUND",
+      "NPM_CONFIG_UPDATE_NOTIFIER",
+    ]) {
+      expect(workflow.match(new RegExp(`${variable}:`, "gu"))).toHaveLength(
+        pnpmSetupSteps.length,
+      );
+    }
+  });
+
   it("gates every provider-secret job with stable actor IDs", async () => {
     const workflows = await Promise.all(
       ["runner-full-stack-e2e.yml", "runner-live-evals.yml", "e2e.yml"].map(


### PR DESCRIPTION
## Thinking Path
Every trusted PR and paid-workflow job invokes the pinned pnpm setup action. Its internal npm install is currently waiting four to seven minutes on npm audit telemetry before any Paperclip or provider code runs. Audit, funding, and update notifications are not integrity controls for this action; its committed lockfile still verifies installed package bytes.

## What Changed
- disable npm audit, funding, and update-notifier telemetry narrowly on all seven pinned setup steps in each of the trusted PR and full-stack workflows
- add a workflow security contract proving every setup invocation remains covered and the overrides do not leak elsewhere

## Verification
- focused workflow security tests: 6/6 passed
- Prettier and git diff checks passed
- observed unhealthy setup: 4-7+ minutes; historical healthy setup: about four seconds

## Risks
This skips npm vulnerability-report telemetry for the setup action bootstrap only. Repository dependency checks, lockfile integrity, provider-secret authorization, and target-lock verification remain unchanged.

## Model Used
Codex (GPT-5)