### PR TITLE
Fix concurrent work product deadlocks and retries

### DIFF
--- a/server/src/__tests__/work-products.test.ts
+++ b/server/src/__tests__/work-products.test.ts
@@ -1,4 +1,11 @@
-import { describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
+import { eq } from "drizzle-orm";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { companies, createDb, issueWorkProducts, issues } from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
 import {
   enrichWorkProductMetadataWithDiff,
   refreshPullRequestWorkProductMetadata,
@@ -138,6 +145,7 @@ describe("workProductService", () => {
     const txInsert = vi.fn(() => ({ values: insertValues }));
 
     const tx = {
+      execute: vi.fn(async () => undefined),
       update: txUpdate,
       insert: txInsert,
     };
@@ -159,6 +167,32 @@ describe("workProductService", () => {
     expect(result?.id).toBe("work-product-1");
   });
 
+  it("retries a deadlocked create transaction", async () => {
+    const insertedRow = createWorkProductRow({ isPrimary: false });
+    const tx = {
+      execute: vi.fn(async () => undefined),
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({ returning: vi.fn(async () => [insertedRow]) })),
+      })),
+    };
+    const deadlock = Object.assign(new Error("deadlock detected"), { code: "40P01" });
+    const transaction = vi.fn()
+      .mockRejectedValueOnce(deadlock)
+      .mockImplementation(async (callback: (input: typeof tx) => Promise<unknown>) => await callback(tx));
+
+    const product = await workProductService({ transaction } as any).createForIssue("issue-1", "company-1", {
+      type: "artifact",
+      provider: "paperclip",
+      title: "Artifact",
+      status: "active",
+      reviewState: "none",
+      isPrimary: false,
+    });
+
+    expect(product?.id).toBe("work-product-1");
+    expect(transaction).toHaveBeenCalledTimes(2);
+  });
+
   it("uses a transaction when promoting an existing work product to primary", async () => {
     const existingRow = createWorkProductRow({ isPrimary: false });
 
@@ -174,6 +208,7 @@ describe("workProductService", () => {
     const txUpdate = vi.fn(() => ({ set: updateSet }));
 
     const tx = {
+      execute: vi.fn(async () => undefined),
       select: txSelect,
       update: txUpdate,
     };
@@ -189,5 +224,72 @@ describe("workProductService", () => {
     expect(txSelect).toHaveBeenCalledTimes(1);
     expect(txUpdate).toHaveBeenCalledTimes(2);
     expect(result?.reviewState).toBe("ready_for_review");
+  });
+});
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+describeEmbeddedPostgres("workProductService concurrent creates", () => {
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  it("serializes eight primary transitions and deduplicates an attachment retry", async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-work-product-concurrency-");
+    const db = createDb(tempDb.connectionString);
+    const companyId = randomUUID();
+    const issueId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Work product concurrency",
+      issuePrefix: "WPC",
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Concurrent artifacts",
+      status: "in_progress",
+      priority: "high",
+    });
+
+    const attachmentIds = Array.from({ length: 8 }, () => randomUUID());
+    const service = workProductService(db);
+    const products = await Promise.all(attachmentIds.map((attachmentId, index) => service.createForIssue(
+      issueId,
+      companyId,
+      {
+        type: "artifact",
+        provider: "paperclip",
+        title: `Artifact ${index}`,
+        status: "active",
+        reviewState: "none",
+        isPrimary: index % 2 === 0,
+        metadata: { attachmentId },
+      },
+    )));
+
+    expect(products).toHaveLength(8);
+    expect(products.every(Boolean)).toBe(true);
+    const rows = await db.select().from(issueWorkProducts).where(eq(issueWorkProducts.issueId, issueId));
+    expect(rows).toHaveLength(8);
+    expect(rows.filter((row) => row.isPrimary)).toHaveLength(1);
+
+    const repeated = await service.createForIssue(issueId, companyId, {
+      type: "artifact",
+      provider: "paperclip",
+      title: "Artifact retry",
+      status: "active",
+      reviewState: "none",
+      isPrimary: true,
+      metadata: { attachmentId: attachmentIds[0] },
+    });
+    const afterRetry = await db.select().from(issueWorkProducts).where(eq(issueWorkProducts.issueId, issueId));
+    expect(repeated?.id).toBe(products[0]?.id);
+    expect(afterRetry).toHaveLength(8);
+    expect(afterRetry.filter((row) => row.isPrimary)).toHaveLength(1);
   });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -8409,24 +8409,8 @@ export function issueRoutes(
     const attachmentId = createInput.type === "artifact" && createInput.provider === "paperclip"
       ? (createInput.metadata as Record<string, unknown> | null)?.attachmentId
       : null;
-    const existingRunAttachmentProduct = typeof attachmentId === "string" && createdByRunId
-      ? await db
-        .select({ id: issueWorkProducts.id })
-        .from(issueWorkProducts)
-        .where(and(
-          eq(issueWorkProducts.companyId, issue.companyId),
-          eq(issueWorkProducts.issueId, issue.id),
-          eq(issueWorkProducts.type, "artifact"),
-          eq(issueWorkProducts.provider, "paperclip"),
-          eq(issueWorkProducts.externalId, attachmentId),
-          eq(issueWorkProducts.createdByRunId, createdByRunId),
-        ))
-        .limit(1)
-        .then((rows) => rows[0] ?? null)
-      : null;
-    const product = existingRunAttachmentProduct
-      ? await workProductsSvc.update(existingRunAttachmentProduct.id, createInput)
-      : await workProductsSvc.createForIssue(issue.id, issue.companyId, createInput);
+    if (typeof attachmentId === "string") createInput.externalId = attachmentId;
+    const product = await workProductsSvc.createForIssue(issue.id, issue.companyId, createInput);
     if (!product) {
       res.status(422).json({ error: "Invalid work product payload" });
       return;

--- a/server/src/services/work-products.ts
+++ b/server/src/services/work-products.ts
@@ -1,6 +1,6 @@
-import { and, desc, eq, inArray } from "drizzle-orm";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { heartbeatRunEvents, issueWorkProducts, workspaceRuntimeServices } from "@paperclipai/db";
+import { heartbeatRunEvents, issues, issueWorkProducts, workspaceRuntimeServices } from "@paperclipai/db";
 import type { IssueWorkProduct } from "@paperclipai/shared";
 import { insertRowsInChunks } from "./batch-insert.js";
 import {
@@ -16,6 +16,44 @@ import {
 import type { ImportIssueWorkProductRow } from "./import-write-types.js";
 
 type IssueWorkProductRow = typeof issueWorkProducts.$inferSelect;
+
+const DEADLOCK_SQLSTATE = "40P01";
+const WORK_PRODUCT_TRANSACTION_ATTEMPTS = 3;
+
+function postgresErrorCode(error: unknown): string | null {
+  let candidate: unknown = error;
+  for (let depth = 0; depth < 4 && candidate && typeof candidate === "object"; depth += 1) {
+    const record = candidate as Record<string, unknown>;
+    if (typeof record.code === "string") return record.code;
+    candidate = record.cause;
+  }
+  return null;
+}
+
+async function withDeadlockRetry<T>(operation: () => Promise<T>): Promise<T> {
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (postgresErrorCode(error) !== DEADLOCK_SQLSTATE || attempt >= WORK_PRODUCT_TRANSACTION_ATTEMPTS) {
+        throw error;
+      }
+      const jitterMs = 10 + Math.floor(Math.random() * 31) * attempt;
+      await new Promise((resolve) => setTimeout(resolve, jitterMs));
+    }
+  }
+}
+
+function workProductIdempotencyExternalId(
+  data: Omit<typeof issueWorkProducts.$inferInsert, "issueId" | "companyId">,
+): string | null {
+  if (data.externalId) return data.externalId;
+  if (data.type !== "artifact" || data.provider !== "paperclip") return null;
+  const attachmentId = data.metadata && typeof data.metadata === "object"
+    ? data.metadata.attachmentId
+    : null;
+  return typeof attachmentId === "string" && attachmentId.length > 0 ? attachmentId : null;
+}
 
 export interface WorkProductDiffSummary {
   additions: number | null;
@@ -244,8 +282,31 @@ export function workProductService(
     },
 
     createForIssue: async (issueId: string, companyId: string, data: Omit<typeof issueWorkProducts.$inferInsert, "issueId" | "companyId">) => {
-      const row = await db.transaction(async (tx) => {
-        if (data.isPrimary) {
+      const row = await withDeadlockRetry(() => db.transaction(async (tx) => {
+        // The issue row is the per-issue serialization point. Taking it before
+        // any work-product write gives primary transitions one lock order.
+        await tx.execute(sql`select ${issues.id} from ${issues} where ${issues.id} = ${issueId} for update`);
+
+        const idempotencyExternalId = workProductIdempotencyExternalId(data);
+        const normalizedData = idempotencyExternalId && data.externalId !== idempotencyExternalId
+          ? { ...data, externalId: idempotencyExternalId }
+          : data;
+        const existing = idempotencyExternalId
+          ? await tx
+            .select()
+            .from(issueWorkProducts)
+            .where(and(
+              eq(issueWorkProducts.companyId, companyId),
+              eq(issueWorkProducts.issueId, issueId),
+              eq(issueWorkProducts.type, normalizedData.type),
+              eq(issueWorkProducts.provider, normalizedData.provider),
+              eq(issueWorkProducts.externalId, idempotencyExternalId),
+            ))
+            .limit(1)
+            .then((rows) => rows[0] ?? null)
+          : null;
+
+        if (normalizedData.isPrimary) {
           await tx
             .update(issueWorkProducts)
             .set({ isPrimary: false, updatedAt: new Date() })
@@ -253,31 +314,43 @@ export function workProductService(
               and(
                 eq(issueWorkProducts.companyId, companyId),
                 eq(issueWorkProducts.issueId, issueId),
-                eq(issueWorkProducts.type, data.type),
+                eq(issueWorkProducts.type, normalizedData.type),
               ),
             );
+        }
+        if (existing) {
+          return await tx
+            .update(issueWorkProducts)
+            .set({ ...normalizedData, updatedAt: new Date() })
+            .where(eq(issueWorkProducts.id, existing.id))
+            .returning()
+            .then((rows) => rows[0] ?? null);
         }
         return await tx
           .insert(issueWorkProducts)
           .values({
-            ...data,
+            ...normalizedData,
             companyId,
             issueId,
           })
           .returning()
           .then((rows) => rows[0] ?? null);
-      });
+      }));
       return row ? toIssueWorkProduct(row) : null;
     },
 
     update: async (id: string, patch: Partial<typeof issueWorkProducts.$inferInsert>) => {
-      const row = await db.transaction(async (tx) => {
+      const row = await withDeadlockRetry(() => db.transaction(async (tx) => {
         const existing = await tx
           .select()
           .from(issueWorkProducts)
           .where(eq(issueWorkProducts.id, id))
           .then((rows) => rows[0] ?? null);
         if (!existing) return null;
+
+        await tx.execute(
+          sql`select ${issues.id} from ${issues} where ${issues.id} = ${existing.issueId} for update`,
+        );
 
         if (patch.isPrimary === true) {
           await tx
@@ -298,7 +371,7 @@ export function workProductService(
           .where(eq(issueWorkProducts.id, id))
           .returning()
           .then((rows) => rows[0] ?? null);
-      });
+      }));
       return row ? toIssueWorkProduct(row) : null;
     },
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages concurrent AI agent work through its control-plane API.
> - Work products publish inspectable outputs on issues.
> - Concurrent primary work-product writes acquired database locks in different orders.
> - PostgreSQL could abort these requests with SQLSTATE 40P01.
> - Client retries could also duplicate a committed attachment work product.
> - This pull request serializes work-product writes on the issue row and retries deadlocks.
> - It also makes attachment identity atomic inside the same transaction.
> - The benefit is reliable concurrent publication with one primary product per type.

## Linked Issues or Issue Description

**What happened?**

Concurrent `POST /api/issues/{id}/work-products` requests could deadlock when several requests made attachment-backed products primary. A retry could create a second product for an attachment after the first request committed.

**Expected behavior**

All concurrent requests should complete without server errors. Each attachment should have one work product. Each issue and work-product type should have at most one primary product.

**Steps to reproduce**

1. Create one issue and eight attachments.
2. Send eight concurrent work-product create requests for that issue.
3. Set `isPrimary` on several requests.
4. Repeat one request with the same attachment ID.

**Paperclip version or commit**

`b98badb2468df7dee10c6d330158440fbec414de`

**Deployment mode**

Self-hosted server with external PostgreSQL.

## What Changed

- Lock the issue row before each create or update writes work-product rows.
- Retry work-product transactions up to three times for PostgreSQL deadlock SQLSTATE `40P01`.
- Use bounded jitter between retry attempts.
- Normalize a Paperclip attachment ID into `externalId`.
- Reuse and update an existing matching record inside the serialized transaction.
- Add an embedded-PostgreSQL test with eight concurrent attachment-backed creates and one repeated request.

## Verification

- `pnpm exec vitest run server/src/__tests__/work-products.test.ts server/src/__tests__/issue-attachment-routes.test.ts` — 2 files and 29 tests passed.
- `pnpm --filter @paperclipai/plugin-sdk build && pnpm --filter @paperclipai/server exec tsc --noEmit` — passed.

## Risks

- Concurrent work-product writes for one issue now run in sequence. This can add small latency under heavy publication bursts.
- The retry is limited to three attempts. A sustained database deadlock still returns an error.
- An explicit external ID now acts as an idempotency identity within one issue, type, and provider.

> This is a focused bug fix. It does not duplicate a planned roadmap feature.

## Model Used

- OpenAI Codex, GPT-5.6, agentic tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
