### PR TITLE
fix(server): keep the process alive when the postgres driver writes to a closed socket

### DIFF
--- a/doc/observability.md
+++ b/doc/observability.md
@@ -382,12 +382,16 @@ integration list of `@sentry/node@10.71.0` and `@sentry/browser@10.71.0`.
 
 **Server events the default integrations add**
 
-- `OnUncaughtException` — each uncaught exception on the main thread, at
-  level `fatal`. The process still exits.
 - `OnUnhandledRejection` — each unhandled promise rejection. The mode is
   `strict`, so the process exits after the capture.
 - `ChildProcess` — one event for each worker-thread `error`.
 - `LinkedErrors` — the `error.cause` chain of each captured error.
+
+An uncaught exception on the main thread is a server event too, but it does
+not come from a default Sentry integration. See "PostgreSQL Null-Socket
+Write Guard" below: that guard, not `OnUncaughtException`, owns the
+process's `uncaughtException` decision, and it reports the exception to
+Sentry itself before the process exits.
 
 **Server context the kept integrations attach**
 
@@ -409,6 +413,9 @@ integration list of `@sentry/node@10.71.0` and `@sentry/browser@10.71.0`.
 - `ContextLines` — 7 local source lines around each stack frame.
 - The outbound breadcrumb of `Http` — outbound request URLs and query
   strings.
+- `OnUncaughtException` — removed so it never registers its own
+  `uncaughtException` listener. See "PostgreSQL Null-Socket Write Guard"
+  below for why one listener, not two, must own that event.
 
 **Browser events this feature adds**
 
@@ -449,6 +456,64 @@ Two controls belong to the operator. This feature ships neither one.
    events from the operator's network, not from the server's network, so
    an internal-only host name fails silently for the browser even when it
    works for the server.
+
+## PostgreSQL Null-Socket Write Guard
+
+The `postgres` driver, at the version this repository pins
+(`postgres@3.4.9`), has a known defect. When a database backend closes a
+connection that a transaction still holds, a later query on that same
+connection can still start. The driver defers that query's wire write to a
+timer callback. By the time the callback runs, the driver has already set
+its socket reference to `null`, and the write throws a `TypeError`. No
+application code sits between that timer callback and the process, so
+Node ends the process by default.
+
+The server adds one process-level guard against this exact fault. The
+guard does not patch the driver and does not change the driver version.
+It adds one `uncaughtException` listener, early in server startup, before
+every other startup step. For the one known, matching `TypeError`, the
+listener logs one structured line with a fixed marker
+(`postgres_null_socket_write_guard_neutralized`) and the error name, then
+lets the process keep running. For every other uncaught exception, the
+listener keeps today's default behavior: it logs the error, reports it to
+Sentry when Sentry is enabled (see "Sentry Error Monitoring" above), waits
+for that report to flush, then ends the process with exit code 1.
+
+### `POSTGRES_NULL_SOCKET_GUARD_ENABLED`
+
+This environment variable is the guard's one operator control.
+
+- **Default:** the guard is on. An unset variable, or an empty string,
+  means enabled.
+- **Accepted values:** `true` or `1` keep the guard on. `false` or `0`
+  turn it off. The comparison ignores letter case and leading or trailing
+  spaces.
+- **An unrecognized value stops the server at startup.** A value other
+  than the six listed above (for example `yes` or `disabled`) throws an
+  error that names the variable and the value the operator set, instead
+  of silently guessing what the operator meant.
+- **Operational effect of turning the guard off:** the server registers
+  no `uncaughtException` listener of its own for this fault, so Node's
+  default behavior returns for it: the known, otherwise-neutralized
+  `TypeError` ends the server process the same way it did before this
+  guard existed. Turn the guard off only to compare behavior against the
+  unguarded process, or once the operator has upgraded past the
+  underlying driver defect.
+
+### Sentry interaction
+
+An operator who also enables server-side Sentry error monitoring gets no
+second, independent `uncaughtException` listener from Sentry. `sentry.ts`
+removes Sentry's default `OnUncaughtException` integration for exactly
+this reason: Node calls every listener registered for an event, not only
+the first one, so a second listener would still end the process on the
+known, neutralized fault, regardless of which listener runs first. This
+guard is the sole owner of the process's `uncaughtException` decision. It
+reports every exception it does not neutralize to Sentry itself, through
+the same `captureException` and `shutdownSentry` calls a server startup
+failure uses (see "Sentry Error Monitoring" above). A deployment with no
+Sentry DSN set sees no change from this interaction: both calls are
+no-ops.
 
 ## Sandbox Startup Trace Spans
 

--- a/doc/observability.md
+++ b/doc/observability.md
@@ -387,11 +387,13 @@ integration list of `@sentry/node@10.71.0` and `@sentry/browser@10.71.0`.
 - `ChildProcess` — one event for each worker-thread `error`.
 - `LinkedErrors` — the `error.cause` chain of each captured error.
 
-An uncaught exception on the main thread is a server event too, but it does
-not come from a default Sentry integration. See "PostgreSQL Null-Socket
-Write Guard" below: that guard, not `OnUncaughtException`, owns the
-process's `uncaughtException` decision, and it reports the exception to
-Sentry itself before the process exits.
+An uncaught exception on the main thread is a server event too. While the
+PostgreSQL null-socket write guard is on, it does not come from a default
+Sentry integration — see "PostgreSQL Null-Socket Write Guard" below: that
+guard, not `OnUncaughtException`, owns the process's `uncaughtException`
+decision, and it reports the exception to Sentry itself before the process
+exits. When an operator turns that guard off, `OnUncaughtException` stays
+active and reports the exception instead.
 
 **Server context the kept integrations attach**
 
@@ -413,9 +415,10 @@ Sentry itself before the process exits.
 - `ContextLines` — 7 local source lines around each stack frame.
 - The outbound breadcrumb of `Http` — outbound request URLs and query
   strings.
-- `OnUncaughtException` — removed so it never registers its own
-  `uncaughtException` listener. See "PostgreSQL Null-Socket Write Guard"
-  below for why one listener, not two, must own that event.
+- `OnUncaughtException` — removed while the PostgreSQL null-socket write
+  guard is on, so it never registers a second, independent
+  `uncaughtException` listener. Kept active when an operator turns that
+  guard off. See "PostgreSQL Null-Socket Write Guard" below.
 
 **Browser events this feature adds**
 
@@ -496,24 +499,34 @@ This environment variable is the guard's one operator control.
   no `uncaughtException` listener of its own for this fault, so Node's
   default behavior returns for it: the known, otherwise-neutralized
   `TypeError` ends the server process the same way it did before this
-  guard existed. Turn the guard off only to compare behavior against the
-  unguarded process, or once the operator has upgraded past the
-  underlying driver defect.
+  guard existed. When Sentry error monitoring is also on, Sentry's own
+  default `OnUncaughtException` integration stays active in this case (see
+  "Sentry interaction" below), so the exception still reaches Sentry
+  before the process ends. Turn the guard off only to compare behavior
+  against the unguarded process, or once the operator has upgraded past
+  the underlying driver defect.
 
 ### Sentry interaction
 
 An operator who also enables server-side Sentry error monitoring gets no
-second, independent `uncaughtException` listener from Sentry. `sentry.ts`
-removes Sentry's default `OnUncaughtException` integration for exactly
-this reason: Node calls every listener registered for an event, not only
-the first one, so a second listener would still end the process on the
-known, neutralized fault, regardless of which listener runs first. This
-guard is the sole owner of the process's `uncaughtException` decision. It
-reports every exception it does not neutralize to Sentry itself, through
-the same `captureException` and `shutdownSentry` calls a server startup
-failure uses (see "Sentry Error Monitoring" above). A deployment with no
-Sentry DSN set sees no change from this interaction: both calls are
-no-ops.
+second, independent `uncaughtException` listener from Sentry while this
+guard is on. `sentry.ts` removes Sentry's default `OnUncaughtException`
+integration for exactly this reason: Node calls every listener registered
+for an event, not only the first one, so a second listener would still end
+the process on the known, neutralized fault, regardless of which listener
+runs first. While the guard is on, it is the sole owner of the process's
+`uncaughtException` decision. It reports every exception it does not
+neutralize to Sentry itself, through the same `captureException` and
+`shutdownSentry` calls a server startup failure uses (see "Sentry Error
+Monitoring" above). A deployment with no Sentry DSN set sees no change
+from this interaction: both calls are no-ops.
+
+When an operator turns the guard off
+(`POSTGRES_NULL_SOCKET_GUARD_ENABLED=false`), no module registers an
+`uncaughtException` listener on the guard's behalf, so `sentry.ts` keeps
+Sentry's default `OnUncaughtException` integration active instead. An
+unrelated uncaught exception then reaches Sentry through that default
+integration rather than through the guard's own reporting call.
 
 ## Sandbox Startup Trace Spans
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
 
   cli:
     dependencies:
@@ -281,7 +281,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
 
   packages/adapters/hermes-gateway:
     dependencies:
@@ -297,7 +297,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
 
   packages/adapters/kimi-local:
     dependencies:
@@ -398,7 +398,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
 
   packages/google-sheets-mcp-server:
     dependencies:
@@ -420,7 +420,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
 
   packages/kv-demo-mcp-server:
     dependencies:
@@ -439,7 +439,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
 
   packages/mcp-server:
     dependencies:
@@ -461,7 +461,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
 
   packages/paperclip-eval-kernel:
     devDependencies:
@@ -537,7 +537,7 @@ importers:
         version: 6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.12)
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.12))
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
 
   packages/plugins/create-paperclip-plugin:
     dependencies:
@@ -584,7 +584,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
 
   packages/plugins/examples/plugin-file-browser-example:
     dependencies:
@@ -702,7 +702,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
 
   packages/plugins/plugin-llm-wiki:
     devDependencies:
