### PR TITLE
fix(built-in-agents): resolve a real responsible user for bundle routines

### DIFF
--- a/server/src/__tests__/built-in-agents.test.ts
+++ b/server/src/__tests__/built-in-agents.test.ts
@@ -648,6 +648,14 @@ describeEmbeddedPostgres("built-in agents", () => {
       status: "paused",
       assigneeAgentId: state.agentId,
     });
+    // Regression: the bundle installer used to pass a synthetic
+    // { userId: "built-in-bundles" } actor, which resolveRoutineResponsibleUserId
+    // returns verbatim. Every issue the routine spawned inherited that value and
+    // the assignee was then denied its own reads/writes with
+    // RESPONSIBLE_USER_UNAVAILABLE, because no such user exists. Bundle-managed
+    // routines must resolve a real responsible user like any other routine.
+    expect(routine!.responsibleUserId).not.toBe("built-in-bundles");
+    expect(routine!.responsibleUserId).toBe("responsible-user");
     const [trigger] = await db.select().from(routineTriggers).where(eq(routineTriggers.routineId, routine!.id));
     expect(trigger).toMatchObject({
       kind: "schedule",

--- a/server/src/services/built-in-agents.ts
+++ b/server/src/services/built-in-agents.ts
@@ -1284,7 +1284,15 @@ export function builtInAgentService(db: Db) {
 
   async function createOrResetRoutine(agent: Agent, definition: BuiltInAgentDefinition, existing: Routine | null, mode: "reconcile" | "reset") {
     const routine = definition.bundle!.routine;
-    const actor = { agentId: null, userId: "built-in-bundles" };
+    // Bundle installs have no human actor. Passing a synthetic label here would
+    // land in routines.responsible_user_id (see resolveRoutineResponsibleUserId,
+    // which returns actorUserId verbatim), and every issue the routine spawns
+    // inherits it -- the authorization layer then denies the assignee's own reads
+    // and writes with RESPONSIBLE_USER_UNAVAILABLE because no such user exists.
+    // Leave it null so the company default responsible user is resolved instead;
+    // bundle provenance is already recorded via origin_kind/origin_id and the
+    // activity log below.
+    const actor = { agentId: null, userId: null };
     const nextRoutine = existing
       ? await routineSvc.update(existing.id, {
         title: routine.title,


### PR DESCRIPTION
## Problem

Built-in agent bundles install their routine with a synthetic actor whose `userId` is the
literal string `"built-in-bundles"`:

```ts
// server/src/services/built-in-agents.ts:1287
const actor = { agentId: null, userId: "built-in-bundles" };
```

That actor flows into `routineSvc.create()` → `resolveRoutineResponsibleUserId()`, which returns
the caller's user id **verbatim, without checking that such a user exists**:

```ts
// server/src/services/routines.ts:162
if (actorUserId) return actorUserId;
```

So the routine is stored with `responsible_user_id = "built-in-bundles"`, and **every issue the
routine spawns inherits it**. The authorization layer then looks that user up, finds nothing, and
returns `RESPONSIBLE_USER_UNAVAILABLE`:

```ts
// server/src/services/authorization.ts:2305
const denyCode = snapshot.userExists && snapshot.activeMembership
  ? "RESPONSIBLE_USER_UNAUTHORIZED"
  : "RESPONSIBLE_USER_UNAVAILABLE";
```

**Net effect: the routine's own assignee gets a 403 on every read and write of its own issue.**
`GET /api/agents/me` still works, which makes it look like a partial outage rather than an
authorization defect.

## Observed impact

On a local instance running the Reflection Coach bundle (`reflection-coach:recent-agent-reflection`):

- The agent ran, produced its analysis, then could not post a comment or set a terminal status.
- The platform re-invoked it 4 times (21:00:04 / 21:04:09 / 21:08:04 / 21:09:01), each run exiting
  `succeeded` with `liveness_state = needs_followup` and no disposition.
- The issue was then auto-blocked with *"Paperclip could not resolve this issue's missing
  disposition automatically. The source assignment is unchanged and a board decision is required."*
- The agent's own run log:
  > `/api/agents/me` returns 200, but read **and** write on `/api/issues/$PAPERCLIP_TASK_ID` are
  > still `RESPONSIBLE_USER_UNAVAILABLE` (403), stopping retries after 2 failures.

This reproduced on two consecutive days (two separate issues from the same routine). On the same
instance, the nine manually-created routines all carry a valid `responsible_user_id` and work fine —
the bundle-installed one was the only broken routine, which is what made the cause identifiable.

## Fix

Pass `userId: null` for bundle installs so `resolveRoutineResponsibleUserId` falls through to
`resolveCompanyDefaultResponsibleUserId` (company `default_responsible_user_id`, then the active
owner membership) — the same resolution path every other routine already takes.

Bundle provenance is not lost: it is still recorded by `origin_kind = built_in_agent_bundle` /
`origin_id`, and by the activity-log entry a few lines below, which keeps
`actorId: "built-in-bundles"` — that field is a provenance label, and is the correct place for one.

## Test

Extends the existing case
`"reconciles an enabled Reflection Coach bundle with skill sync and a disabled routine"` in
`server/src/__tests__/built-in-agents.test.ts` with two assertions on the installed routine:

```ts
expect(routine!.responsibleUserId).not.toBe("built-in-bundles");
expect(routine!.responsibleUserId).toBe("responsible-user"); // seedCompany's defaultResponsibleUserId
```

Both fail on `master` and pass with the fix.

## Note for maintainers

The narrow fix is the call site, but the sharp edge is `resolveRoutineResponsibleUserId` returning
an unvalidated user id. Any caller that passes a non-user string produces a routine whose assignee
is silently locked out of its own issues, surfacing much later as an opaque 403. Validating the id
(or typing the actor so a provenance label cannot occupy the field) would close the class rather
than this instance. Happy to follow up with that if you'd like it in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017D7U13qfjL1d5H2rVWqrsx
