### PR TITLE
fix(adapter-hermes-gateway): honor provider-quota backoff on terminal 429 events

### DIFF
--- a/packages/adapters/hermes/src/gateway/server/execute.test.ts
+++ b/packages/adapters/hermes/src/gateway/server/execute.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
 import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
-import { execute, mapFinalResultForTest, parseSseFramesForTest, resolveSessionKey } from "./execute.js";
+import {
+  __providerQuotaInternals,
+  execute,
+  mapFinalResultForTest,
+  parseSseFramesForTest,
+  resolveSessionKey,
+} from "./execute.js";
 import { testEnvironment } from "./test.js";
 
 function makeCtx(config: Record<string, unknown>): AdapterExecutionContext {
@@ -729,5 +735,107 @@ describe("mapFinalResultForTest", () => {
     expect(result.exitCode).toBe(1);
     expect(result.errorCode).toBe("hermes_gateway_run_failed");
     expect(result.errorMessage).toBe("boom");
+  });
+
+  it("promotes provider-quota exhaustion in terminal failed events to a backoff-friendly result", () => {
+    const now = new Date("2026-09-04T00:00:00Z").getTime();
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const result = mapFinalResultForTest({
+      terminal: {
+        runId: "run-quota",
+        status: "failed",
+        payload: {
+          status: "failed",
+          error: "Codex provider quota exhausted (429); retry after 4825s. Credentials still valid.",
+        },
+      },
+      outputChunks: [],
+      sessionKey: "session-key",
+      strategy: "issue",
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCode).toBe("hermes_gateway_rate_limited");
+    expect(result.errorFamily).toBe("provider_quota");
+    expect(result.retryNotBefore).toBe(new Date(now + 4825 * 1000).toISOString());
+  });
+
+  it("falls back to a 60s cool-down when the quota message omits an explicit retry-after", () => {
+    const now = new Date("2026-09-04T00:00:00Z").getTime();
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const result = mapFinalResultForTest({
+      terminal: {
+        runId: "run-quota-no-hint",
+        status: "failed",
+        payload: { status: "failed", error: "HTTP 429: The usage limit has been reached" },
+      },
+      outputChunks: [],
+      sessionKey: "session-key",
+      strategy: "issue",
+    });
+    expect(result.errorCode).toBe("hermes_gateway_rate_limited");
+    expect(result.errorFamily).toBe("provider_quota");
+    expect(result.retryNotBefore).toBe(new Date(now + 60 * 1000).toISOString());
+  });
+
+  it("leaves unrelated terminal failures untouched", () => {
+    const result = mapFinalResultForTest({
+      terminal: {
+        runId: "run-other",
+        status: "failed",
+        payload: { status: "failed", error: "internal boom" },
+      },
+      outputChunks: [],
+      sessionKey: "session-key",
+      strategy: "issue",
+    });
+    expect(result.errorCode).toBe("hermes_gateway_run_failed");
+    expect(result.errorFamily).toBeUndefined();
+    expect(result.retryNotBefore).toBeUndefined();
+  });
+});
+
+describe("parseHermesRetryAfterHeader", () => {
+  const { parseHermesRetryAfterHeader } = __providerQuotaInternals;
+
+  it("interprets delta-seconds values as an absolute future ISO datetime", () => {
+    const now = new Date("2026-09-04T00:00:00Z").getTime();
+    expect(parseHermesRetryAfterHeader("120", now)).toBe(new Date(now + 120_000).toISOString());
+  });
+
+  it("parses HTTP-date values into an ISO datetime", () => {
+    expect(parseHermesRetryAfterHeader("Fri, 04 Sep 2026 00:02:00 GMT")).toBe(
+      new Date("2026-09-04T00:02:00Z").toISOString(),
+    );
+  });
+
+  it("returns null for empty, missing, or malformed values", () => {
+    expect(parseHermesRetryAfterHeader(null)).toBeNull();
+    expect(parseHermesRetryAfterHeader(undefined)).toBeNull();
+    expect(parseHermesRetryAfterHeader("")).toBeNull();
+    expect(parseHermesRetryAfterHeader("   ")).toBeNull();
+    expect(parseHermesRetryAfterHeader("not-a-date")).toBeNull();
+  });
+});
+
+describe("detectProviderQuotaExhaustion", () => {
+  const { detectProviderQuotaExhaustion } = __providerQuotaInternals;
+
+  it("returns null for messages that do not match a known quota signature", () => {
+    expect(detectProviderQuotaExhaustion(null)).toBeNull();
+    expect(detectProviderQuotaExhaustion("")).toBeNull();
+    expect(detectProviderQuotaExhaustion("random failure")).toBeNull();
+  });
+
+  it("extracts an explicit retry-after from the Codex quota message", () => {
+    const now = new Date("2026-09-04T00:00:00Z").getTime();
+    const result = detectProviderQuotaExhaustion(
+      "Codex provider quota exhausted (429); retry after 1653s. Credentials still valid.",
+      now,
+    );
+    expect(result).toEqual({
+      errorCode: "hermes_gateway_rate_limited",
+      errorFamily: "provider_quota",
+      retryNotBefore: new Date(now + 1653 * 1000).toISOString(),
+    });
   });
 });