@@ -741,7 +741,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
 
   packages/plugins/plugin-workspace-diff:
     dependencies:
@@ -775,7 +775,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
 
   packages/plugins/sdk:
     dependencies:
@@ -829,7 +829,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
 
   packages/teams-catalog:
     devDependencies:
@@ -895,7 +895,7 @@ importers:
         version: link:../packages/skills-catalog
       '@vercel/connect':
         specifier: 0.6.1
-        version: 0.6.1(better-auth@1.7.2(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9))(pg@8.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))))
+        version: 0.6.1(better-auth@1.7.2(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9))(pg@8.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)))
       acpx:
         specifier: 0.13.1
         version: 0.13.1(patch_hash=lzpwjtiaybzoijy455dfycwavu)
@@ -907,7 +907,7 @@ importers:
         version: 3.0.1(ajv@8.20.0)
       better-auth:
         specifier: 1.7.2
-        version: 1.7.2(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9))(pg@8.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)))
+        version: 1.7.2(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9))(pg@8.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12))
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0
@@ -1007,7 +1007,7 @@ importers:
         version: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
 
   ui:
     dependencies:
@@ -1182,7 +1182,7 @@ importers:
         version: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
 
 packages:
 
@@ -8239,7 +8239,6 @@ packages:
       '@vitest/ui': 4.1.11
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -12233,11 +12232,11 @@ snapshots:
     dependencies:
       execa: 5.1.1
 
-  '@vercel/connect@0.6.1(better-auth@1.7.2(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9))(pg@8.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))))':
+  '@vercel/connect@0.6.1(better-auth@1.7.2(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9))(pg@8.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)))':
     dependencies:
       '@vercel/oidc': 3.8.2
     optionalDependencies:
-      better-auth: 1.7.2(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9))(pg@8.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)))
+      better-auth: 1.7.2(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9))(pg@8.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12))
 
   '@vercel/oidc@3.8.2':
     dependencies:
@@ -12271,14 +12270,6 @@ snapshots:
       '@vitest/utils': 4.1.11
       chai: 6.2.2
       tinyrainbow: 3.1.1
-
-  '@vitest/mocker@4.1.11(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.12))':
-    dependencies:
-      '@vitest/spy': 4.1.11
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.12)
 
   '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))':
     dependencies:
@@ -12493,7 +12484,7 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
-  better-auth@1.7.2(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9))(pg@8.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))):
+  better-auth@1.7.2(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9))(pg@8.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)):
     dependencies:
       '@better-auth/core': 1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.29.5)(nanostores@1.5.3)
       '@better-auth/drizzle-adapter': 1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.29.5)(nanostores@1.5.3))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9))
@@ -12518,7 +12509,7 @@ snapshots:
       pg: 8.18.0
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -15831,36 +15822,7 @@ snapshots:
       jiti: 2.7.0
       tsx: 4.23.12
 
-  vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.12)):
-    dependencies:
-      '@vitest/expect': 4.1.11
-      '@vitest/mocker': 4.1.11(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.12))
-      '@vitest/pretty-format': 4.1.11
-      '@vitest/runner': 4.1.11
-      '@vitest/snapshot': 4.1.11
-      '@vitest/spy': 4.1.11
-      '@vitest/utils': 4.1.11
-      es-module-lexer: 2.3.2
-      expect-type: 1.4.0
-      magic-string: 0.30.21
-      obug: 2.1.4
-      pathe: 2.0.3
-      picomatch: 4.0.7
-      std-env: 4.2.0
-      tinybench: 2.9.0
-      tinyexec: 1.3.1
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.1
-      vite: 6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.12)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 24.13.3
-      jsdom: 30.0.1(@noble/hashes@2.4.0)
-    transitivePeerDependencies:
-      - msw
-
-  vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)):
+  vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12):
     dependencies:
       '@vitest/expect': 4.1.11
       '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
@@ -15887,7 +15849,18 @@ snapshots:
       '@types/node': 24.13.3
       jsdom: 30.0.1(@noble/hashes@2.4.0)
     transitivePeerDependencies:
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
       - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   vscode-jsonrpc@9.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -990,9 +990,6 @@ importers:
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
-      postgres:
-        specifier: ^3.4.9
-        version: 3.4.9
       supertest:
         specifier: ^7.0.0
         version: 7.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
 
   cli:
     dependencies:
@@ -281,7 +281,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
 
   packages/adapters/hermes-gateway:
     dependencies:
@@ -297,7 +297,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
 
   packages/adapters/kimi-local:
     dependencies:
@@ -398,7 +398,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
 
   packages/google-sheets-mcp-server:
     dependencies:
@@ -420,7 +420,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
 
   packages/kv-demo-mcp-server:
     dependencies:
@@ -439,7 +439,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
 
   packages/mcp-server:
     dependencies:
@@ -461,7 +461,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
 
   packages/paperclip-eval-kernel:
     devDependencies:
@@ -537,7 +537,7 @@ importers:
         version: 6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.12)
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.12))
 
   packages/plugins/create-paperclip-plugin:
     dependencies:
@@ -584,7 +584,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
 
   packages/plugins/examples/plugin-file-browser-example:
     dependencies:
@@ -702,7 +702,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
 
   packages/plugins/plugin-llm-wiki:
     devDependencies:
@@ -741,7 +741,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
 
   packages/plugins/plugin-workspace-diff:
     dependencies:
@@ -775,7 +775,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
 
   packages/plugins/sdk:
     dependencies:
@@ -829,7 +829,7 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
 
   packages/teams-catalog:
     devDependencies:
@@ -895,7 +895,7 @@ importers:
         version: link:../packages/skills-catalog
       '@vercel/connect':
         specifier: 0.6.1
-        version: 0.6.1(better-auth@1.7.2(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9))(pg@8.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)))
+        version: 0.6.1(better-auth@1.7.2(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9))(pg@8.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))))
       acpx:
         specifier: 0.13.1
         version: 0.13.1(patch_hash=lzpwjtiaybzoijy455dfycwavu)
@@ -907,7 +907,7 @@ importers:
         version: 3.0.1(ajv@8.20.0)
       better-auth:
         specifier: 1.7.2
-        version: 1.7.2(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9))(pg@8.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12))
+        version: 1.7.2(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9))(pg@8.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)))
       chokidar:
         specifier: ^5.0.0
         version: 5.0.0
@@ -990,6 +990,9 @@ importers:
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
+      postgres:
+        specifier: ^3.4.9
+        version: 3.4.9
       supertest:
         specifier: ^7.0.0
         version: 7.2.2
@@ -1004,7 +1007,7 @@ importers:
         version: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
 
   ui:
     dependencies:
@@ -1179,7 +1182,7 @@ importers:
         version: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
 
 packages:
 
@@ -8236,6 +8239,7 @@ packages:
       '@vitest/ui': 4.1.11
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -12229,11 +12233,11 @@ snapshots:
     dependencies:
       execa: 5.1.1
 
-  '@vercel/connect@0.6.1(better-auth@1.7.2(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9))(pg@8.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)))':
+  '@vercel/connect@0.6.1(better-auth@1.7.2(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9))(pg@8.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))))':
     dependencies:
       '@vercel/oidc': 3.8.2
     optionalDependencies:
-      better-auth: 1.7.2(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9))(pg@8.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12))
+      better-auth: 1.7.2(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9))(pg@8.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)))
 
   '@vercel/oidc@3.8.2':
     dependencies:
@@ -12267,6 +12271,14 @@ snapshots:
       '@vitest/utils': 4.1.11
       chai: 6.2.2
       tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.11(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.12))':
+    dependencies:
+      '@vitest/spy': 4.1.11
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.12)
 
   '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))':
     dependencies:
@@ -12481,7 +12493,7 @@ snapshots:
     dependencies:
       tweetnacl: 0.14.5
 
-  better-auth@1.7.2(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9))(pg@8.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)):
+  better-auth@1.7.2(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9))(pg@8.18.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))):
     dependencies:
       '@better-auth/core': 1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.29.5)(nanostores@1.5.3)
       '@better-auth/drizzle-adapter': 1.7.2(@better-auth/core@1.7.2(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.10)(kysely@0.29.5)(nanostores@1.5.3))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.5)(pg@8.18.0)(postgres@3.4.9))
@@ -12506,7 +12518,7 @@ snapshots:
       pg: 8.18.0
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12)
+      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -15819,7 +15831,36 @@ snapshots:
       jiti: 2.7.0
       tsx: 4.23.12
 
-  vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(tsx@4.23.12):
+  vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.12)):
+    dependencies:
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.12))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.7
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.1
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.23.12)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 24.13.3
+      jsdom: 30.0.1(@noble/hashes@2.4.0)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)):
     dependencies:
       '@vitest/expect': 4.1.11
       '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
@@ -15846,18 +15887,7 @@ snapshots:
       '@types/node': 24.13.3
       jsdom: 30.0.1(@noble/hashes@2.4.0)
     transitivePeerDependencies:
-      - '@vitejs/devtools'
-      - esbuild
-      - jiti
-      - less
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   vscode-jsonrpc@9.0.1: {}
 

--- a/server/package.json
+++ b/server/package.json
@@ -99,6 +99,7 @@
     "@types/supertest": "^7.2.1",
     "@types/ws": "^8.18.1",
     "cross-env": "^10.1.0",
+    "postgres": "^3.4.9",
     "supertest": "^7.0.0",
     "tsx": "^4.23.12",
     "typescript": "^7.0.2",

