### PR TITLE
Onboarding: the API key field is the same card as the sign-in

### DIFF
--- a/ui/src/components/AdapterLoginChrome.test.tsx
+++ b/ui/src/components/AdapterLoginChrome.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+
+import { createRoot, type Root } from "react-dom/client";
+import { flushSync } from "react-dom";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  OnboardingLoginCard,
+  OnboardingLoginCodeInput,
+  onboardingCardInputClass,
+} from "./AdapterLoginChrome";
+import { ApiKeyField } from "./onboarding/ConnectInputCanvas";
+
+/**
+ * The connect step's canvas holds one of two cards, and the credential switch
+ * above trades between them. They are two answers to one question, so they have
+ * to be built the same way — and the last time they were only *matched*, by
+ * restating each other's measurements, they drifted the moment one was redrawn.
+ *
+ * These tests pin the sharing rather than the appearance. A colour or a radius
+ * is the design's to change; what must not change is that both cards get it
+ * from the same declaration.
+ */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+async function act(callback: () => void | Promise<void>) {
+  let result: void | Promise<void> = undefined;
+  flushSync(() => {
+    result = callback();
+  });
+  await result;
+}
+
+let roots: Root[] = [];
+
+afterEach(async () => {
+  for (const root of roots) {
+    await act(async () => root.unmount());
+  }
+  roots = [];
+  document.body.innerHTML = "";
+});
+
+async function render(node: React.ReactNode): Promise<HTMLElement> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push(root);
+  await act(async () => root.render(node));
+  return container;
+}
+
+describe("the connect step's two cards", () => {
+  it("gives the key field and the sign-in field the same input, from one declaration", async () => {
+    // The assertion that would have caught the drift this file exists for: not
+    // "both look like X", which passes right up until one of them is restyled,
+    // but that the two carry the byte-identical class string.
+    const signIn = await render(
+      <OnboardingLoginCard instruction="Open Claude link then come back and enter code">
+        <OnboardingLoginCodeInput value="" onChange={() => {}} onSubmit={() => {}} />
+      </OnboardingLoginCard>,
+    );
+    const keyCard = await render(
+      <ApiKeyField envKey="ANTHROPIC_API_KEY" value="" onChange={() => {}} />,
+    );
+
+    const codeInput = signIn.querySelector("input")!;
+    const keyInput = keyCard.querySelector("input")!;
+    expect(codeInput.className).toBe(onboardingCardInputClass);
+    expect(keyInput.className).toBe(codeInput.className);
+  });
+
+  it("wraps the key field in the same card shell as the sign-in", async () => {
+    // The shell, not just the input. The key field used to draw its own
+    // bordered box, so flipping the credential switch changed the shape of the
+    // step rather than its content.
+    const signIn = await render(
+      <OnboardingLoginCard instruction="Open Claude link then come back and enter code">
+        <OnboardingLoginCodeInput value="" onChange={() => {}} onSubmit={() => {}} />
+      </OnboardingLoginCard>,
+    );
+    const keyCard = await render(
+      <ApiKeyField envKey="ANTHROPIC_API_KEY" value="" onChange={() => {}} />,
+    );
+
+    expect(keyCard.firstElementChild!.className).toBe(signIn.firstElementChild!.className);
+  });
+
+  it("labels the key field with the variable it will be written to", async () => {
+    // The name answers what a paster cannot answer for themselves — where this
+    // step puts the key — so it is the label rather than a sentence about it,
+    // and it reaches assistive tech as the field's name too.
+    const keyCard = await render(
+      <ApiKeyField envKey="ANTHROPIC_API_KEY" value="" onChange={() => {}} />,
+    );
+
+    expect(keyCard.textContent).toContain("ANTHROPIC_API_KEY");
+    expect(keyCard.querySelector("input")!.getAttribute("aria-label")).toBe("ANTHROPIC_API_KEY");
+    // Still a password field: the key is a secret even while being pasted.
+    expect(keyCard.querySelector("input")!.getAttribute("type")).toBe("password");
+  });
+});