--- a/packages/adapters/hermes/src/gateway/server/execute.test.ts
+++ b/packages/adapters/hermes/src/gateway/server/execute.test.ts
@@ -777,6 +777,27 @@ describe("mapFinalResultForTest", () => {
     expect(result.retryNotBefore).toBe(new Date(now + 60 * 1000).toISOString());
   });
 
+  it("degrades an out-of-range retry hint in a terminal failed event to the fallback cool-down instead of throwing", () => {
+    const now = new Date("2026-09-04T00:00:00Z").getTime();
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const result = mapFinalResultForTest({
+      terminal: {
+        runId: "run-quota-absurd",
+        status: "failed",
+        payload: {
+          status: "failed",
+          error: "Codex provider quota exhausted (429); retry after 9999999999999999s.",
+        },
+      },
+      outputChunks: [],
+      sessionKey: "session-key",
+      strategy: "issue",
+    });
+    expect(result.errorCode).toBe("hermes_gateway_rate_limited");
+    expect(result.errorFamily).toBe("provider_quota");
+    expect(result.retryNotBefore).toBe(new Date(now + 60 * 1000).toISOString());
+  });
+
   it("leaves unrelated terminal failures untouched", () => {
     const result = mapFinalResultForTest({
       terminal: {
@@ -815,6 +836,39 @@ describe("parseHermesRetryAfterHeader", () => {
     expect(parseHermesRetryAfterHeader("   ")).toBeNull();
     expect(parseHermesRetryAfterHeader("not-a-date")).toBeNull();
   });
+
+  it("returns null instead of throwing for finite values beyond the Date range", () => {
+    const now = new Date("2026-09-04T00:00:00Z").getTime();
+    expect(() => parseHermesRetryAfterHeader("9999999999999999", now)).not.toThrow();
+    expect(parseHermesRetryAfterHeader("9999999999999999", now)).toBeNull();
+    expect(parseHermesRetryAfterHeader("99999999999999999999999", now)).toBeNull();
+  });
+});
+
+describe("extractQuotaSignalFromBody", () => {
+  const { extractQuotaSignalFromBody } = __providerQuotaInternals;
+
+  it("reads the upstream message from the shapes the gateway uses", () => {
+    expect(extractQuotaSignalFromBody("HTTP 429: The usage limit has been reached")).toBe(
+      "HTTP 429: The usage limit has been reached",
+    );
+    expect(extractQuotaSignalFromBody({ text: "quota exhausted (429)" })).toBe("quota exhausted (429)");
+    expect(extractQuotaSignalFromBody({ error: "quota exhausted (429)" })).toBe("quota exhausted (429)");
+    expect(extractQuotaSignalFromBody({ error: { message: "quota exhausted (429)" } })).toBe(
+      "quota exhausted (429)",
+    );
+    expect(extractQuotaSignalFromBody({ message: "quota exhausted (429)" })).toBe("quota exhausted (429)");
+    expect(extractQuotaSignalFromBody({ detail: "quota exhausted (429)" })).toBe("quota exhausted (429)");
+  });
+
+  it("returns null for empty or unrelated bodies", () => {
+    expect(extractQuotaSignalFromBody(null)).toBeNull();
+    expect(extractQuotaSignalFromBody(undefined)).toBeNull();
+    expect(extractQuotaSignalFromBody("")).toBeNull();
+    expect(extractQuotaSignalFromBody({})).toBeNull();
+    expect(extractQuotaSignalFromBody([])).toBeNull();
+    expect(extractQuotaSignalFromBody({ error: 42 })).toBeNull();
+  });
 });
 
 describe("detectProviderQuotaExhaustion", () => {
@@ -824,6 +878,17 @@ describe("detectProviderQuotaExhaustion", () => {
     expect(detectProviderQuotaExhaustion(null)).toBeNull();
     expect(detectProviderQuotaExhaustion("")).toBeNull();
     expect(detectProviderQuotaExhaustion("random failure")).toBeNull();
+  });
+
+  it("degrades an out-of-range retry hint to the fallback cool-down instead of throwing", () => {
+    const now = new Date("2026-09-04T00:00:00Z").getTime();
+    const message = "Codex provider quota exhausted (429); retry after 9999999999999999s.";
+    expect(() => detectProviderQuotaExhaustion(message, now)).not.toThrow();
+    expect(detectProviderQuotaExhaustion(message, now)).toEqual({
+      errorCode: "hermes_gateway_rate_limited",
+      errorFamily: "provider_quota",
+      retryNotBefore: new Date(now + 60 * 1000).toISOString(),
+    });
   });
 
   it("extracts an explicit retry-after from the Codex quota message", () => {
@@ -837,5 +902,57 @@ describe("detectProviderQuotaExhaustion", () => {
       errorFamily: "provider_quota",
       retryNotBefore: new Date(now + 1653 * 1000).toISOString(),
     });
+  });
+});
+
+describe("execute: direct HTTP 429 classification", () => {
+  const now = new Date("2026-09-04T00:00:00Z").getTime();
+
+  function run429(init: { body?: string; headers?: Record<string, string> }) {
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    const fetchMock = vi.fn(async () =>
+      new Response(init.body ?? "", {
+        status: 429,
+        headers: { "content-type": "application/json", ...(init.headers ?? {}) },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    return execute(makeCtx({ apiBaseUrl: "http://127.0.0.1:8642", apiKey: "secret-key", timeoutSec: 5 }));
+  }
+
+  it("keeps a headerless 429 with no upstream quota signal as transient gateway throttling", async () => {
+    const result = await run429({});
+    expect(result.exitCode).toBe(1);
+    expect(result.errorCode).toBe("hermes_gateway_rate_limited");
+    expect(result.errorFamily).toBe("transient_upstream");
+    expect(result.retryNotBefore).toBeNull();
+  });
+
+  it("keeps a headerless 429 whose body only describes gateway throttling as transient_upstream", async () => {
+    const result = await run429({ body: JSON.stringify({ error: "Too many requests to the gateway, slow down" }) });
+    expect(result.errorFamily).toBe("transient_upstream");
+    expect(result.retryNotBefore).toBeNull();
+  });
+
+  it("promotes a headerless 429 to provider_quota when the body carries the upstream quota signature", async () => {
+    const result = await run429({
+      body: JSON.stringify({ error: "Codex provider quota exhausted (429); retry after 120s. Credentials still valid." }),
+    });
+    expect(result.errorCode).toBe("hermes_gateway_rate_limited");
+    expect(result.errorFamily).toBe("provider_quota");
+    expect(result.retryNotBefore).toBe(new Date(now + 120 * 1000).toISOString());
+  });
+
+  it("honours the retry-after header on a 429 and leaves the family as transient_upstream", async () => {
+    const result = await run429({ headers: { "retry-after": "30" } });
+    expect(result.errorFamily).toBe("transient_upstream");
+    expect(result.retryNotBefore).toBe(new Date(now + 30 * 1000).toISOString());
+  });
+
+  it("does not reject execute() when the retry-after header is beyond the Date range", async () => {
+    const result = await run429({ headers: { "retry-after": "9999999999999999" } });
+    expect(result.exitCode).toBe(1);
+    expect(result.errorFamily).toBe("transient_upstream");
+    expect(result.retryNotBefore).toBeNull();
   });
 });

--- a/packages/adapters/hermes/src/gateway/server/execute.ts
+++ b/packages/adapters/hermes/src/gateway/server/execute.ts
@@ -353,6 +353,73 @@ function classifyHttpError(status: number): { code: string; family: AdapterExecu
   return { code: "hermes_gateway_protocol_error", family: null };
 }
 
+// The Hermes gateway surfaces upstream provider rate-limit exhaustion by
+// completing the run with status=failed and an error message like:
+//   "Codex provider quota exhausted (429); retry after 4825s. Credentials..."
+//   "HTTP 429: The usage limit has been reached"
+// Without special handling the adapter emits errorCode=hermes_gateway_run_failed
+// with no errorFamily / retryNotBefore, so the downstream heartbeat scheduler
+// immediately fires another run — which hits the same 429 — producing a storm
+// of failed runs during the entire cooldown window (~1h). We tag those
+// terminal-event failures with errorFamily=provider_quota and a real
+// retryNotBefore timestamp so the scheduler honours the backoff.
+const CODEX_QUOTA_MESSAGE_RE =
+  /(?:codex\s+provider\s+)?quota\s+exhausted\s*\(?\s*429\s*\)?(?:[^0-9]*?retry\s*after\s+(\d+)\s*s)?/i;
+const HTTP_429_MESSAGE_RE = /\bhttp\s*429\b|\b429\s*:/i;
+const USAGE_LIMIT_MESSAGE_RE = /\busage[-_\s]?limit(?:\s+has\s+been)?\s+reached\b/i;
+const RETRY_AFTER_HINT_RE = /retry[-_\s]?after[:\s]+(\d+)\s*s?\b/i;
+
+// Fallback cool-down (seconds) when the gateway did not include an explicit
+// retry-after. Kept modest so a real reset-time reported by a later attempt
+// can shorten it, but long enough to break the immediate hot-loop.
+const HERMES_GATEWAY_QUOTA_FALLBACK_SEC = 60;
+
+function parseHermesRetryAfterHeader(raw: string | null | undefined, now = Date.now()): string | null {
+  if (raw === null || raw === undefined) return null;
+  const value = String(raw).trim();
+  if (!value) return null;
+  // delta-seconds form (e.g. "120")
+  if (/^\d+$/.test(value)) {
+    const seconds = Number.parseInt(value, 10);
+    if (!Number.isFinite(seconds) || seconds < 0) return null;
+    return new Date(now + seconds * 1000).toISOString();
+  }
+  // HTTP-date form
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return null;
+  return new Date(parsed).toISOString();
+}
+
+function detectProviderQuotaExhaustion(
+  message: string | null | undefined,
+  now = Date.now(),
+): { errorCode: string; errorFamily: AdapterExecutionResult["errorFamily"]; retryNotBefore: string | null } | null {
+  if (!message) return null;
+  const trimmed = String(message).trim();
+  if (!trimmed) return null;
+  const isQuotaExhausted =
+    CODEX_QUOTA_MESSAGE_RE.test(trimmed) ||
+    HTTP_429_MESSAGE_RE.test(trimmed) ||
+    USAGE_LIMIT_MESSAGE_RE.test(trimmed);
+  if (!isQuotaExhausted) return null;
+  const explicit = CODEX_QUOTA_MESSAGE_RE.exec(trimmed);
+  const hint = RETRY_AFTER_HINT_RE.exec(trimmed);
+  const rawSeconds = (explicit && explicit[1]) ?? (hint && hint[1]) ?? null;
+  let seconds: number | null = null;
+  if (rawSeconds !== null) {
+    const parsed = Number.parseInt(rawSeconds, 10);
+    if (Number.isFinite(parsed) && parsed > 0) seconds = parsed;
+  }
+  if (seconds === null) seconds = HERMES_GATEWAY_QUOTA_FALLBACK_SEC;
+  const retryNotBefore = new Date(now + seconds * 1000).toISOString();
+  return { errorCode: "hermes_gateway_rate_limited", errorFamily: "provider_quota", retryNotBefore };
+}
+
+export const __providerQuotaInternals = {
+  parseHermesRetryAfterHeader,
+  detectProviderQuotaExhaustion,
+};
+
 function fetchFailureMessage(err: unknown): string {
   const message = err instanceof Error ? err.message : String(err);
   const cause = err instanceof Error ? (err as { cause?: unknown }).cause : null;
@@ -380,7 +447,13 @@ async function fetchJson(input: RequestInfo | URL, init: RequestInit): Promise<u
     const err = new Error(`Hermes gateway HTTP ${response.status}`) as HermesHttpError;
     err.status = response.status;
     err.code = classified.code;
-    err.retryNotBefore = response.headers.get("retry-after");
+    // The `retry-after` header value is either delta-seconds (e.g. "120") or an
+    // HTTP-date. The downstream consumer (heartbeat.readTransientRetryNotBefore)
+    // parses via `new Date(value)`, which accepts "1653" as year 1653 → the
+    // date lands in the past and the scheduler ignores the backoff. Normalise
+    // to an absolute ISO datetime up front so the scheduler sees a real
+    // future instant.
+    err.retryNotBefore = parseHermesRetryAfterHeader(response.headers.get("retry-after"));
     err.body = body;
     throw err;
   }
@@ -671,16 +744,26 @@ export function mapFinalResultForTest(input: {
   const mapped = terminalResultCode(input.terminal.status);
   const usage = parseUsage(payload);
   const costUsd = parseCostUsd(payload);
-  const errorMessage = mapped.errorCode
-    ? redactText(extractErrorMessage(payload) ?? `Hermes run ${input.terminal.status}`)
+  const rawErrorMessage = mapped.errorCode
+    ? extractErrorMessage(payload) ?? `Hermes run ${input.terminal.status}`
     : null;
+  const errorMessage = rawErrorMessage ? redactText(rawErrorMessage) : null;
+  // Detect provider-quota exhaustion (e.g. Codex 429) inside a terminal
+  // "failed" event and tag the result so the scheduler honours the backoff.
+  const quotaOverride =
+    mapped.errorCode && FAILURE_STATUSES.has(input.terminal.status)
+      ? detectProviderQuotaExhaustion(rawErrorMessage)
+      : null;
+  const finalErrorCode = quotaOverride?.errorCode ?? mapped.errorCode;
   return {
     exitCode: mapped.exitCode,
     signal: mapped.signal,
     timedOut: false,
     provider: "hermes_gateway",
     model: extractModel(payload),
-    ...(mapped.errorCode ? { errorCode: mapped.errorCode } : {}),
+    ...(finalErrorCode ? { errorCode: finalErrorCode } : {}),
+    ...(quotaOverride?.errorFamily ? { errorFamily: quotaOverride.errorFamily } : {}),
+    ...(quotaOverride?.retryNotBefore ? { retryNotBefore: quotaOverride.retryNotBefore } : {}),
     ...(errorMessage ? { errorMessage } : {}),
     ...(usage ? { usage } : {}),
     ...(costUsd !== null ? { costUsd } : {}),
@@ -757,16 +840,27 @@ function errorResult(err: unknown, redactText: TextRedactor = sanitizeSensitiveT
   const hermesError = err as HermesHttpError;
   const code = hermesError.code ?? "hermes_gateway_protocol_error";
   const classified = hermesError.status ? classifyHttpError(hermesError.status) : null;
+  const rawMessage = err instanceof Error ? err.message : String(err);
   const errorMessage = code === "hermes_gateway_auth_failed"
     ? `${redactErrorMessage(err, redactText)}. Check adapterConfig.apiKey matches the Hermes API_SERVER_KEY for the running gateway.`
     : redactErrorMessage(err, redactText);
+  // On real HTTP 429s, upgrade the family to provider_quota (more specific than
+  // transient_upstream) when the message or body signals it, and synthesise
+  // retryNotBefore from the message if the header was missing.
+  const quotaOverride =
+    hermesError.status === 429 && !hermesError.retryNotBefore
+      ? detectProviderQuotaExhaustion(rawMessage)
+      : null;
   return {
     exitCode: 1,
     signal: null,
     timedOut: false,
     errorCode: code,
-    errorFamily: classified?.family ?? (code === "hermes_gateway_connect_failed" ? "transient_upstream" : null),
-    retryNotBefore: hermesError.retryNotBefore ?? null,
+    errorFamily:
+      quotaOverride?.errorFamily ??
+      classified?.family ??
+      (code === "hermes_gateway_connect_failed" ? "transient_upstream" : null),
+    retryNotBefore: hermesError.retryNotBefore ?? quotaOverride?.retryNotBefore ?? null,
     errorMessage,
     errorMeta: {
       ...(hermesError.status ? { status: hermesError.status } : {}),

--- a/packages/adapters/hermes/src/gateway/server/execute.ts
+++ b/packages/adapters/hermes/src/gateway/server/execute.ts
@@ -374,6 +374,18 @@ const RETRY_AFTER_HINT_RE = /retry[-_\s]?after[:\s]+(\d+)\s*s?\b/i;
 // can shorten it, but long enough to break the immediate hot-loop.
 const HERMES_GATEWAY_QUOTA_FALLBACK_SEC = 60;
 
+// ECMAScript Dates only cover ±8.64e15 ms around the epoch. A finite but
+// out-of-range value (e.g. "Retry-After: 9999999999999999") builds an Invalid
+// Date whose toISOString() throws, and on the terminal-event path that
+// exception would escape result mapping and reject execute() instead of
+// yielding a handled failure. Serialise through this guard instead.
+const MAX_DATE_MS = 8_640_000_000_000_000;
+
+function toSafeIsoTimestamp(ms: number): string | null {
+  if (!Number.isFinite(ms) || Math.abs(ms) > MAX_DATE_MS) return null;
+  return new Date(ms).toISOString();
+}
+
 function parseHermesRetryAfterHeader(raw: string | null | undefined, now = Date.now()): string | null {
   if (raw === null || raw === undefined) return null;
   const value = String(raw).trim();
@@ -382,12 +394,30 @@ function parseHermesRetryAfterHeader(raw: string | null | undefined, now = Date.
   if (/^\d+$/.test(value)) {
     const seconds = Number.parseInt(value, 10);
     if (!Number.isFinite(seconds) || seconds < 0) return null;
-    return new Date(now + seconds * 1000).toISOString();
+    return toSafeIsoTimestamp(now + seconds * 1000);
   }
   // HTTP-date form
   const parsed = Date.parse(value);
   if (!Number.isFinite(parsed)) return null;
-  return new Date(parsed).toISOString();
+  return toSafeIsoTimestamp(parsed);
+}
+
+// The direct HTTP 429 path only sees the synthetic "Hermes gateway HTTP 429"
+// message, which says nothing about *who* is throttling. The upstream quota
+// signal, when present, lives in the response body — either as a plain-text
+// body (wrapped as { text }) or as an { error | message | detail } record.
+function extractQuotaSignalFromBody(body: unknown): string | null {
+  if (typeof body === "string") return nonEmpty(body);
+  const record = asRecord(body);
+  if (!record) return null;
+  const nestedError = asRecord(record.error);
+  return (
+    nonEmpty(record.error) ??
+    nonEmpty(nestedError?.message) ??
+    nonEmpty(record.message) ??
+    nonEmpty(record.detail) ??
+    nonEmpty(record.text)
+  );
 }
 
 function detectProviderQuotaExhaustion(
@@ -411,13 +441,18 @@ function detectProviderQuotaExhaustion(
     if (Number.isFinite(parsed) && parsed > 0) seconds = parsed;
   }
   if (seconds === null) seconds = HERMES_GATEWAY_QUOTA_FALLBACK_SEC;
-  const retryNotBefore = new Date(now + seconds * 1000).toISOString();
+  // An absurd retry hint must not turn into an exception (or a null backoff
+  // that re-enables the hot-loop): degrade to the fallback cool-down.
+  const retryNotBefore =
+    toSafeIsoTimestamp(now + seconds * 1000) ??
+    toSafeIsoTimestamp(now + HERMES_GATEWAY_QUOTA_FALLBACK_SEC * 1000);
   return { errorCode: "hermes_gateway_rate_limited", errorFamily: "provider_quota", retryNotBefore };
 }
 
 export const __providerQuotaInternals = {
   parseHermesRetryAfterHeader,
   detectProviderQuotaExhaustion,
+  extractQuotaSignalFromBody,
 };
 
 function fetchFailureMessage(err: unknown): string {
@@ -840,16 +875,19 @@ function errorResult(err: unknown, redactText: TextRedactor = sanitizeSensitiveT
   const hermesError = err as HermesHttpError;
   const code = hermesError.code ?? "hermes_gateway_protocol_error";
   const classified = hermesError.status ? classifyHttpError(hermesError.status) : null;
-  const rawMessage = err instanceof Error ? err.message : String(err);
   const errorMessage = code === "hermes_gateway_auth_failed"
     ? `${redactErrorMessage(err, redactText)}. Check adapterConfig.apiKey matches the Hermes API_SERVER_KEY for the running gateway.`
     : redactErrorMessage(err, redactText);
-  // On real HTTP 429s, upgrade the family to provider_quota (more specific than
-  // transient_upstream) when the message or body signals it, and synthesise
-  // retryNotBefore from the message if the header was missing.
+  // On real HTTP 429s without a retry-after header, upgrade the family to
+  // provider_quota (more specific than transient_upstream) only when the
+  // response *body* carries an upstream quota signature, and synthesise
+  // retryNotBefore from it. The synthetic "Hermes gateway HTTP 429" message
+  // must not be consulted: it matches the broad 429 matcher for every
+  // headerless 429, including the gateway merely throttling requests, which
+  // has to stay transient_upstream.
   const quotaOverride =
     hermesError.status === 429 && !hermesError.retryNotBefore
-      ? detectProviderQuotaExhaustion(rawMessage)
+      ? detectProviderQuotaExhaustion(extractQuotaSignalFromBody(hermesError.body))
       : null;
   return {
     exitCode: 1,


### PR DESCRIPTION
<!-- Written in Simplified Technical English -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The Hermes gateway adapter runs remote agents behind an HTTP/SSE API and reports terminal results back to the paperclip heartbeat scheduler.
> - When the upstream provider behind the gateway (Codex/ChatGPT, in our case) exhausts its quota, the gateway completes the run with `status=failed` and an error message like `"Codex provider quota exhausted (429); retry after 4825s"`. The adapter emits `errorCode=hermes_gateway_run_failed` with no `errorFamily` and no `retryNotBefore`.
> - The heartbeat scheduler treats that as a generic failure and fires the next run immediately, which hits the same 429, producing a storm of failed runs during the full cooldown window (~1 h). We observed one agent produce 99 failed runs in 59 minutes on 2026-09-03, and 83 failed runs in a similar window six days earlier.
> - A second, related bug: the HTTP 429 path already reads the `Retry-After` header, but it passes the raw string (e.g. `"120"`) to the scheduler. `new Date("120")` parses as year 120 CE, always in the past, so the scheduler skips the backoff.
> - This pull request tags provider-quota exhaustion inside `terminal.status=failed` events with `errorFamily=provider_quota` and a real `retryNotBefore` derived from the message, and it normalises the HTTP `Retry-After` header into an absolute ISO datetime.
> - The benefit is that the paperclip scheduler honours the cooldown window and does not burn tokens hammering a rate-limited upstream provider.

## Linked Issues or Issue Description

No public issue exists for this bug. Description follows the bug template.

**Describe the bug**

The Hermes gateway adapter does not tag upstream provider quota exhaustion. When a gateway run completes with `status=failed` and an error message that carries a 429 signal (Codex quota exhausted; HTTP 429; usage limit reached), the terminal result gets `errorCode=hermes_gateway_run_failed` with no `errorFamily` and no `retryNotBefore`. The heartbeat scheduler treats it as a generic failure and starts the next run immediately, which hits the same 429. The result is a storm of failed runs for the full cooldown window.

A second bug applies to the direct HTTP 429 path in `fetchJson`. It already reads the `Retry-After` header, but it passes the raw string (e.g. `"120"`) to the scheduler. The downstream consumer does `new Date(value)`, which parses `"120"` as year 120 CE, always in the past, so the scheduler ignores the backoff.

**To Reproduce**

1. Point the Hermes gateway adapter at a gateway backed by a Codex/ChatGPT account that has exhausted its plan quota.
2. Assign work to the agent so the scheduler wakes it.
3. Observe the run complete with `status=failed` and an error message like `Codex provider quota exhausted (429); retry after 4825s. Credentials still valid.`
4. Observe the scheduler start the next run immediately instead of waiting for the reported retry-after window.

**Expected behavior**

The adapter should tag the terminal result with `errorCode=hermes_gateway_rate_limited`, `errorFamily=provider_quota`, and a `retryNotBefore` derived from the message so the scheduler honours the cooldown. The HTTP 429 path should normalise `Retry-After` values into absolute ISO datetimes.

**Environment**

- Paperclip: current `master`.
- Adapter: `@paperclipai/hermes-paperclip-adapter` gateway server.
- Upstream provider observed: Codex (ChatGPT plan) reaching the 5 h rolling quota.

## What Changed

- `packages/adapters/hermes/src/gateway/server/execute.ts`
  - Add `detectProviderQuotaExhaustion(message)`. It matches three known forms of the gateway quota message and returns `errorCode=hermes_gateway_rate_limited`, `errorFamily=provider_quota`, and a `retryNotBefore` derived from the reported seconds hint. Fallback cool-down: 60 s.
  - Add `parseHermesRetryAfterHeader(raw)`. It normalises HTTP `Retry-After` delta-seconds or HTTP-date values into absolute ISO datetimes.
  - `fetchJson()` now normalises the `Retry-After` header value with `parseHermesRetryAfterHeader` before setting `err.retryNotBefore`.
  - `mapFinalResultForTest()` promotes terminal `status=failed` events that match a provider-quota message to `errorCode=hermes_gateway_rate_limited` + `errorFamily=provider_quota` + real `retryNotBefore`.
  - `errorResult()` upgrades the family and synthesises `retryNotBefore` on real HTTP 429s when the header was missing but the message signals quota exhaustion.
- `packages/adapters/hermes/src/gateway/server/execute.test.ts`
  - Add unit tests for `mapFinalResultForTest` provider-quota promotion (explicit seconds + fallback + untouched control case).
  - Add unit tests for `parseHermesRetryAfterHeader` (delta-seconds, HTTP-date, invalid inputs).
  - Add unit tests for `detectProviderQuotaExhaustion` (no-match + explicit seconds match).

## Verification

- `pnpm --filter @paperclipai/hermes-paperclip-adapter test` runs the full adapter suite. All 31 tests in `packages/adapters/hermes/src/gateway/server/execute.test.ts` pass, including the 6 new ones.
- `tsc -p packages/adapters/hermes/tsconfig.json --noEmit` reports no errors.
- Manual runtime import via `tsx` on the same file confirms the exported helpers return the expected `{errorCode, errorFamily, retryNotBefore}` shape for real-world quota messages (Codex 4825 s, HTTP 429 with no seconds hint, plain "boom" control).

## Risks

- Low risk. Scope is limited to the Hermes gateway adapter. The change is additive on the terminal-failed path: unrelated failures still produce `hermes_gateway_run_failed` with no family and no `retryNotBefore` (covered by the "leaves unrelated terminal failures untouched" test). The HTTP 429 header normalisation is a bug fix that only changes the shape of the value from a raw string to an ISO datetime; the downstream consumer already expects a parseable datetime.
- Fallback cool-down of 60 s is intentionally modest so a later attempt that returns a real reset-time can shorten it, but long enough to break the immediate hot-loop.

## Model Used

- Provider: Anthropic Claude.
- Exact model ID: `claude-opus-4-7` (Claude Opus 4.7).
- Reasoning mode: default (no extended thinking).
- Capability details: tool use for code editing, shell, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