--- a/server/src/__tests__/postgres-null-socket-guard.test-fixture.ts
+++ b/server/src/__tests__/postgres-null-socket-guard.test-fixture.ts
@@ -1,0 +1,239 @@
+// Child-process fixture for the postgres driver null-socket write crash.
+//
+// A single process cannot prove its own survival — a test in the same
+// process as an unguarded crash would take the whole test run down with
+// it. This script runs in its own forked process. It reproduces the crash
+// sequence against a fake wire-protocol server, then reports each
+// checkpoint to the parent test over IPC. The parent asserts on those
+// messages and on this process's own exit code.
+//
+// This is not a real PostgreSQL server. It speaks only the small subset of
+// the wire protocol the driver needs for a startup handshake and a simple
+// query: no SSL negotiation, no authentication challenge, no extended
+// query protocol. `fetch_types: false` on the client skips the driver's
+// own startup catalog query, and every query used here carries no bind
+// parameters, so the driver always uses the simple query protocol.
+//
+// A note on "the client recovers": the driver's own write-scheduling state
+// (a buffered chunk and a scheduled-write flag, both private to one
+// connection's closure) is never reset on the throw path this guard
+// neutralizes — the two statements that would reset them sit after the
+// line that throws. A later query on that exact same connection can
+// therefore never send another byte; it silently times out instead of
+// failing fast. A pool with more than one connection is not stuck: the
+// pool's other connections are separate closures the crash never touches,
+// so a query on any of them succeeds normally. This fixture proves both
+// outcomes — see the "same connection" and "pool" scenarios below.
+import net from "node:net";
+import { sql } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { registerPostgresNullSocketGuard } from "../postgres-null-socket-guard.js";
+
+const scenario = process.argv[2];
+
+function send(message: Record<string, unknown>): void {
+  process.send?.(message);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function beMessage(type: string, payload: Buffer): Buffer {
+  const header = Buffer.alloc(5);
+  header.write(type, 0, "ascii");
+  header.writeUInt32BE(payload.length + 4, 1);
+  return Buffer.concat([header, payload]);
+}
+
+function authenticationOkMessage(): Buffer {
+  return beMessage("R", Buffer.alloc(4));
+}
+
+function readyForQueryMessage(status: "I" | "T"): Buffer {
+  return beMessage("Z", Buffer.from(status, "ascii"));
+}
+
+function commandCompleteMessage(tag: string): Buffer {
+  return beMessage("C", Buffer.from(`${tag}\0`, "ascii"));
+}
+
+/**
+ * Speaks just enough of the wire protocol for one connection: an untyped
+ * startup packet, then a stream of typed messages. The only typed message
+ * this test ever sends is a simple-protocol query ('Q'). A `begin` query
+ * gets a `BEGIN` response, followed at once by the server closing the
+ * socket — standing in for a database backend that drops a connection
+ * while a transaction still holds it. Every other query gets a generic
+ * success response and the socket stays open.
+ */
+function attachFakeBackend(socket: net.Socket): void {
+  let buffer = Buffer.alloc(0);
+  let startupDone = false;
+
+  socket.on("data", (chunk: Buffer) => {
+    buffer = Buffer.concat([buffer, chunk]);
+
+    for (;;) {
+      if (!startupDone) {
+        if (buffer.length < 4) return;
+        const length = buffer.readUInt32BE(0);
+        if (buffer.length < length) return;
+        buffer = buffer.subarray(length);
+        startupDone = true;
+        socket.write(authenticationOkMessage());
+        socket.write(readyForQueryMessage("I"));
+        continue;
+      }
+
+      if (buffer.length < 5) return;
+      const type = String.fromCharCode(buffer[0] ?? 0);
+      const length = buffer.readUInt32BE(1);
+      const total = 1 + length;
+      if (buffer.length < total) return;
+      const payload = buffer.subarray(5, total);
+      buffer = buffer.subarray(total);
+
+      if (type === "Q") {
+        const text = payload
+          .toString("utf8", 0, Math.max(payload.length - 1, 0))
+          .trim()
+          .toLowerCase();
+        if (text.startsWith("begin")) {
+          socket.write(commandCompleteMessage("BEGIN"));
+          socket.write(readyForQueryMessage("T"));
+          socket.end();
+        } else {
+          socket.write(commandCompleteMessage("SELECT 0"));
+          socket.write(readyForQueryMessage("I"));
+        }
+      }
+    }
+  });
+}
+
+async function startFakeServer(): Promise<{ port: number; close: () => Promise<void> }> {
+  const server = net.createServer((socket) => attachFakeBackend(socket));
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("the fake wire server did not bind a TCP port");
+  }
+  return {
+    port: address.port,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+async function runDriverCrashScenario(withGuard: boolean, poolMax: number): Promise<void> {
+  if (withGuard) registerPostgresNullSocketGuard();
+
+  const { port, close } = await startFakeServer();
+
+  let resolveClosed = () => {};
+  const closedPromise = new Promise<void>((resolve) => {
+    resolveClosed = resolve;
+  });
+
+  const client = postgres({
+    host: "127.0.0.1",
+    port,
+    user: "test",
+    password: "test",
+    database: "test",
+    max: poolMax,
+    fetch_types: false,
+    idle_timeout: null,
+    max_lifetime: null,
+    keep_alive: false,
+    connect_timeout: 3,
+    // Fires once the driver has fully processed the closed connection —
+    // after the transaction's own rejection, per the ordering documented
+    // in the module this fixture exercises. Gates the next query so the
+    // crash reproduces deterministically instead of racing a real close.
+    onclose: () => resolveClosed(),
+  });
+
+  const db = drizzle(client);
+
+  const transactionPromise = db.transaction(async (tx) => {
+    await closedPromise;
+    // Triggers the defect: the driver defers this write to a timer
+    // callback, which throws once it runs because the socket is already
+    // null. That promise never settles, so it is deliberately not awaited.
+    void tx.execute(sql`select 1`).catch(() => {});
+    // Keeps this transaction scope from following up with a commit
+    // attempt on the same dead connection, which would throw a second
+    // time and add noise this test does not need.
+    return await new Promise<void>(() => {});
+  });
+
+  transactionPromise.then(
+    () => send({ type: "transaction-resolved-unexpectedly" }),
+    (error: unknown) => {
+      send({
+        type: "transaction-rejected",
+        message: error instanceof Error ? error.message : String(error),
+      });
+    },
+  );
+
+  // Gives the deferred write time to fire — and, with the guard registered,
+  // time to be neutralized — before this process checks whether it is
+  // still the one running.
+  await delay(300);
+  send({ type: "still-alive" });
+
+  try {
+    const recovery = await db.execute(sql`select 1`);
+    send({ type: "recovery-ok", rowCount: Array.isArray(recovery) ? recovery.length : null });
+  } catch (error) {
+    // See the module comment above `runDriverCrashScenario`: with a
+    // single-connection pool, the crashed connection's own write-scheduling
+    // state is never reset on the throw path, so it can never send another
+    // byte. This is expected and reported, not swallowed.
+    send({
+      type: "recovery-failed",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  await client.end({ timeout: 1 });
+  await close();
+  send({ type: "survived" });
+  process.exit(0);
+}
+
+async function runUnrelatedCrashScenario(): Promise<void> {
+  registerPostgresNullSocketGuard();
+  setImmediate(() => {
+    throw new TypeError("an unrelated failure the guard must not swallow");
+  });
+  // If the guard wrongly neutralized this unrelated error, this process
+  // would still be alive to send this message. Give the throw time to
+  // reach the guard and end the process first.
+  await delay(500);
+  send({ type: "unexpected-survival" });
+}
+
+async function main(): Promise<void> {
+  switch (scenario) {
+    case "guarded-crash-same-connection":
+      await runDriverCrashScenario(true, 1);
+      return;
+    case "guarded-crash-pool":
+      await runDriverCrashScenario(true, 2);
+      return;
+    case "unguarded-crash":
+      await runDriverCrashScenario(false, 1);
+      return;
+    case "unrelated-crash":
+      await runUnrelatedCrashScenario();
+      return;
+    default:
+      throw new Error(`Unknown fixture scenario: ${scenario}`);
+  }
+}
+
+void main();

--- a/server/src/__tests__/postgres-null-socket-guard.test.ts
+++ b/server/src/__tests__/postgres-null-socket-guard.test.ts
@@ -1,0 +1,266 @@
+import { fork } from "node:child_process";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockLoggerError = vi.hoisted(() => vi.fn());
+const mockLoggerFatal = vi.hoisted(() => vi.fn());
+
+vi.mock("../middleware/logger.js", () => ({
+  logger: {
+    error: mockLoggerError,
+    fatal: mockLoggerFatal,
+  },
+}));
+
+const {
+  handlePostgresNullSocketGuardException,
+  isGuardEnabled,
+  isPostgresNullSocketWriteCrash,
+  registerPostgresNullSocketGuard,
+} = await import("../postgres-null-socket-guard.js");
+
+const FIXTURE_PATH = fileURLToPath(new URL("./postgres-null-socket-guard.test-fixture.ts", import.meta.url));
+
+interface ChildRunResult {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  messages: Array<Record<string, unknown>>;
+}
+
+function runFixture(scenario: string): Promise<ChildRunResult> {
+  return new Promise((resolve, reject) => {
+    const child = fork(FIXTURE_PATH, [scenario], {
+      // `tsx` is a devDependency of the server package only, so the child's
+      // module resolution for `--import tsx` needs a cwd under server/ to
+      // find it — the repo root has no top-level `tsx` package.
+      cwd: dirname(dirname(dirname(FIXTURE_PATH))),
+      execArgv: ["--import", "tsx"],
+      stdio: ["ignore", "pipe", "pipe", "ipc"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    const messages: Array<Record<string, unknown>> = [];
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("message", (message) => {
+      messages.push(message as Record<string, unknown>);
+    });
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      resolve({ code, signal, stdout, stderr, messages });
+    });
+  });
+}
+
+function messageTypes(result: ChildRunResult): string[] {
+  return result.messages.map((message) => String(message.type));
+}
+
+/**
+ * Builds a `TypeError` whose stack carries a `nextWrite` frame in
+ * `postgres/src/connection.js`, matching the real crash signature. The path
+ * prefix before `postgres/src/connection.js` stands in for any install
+ * layout (a package-store path in this repository, a plain
+ * `node_modules/postgres` path elsewhere).
+ */
+function makeDriverCrashError(message: string): Error {
+  const error = new TypeError(message);
+  error.stack =
+    `TypeError: ${message}\n` +
+    "    at Immediate.nextWrite (/app/node_modules/.pnpm/postgres@3.4.9/node_modules/postgres/src/connection.js:255:20)\n" +
+    "    at processImmediate (node:internal/timers:483:21)";
+  return error;
+}
+
+describe("isPostgresNullSocketWriteCrash", () => {
+  it("matches the older V8 message spelling with the driver frame", () => {
+    const error = makeDriverCrashError("Cannot read property 'write' of null");
+    expect(isPostgresNullSocketWriteCrash(error)).toBe(true);
+  });
+
+  it("matches the newer V8 message spelling with the driver frame", () => {
+    const error = makeDriverCrashError("Cannot read properties of null (reading 'write')");
+    expect(isPostgresNullSocketWriteCrash(error)).toBe(true);
+  });
+
+  it("does not match an unrelated TypeError with a different message", () => {
+    const error = makeDriverCrashError("Cannot read properties of null (reading 'foo')");
+    expect(isPostgresNullSocketWriteCrash(error)).toBe(false);
+  });
+
+  it("does not match the right message from an unrelated frame", () => {
+    const error = new TypeError("Cannot read properties of null (reading 'write')");
+    error.stack =
+      "TypeError: Cannot read properties of null (reading 'write')\n" +
+      "    at Object.<anonymous> (/app/server/src/services/unrelated.js:12:5)";
+    expect(isPostgresNullSocketWriteCrash(error)).toBe(false);
+  });
+
+  it("does not match a non-TypeError with the same message and frame", () => {
+    const error = new Error("Cannot read properties of null (reading 'write')");
+    error.stack =
+      "Error: Cannot read properties of null (reading 'write')\n" +
+      "    at Immediate.nextWrite (/app/node_modules/postgres/src/connection.js:255:20)";
+    expect(isPostgresNullSocketWriteCrash(error)).toBe(false);
+  });
+});
+
+describe("isGuardEnabled", () => {
+  it("defaults to enabled when the variable is unset", () => {
+    expect(isGuardEnabled({})).toBe(true);
+  });
+
+  it("stays enabled for \"true\" and \"1\"", () => {
+    expect(isGuardEnabled({ POSTGRES_NULL_SOCKET_GUARD_ENABLED: "true" })).toBe(true);
+    expect(isGuardEnabled({ POSTGRES_NULL_SOCKET_GUARD_ENABLED: "1" })).toBe(true);
+  });
+
+  it("disables for \"false\" and \"0\"", () => {
+    expect(isGuardEnabled({ POSTGRES_NULL_SOCKET_GUARD_ENABLED: "false" })).toBe(false);
+    expect(isGuardEnabled({ POSTGRES_NULL_SOCKET_GUARD_ENABLED: "0" })).toBe(false);
+  });
+
+  it("throws on an unrecognized value", () => {
+    expect(() => isGuardEnabled({ POSTGRES_NULL_SOCKET_GUARD_ENABLED: "maybe" })).toThrow(
+      /must be "true" or "false"/,
+    );
+  });
+});
+
+describe("registerPostgresNullSocketGuard", () => {
+  afterEach(() => {
+    process.off("uncaughtException", handlePostgresNullSocketGuardException);
+  });
+
+  it("registers a listener by default", () => {
+    const before = process.listenerCount("uncaughtException");
+    registerPostgresNullSocketGuard({});
+    expect(process.listenerCount("uncaughtException")).toBe(before + 1);
+  });
+
+  it("registers no listener when an operator disables it", () => {
+    const before = process.listenerCount("uncaughtException");
+    registerPostgresNullSocketGuard({ POSTGRES_NULL_SOCKET_GUARD_ENABLED: "false" });
+    expect(process.listenerCount("uncaughtException")).toBe(before);
+  });
+});
+
+describe("handlePostgresNullSocketGuardException", () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockLoggerError.mockReset();
+    mockLoggerFatal.mockReset();
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as unknown as never);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+  });
+
+  it("logs a stable marker and the error name, and does not exit, on a matching crash", () => {
+    const error = makeDriverCrashError("Cannot read properties of null (reading 'write')");
+
+    handlePostgresNullSocketGuardException(error);
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+    const [fields] = mockLoggerError.mock.calls[0] as [Record<string, unknown>];
+    expect(fields).toMatchObject({
+      marker: "postgres_null_socket_write_guard_neutralized",
+      errorName: "TypeError",
+    });
+  });
+
+  it("never logs the query text, the message, or the stack for a matching crash", () => {
+    const secret = "select * from accounts where token = 'hunter2-secret-token'";
+    const error = makeDriverCrashError(`Cannot read properties of null (reading 'write') — ${secret}`);
+    // The classifier only matches the exact V8 message, so force a match by
+    // constructing the error the classifier itself would accept, then
+    // verify no field of the log call carries anything beyond the marker
+    // and the fixed error name.
+    error.message = "Cannot read properties of null (reading 'write')";
+
+    handlePostgresNullSocketGuardException(error);
+
+    const [fields] = mockLoggerError.mock.calls[0] as [Record<string, unknown>];
+    expect(Object.keys(fields).sort()).toEqual(["errorName", "marker"]);
+    for (const value of Object.values(fields)) {
+      expect(String(value)).not.toContain(secret);
+    }
+  });
+
+  it("logs and exits non-zero for a non-matching error", () => {
+    const error = new RangeError("some unrelated fatal condition");
+
+    handlePostgresNullSocketGuardException(error);
+
+    expect(mockLoggerError).not.toHaveBeenCalled();
+    expect(mockLoggerFatal).toHaveBeenCalledTimes(1);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("exits non-zero for a non-Error thrown value", () => {
+    handlePostgresNullSocketGuardException("a thrown string");
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});
+
+describe("the driver crash sequence, reproduced against a fake wire server", () => {
+  it("without the guard: the process ends and never reaches recovery", async () => {
+    const result = await runFixture("unguarded-crash");
+
+    expect(messageTypes(result)).toContain("transaction-rejected");
+    expect(messageTypes(result)).not.toContain("still-alive");
+    expect(messageTypes(result)).not.toContain("survived");
+    expect(result.code).not.toBe(0);
+  }, 20_000);
+
+  // Finding, not a defect in this guard: the driver never resets the
+  // crashed connection's own write-scheduling state on the throw path this
+  // guard neutralizes (see the module comment in
+  // postgres-null-socket-guard.test-fixture.ts). A later query on that
+  // exact same connection can never send another byte and times out
+  // instead of failing fast. A single-connection pool (`max: 1`) has no
+  // other connection to fall back to, so this is the worst case.
+  it("with the guard: the transaction rejects, the process survives, but the same crashed connection does not recover", async () => {
+    const result = await runFixture("guarded-crash-same-connection");
+
+    expect(messageTypes(result)).toContain("transaction-rejected");
+    expect(messageTypes(result)).toContain("still-alive");
+    expect(messageTypes(result)).not.toContain("recovery-ok");
+    expect(messageTypes(result)).toContain("recovery-failed");
+    expect(messageTypes(result)).toContain("survived");
+    expect(result.code).toBe(0);
+    expect(result.stdout + result.stderr).toContain("postgres_null_socket_write_guard_neutralized");
+  }, 20_000);
+
+  // The realistic production shape: a pool with more than one connection.
+  // The crash never touches the pool's other connections — each is its own
+  // closure — so a later query routed to a different connection succeeds.
+  it("with the guard: a pool with another connection keeps serving queries", async () => {
+    const result = await runFixture("guarded-crash-pool");
+
+    expect(messageTypes(result)).toContain("transaction-rejected");
+    expect(messageTypes(result)).toContain("recovery-ok");
+    expect(messageTypes(result)).toContain("survived");
+    expect(result.code).toBe(0);
+  }, 20_000);
+
+  it("a non-matching uncaught exception still ends the process", async () => {
+    const result = await runFixture("unrelated-crash");
+
+    expect(messageTypes(result)).not.toContain("unexpected-survival");
+    expect(result.code).toBe(1);
+  }, 20_000);
+});

--- a/server/src/__tests__/postgres-null-socket-guard.test.ts
+++ b/server/src/__tests__/postgres-null-socket-guard.test.ts
@@ -152,6 +152,13 @@ describe("registerPostgresNullSocketGuard", () => {
     registerPostgresNullSocketGuard({ POSTGRES_NULL_SOCKET_GUARD_ENABLED: "false" });
     expect(process.listenerCount("uncaughtException")).toBe(before);
   });
+
+  it("adds one listener however many times it runs", () => {
+    const before = process.listenerCount("uncaughtException");
+    registerPostgresNullSocketGuard({});
+    registerPostgresNullSocketGuard({});
+    expect(process.listenerCount("uncaughtException")).toBe(before + 1);
+  });
 });
 
 describe("handlePostgresNullSocketGuardException", () => {
@@ -257,10 +264,16 @@ describe("the driver crash sequence, reproduced against a fake wire server", () 
     expect(result.code).toBe(0);
   }, 20_000);
 
-  it("a non-matching uncaught exception still ends the process", async () => {
+  it("a non-matching uncaught exception still ends the process and reports its cause", async () => {
     const result = await runFixture("unrelated-crash");
 
     expect(messageTypes(result)).not.toContain("unexpected-survival");
     expect(result.code).toBe(1);
+    // The logger writes the fatal record to standard output; Node's own
+    // default handler would have used standard error, but the guard
+    // replaces that handler for every uncaught exception, so this is the
+    // only place the message and the stack can appear.
+    expect(result.stdout).toContain("an unrelated failure the guard must not swallow");
+    expect(result.stdout).toContain("at Immediate");
   }, 20_000);
 });

--- a/server/src/__tests__/postgres-null-socket-guard.test.ts
+++ b/server/src/__tests__/postgres-null-socket-guard.test.ts
@@ -5,12 +5,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockLoggerError = vi.hoisted(() => vi.fn());
 const mockLoggerFatal = vi.hoisted(() => vi.fn());
+const mockCaptureException = vi.hoisted(() => vi.fn());
+const mockShutdownSentry = vi.hoisted(() => vi.fn(async () => {}));
 
 vi.mock("../middleware/logger.js", () => ({
   logger: {
     error: mockLoggerError,
     fatal: mockLoggerFatal,
   },
+}));
+
+vi.mock("../sentry.js", () => ({
+  captureException: mockCaptureException,
+  shutdownSentry: mockShutdownSentry,
 }));
 
 const {
@@ -167,6 +174,9 @@ describe("handlePostgresNullSocketGuardException", () => {
   beforeEach(() => {
     mockLoggerError.mockReset();
     mockLoggerFatal.mockReset();
+    mockCaptureException.mockReset();
+    mockShutdownSentry.mockReset();
+    mockShutdownSentry.mockImplementation(async () => {});
     exitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as unknown as never);
   });
 
@@ -174,10 +184,10 @@ describe("handlePostgresNullSocketGuardException", () => {
     exitSpy.mockRestore();
   });
 
-  it("logs a stable marker and the error name, and does not exit, on a matching crash", () => {
+  it("logs a stable marker and the error name, and does not exit, on a matching crash", async () => {
     const error = makeDriverCrashError("Cannot read properties of null (reading 'write')");
 
-    handlePostgresNullSocketGuardException(error);
+    await handlePostgresNullSocketGuardException(error);
 
     expect(exitSpy).not.toHaveBeenCalled();
     expect(mockLoggerError).toHaveBeenCalledTimes(1);
@@ -188,7 +198,7 @@ describe("handlePostgresNullSocketGuardException", () => {
     });
   });
 
-  it("never logs the query text, the message, or the stack for a matching crash", () => {
+  it("never logs the query text, the message, or the stack for a matching crash", async () => {
     const secret = "select * from accounts where token = 'hunter2-secret-token'";
     const error = makeDriverCrashError(`Cannot read properties of null (reading 'write') — ${secret}`);
     // The classifier only matches the exact V8 message, so force a match by
@@ -197,7 +207,7 @@ describe("handlePostgresNullSocketGuardException", () => {
     // and the fixed error name.
     error.message = "Cannot read properties of null (reading 'write')";
 
-    handlePostgresNullSocketGuardException(error);
+    await handlePostgresNullSocketGuardException(error);
 
     const [fields] = mockLoggerError.mock.calls[0] as [Record<string, unknown>];
     expect(Object.keys(fields).sort()).toEqual(["errorName", "marker"]);
@@ -206,19 +216,48 @@ describe("handlePostgresNullSocketGuardException", () => {
     }
   });
 
-  it("logs and exits non-zero for a non-matching error", () => {
+  it("never reports a matching crash to Sentry — the process survives on its own", async () => {
+    const error = makeDriverCrashError("Cannot read properties of null (reading 'write')");
+
+    await handlePostgresNullSocketGuardException(error);
+
+    expect(mockCaptureException).not.toHaveBeenCalled();
+    expect(mockShutdownSentry).not.toHaveBeenCalled();
+  });
+
+  it("logs, reports to Sentry, flushes, and exits non-zero for a non-matching error", async () => {
     const error = new RangeError("some unrelated fatal condition");
 
-    handlePostgresNullSocketGuardException(error);
+    await handlePostgresNullSocketGuardException(error);
 
     expect(mockLoggerError).not.toHaveBeenCalled();
     expect(mockLoggerFatal).toHaveBeenCalledTimes(1);
+    expect(mockCaptureException).toHaveBeenCalledWith(error);
+    expect(mockShutdownSentry).toHaveBeenCalledTimes(1);
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
-  it("exits non-zero for a non-Error thrown value", () => {
-    handlePostgresNullSocketGuardException("a thrown string");
+  it("waits for the Sentry client to flush before it exits", async () => {
+    const error = new RangeError("some unrelated fatal condition");
+    let shutdownResolved = false;
+    mockShutdownSentry.mockImplementation(async () => {
+      await Promise.resolve();
+      shutdownResolved = true;
+    });
+    exitSpy.mockImplementation((() => {
+      expect(shutdownResolved).toBe(true);
+      return undefined;
+    }) as unknown as never);
 
+    await handlePostgresNullSocketGuardException(error);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("exits non-zero for a non-Error thrown value", async () => {
+    await handlePostgresNullSocketGuardException("a thrown string");
+
+    expect(mockCaptureException).toHaveBeenCalledWith(expect.any(Error));
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 });

--- a/server/src/__tests__/sentry.test.ts
+++ b/server/src/__tests__/sentry.test.ts
@@ -23,9 +23,11 @@ import * as sentryModule from "../sentry.js";
 const DSN_ENV = "SENTRY_DSN";
 const FRONTEND_DSN_ENV = "SENTRY_DSN_FRONTEND";
 const BACKEND_DSN_ENV = "SENTRY_DSN_BACKEND";
+const GUARD_ENABLED_ENV = "POSTGRES_NULL_SOCKET_GUARD_ENABLED";
 const originalDsn = process.env[DSN_ENV];
 const originalFrontendDsn = process.env[FRONTEND_DSN_ENV];
 const originalBackendDsn = process.env[BACKEND_DSN_ENV];
+const originalGuardEnabled = process.env[GUARD_ENABLED_ENV];
 
 async function importFreshSentry() {
   vi.resetModules();
@@ -96,6 +98,7 @@ beforeEach(() => {
   delete process.env[DSN_ENV];
   delete process.env[FRONTEND_DSN_ENV];
   delete process.env[BACKEND_DSN_ENV];
+  delete process.env[GUARD_ENABLED_ENV];
 });
 
 afterEach(() => {
@@ -105,6 +108,8 @@ afterEach(() => {
   else process.env[FRONTEND_DSN_ENV] = originalFrontendDsn;
   if (originalBackendDsn === undefined) delete process.env[BACKEND_DSN_ENV];
   else process.env[BACKEND_DSN_ENV] = originalBackendDsn;
+  if (originalGuardEnabled === undefined) delete process.env[GUARD_ENABLED_ENV];
+  else process.env[GUARD_ENABLED_ENV] = originalGuardEnabled;
   vi.restoreAllMocks();
   vi.doUnmock("@sentry/node");
   vi.doUnmock("../peer-version-check.js");
@@ -422,6 +427,26 @@ describe("buildSentryInitOptions", () => {
     expect(names).not.toContain("OnUncaughtException");
   });
 
+  it("keeps OnUncaughtException in the resolved list when the guard does not own it", async () => {
+    const { buildSentryInitOptions } = await importFreshSentry();
+
+    const options = buildSentryInitOptions(
+      "https://public@o0.ingest.sentry.io/1",
+      {
+        httpIntegration: () => ({ name: "Http" }),
+        onUnhandledRejectionIntegration: () => ({ name: "OnUnhandledRejection" }),
+      },
+      false,
+    );
+    const resolved = options.integrations(DEFAULT_INTEGRATION_NAMES.map((name) => ({ name })));
+
+    // The postgres null-socket write guard registers no `uncaughtException`
+    // listener when an operator disables it, so Sentry's own default
+    // integration must stay active — otherwise an unrelated uncaught
+    // exception would reach no error reporter at all.
+    expect(resolved.map((i) => i.name)).toContain("OnUncaughtException");
+  });
+
   it("the resolved server integration list keeps OnUnhandledRejection, LinkedErrors, and RequestData", async () => {
     const { buildSentryInitOptions } = await importFreshSentry();
 
@@ -479,6 +504,40 @@ describe("with @sentry/node mocked", () => {
 
     await shutdownSentry();
     expect(mocks.close).toHaveBeenCalledWith(5_000);
+  });
+
+  it("removes the default OnUncaughtException integration when the postgres null-socket write guard is on", async () => {
+    process.env[DSN_ENV] = "https://public@o0.ingest.sentry.io/1";
+    const mocks = mockSentryPackage();
+
+    const { sentryReady } = await importFreshSentry();
+    await sentryReady;
+
+    const initOptions = mocks.init.mock.calls[0][0] as {
+      integrations: (defaults: Array<{ name: string }>) => Array<{ name: string }>;
+    };
+    const resolved = initOptions.integrations([{ name: "OnUncaughtException" }]);
+
+    expect(resolved.map((i) => i.name)).not.toContain("OnUncaughtException");
+  });
+
+  it("keeps the default OnUncaughtException integration when an operator disables the guard", async () => {
+    process.env[DSN_ENV] = "https://public@o0.ingest.sentry.io/1";
+    process.env[GUARD_ENABLED_ENV] = "false";
+    const mocks = mockSentryPackage();
+
+    const { sentryReady } = await importFreshSentry();
+    await sentryReady;
+
+    const initOptions = mocks.init.mock.calls[0][0] as {
+      integrations: (defaults: Array<{ name: string }>) => Array<{ name: string }>;
+    };
+    const resolved = initOptions.integrations([{ name: "OnUncaughtException" }]);
+
+    // The guard registers no `uncaughtException` listener when disabled, so
+    // Sentry's own default integration must stay active — otherwise an
+    // unrelated uncaught exception reaches no error reporter at all.
+    expect(resolved.map((i) => i.name)).toContain("OnUncaughtException");
   });
 });
 

--- a/server/src/__tests__/sentry.test.ts
+++ b/server/src/__tests__/sentry.test.ts
@@ -403,7 +403,7 @@ describe("buildSentryInitOptions", () => {
     expect(resolved.filter((i) => i.name === "OnUnhandledRejection")).toHaveLength(1);
   });
 
-  it("the resolved server integration list holds no Console integration and no ContextLines integration", async () => {
+  it("the resolved server integration list holds no Console, ContextLines, or OnUncaughtException integration", async () => {
     const { buildSentryInitOptions } = await importFreshSentry();
 
     const options = buildSentryInitOptions("https://public@o0.ingest.sentry.io/1", {
@@ -415,9 +415,14 @@ describe("buildSentryInitOptions", () => {
 
     expect(names).not.toContain("Console");
     expect(names).not.toContain("ContextLines");
+    // Removed so this default integration never registers its own
+    // `uncaughtException` listener — see the module comment in sentry.ts.
+    // `postgres-null-socket-guard.ts` is the sole owner of that decision,
+    // and it reports non-neutralized exceptions to Sentry itself.
+    expect(names).not.toContain("OnUncaughtException");
   });
 
-  it("the resolved server integration list keeps OnUncaughtException, OnUnhandledRejection, LinkedErrors, and RequestData", async () => {
+  it("the resolved server integration list keeps OnUnhandledRejection, LinkedErrors, and RequestData", async () => {
     const { buildSentryInitOptions } = await importFreshSentry();
 
     const options = buildSentryInitOptions("https://public@o0.ingest.sentry.io/1", {
@@ -427,11 +432,10 @@ describe("buildSentryInitOptions", () => {
     const resolved = options.integrations(DEFAULT_INTEGRATION_NAMES.map((name) => ({ name })));
     const names = resolved.map((i) => i.name);
 
-    // The full error-capture set the plan requires, not just the four named
+    // The full error-capture set the plan requires, not just the three named
     // in this test's title.
     expect(names).toEqual(
       expect.arrayContaining([
-        "OnUncaughtException",
         "OnUnhandledRejection",
         "ChildProcess",
         "LinkedErrors",
@@ -564,6 +568,23 @@ describe.skipIf(!sentryPackage)("captured event shape against the real @sentry/n
     };
     Sentry.init(options);
   }
+
+  /**
+   * Proves the fix for the finding that this feature could keep a
+   * Sentry-enabled deployment from surviving the known, neutralized
+   * postgres driver crash: `Sentry.init` must add no `uncaughtException`
+   * listener of its own. `postgres-null-socket-guard.ts` is the sole owner
+   * of that event; a second, independent listener from Sentry's default
+   * `OnUncaughtException` integration would still end the process on the
+   * known fault, no matter which listener Node calls first.
+   */
+  it("adds no uncaughtException listener", async () => {
+    const before = process.listenerCount("uncaughtException");
+
+    await initRealSentryForTest(() => {});
+
+    expect(process.listenerCount("uncaughtException")).toBe(before);
+  });
 
   it("a server event captured after a console.error call carries no console breadcrumb", async () => {
     const Sentry = sentryPackage!;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,6 +5,7 @@
 // HTTP server, so trace coverage does not depend on incidental timing.
 import { instrumentationReady, shutdownInstrumentation } from "./instrumentation.js";
 import { sentryReady, shutdownSentry, captureException } from "./sentry.js";
+import { registerPostgresNullSocketGuard } from "./postgres-null-socket-guard.js";
 import { existsSync, readFileSync, rmSync } from "node:fs";
 import { createServer } from "node:http";
 import { resolve } from "node:path";
@@ -155,6 +156,11 @@ export interface StartedServer {
 }
 
 export async function startServer(): Promise<StartedServer> {
+  // Registered before every other startup step, including Sentry, so this
+  // listener runs first on any later uncaught exception — see
+  // postgres-null-socket-guard.ts for why that order matters.
+  registerPostgresNullSocketGuard();
+
   warnIfUnsupportedNodeVersion(process.versions.node, (message) => logger.warn(message));
 
   // Tracing must be active (or have failed and logged) before the first DB

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -156,9 +156,10 @@ export interface StartedServer {
 }
 
 export async function startServer(): Promise<StartedServer> {
-  // Registered before every other startup step, including Sentry, so this
-  // listener runs first on any later uncaught exception — see
-  // postgres-null-socket-guard.ts for why that order matters.
+  // Registered before every other startup step, so it is the process's
+  // `uncaughtException` handler for the entire startup sequence, not just
+  // once the server is listening — see postgres-null-socket-guard.ts for
+  // how it owns that decision, Sentry reporting included.
   registerPostgresNullSocketGuard();
 
   warnIfUnsupportedNodeVersion(process.versions.node, (message) => logger.warn(message));

--- a/server/src/postgres-null-socket-guard-env.ts
+++ b/server/src/postgres-null-socket-guard-env.ts
@@ -1,0 +1,22 @@
+// The `POSTGRES_NULL_SOCKET_GUARD_ENABLED` env-var contract, split into its
+// own leaf module so both `postgres-null-socket-guard.ts` (to decide whether
+// to register its `uncaughtException` listener) and `sentry.ts` (to decide
+// whether Sentry's own `OnUncaughtException` integration must stay active)
+// can read the same value without importing each other.
+
+const GUARD_ENABLED_ENV_VAR = "POSTGRES_NULL_SOCKET_GUARD_ENABLED";
+
+/**
+ * Reads the runtime opt-out. An operator sets `false` or `0` to disable the
+ * guard; every other value, including an unset variable, keeps it enabled.
+ * Follows the same boolean convention as `envBoolean` in
+ * `packages/db/src/client.ts`: a value other than a recognized true/false
+ * spelling is a configuration mistake, so this throws instead of guessing.
+ */
+export function isGuardEnabled(env: NodeJS.ProcessEnv): boolean {
+  const value = env[GUARD_ENABLED_ENV_VAR]?.trim().toLowerCase();
+  if (value === undefined || value === "") return true;
+  if (value === "true" || value === "1") return true;
+  if (value === "false" || value === "0") return false;
+  throw new Error(`${GUARD_ENABLED_ENV_VAR} must be "true" or "false", got: ${env[GUARD_ENABLED_ENV_VAR]}`);
+}

--- a/server/src/postgres-null-socket-guard.ts
+++ b/server/src/postgres-null-socket-guard.ts
@@ -1,0 +1,105 @@
+// Process-level guard for a known defect in the `postgres` driver: when a
+// database backend closes a connection that a transaction still holds, the
+// driver's own reconnect bookkeeping still lets a later query on that same
+// connection object proceed. That query defers its wire write to a timer
+// callback. By the time the callback runs, the driver has already set its
+// socket reference to null, and the write throws a `TypeError`. No
+// application `try`/`catch` sits between that timer callback and the
+// process, so Node ends the process by default.
+//
+// This module does not patch the driver and does not change the driver
+// version. It adds one `uncaughtException` listener. Registering a listener
+// cancels Node's default crash-on-uncaught-exception behavior, so the
+// listener must end the process itself for every uncaught exception except
+// the one known, neutralized fault below — otherwise an unrelated bug would
+// leave the process running in a state nobody chose.
+//
+// This module reports no telemetry event and calls no external
+// error-reporting client. It logs one structured line, with a fixed marker
+// and the error name only — never a query, a query parameter, a connection
+// URL, a host name, or a database name.
+//
+// Interaction with Sentry: `./sentry.js` registers no `uncaughtException`
+// listener today. `@sentry/node` is an optional peer dependency this
+// repository does not install (`bootstrapSentry` fails its own version
+// check and returns before it calls `Sentry.init`), so Sentry never adds a
+// listener of its own. If an operator later installs `@sentry/node` and
+// sets a Sentry DSN, the default `OnUncaughtException` integration is not
+// among the integrations `sentry.ts` removes, so it would register its own
+// listener too. This module registers first (from the server entry point,
+// before `sentryReady`), so it runs first on every uncaught exception.
+
+import { logger } from "./middleware/logger.js";
+
+const GUARD_ENABLED_ENV_VAR = "POSTGRES_NULL_SOCKET_GUARD_ENABLED";
+const GUARD_MARKER = "postgres_null_socket_write_guard_neutralized";
+
+// Both V8 message spellings for a read of a property on `null`. The wording
+// changed between an older V8 (`Cannot read property 'write' of null`) and
+// a newer V8 (`Cannot read properties of null (reading 'write')`).
+const NULL_WRITE_MESSAGE_PATTERN =
+  /Cannot read propert(?:y 'write' of null|ies of null \(reading 'write'\))/;
+
+// Matches the frame, not an absolute path, so the check survives any
+// install-path prefix (a package-store path, a different path separator).
+const NEXT_WRITE_FRAME_PATTERN = /\bnextWrite\b.*postgres[\\/]src[\\/]connection\.js/;
+
+/**
+ * Matches the known driver defect: a `TypeError` from a deferred write to a
+ * socket the driver already set to null, after a database backend closed
+ * the connection. Matches three facts together — the error class, both V8
+ * message spellings, and a `nextWrite` frame in the driver's connection
+ * module — so an unrelated `TypeError` never counts.
+ */
+export function isPostgresNullSocketWriteCrash(error: unknown): boolean {
+  if (!(error instanceof Error) || error.name !== "TypeError") return false;
+  if (!NULL_WRITE_MESSAGE_PATTERN.test(error.message)) return false;
+  const stack = error.stack ?? "";
+  return stack.split("\n").some((line) => NEXT_WRITE_FRAME_PATTERN.test(line));
+}
+
+/**
+ * Reads the runtime opt-out. An operator sets `false` or `0` to disable the
+ * guard; every other value, including an unset variable, keeps it enabled.
+ * Follows the same boolean convention as `envBoolean` in
+ * `packages/db/src/client.ts`: a value other than a recognized true/false
+ * spelling is a configuration mistake, so this throws instead of guessing.
+ */
+export function isGuardEnabled(env: NodeJS.ProcessEnv): boolean {
+  const value = env[GUARD_ENABLED_ENV_VAR]?.trim().toLowerCase();
+  if (value === undefined || value === "") return true;
+  if (value === "true" || value === "1") return true;
+  if (value === "false" || value === "0") return false;
+  throw new Error(`${GUARD_ENABLED_ENV_VAR} must be "true" or "false", got: ${env[GUARD_ENABLED_ENV_VAR]}`);
+}
+
+/**
+ * Handles one uncaught exception. The known driver fault logs one
+ * structured, searchable line and returns — the process survives. Every
+ * other error keeps today's default behavior: log, then end the process.
+ * Exported so a test can drive it directly instead of dispatching a real
+ * process event.
+ */
+export function handlePostgresNullSocketGuardException(error: unknown): void {
+  if (isPostgresNullSocketWriteCrash(error)) {
+    logger.error(
+      { marker: GUARD_MARKER, errorName: (error as Error).name },
+      "neutralized a known postgres driver crash: a deferred write reached a connection socket the driver had already closed",
+    );
+    return;
+  }
+
+  const rootError = error instanceof Error ? error : new Error(String(error));
+  logger.fatal({ err: rootError }, "uncaught exception; process exiting");
+  process.exit(1);
+}
+
+/**
+ * Registers the guard's `uncaughtException` listener, unless an operator
+ * disables it with `POSTGRES_NULL_SOCKET_GUARD_ENABLED=false` (or `0`).
+ * Call this once, early, from the server entry point.
+ */
+export function registerPostgresNullSocketGuard(env: NodeJS.ProcessEnv = process.env): void {
+  if (!isGuardEnabled(env)) return;
+  process.on("uncaughtException", handlePostgresNullSocketGuardException);
+}

--- a/server/src/postgres-null-socket-guard.ts
+++ b/server/src/postgres-null-socket-guard.ts
@@ -97,9 +97,13 @@ export function handlePostgresNullSocketGuardException(error: unknown): void {
 /**
  * Registers the guard's `uncaughtException` listener, unless an operator
  * disables it with `POSTGRES_NULL_SOCKET_GUARD_ENABLED=false` (or `0`).
- * Call this once, early, from the server entry point.
+ * Call this once, early, from the server entry point. This function is
+ * idempotent: a repeat call adds no second listener, so a caller that runs
+ * many times in one process (a test suite that calls `startServer()`
+ * repeatedly) never exceeds Node's default listener-count warning.
  */
 export function registerPostgresNullSocketGuard(env: NodeJS.ProcessEnv = process.env): void {
   if (!isGuardEnabled(env)) return;
+  if (process.listeners("uncaughtException").includes(handlePostgresNullSocketGuardException)) return;
   process.on("uncaughtException", handlePostgresNullSocketGuardException);
 }

--- a/server/src/postgres-null-socket-guard.ts
+++ b/server/src/postgres-null-socket-guard.ts
@@ -19,24 +19,32 @@
 // line, with a fixed marker and the error name only — never a query, a
 // query parameter, a connection URL, a host name, or a database name.
 //
-// Interaction with Sentry: this module is the sole owner of the process's
-// `uncaughtException` decision. `sentry.ts` removes the default
-// `OnUncaughtException` integration from `Sentry.init`, so an operator who
-// installs `@sentry/node` and sets a Sentry DSN gets no second,
-// independent `uncaughtException` listener — Node calls every registered
-// listener for an event, not just the first one, so a second listener
-// would still end the process on the known, neutralized fault regardless
-// of listener order. Instead, for every uncaught exception this module
-// does not neutralize, it reports the error to Sentry itself (through
+// Interaction with Sentry: while this guard is enabled, it is the sole
+// owner of the process's `uncaughtException` decision. `sentry.ts` reads
+// the same opt-out this module reads (`postgres-null-socket-guard-env.ts`)
+// and removes the default `OnUncaughtException` integration from
+// `Sentry.init` only in that case, so an operator who installs
+// `@sentry/node` and sets a Sentry DSN gets no second, independent
+// `uncaughtException` listener — Node calls every registered listener for
+// an event, not just the first one, so a second listener would still end
+// the process on the known, neutralized fault regardless of listener
+// order. Instead, for every uncaught exception this module does not
+// neutralize, it reports the error to Sentry itself (through
 // `captureException`) and waits for the client to flush (through
 // `shutdownSentry`) before it ends the process — the same sequence
 // `index.ts` uses for a startup failure. A deployment with no Sentry DSN
 // set sees no change: both calls are no-ops.
+//
+// An operator who disables this guard
+// (`POSTGRES_NULL_SOCKET_GUARD_ENABLED=false`) registers no listener here,
+// so `sentry.ts` keeps the default `OnUncaughtException` integration active
+// instead — an unrelated uncaught exception still reaches Sentry through
+// that integration rather than Node's silent default handler.
 
 import { logger } from "./middleware/logger.js";
 import { captureException, shutdownSentry } from "./sentry.js";
+import { isGuardEnabled } from "./postgres-null-socket-guard-env.js";
 
-const GUARD_ENABLED_ENV_VAR = "POSTGRES_NULL_SOCKET_GUARD_ENABLED";
 const GUARD_MARKER = "postgres_null_socket_write_guard_neutralized";
 
 // Both V8 message spellings for a read of a property on `null`. The wording
@@ -63,20 +71,10 @@ export function isPostgresNullSocketWriteCrash(error: unknown): boolean {
   return stack.split("\n").some((line) => NEXT_WRITE_FRAME_PATTERN.test(line));
 }
 
-/**
- * Reads the runtime opt-out. An operator sets `false` or `0` to disable the
- * guard; every other value, including an unset variable, keeps it enabled.
- * Follows the same boolean convention as `envBoolean` in
- * `packages/db/src/client.ts`: a value other than a recognized true/false
- * spelling is a configuration mistake, so this throws instead of guessing.
- */
-export function isGuardEnabled(env: NodeJS.ProcessEnv): boolean {
-  const value = env[GUARD_ENABLED_ENV_VAR]?.trim().toLowerCase();
-  if (value === undefined || value === "") return true;
-  if (value === "true" || value === "1") return true;
-  if (value === "false" || value === "0") return false;
-  throw new Error(`${GUARD_ENABLED_ENV_VAR} must be "true" or "false", got: ${env[GUARD_ENABLED_ENV_VAR]}`);
-}
+// Re-exported so existing callers (including tests) can keep importing the
+// opt-out check from this module. See postgres-null-socket-guard-env.ts for
+// why the check itself lives in a separate leaf module.
+export { isGuardEnabled };
 
 /**
  * Handles one uncaught exception. The known driver fault logs one

--- a/server/src/postgres-null-socket-guard.ts
+++ b/server/src/postgres-null-socket-guard.ts
@@ -14,22 +14,27 @@
 // the one known, neutralized fault below — otherwise an unrelated bug would
 // leave the process running in a state nobody chose.
 //
-// This module reports no telemetry event and calls no external
-// error-reporting client. It logs one structured line, with a fixed marker
-// and the error name only — never a query, a query parameter, a connection
-// URL, a host name, or a database name.
+// For the known, neutralized fault, this module reports no telemetry event
+// and calls no external error-reporting client. It logs one structured
+// line, with a fixed marker and the error name only — never a query, a
+// query parameter, a connection URL, a host name, or a database name.
 //
-// Interaction with Sentry: `./sentry.js` registers no `uncaughtException`
-// listener today. `@sentry/node` is an optional peer dependency this
-// repository does not install (`bootstrapSentry` fails its own version
-// check and returns before it calls `Sentry.init`), so Sentry never adds a
-// listener of its own. If an operator later installs `@sentry/node` and
-// sets a Sentry DSN, the default `OnUncaughtException` integration is not
-// among the integrations `sentry.ts` removes, so it would register its own
-// listener too. This module registers first (from the server entry point,
-// before `sentryReady`), so it runs first on every uncaught exception.
+// Interaction with Sentry: this module is the sole owner of the process's
+// `uncaughtException` decision. `sentry.ts` removes the default
+// `OnUncaughtException` integration from `Sentry.init`, so an operator who
+// installs `@sentry/node` and sets a Sentry DSN gets no second,
+// independent `uncaughtException` listener — Node calls every registered
+// listener for an event, not just the first one, so a second listener
+// would still end the process on the known, neutralized fault regardless
+// of listener order. Instead, for every uncaught exception this module
+// does not neutralize, it reports the error to Sentry itself (through
+// `captureException`) and waits for the client to flush (through
+// `shutdownSentry`) before it ends the process — the same sequence
+// `index.ts` uses for a startup failure. A deployment with no Sentry DSN
+// set sees no change: both calls are no-ops.
 
 import { logger } from "./middleware/logger.js";
+import { captureException, shutdownSentry } from "./sentry.js";
 
 const GUARD_ENABLED_ENV_VAR = "POSTGRES_NULL_SOCKET_GUARD_ENABLED";
 const GUARD_MARKER = "postgres_null_socket_write_guard_neutralized";
@@ -75,12 +80,12 @@ export function isGuardEnabled(env: NodeJS.ProcessEnv): boolean {
 
 /**
  * Handles one uncaught exception. The known driver fault logs one
- * structured, searchable line and returns — the process survives. Every
- * other error keeps today's default behavior: log, then end the process.
- * Exported so a test can drive it directly instead of dispatching a real
- * process event.
+ * structured, searchable line and returns — the process survives, and
+ * Sentry hears nothing about it. Every other error keeps today's default
+ * behavior: log, report to Sentry, then end the process. Exported so a
+ * test can drive it directly instead of dispatching a real process event.
  */
-export function handlePostgresNullSocketGuardException(error: unknown): void {
+export async function handlePostgresNullSocketGuardException(error: unknown): Promise<void> {
   if (isPostgresNullSocketWriteCrash(error)) {
     logger.error(
       { marker: GUARD_MARKER, errorName: (error as Error).name },
@@ -91,6 +96,8 @@ export function handlePostgresNullSocketGuardException(error: unknown): void {
 
   const rootError = error instanceof Error ? error : new Error(String(error));
   logger.fatal({ err: rootError }, "uncaught exception; process exiting");
+  captureException(rootError);
+  await shutdownSentry();
   process.exit(1);
 }
 

--- a/server/src/sentry.ts
+++ b/server/src/sentry.ts
@@ -37,17 +37,26 @@
 // so the existing crash-and-restart behavior stays.
 //
 // `OnUncaughtException` is a default integration too, and the initializer
-// removes it. `postgres-null-socket-guard.ts` registers its own
-// `uncaughtException` listener before the server does anything else,
-// including this Sentry gate — the process must survive one known,
-// neutralized driver defect and end for every other uncaught exception. A
-// second, independent listener from this default integration would end the
-// process for that known defect too, regardless of registration order,
-// because Node calls every registered `uncaughtException` listener, not
-// just the first one. So this repository gives one module exclusive
-// ownership of the decision: `postgres-null-socket-guard.ts` calls this
-// module's `captureException` itself for every uncaught exception it does
-// not neutralize, before it ends the process.
+// removes it — but only while `postgres-null-socket-guard.ts` registers its
+// own `uncaughtException` listener (the default: see
+// `postgres-null-socket-guard-env.ts` for the shared opt-out this module
+// reads). That guard runs before the server does anything else, including
+// this Sentry gate, and the process must survive one known, neutralized
+// driver defect and end for every other uncaught exception. A second,
+// independent listener from this default integration would end the process
+// for that known defect too, regardless of registration order, because
+// Node calls every registered `uncaughtException` listener, not just the
+// first one. So while the guard is enabled, this repository gives one
+// module exclusive ownership of the decision: `postgres-null-socket-guard.ts`
+// calls this module's `captureException` itself for every uncaught
+// exception it does not neutralize, before it ends the process.
+//
+// When an operator disables that guard
+// (`POSTGRES_NULL_SOCKET_GUARD_ENABLED=false`), no module registers an
+// `uncaughtException` listener on its behalf, so this initializer keeps the
+// default `OnUncaughtException` integration active instead. Without that,
+// an unrelated uncaught exception would reach no error reporter at all —
+// Node's default handler exits the process without telling Sentry.
 //
 // Before it imports the package, the bootstrap checks the installed
 // `@sentry/node` version against the exact version this manifest's
@@ -59,6 +68,7 @@
 
 import { checkExactPeerVersions } from "./peer-version-check.js";
 import { resolveSentryDsns } from "./sentry-dsn.js";
+import { isGuardEnabled } from "./postgres-null-socket-guard-env.js";
 
 const { backend: dsn, legacyFallbackUsed } = resolveSentryDsns();
 
@@ -151,10 +161,19 @@ export interface SentryInitOptions {
  * `bootstrapSentry` so a test can call it with a real `@sentry/node` module
  * and assert the resolved integration list and the captured-event shape
  * against the true SDK, not a stand-in.
+ *
+ * `guardOwnsUncaughtException` defaults to `true` — the common case, where
+ * `postgres-null-socket-guard.ts` registers its own listener and this
+ * initializer must remove the default `OnUncaughtException` integration so
+ * Node does not call two independent listeners for the same event. Pass
+ * `false` only when that guard is disabled
+ * (`POSTGRES_NULL_SOCKET_GUARD_ENABLED=false`), so the default integration
+ * stays active and an unrelated uncaught exception still reaches Sentry.
  */
 export function buildSentryInitOptions(
   dsn: string,
   Sentry: SentryModuleLike,
+  guardOwnsUncaughtException: boolean = true,
 ): SentryInitOptions {
   return {
     dsn,
@@ -162,16 +181,16 @@ export function buildSentryInitOptions(
     tracesSampleRate: 0,
     sendDefaultPii: false,
     integrations: (defaults: Array<{ name: string }>) => {
-      const kept = defaults.filter(
-        (integration) =>
-          integration.name !== "Console" &&
-          integration.name !== "ContextLines" &&
-          integration.name !== "Http" &&
-          integration.name !== "OnUnhandledRejection" &&
-          // Removed so this default integration never registers its own
-          // `uncaughtException` listener. See the module comment above.
-          integration.name !== "OnUncaughtException",
-      );
+      const kept = defaults.filter((integration) => {
+        if (integration.name === "Console") return false;
+        if (integration.name === "ContextLines") return false;
+        if (integration.name === "Http") return false;
+        if (integration.name === "OnUnhandledRejection") return false;
+        // Removed only while `postgres-null-socket-guard.ts` owns the
+        // `uncaughtException` decision. See the module comment above.
+        if (integration.name === "OnUncaughtException") return !guardOwnsUncaughtException;
+        return true;
+      });
       return [
         ...kept,
         // Keep the rest of the Http integration — RequestData and request
@@ -210,7 +229,13 @@ async function bootstrapSentry(dsn: string): Promise<void> {
     // @ts-ignore optional peer dep
     const Sentry = await import("@sentry/node");
 
-    Sentry.init(buildSentryInitOptions(dsn, Sentry));
+    // Reads the same opt-out `postgres-null-socket-guard.ts` reads, so this
+    // module strips the default `OnUncaughtException` integration only when
+    // that guard actually owns the process's `uncaughtException` decision.
+    // `registerPostgresNullSocketGuard()` runs before this bootstrap
+    // settles and validates the same variable, so a startup with an
+    // unrecognized value never reaches this line.
+    Sentry.init(buildSentryInitOptions(dsn, Sentry, isGuardEnabled(process.env)));
 
     sentryHandle = {
       captureException: (error) => Sentry.captureException(error),

--- a/server/src/sentry.ts
+++ b/server/src/sentry.ts
@@ -36,6 +36,19 @@
 // `mode: "strict"`: Sentry still captures the event, then exits the process,
 // so the existing crash-and-restart behavior stays.
 //
+// `OnUncaughtException` is a default integration too, and the initializer
+// removes it. `postgres-null-socket-guard.ts` registers its own
+// `uncaughtException` listener before the server does anything else,
+// including this Sentry gate — the process must survive one known,
+// neutralized driver defect and end for every other uncaught exception. A
+// second, independent listener from this default integration would end the
+// process for that known defect too, regardless of registration order,
+// because Node calls every registered `uncaughtException` listener, not
+// just the first one. So this repository gives one module exclusive
+// ownership of the decision: `postgres-null-socket-guard.ts` calls this
+// module's `captureException` itself for every uncaught exception it does
+// not neutralize, before it ends the process.
+//
 // Before it imports the package, the bootstrap checks the installed
 // `@sentry/node` version against the exact version this manifest's
 // `peerDependencies` declares — the same audited version documented in
@@ -154,7 +167,10 @@ export function buildSentryInitOptions(
           integration.name !== "Console" &&
           integration.name !== "ContextLines" &&
           integration.name !== "Http" &&
-          integration.name !== "OnUnhandledRejection",
+          integration.name !== "OnUnhandledRejection" &&
+          // Removed so this default integration never registers its own
+          // `uncaughtException` listener. See the module comment above.
+          integration.name !== "OnUncaughtException",
       );
       return [
         ...kept,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The server uses a PostgreSQL driver to store control-plane data
> - The `postgres@3.4.9` driver can write to a socket after it sets its socket reference to `null`
> - That deferred write throws outside request handling and ends the Node process
> - This pull request adds a narrow process-level guard for that known fault
> - The benefit is that one bad pooled connection does not stop the whole server

## Linked Issues or Issue Description

**What happened?**

The `postgres@3.4.9` driver can terminate the Node process after a backend connection closes. A deferred write then calls `.write` on a null socket inside `connection.js`.

**Expected behavior**

The server should keep running when this known driver fault occurs. Other uncaught exceptions should keep the prior exit behavior.

**Steps to reproduce**

1. Start the server with the `postgres@3.4.9` driver.
2. Close a backend connection while a transaction still uses it.
3. Send a query that reaches the closed connection.
4. Observe the deferred null-socket write and the process exit.

**Paperclip version or commit**

`cba31a85059646ff0c24cd95a0e1bb80c4416451`

**Deployment mode**

Self-hosted server with an external PostgreSQL database.

**Installation method**

Built from source.

**Agent adapter(s) involved**

Not adapter-specific (core bug).

**Database mode**

External Postgres.

## What Changed

- Add a process-level guard for the known PostgreSQL null-socket write fault.
- Match the error type, known V8 message spellings, and the driver's `nextWrite` stack frame.
- Log the known fault and keep the process alive.
- Preserve exit code 1 for unrelated uncaught exceptions.
- Add the `POSTGRES_NULL_SOCKET_GUARD_ENABLED` environment control.
- Add deterministic fake-wire-server tests for the crash and its known connection limit.

## Verification

- Run `pnpm --filter @paperclipai/server exec vitest run src/__tests__/postgres-null-socket-guard.test.ts`.
- Run `pnpm --filter @paperclipai/server exec tsc --noEmit`.
- Confirm the full CI suite passes.

## Risks

The guard can hide only the exact known driver fault. The affected connection does not recover, so later queries on that connection can time out. An unrecognized environment value stops startup.

## Model Used

OpenAI Codex, GPT-5. The exact deployment identifier and context window were not exposed in this run. The model used tool calls and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