--- a/ui/src/components/AdapterLoginChrome.tsx
+++ b/ui/src/components/AdapterLoginChrome.tsx
@@ -35,7 +35,12 @@ export function OnboardingLoginCard({
   onCancel,
   children,
 }: {
-  instruction: string;
+  /**
+   * A node rather than a string: the sign-in cards pass a sentence, and the
+   * key card passes the environment variable it will write to, which has to
+   * be mono to read as a name rather than as prose.
+   */
+  instruction: ReactNode;
   onCancel?: () => void;
   children: ReactNode;
 }) {
@@ -202,6 +207,19 @@ export function OnboardingLoginCodeRow({ code }: { code: string }) {
 }
 
 /**
+ * One row's worth of input, shared by every card that takes one.
+ *
+ * Exported rather than duplicated because the two inputs that use it — the
+ * browser code here and the API key on the credential card — sit in the same
+ * canvas one toggle apart, so a divergence between them is visible by flipping
+ * a switch. They differ in what they hold, not in what they look like.
+ */
+export const onboardingCardInputClass =
+  "h-(--sz-44px) w-full rounded-lg bg-muted px-5 font-mono text-xs text-foreground " +
+  "placeholder:font-sans placeholder:text-sm placeholder:text-muted-foreground " +
+  "outline-none focus-visible:ring-ring/50 focus-visible:ring-(length:--rad-3)";
+
+/**
  * The field the browser code is pasted back into.
  *
  * No Submit button beside it: the code arrives in one piece, off the clipboard,
@@ -245,7 +263,7 @@ export function OnboardingLoginCodeInput({
           onSubmit();
         }
       }}
-      className="h-(--sz-44px) w-full rounded-lg bg-muted px-5 font-mono text-xs text-foreground placeholder:font-sans placeholder:text-sm placeholder:text-muted-foreground outline-none focus-visible:ring-ring/50 focus-visible:ring-(length:--rad-3)"
+      className={onboardingCardInputClass}
     />
   );
 }

--- a/ui/src/components/onboarding/ConnectInputCanvas.tsx
+++ b/ui/src/components/onboarding/ConnectInputCanvas.tsx
@@ -1,7 +1,10 @@
 import { useLayoutEffect, useRef, type ReactNode } from "react";
 import { AnimatePresence, motion } from "motion/react";
 
-import { cn } from "../../lib/utils";
+import {
+  OnboardingLoginCard,
+  onboardingCardInputClass,
+} from "../AdapterLoginChrome";
 import {
   CANVAS_CONTENT_ENTER,
   CANVAS_ENTER_TRAVEL,
@@ -105,20 +108,24 @@ export function ConnectInputCanvas({
  * The API key field, for when the credential mode is keys rather than a
  * subscription.
  *
- * Built to the login panel's shape on purpose: same card, same padding, same
- * label-left / control-right row, same 28px control height. These two are
- * alternatives to each other — one canvas shows one or the other, and the
- * credential switch above trades between them — so they should read as two
- * answers to one question rather than as two different kinds of thing. Before
- * this the key field was a stacked label over a full-width input with no card
- * at all, and flipping the mode changed the shape of the step rather than its
- * content.
+ * Built to the sign-in card's shape on purpose, and that reasoning is
+ * unchanged from when it was written — only its target moved. These two are
+ * alternatives to each other: one canvas shows one or the other and the
+ * credential switch above trades between them, so they have to read as two
+ * answers to one question rather than as two different kinds of thing. It was
+ * matched to the old bordered panel; the connect step's sign-in became a
+ * borderless card with 44px rows, and this stayed behind, so flipping the
+ * toggle changed the shape of the step rather than its content — the exact
+ * failure the original note was written to prevent.
+ *
+ * It now composes the same primitives rather than restating their measurements,
+ * which is what keeps that from happening again.
  *
  * The variable name is the label rather than a sentence about it. Someone
- * pasting a key knows which one they are holding; what they cannot know is where
- * this step will put it, and the name answers that in the place it is asked —
- * while staying short enough to sit opposite the field the way "Sign in to the
- * environment" sits opposite its button.
+ * pasting a key knows which one they are holding; what they cannot know is
+ * where this step will put it, and the name answers that in the place it is
+ * asked. It takes the instruction slot the sign-in cards use for their
+ * sentence, in mono, because it is a name and not prose.
  */
 export function ApiKeyField({
   envKey,
@@ -139,29 +146,20 @@ export function ApiKeyField({
   }, []);
 
   return (
-    <div className="rounded-md border border-border bg-muted/40 px-3 py-2">
-      <label className="flex items-center justify-between gap-3">
-        <span className="font-mono text-xs font-medium text-foreground">
-          {envKey}
-        </span>
-        <input
-          ref={inputRef}
-          type="password"
-          autoComplete="off"
-          spellCheck={false}
-          value={value}
-          onChange={(event) => onChange(event.target.value)}
-          placeholder="Paste your key"
-          // `h-7` is the login button's height, so the two states put their
-          // control on the same line and the card does not change depth when the
-          // mode is flipped.
-          className={cn(
-            "h-7 w-(--sz-220px) shrink-0 rounded-md border border-border bg-background px-2",
-            "font-mono text-xs outline-none placeholder:font-sans",
-            "focus-visible:ring-ring/50 focus-visible:ring-(length:--rad-3)",
-          )}
-        />
-      </label>
-    </div>
+    <OnboardingLoginCard
+      instruction={<span className="font-mono">{envKey}</span>}
+    >
+      <input
+        ref={inputRef}
+        aria-label={envKey}
+        type="password"
+        autoComplete="off"
+        spellCheck={false}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder="Paste your key"
+        className={onboardingCardInputClass}
+      />
+    </OnboardingLoginCard>
   );
 }


### PR DESCRIPTION
## Thinking Path

#12801 redrew the connect step's sign-in as a borderless card with 44px rows, taken from the PCLP-Onboarding frames. The API key field is the *other* half of that step — the same canvas, reached by the "Use API key instead" toggle — and the design board never draws it, so it kept the chrome it was built to two designs ago.

The result is that flipping the toggle changes the shape of the step rather than its content, which is the specific failure the field's own doc comment was written to prevent. This closes that.

## Linked Issues or Issue Description

No tracking issue — described inline, per CONTRIBUTING.md.

**What's wrong.** On the connect step, the credential switch trades between two cards in one canvas. Since #12801 they no longer look like the same kind of thing:

| | sign-in card | API key field |
|---|---|---|
| shape | `rounded-xl`, no border | `rounded-md`, `border-border` |
| padding | `px-4 py-3.5` | `px-3 py-2` |
| control | 44px full-width row | 28px, `w-(--sz-220px)`, right-aligned |

**Expected.** Both read as two answers to one question. Pressing the toggle changes what is asked, not how the step is built.

## What Changed

`ApiKeyField` composes `OnboardingLoginCard` and the shared row input rather than restating their measurements. The environment variable name takes the instruction slot the sign-in cards use for their sentence, in mono — it is a name, not prose, and it still answers the thing a paster cannot answer for themselves: where this step will put the key.

Two supporting changes to the primitives:

- **`instruction` widens from `string` to `ReactNode`.** A variable name wants mono and a string cannot carry that.
- **The row input's classes move to an exported `onboardingCardInputClass`**, shared by the browser-code field and this one. Matching by restating measurements is what let these drift in the first place; sharing the declaration is what stops it happening again.

The autofocus-on-mount behaviour is unchanged.

## Verification

Measured both cards rendered side by side rather than eyeballing them:

```
signin: 432x176  radius 11.2px  border 0px  bg oklab(0.269 0 0 / 0.4)
apikey: 432x104  radius 11.2px  border 0px  bg oklab(0.269 0 0 / 0.4)
apikey input height: 44px
```

Identical width, radius, border and surface; the key card is shorter because it holds one row rather than two, and its input matches the card's row height.

`AdapterLoginChrome.test.tsx` pins the sharing rather than the appearance: the two inputs carry the byte-identical class string, and the key field's shell is the same element the sign-in card renders. "Both look like X" would pass right up until one is restyled — which is how these drifted in the first place. Both assertions fail against the old bordered box.

Full UI suite green — 555 files, 5381 tests. `tsc --noEmit` clean. `pnpm check:token-gates` clean on all four gates. The now-dead `cn` import was removed.

## Risks

- **Shared primitive.** `onboardingCardInputClass` and the widened `instruction` are used by the sign-in cards too, so a mistake here is visible on both. The measurements are unchanged — this moves a string, it does not restyle anything — and the suite covers the sign-in cards.
- **The API path is still undesigned.** This makes it consistent with the sign-in card; it is not a design of the key card, because the board does not contain one. If one arrives, this is the thing to redraw.
- **Visual-only.** No behaviour, no schema, no server, no persistence change. The key is still written into the adapter config at hire time and never into the draft.

## Model Used

Anthropic Claude — Opus 5, model ID `claude-opus-5`, run through Claude Code.

Extended thinking enabled. Tool use throughout: repo search and file edits, `vitest`, `tsc` and `check-token-gates` runs, and Playwright to render and measure both cards against each other.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

Follows #12801.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
