### PR TITLE
fix(server): stop mock leakage between interaction-route tests

### DIFF
--- a/server/src/__tests__/issue-thread-interaction-routes.test.ts
+++ b/server/src/__tests__/issue-thread-interaction-routes.test.ts
@@ -312,13 +312,26 @@ describe.sequential("issue thread interaction routes", () => {
     vi.doUnmock("../middleware/index.js");
     vi.doUnmock("../services/index.js");
     registerModuleMocks();
-    vi.clearAllMocks();
-    mockInteractionService.getForIssue.mockReset();
+    // Every mock here is a vi.hoisted() singleton. All 70+ tests share it.
+    // A queued mockResolvedValueOnce() value can outlive its own test and
+    // leak into a later, unrelated test. vi.resetAllMocks() drains that
+    // queue for every mock in one call. It also keeps each mock's
+    // constructor-provided vi.fn(impl) default. So the code below only
+    // sets values that must differ from that default.
+    // vi.clearAllMocks() clears call history only. It does not drain the
+    // queue. That gap once let a leftover queued value deny an unrelated
+    // later test.
+    vi.resetAllMocks();
+    // mockRunAttribution.value is a plain object, not a vi.fn().
+    // resetAllMocks() does not reset it. createApp() overwrites it for an
+    // agent actor. A board actor leaves whatever value a prior test set here.
+    mockRunAttribution.value = {
+      companyId: "company-1",
+      agentId: CREATED_AGENT_ID,
+      responsibleUserId: null,
+    };
     mockQuestionResponseDeliveries.deliver.mockResolvedValue(null);
     mockRequestNativeQuestionRunCancellation.mockResolvedValue(null);
-    mockResolveTaskWatchdogMutationScope.mockReset();
-    mockResolveCoreTrustPreset.mockReset();
-    mockAccessDecide.mockReset();
     mockResolveTaskWatchdogMutationScope.mockResolvedValue({ kind: "none" });
     mockResolveCoreTrustPreset.mockReturnValue({ kind: "standard" });
     mockAccessDecide.mockImplementation(async (input: { action?: string }) => ({


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The server test suite checks issue-thread interaction routes
> - Shared Vitest mocks can keep queued one-shot values between tests
> - A leftover value can change the issue returned to a route and cause a false authorization failure
> - This pull request resets all mocks and restores the plain run-attribution value before each test
> - The benefit is stable interaction-route tests that do not depend on test order

## Linked Issues or Issue Description

This pull request has no public issue link. The bug details follow.

**What happened?**

The interaction-route server test suite failed intermittently in continuous integration. The test named `lets a watchdog-scoped assignee withdraw through ordinary containment` sometimes failed because `withdrawInteraction` received no call. The test suite used `vi.clearAllMocks()`, which clears call history but does not clear queued one-shot mock values. A queued value from `mockIssueService.getById` could change a later test's issue and make the route return `403`.

**Expected behavior**

Each test must start with empty mock queues and the default run-attribution value. Test results must not depend on test order.

**Steps to reproduce**

1. Run the interaction-route test file many times in sequence.
2. Run the same file with shuffled test seeds.
3. Observe the intermittent containment failure before this change.

**Paperclip version or commit**

Current `master` plus commit `8cd56b38a77f1feecac495f57a48d3f0a1b3b01c`.

**Deployment mode**

Built from source. The failure occurs in the server test suite.

## What Changed

- Replace the partial mock reset with `vi.resetAllMocks()`.
- Reset `mockRunAttribution.value` before each test.
- Keep the change within the interaction-route test file.

## Verification

- The target suite passes 77 of 77 runs.
- The test count remains 64 `it(...)` sites, including five `it.each(...)` blocks that expand to 77 runs.
- The file contains no skipped or focused tests.
- The diff changes no production code.
- A defect-detection round trip reproduces the failure when the containment guard is broken and passes after the guard is restored.
- Ten sequential runs and five shuffled-seed runs pass 77 of 77.

## Risks

Low risk. The change affects test setup only. It does not change production code or route behavior.

## Model Used

OpenAI GPT-5, exact runtime model `gpt-5`, tool use and code execution, context window not exposed by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge