### PR TITLE
fix(environments): merge realization metadata before sync

### DIFF
--- a/server/src/__tests__/environment-run-orchestrator.test.ts
+++ b/server/src/__tests__/environment-run-orchestrator.test.ts
@@ -416,6 +416,87 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
     expect(result.persistedExecutionWorkspace).toEqual(updatedEw);
   });
 
+  it("merges provider realization metadata into the lease used by subsequent syncs", async () => {
+    const providerWorkspaceRealization = {
+      version: 1,
+      mode: "copy",
+      authoritativeRoot: "/workspace",
+      pathAliases: [],
+      outboundRestorePaths: [],
+    };
+    const lease = makeLease({
+      metadata: {
+        remoteCwd: "/stale-workspace",
+        phase: "Pending",
+        namespace: "preserved-namespace",
+        workspaceRealization: { version: 0 },
+      },
+    });
+    const updatedLease = {
+      ...lease,
+      metadata: {
+        ...lease.metadata,
+        provider: "kubernetes",
+        remoteCwd: "/workspace",
+        phase: "Ready",
+        workspaceRealization: providerWorkspaceRealization,
+      },
+    };
+    const syncIn = vi.fn();
+    const syncOut = vi.fn();
+
+    mockUpdateLeaseMetadata.mockResolvedValue(updatedLease);
+    mockResolveEnvironmentExecutionTarget.mockImplementation(async ({ lease: resolvedLease }) => ({
+      kind: "remote",
+      transport: "sandbox",
+      remoteCwd: "/workspace",
+      runner: {
+        syncIn: async () => syncIn(resolvedLease.metadata),
+        syncOut: async () => syncOut(resolvedLease.metadata),
+      },
+    }));
+    const runtime = makeMockRuntime({
+      realizeWorkspace: vi.fn().mockResolvedValue({
+        cwd: "/workspace",
+        metadata: {
+          provider: "kubernetes",
+          remoteCwd: "/workspace",
+          phase: "Ready",
+          workspaceRealization: providerWorkspaceRealization,
+        },
+      }),
+    });
+    const orchestrator = environmentRunOrchestrator(mockDb, { environmentRuntime: runtime });
+
+    const result = await orchestrator.realizeForRun(makeRealizeInput({
+      environment: makeEnvironment("sandbox"),
+      lease,
+    }));
+    const runner = result.executionTarget?.runner;
+    if (!runner?.syncIn || !runner.syncOut) {
+      throw new Error("Expected a sync-capable execution target");
+    }
+    await runner.syncIn([]);
+    await runner.syncOut([]);
+
+    expect(mockUpdateLeaseMetadata).toHaveBeenCalledWith("lease-1", {
+      namespace: "preserved-namespace",
+      provider: "kubernetes",
+      remoteCwd: "/workspace",
+      phase: "Ready",
+      workspaceRealization: providerWorkspaceRealization,
+    });
+    expect(result.lease.metadata).toEqual({
+      namespace: "preserved-namespace",
+      provider: "kubernetes",
+      remoteCwd: "/workspace",
+      phase: "Ready",
+      workspaceRealization: providerWorkspaceRealization,
+    });
+    expect(syncIn).toHaveBeenCalledWith(result.lease.metadata);
+    expect(syncOut).toHaveBeenCalledWith(result.lease.metadata);
+  });
+
   it("runs a remote provision command after workspace realization when configured", async () => {
     mockBuildWorkspaceRealizationRequest.mockReturnValue({
       version: 1,

--- a/server/src/__tests__/environment-run-orchestrator.test.ts
+++ b/server/src/__tests__/environment-run-orchestrator.test.ts
@@ -416,7 +416,7 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
     expect(result.persistedExecutionWorkspace).toEqual(updatedEw);
   });
 
-  it("merges provider realization metadata into the lease used by subsequent syncs", async () => {
+  it("merges realization-owned metadata into the lease used by subsequent syncs", async () => {
     const providerWorkspaceRealization = {
       version: 1,
       mode: "copy",
@@ -427,8 +427,14 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
     const lease = makeLease({
       metadata: {
         remoteCwd: "/stale-workspace",
-        phase: "Pending",
         namespace: "preserved-namespace",
+        driver: "sandbox",
+        backend: "sandbox-cr",
+        reuse: "existing",
+        capabilities: ["sync"],
+        lifecycleId: "lifecycle-1",
+        phase: "Pending",
+        provider: "acquired-provider",
         workspaceRealization: { version: 0 },
       },
     });
@@ -436,9 +442,7 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
       ...lease,
       metadata: {
         ...lease.metadata,
-        provider: "kubernetes",
         remoteCwd: "/workspace",
-        phase: "Ready",
         workspaceRealization: providerWorkspaceRealization,
       },
     };
@@ -459,9 +463,15 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
       realizeWorkspace: vi.fn().mockResolvedValue({
         cwd: "/workspace",
         metadata: {
-          provider: "kubernetes",
           remoteCwd: "/workspace",
-          phase: "Ready",
+          driver: "malicious-driver",
+          backend: "malicious-backend",
+          reuse: "malicious-reuse",
+          capabilities: ["malicious-capability"],
+          lifecycleId: "malicious-lifecycle",
+          namespace: "malicious-namespace",
+          phase: "malicious-phase",
+          provider: "malicious-provider",
           workspaceRealization: providerWorkspaceRealization,
         },
       }),
@@ -481,16 +491,26 @@ describe("environmentRunOrchestrator — realizeForRun", () => {
 
     expect(mockUpdateLeaseMetadata).toHaveBeenCalledWith("lease-1", {
       namespace: "preserved-namespace",
-      provider: "kubernetes",
       remoteCwd: "/workspace",
-      phase: "Ready",
+      driver: "sandbox",
+      backend: "sandbox-cr",
+      reuse: "existing",
+      capabilities: ["sync"],
+      lifecycleId: "lifecycle-1",
+      phase: "Pending",
+      provider: "acquired-provider",
       workspaceRealization: providerWorkspaceRealization,
     });
     expect(result.lease.metadata).toEqual({
       namespace: "preserved-namespace",
-      provider: "kubernetes",
       remoteCwd: "/workspace",
-      phase: "Ready",
+      driver: "sandbox",
+      backend: "sandbox-cr",
+      reuse: "existing",
+      capabilities: ["sync"],
+      lifecycleId: "lifecycle-1",
+      phase: "Pending",
+      provider: "acquired-provider",
       workspaceRealization: providerWorkspaceRealization,
     });
     expect(syncIn).toHaveBeenCalledWith(result.lease.metadata);

--- a/server/src/services/environment-run-orchestrator.ts
+++ b/server/src/services/environment-run-orchestrator.ts
@@ -147,6 +147,18 @@ function formatProvisionFailureDetail(result: {
   return detail ? `${status}: ${detail}` : status;
 }
 
+const REALIZATION_LEASE_METADATA_KEYS = ["remoteCwd", "workspaceRealization"] as const;
+
+function selectRealizationLeaseMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
+  const selected: Record<string, unknown> = {};
+  for (const key of REALIZATION_LEASE_METADATA_KEYS) {
+    if (Object.hasOwn(metadata, key)) {
+      selected[key] = metadata[key];
+    }
+  }
+  return selected;
+}
+
 // ---------------------------------------------------------------------------
 // Service factory
 // ---------------------------------------------------------------------------
@@ -383,7 +395,7 @@ export function environmentRunOrchestrator(
 
     // Step 2: Realize workspace in the environment via the runtime driver
     let workspaceRealization: Record<string, unknown> = {};
-    let realizationMetadata: Record<string, unknown> = {};
+    let leaseRealizationMetadata: Record<string, unknown> = {};
     let realizedWorkspaceCwd: string | null = null;
     if (ENVIRONMENT_DRIVER_TRAITS[environment.driver].realizesWorkspace) {
       try {
@@ -407,8 +419,9 @@ export function environmentRunOrchestrator(
           typeof workspaceRealizationResult.cwd === "string" && workspaceRealizationResult.cwd.trim().length > 0
             ? workspaceRealizationResult.cwd.trim()
             : null;
-        realizationMetadata = parseObject(workspaceRealizationResult.metadata);
-        workspaceRealization = parseObject(realizationMetadata.workspaceRealization);
+        const realizationMetadata = parseObject(workspaceRealizationResult.metadata);
+        leaseRealizationMetadata = selectRealizationLeaseMetadata(realizationMetadata);
+        workspaceRealization = parseObject(leaseRealizationMetadata.workspaceRealization);
       } catch (err) {
         throw new EnvironmentRunError(
           "workspace_realization_failed",
@@ -487,10 +500,10 @@ export function environmentRunOrchestrator(
     }
 
     // Step 3: Persist realization metadata on lease and execution workspace
-    if (Object.keys(realizationMetadata).length > 0) {
+    if (Object.keys(leaseRealizationMetadata).length > 0) {
       const nextLeaseMetadata = {
         ...(lease.metadata ?? {}),
-        ...realizationMetadata,
+        ...leaseRealizationMetadata,
       };
       const updatedLease = await environmentsSvc.updateLeaseMetadata(lease.id, nextLeaseMetadata);
       if (updatedLease) {

--- a/server/src/services/environment-run-orchestrator.ts
+++ b/server/src/services/environment-run-orchestrator.ts
@@ -383,6 +383,7 @@ export function environmentRunOrchestrator(
 
     // Step 2: Realize workspace in the environment via the runtime driver
     let workspaceRealization: Record<string, unknown> = {};
+    let realizationMetadata: Record<string, unknown> = {};
     let realizedWorkspaceCwd: string | null = null;
     if (ENVIRONMENT_DRIVER_TRAITS[environment.driver].realizesWorkspace) {
       try {
@@ -406,7 +407,8 @@ export function environmentRunOrchestrator(
           typeof workspaceRealizationResult.cwd === "string" && workspaceRealizationResult.cwd.trim().length > 0
             ? workspaceRealizationResult.cwd.trim()
             : null;
-        workspaceRealization = parseObject(workspaceRealizationResult.metadata?.workspaceRealization);
+        realizationMetadata = parseObject(workspaceRealizationResult.metadata);
+        workspaceRealization = parseObject(realizationMetadata.workspaceRealization);
       } catch (err) {
         throw new EnvironmentRunError(
           "workspace_realization_failed",
@@ -485,10 +487,10 @@ export function environmentRunOrchestrator(
     }
 
     // Step 3: Persist realization metadata on lease and execution workspace
-    if (Object.keys(workspaceRealization).length > 0) {
+    if (Object.keys(realizationMetadata).length > 0) {
       const nextLeaseMetadata = {
         ...(lease.metadata ?? {}),
-        workspaceRealization,
+        ...realizationMetadata,
       };
       const updatedLease = await environmentsSvc.updateLeaseMetadata(lease.id, nextLeaseMetadata);
       if (updatedLease) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents for work.
> - Environment runtimes realize workspaces before agent runs.
> - Native environment sync uses metadata on the returned lease.
> - A provider can return `remoteCwd` during workspace realization.
> - The orchestrator persisted only `workspaceRealization`.
> - Sync then used stale lease metadata and could not find the provider path.
> - This pull request propagates only protocol-owned realization metadata into the lease before sync.
> - The benefit is that provider paths reach native sync without allowing provider metadata to replace acquisition-time lease state.

## Linked Issues or Issue Description

**What happened?**

A provider can return `metadata.remoteCwd` during workspace realization. The orchestrator does not persist that field on the lease. A later native Kubernetes sync reads the old lease metadata and fails because the remote workspace path is absent.

**Expected behavior**

Before native sync starts, the lease may be updated only from realization-owned `remoteCwd` and `workspaceRealization` values. Those two values can replace stale same-key lease values. Unrelated acquisition-time lease metadata remains unchanged.

**Steps to reproduce**

1. Configure an environment runtime that realizes a workspace and returns `metadata.remoteCwd`.
2. Start an agent run that uses native environment sync.
3. Observe that sync reads lease metadata without the provider remote workspace path.

**Paperclip version or commit**

`b5f86237617cbb80f5d7a7519d526be4390574b9` (`master` at verification time).

**Deployment mode**

Built from source for local verification.

**Agent adapter(s) involved**

Not adapter-specific (core bug).

## What Changed

- Propagate only allowlisted realization metadata, `remoteCwd` and `workspaceRealization`, into persisted lease metadata.
- Preserve existing lease values for all other keys, including acquisition-time lifecycle and provider metadata.
- Allow only the two realization-owned keys to replace stale same-key lease values before sync.
- Add regression coverage for protected metadata collisions and both sync directions.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/environment-run-orchestrator.test.ts`
- `pnpm --filter @paperclipai/server exec tsc --noEmit`
- `pnpm --filter @paperclipai/server build`
- Protected collision coverage verifies that provider values cannot replace `driver`, `backend`, `reuse`, `capabilities`, `lifecycleId`, `namespace`, `phase`, or `provider`, while `remoteCwd` and `workspaceRealization` reach sync.

All commands passed locally.

## Risks

Low risk. The narrow allowlist changes only protocol-owned realization metadata and preserves acquisition-time lease metadata. Compatibility is limited to providers that return the established `remoteCwd` or `workspaceRealization` contract; other provider metadata is intentionally not propagated.

## Model Used

OpenAI GPT-5.6 Terra (`openai/gpt-5.6-terra`). Tool-assisted code inspection, editing, testing, type checking, and build verification were used.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] No external documentation update is required for this internal lease-metadata propagation fix
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

> **CI note:** Three current CI jobs (`workspaces-a (2/2)`, `Verify serialized server suites (5/5)`, `verify`) are failing due to unrelated CLI config/onboarding timeouts and a routine-route 500; the focused server tests, typecheck, build, and e2e shards all pass. These failures cannot be rerun from the fork.
