### PR TITLE
fix(issues): report the real wake reason in issue wake diagnostics

### DIFF
--- a/server/src/__tests__/wake-diagnostics-reason-allowlist.test.ts
+++ b/server/src/__tests__/wake-diagnostics-reason-allowlist.test.ts
@@ -33,12 +33,6 @@ const KNOWN_DYNAMIC_REASON_SOURCES = new Set([
   // getHeartbeatDailyCapBlock() only ever returns "heartbeat.daily_run_limit" or
   // "heartbeat.daily_cost_limit", both already in the allow-list.
   "dailyCapBlock.reason",
-  // enqueueWake(input) in server/src/services/native-runtime/status-decision-committer.ts
-  // is a file-local helper; every one of its six call sites passes a literal, and all four
-  // distinct values are in the allow-list: "issue_status_changed", "monitor_due",
-  // "issue_children_completed", "issue_blockers_resolved". Traced by hand when upstream's
-  // native status-decision committer landed.
-  "input.reason",
 ]);
 
 function walkTsFiles(dir: string, out: string[] = []): string[] {
@@ -97,6 +91,59 @@ function buildStringConstantMap(): Map<string, string> {
 }
 
 /**
+ * Resolves a wake `reason` that is a parameter of a file-local helper.
+ *
+ * Several files wrap the `agentWakeupRequests` write in a helper such as
+ * `enqueueWake({ reason, ... })`, so the literal lives at the helper's call sites
+ * rather than at the write itself. Whitelisting the parameter would let a new call
+ * site introduce a new reason without this guard noticing, so instead we find the
+ * enclosing helper and read the `reason` of every call to it in the same file.
+ *
+ * Returns null when the enclosing helper cannot be identified, so the caller can
+ * still report the reason source as unresolved.
+ */
+function resolveReasonFromHelperCallSites(
+  text: string,
+  writeSiteIndex: number,
+  identifier: string,
+): string[] | null {
+  // `input.reason` / `opts.reason` -> the parameter is the part before the dot.
+  const paramName = identifier.split(".")[0];
+  if (!paramName) return null;
+
+  // Walk backwards to the nearest enclosing function declaration.
+  const before = text.slice(0, writeSiteIndex);
+  const declRe = /(?:async\s+)?function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
+  let decl: RegExpExecArray | null;
+  let helperName: string | null = null;
+  while ((decl = declRe.exec(before))) helperName = decl[1];
+  if (!helperName) return null;
+
+  const literals = new Set<string>();
+  const callRe = new RegExp(`\\b${helperName}\\s*\\(`, "g");
+  let call: RegExpExecArray | null;
+  while ((call = callRe.exec(text))) {
+    const openIdx = call.index + call[0].length - 1;
+    // Skip the declaration itself.
+    if (/(?:async\s+)?function\s*$/.test(text.slice(Math.max(0, call.index - 20), call.index))) {
+      continue;
+    }
+    const args = extractBalancedParens(text, openIdx);
+    const reasonLine = args.match(/\breason\s*:\s*([^\n]*)/);
+    if (!reasonLine) continue;
+    // Read only the value position. For a ternary such as
+    // `reason: kind === "monitor" ? "monitor_due" : "issue_status_changed"`, the
+    // strings before the `?` belong to the condition, not to the reason.
+    const questionIdx = reasonLine[1].indexOf("?");
+    const valueExpr = questionIdx === -1
+      ? reasonLine[1]
+      : reasonLine[1].slice(questionIdx + 1);
+    for (const q of valueExpr.matchAll(/"([^"]+)"/g)) literals.add(q[1]);
+  }
+  return literals.size > 0 ? [...literals] : null;
+}
+
+/**
  * Finds every `.insert(agentWakeupRequests)` / `.update(agentWakeupRequests)` call site
  * under server/src and resolves the `reason` field of its `.values(...)`/`.set(...)`
  * argument to a literal string where possible.
@@ -132,6 +179,19 @@ function collectWakeupReasonLiterals(): { reason: string; files: string[] }[] {
         const literal = constMap.get(identifier)!;
         if (!found.has(literal)) found.set(literal, new Set());
         found.get(literal)!.add(relFile);
+      } else if (identifier.includes(".")) {
+        // A helper parameter such as `input.reason`. Trace the helper's call sites
+        // rather than trusting it, so a new call site with a new literal is caught.
+        const traced = resolveReasonFromHelperCallSites(text, m.index, identifier);
+        if (traced) {
+          for (const literal of traced) {
+            if (!found.has(literal)) found.set(literal, new Set());
+            found.get(literal)!.add(relFile);
+          }
+        } else if (!KNOWN_DYNAMIC_REASON_SOURCES.has(identifier)) {
+          if (!unresolved.has(identifier)) unresolved.set(identifier, new Set());
+          unresolved.get(identifier)!.add(relFile);
+        }
       } else if (KNOWN_DYNAMIC_REASON_SOURCES.has(identifier)) {
         // Deliberately excluded -- see KNOWN_DYNAMIC_REASON_SOURCES above.
         continue;

--- a/server/src/__tests__/wake-diagnostics-reason-allowlist.test.ts
+++ b/server/src/__tests__/wake-diagnostics-reason-allowlist.test.ts
@@ -33,6 +33,11 @@ const KNOWN_DYNAMIC_REASON_SOURCES = new Set([
   // getHeartbeatDailyCapBlock() only ever returns "heartbeat.daily_run_limit" or
   // "heartbeat.daily_cost_limit", both already in the allow-list.
   "dailyCapBlock.reason",
+  // services/heartbeat.ts re-enqueues a stored wake: `candidates` is selected
+  // `.from(agentWakeupRequests)`, so `candidate.reason` is a value another write
+  // site already put in this column. It propagates a reason, it never creates one,
+  // so it cannot introduce a literal the allow-list has not already seen.
+  "candidate.reason",
 ]);
 
 function walkTsFiles(dir: string, out: string[] = []): string[] {
@@ -77,6 +82,13 @@ function buildStringConstantMap(): Map<string, string> {
   ].filter((d) => fs.existsSync(d));
   const constMap = new Map<string, string>();
   const constRe = /(?:export\s+)?const\s+([A-Z][A-Z0-9_]*)\s*(?::\s*[^=]+)?=\s*"([^"]+)"/g;
+  // Some reason constants are members of a frozen lookup object rather than plain
+  // string constants, e.g. `RECOVERY_REASON_KINDS = { runLivenessContinuation:
+  // "run_liveness_continuation" } as const`. Index those members as `OBJECT.key`.
+  const constObjRe = /(?:export\s+)?const\s+([A-Z][A-Z0-9_]*)\s*=\s*\{([^}]*)\}\s*as const/g;
+  // And an alias of such a member, e.g. `const X_REASON = RECOVERY_REASON_KINDS.key`.
+  const aliasRe = /(?:export\s+)?const\s+([A-Z][A-Z0-9_]*)\s*=\s*([A-Z][A-Z0-9_]*\.[A-Za-z_][A-Za-z0-9_]*)\s*;/g;
+  const aliases: [string, string][] = [];
   for (const dir of dirs) {
     for (const file of walkTsFiles(dir)) {
       const text = fs.readFileSync(file, "utf8");
@@ -85,9 +97,57 @@ function buildStringConstantMap(): Map<string, string> {
       while ((m = constRe.exec(text))) {
         constMap.set(m[1], m[2]);
       }
+      constObjRe.lastIndex = 0;
+      while ((m = constObjRe.exec(text))) {
+        const objectName = m[1];
+        for (const member of m[2].matchAll(/([A-Za-z_][A-Za-z0-9_]*)\s*:\s*"([^"]+)"/g)) {
+          constMap.set(`${objectName}.${member[1]}`, member[2]);
+        }
+      }
+      aliasRe.lastIndex = 0;
+      while ((m = aliasRe.exec(text))) {
+        aliases.push([m[1], m[2]]);
+      }
     }
   }
+  // Resolve aliases after every file is indexed, so declaration order does not matter.
+  for (const [name, target] of aliases) {
+    const value = constMap.get(target);
+    if (value !== undefined) constMap.set(name, value);
+  }
   return constMap;
+}
+
+/**
+ * Reduces a `reason` expression to the literals it can produce.
+ *
+ * Resolution ladder, in order: a double-quoted literal (both branches of a ternary
+ * count), a SCREAMING_SNAKE string constant from the constant map, or an identifier
+ * already listed in KNOWN_DYNAMIC_REASON_SOURCES. Returns null when none apply, so
+ * the caller reports the site rather than reading an empty result as success.
+ */
+function literalsFromReasonExpression(
+  expression: string,
+  constMap: Map<string, string>,
+): string[] | null {
+  // For `cond ? "a" : "b"`, the strings before the `?` belong to the condition.
+  const questionIdx = expression.indexOf("?");
+  const valueExpr = questionIdx === -1 ? expression : expression.slice(questionIdx + 1);
+
+  const quoted = [...valueExpr.matchAll(/"([^"]+)"/g)].map((q) => q[1]);
+  if (quoted.length > 0) return quoted;
+
+  const resolved: string[] = [];
+  let sawIdentifier = false;
+  for (const idMatch of valueExpr.matchAll(/[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*/g)) {
+    const identifier = idMatch[0];
+    sawIdentifier = true;
+    if (constMap.has(identifier)) resolved.push(constMap.get(identifier)!);
+    else if (KNOWN_DYNAMIC_REASON_SOURCES.has(identifier)) continue;
+    else return null;
+  }
+  if (!sawIdentifier) return null;
+  return resolved;
 }
 
 /** Splits an argument list on top-level commas, ignoring nested brackets and strings. */
@@ -140,6 +200,7 @@ function resolveSpreadReasonFromCallSites(
   text: string,
   writeSiteIndex: number,
   spreadName: string,
+  constMap: Map<string, string>,
 ): { literals: string[] } | null {
   const before = text.slice(0, writeSiteIndex);
   const declRe = /(?:async\s+)?function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
@@ -170,7 +231,14 @@ function resolveSpreadReasonFromCallSites(
     if (arg === undefined) continue; // optional parameter omitted -- carries no reason
     if (!arg.startsWith("{")) return null; // a variable or call -- cannot prove absence
     if (!hasReasonProperty(arg)) continue; // inline object, provably no reason
-    for (const q of arg.matchAll(/reason\s*:\s*"([^"]+)"/g)) literals.add(q[1]);
+    // The property is there. It only counts as resolved when it reduces to a
+    // literal. Shorthand `{ reason }`, or `{ reason: someVar }`, carries a value
+    // this scan cannot see, so it must fail rather than read as an empty success.
+    const reasonExpr = arg.match(/\breason\s*:\s*([^,\n}]*)/);
+    if (!reasonExpr) return null; // shorthand `{ reason }` -- value not visible here
+    const argLiterals = literalsFromReasonExpression(reasonExpr[1], constMap);
+    if (argLiterals === null) return null;
+    for (const literal of argLiterals) literals.add(literal);
   }
   return { literals: [...literals] };
 }
@@ -191,6 +259,7 @@ function resolveReasonFromHelperCallSites(
   text: string,
   writeSiteIndex: number,
   identifier: string,
+  constMap: Map<string, string>,
 ): string[] | null {
   // `input.reason` / `opts.reason` -> the parameter is the part before the dot.
   const paramName = identifier.split(".")[0];
@@ -215,15 +284,20 @@ function resolveReasonFromHelperCallSites(
     }
     const args = extractBalancedParens(text, openIdx);
     const reasonLine = args.match(/\breason\s*:\s*([^\n]*)/);
-    if (!reasonLine) continue;
+    if (!reasonLine) {
+      // Shorthand `{ reason }` at a call site hides the value just as a spread
+      // does. Absence of a `reason:` key is only safe when no reason is mentioned.
+      if (hasReasonProperty(args)) return null;
+      continue;
+    }
     // Read only the value position. For a ternary such as
     // `reason: kind === "monitor" ? "monitor_due" : "issue_status_changed"`, the
     // strings before the `?` belong to the condition, not to the reason.
-    const questionIdx = reasonLine[1].indexOf("?");
-    const valueExpr = questionIdx === -1
-      ? reasonLine[1]
-      : reasonLine[1].slice(questionIdx + 1);
-    for (const q of valueExpr.matchAll(/"([^"]+)"/g)) literals.add(q[1]);
+    // A call site that names a reason but cannot be reduced -- `reason: someVar` --
+    // must not hide behind sibling call sites that could.
+    const callLiterals = literalsFromReasonExpression(reasonLine[1], constMap);
+    if (callLiterals === null) return null;
+    for (const literal of callLiterals) literals.add(literal);
   }
   return literals.size > 0 ? [...literals] : null;
 }
@@ -262,7 +336,7 @@ function collectWakeupReasonLiterals(): { reason: string; files: string[] }[] {
         const spread = /\.\.\.[A-Za-z_][A-Za-z0-9_]*/.test(block);
         if (!shorthand && !spread) continue;
         if (shorthand) {
-          const traced = resolveReasonFromHelperCallSites(text, m.index, "reason");
+          const traced = resolveReasonFromHelperCallSites(text, m.index, "reason", constMap);
           if (traced) {
             for (const literal of traced) {
               if (!found.has(literal)) found.set(literal, new Set());
@@ -280,7 +354,7 @@ function collectWakeupReasonLiterals(): { reason: string; files: string[] }[] {
           // variable, a nested spread, a call -- is reported rather than skipped.
           for (const spreadMatch of block.matchAll(/\.\.\.([A-Za-z_][A-Za-z0-9_]*)/g)) {
             const spreadName = spreadMatch[1];
-            const resolved = resolveSpreadReasonFromCallSites(text, m.index, spreadName);
+            const resolved = resolveSpreadReasonFromCallSites(text, m.index, spreadName, constMap);
             if (!resolved) {
               const key = `...${spreadName} (unprovable spread)`;
               if (!unresolved.has(key)) unresolved.set(key, new Set());
@@ -310,7 +384,7 @@ function collectWakeupReasonLiterals(): { reason: string; files: string[] }[] {
       } else if (identifier.includes(".")) {
         // A helper parameter such as `input.reason`. Trace the helper's call sites
         // rather than trusting it, so a new call site with a new literal is caught.
-        const traced = resolveReasonFromHelperCallSites(text, m.index, identifier);
+        const traced = resolveReasonFromHelperCallSites(text, m.index, identifier, constMap);
         if (traced) {
           for (const literal of traced) {
             if (!found.has(literal)) found.set(literal, new Set());

--- a/server/src/__tests__/wake-diagnostics-reason-allowlist.test.ts
+++ b/server/src/__tests__/wake-diagnostics-reason-allowlist.test.ts
@@ -134,20 +134,30 @@ function literalsFromReasonExpression(
   const questionIdx = expression.indexOf("?");
   const valueExpr = questionIdx === -1 ? expression : expression.slice(questionIdx + 1);
 
-  const quoted = [...valueExpr.matchAll(/"([^"]+)"/g)].map((q) => q[1]);
-  if (quoted.length > 0) return quoted;
+  // Resolve *every* branch. A mixed ternary such as
+  // `cond ? "known_reason" : SOME_REASON_CONSTANT` must contribute both sides;
+  // returning as soon as one quoted branch is found would let the other through.
+  const literals: string[] = [...valueExpr.matchAll(/"([^"]+)"/g)].map((q) => q[1]);
 
-  const resolved: string[] = [];
-  let sawIdentifier = false;
-  for (const idMatch of valueExpr.matchAll(/[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*/g)) {
+  // Blank out the quoted spans, then every identifier that remains has to resolve.
+  const remainder = valueExpr.replace(/"[^"]*"/g, " ");
+  const ignorable = new Set(["true", "false", "null", "undefined"]);
+  let sawToken = literals.length > 0;
+  for (const idMatch of remainder.matchAll(/[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*/g)) {
     const identifier = idMatch[0];
-    sawIdentifier = true;
-    if (constMap.has(identifier)) resolved.push(constMap.get(identifier)!);
-    else if (KNOWN_DYNAMIC_REASON_SOURCES.has(identifier)) continue;
-    else return null;
+    if (ignorable.has(identifier)) continue;
+    sawToken = true;
+    if (constMap.has(identifier)) {
+      literals.push(constMap.get(identifier)!);
+      continue;
+    }
+    // A documented dynamic source resolves to nothing new, which is a valid
+    // outcome -- it is not the same as failing to resolve the expression.
+    if (KNOWN_DYNAMIC_REASON_SOURCES.has(identifier)) continue;
+    return null;
   }
-  if (!sawIdentifier) return null;
-  return resolved;
+  // Null means "could not resolve". An empty list means "resolved, adds nothing".
+  return sawToken ? literals : null;
 }
 
 /** Splits an argument list on top-level commas, ignoring nested brackets and strings. */

--- a/server/src/__tests__/wake-diagnostics-reason-allowlist.test.ts
+++ b/server/src/__tests__/wake-diagnostics-reason-allowlist.test.ts
@@ -1,0 +1,175 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Static, DB-free guard against a recurring bug class: a literal `reason` written to
+// `agentWakeupRequests` that is not in `ISSUE_WAKE_DIAGNOSTIC_KNOWN_REASONS` renders as
+// `"other"` in `GET /api/issues/:id/diagnostics/wakes`. Wake delivery still works, so the
+// gap is invisible until someone reads the diagnostics endpoint and sees `"other"` instead
+// of the real reason. The allow-list drifts every time a new wake site is added, so this
+// test scans every `agentWakeupRequests` insert/update site and fails when it finds a
+// reason the allow-list does not know about.
+
+const SERVER_SRC_DIR = path.resolve(__dirname, "..");
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+const ISSUES_ROUTES_PATH = path.join(SERVER_SRC_DIR, "routes/issues.ts");
+
+// Identifiers observed as the value of `reason`/`wakeReason` at an `agentWakeupRequests`
+// write site that are genuinely open-ended by design (caller-supplied at runtime), not
+// missing allow-list entries. Verified by hand when added. If a new dynamic
+// identifier shows up that isn't listed here, the test below fails loudly rather than
+// silently skipping it, so any addition here must be a deliberate, reviewed decision.
+const KNOWN_DYNAMIC_REASON_SOURCES = new Set([
+  // scheduleBoundedRetryForRun's `opts.wakeReason` is exposed on the exported
+  // `scheduleBoundedRetry` service method for external callers (server/src/services/heartbeat.ts).
+  "wakeReason",
+  // writeSkippedHeartbeatRequest(skipReason, ...) -- every call site passes a literal already
+  // in the allow-list ("heartbeat.scheduling_suppressed" | "heartbeat.worktree_execution_cutoff" |
+  // "heartbeat.timer.no_actionable_work").
+  "skipReason",
+  // issue.status === "todo" ? "issue_assignment_recovery" : "issue_continuation_needed" -- both
+  // branches already in the allow-list.
+  "recoveryReason",
+  // getHeartbeatDailyCapBlock() only ever returns "heartbeat.daily_run_limit" or
+  // "heartbeat.daily_cost_limit", both already in the allow-list.
+  "dailyCapBlock.reason",
+  // enqueueWake(input) in server/src/services/native-runtime/status-decision-committer.ts
+  // is a file-local helper; every one of its six call sites passes a literal, and all four
+  // distinct values are in the allow-list: "issue_status_changed", "monitor_due",
+  // "issue_children_completed", "issue_blockers_resolved". Traced by hand when upstream's
+  // native status-decision committer landed.
+  "input.reason",
+]);
+
+function walkTsFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkTsFiles(full, out);
+    } else if (entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function extractBalancedParens(text: string, openIdx: number): string {
+  let depth = 0;
+  for (let i = openIdx; i < text.length; i++) {
+    if (text[i] === "(") depth++;
+    else if (text[i] === ")") {
+      depth--;
+      if (depth === 0) return text.slice(openIdx, i + 1);
+    }
+  }
+  return text.slice(openIdx);
+}
+
+function extractKnownReasons(): Set<string> {
+  const text = fs.readFileSync(ISSUES_ROUTES_PATH, "utf8");
+  const match = text.match(/const ISSUE_WAKE_DIAGNOSTIC_KNOWN_REASONS = new Set\(\[([\s\S]*?)\]\);/);
+  if (!match) {
+    throw new Error("could not locate ISSUE_WAKE_DIAGNOSTIC_KNOWN_REASONS in server/src/routes/issues.ts");
+  }
+  return new Set([...match[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]));
+}
+
+function buildStringConstantMap(): Map<string, string> {
+  const dirs = [
+    SERVER_SRC_DIR,
+    path.join(REPO_ROOT, "packages/shared/src"),
+    path.join(REPO_ROOT, "packages/db/src"),
+  ].filter((d) => fs.existsSync(d));
+  const constMap = new Map<string, string>();
+  const constRe = /(?:export\s+)?const\s+([A-Z][A-Z0-9_]*)\s*(?::\s*[^=]+)?=\s*"([^"]+)"/g;
+  for (const dir of dirs) {
+    for (const file of walkTsFiles(dir)) {
+      const text = fs.readFileSync(file, "utf8");
+      let m: RegExpExecArray | null;
+      constRe.lastIndex = 0;
+      while ((m = constRe.exec(text))) {
+        constMap.set(m[1], m[2]);
+      }
+    }
+  }
+  return constMap;
+}
+
+/**
+ * Finds every `.insert(agentWakeupRequests)` / `.update(agentWakeupRequests)` call site
+ * under server/src and resolves the `reason` field of its `.values(...)`/`.set(...)`
+ * argument to a literal string where possible.
+ */
+function collectWakeupReasonLiterals(): { reason: string; files: string[] }[] {
+  const constMap = buildStringConstantMap();
+  const found = new Map<string, Set<string>>();
+  const unresolved = new Map<string, Set<string>>();
+
+  for (const file of walkTsFiles(SERVER_SRC_DIR)) {
+    const text = fs.readFileSync(file, "utf8");
+    const sinkRe = /\.(insert|update)\(agentWakeupRequests\)/g;
+    let m: RegExpExecArray | null;
+    while ((m = sinkRe.exec(text))) {
+      const windowEnd = Math.min(text.length, m.index + 4000);
+      const after = text.slice(m.index, windowEnd);
+      const callMatch = after.match(/\.(set|values)\(/);
+      if (!callMatch || callMatch.index === undefined) continue;
+      const openIdx = m.index + callMatch.index + callMatch[0].length - 1;
+      const block = extractBalancedParens(text, openIdx);
+      const reasonMatch = block.match(/reason\s*:\s*("([^"]+)"|[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)/);
+      if (!reasonMatch) continue;
+
+      const relFile = path.relative(REPO_ROOT, file);
+      if (reasonMatch[2]) {
+        if (!found.has(reasonMatch[2])) found.set(reasonMatch[2], new Set());
+        found.get(reasonMatch[2])!.add(relFile);
+        continue;
+      }
+
+      const identifier = reasonMatch[1];
+      if (constMap.has(identifier)) {
+        const literal = constMap.get(identifier)!;
+        if (!found.has(literal)) found.set(literal, new Set());
+        found.get(literal)!.add(relFile);
+      } else if (KNOWN_DYNAMIC_REASON_SOURCES.has(identifier)) {
+        // Deliberately excluded -- see KNOWN_DYNAMIC_REASON_SOURCES above.
+        continue;
+      } else {
+        if (!unresolved.has(identifier)) unresolved.set(identifier, new Set());
+        unresolved.get(identifier)!.add(relFile);
+      }
+    }
+  }
+
+  if (unresolved.size > 0) {
+    const details = [...unresolved.entries()]
+      .map(([id, files]) => `${id} (${[...files].join(", ")})`)
+      .join("\n");
+    throw new Error(
+      `Found reason source(s) at agentWakeupRequests write sites that this scan can't resolve to a literal:\n${details}\n\n` +
+        `Either it resolves to a value already covered by KNOWN_DYNAMIC_REASON_SOURCES (add it there with a comment ` +
+        `explaining why it's safe), or it's a new literal that needs a manual trace and an entry in ` +
+        `ISSUE_WAKE_DIAGNOSTIC_KNOWN_REASONS.`,
+    );
+  }
+
+  return [...found.entries()].map(([reason, files]) => ({ reason, files: [...files] }));
+}
+
+describe("agent_wakeup_requests reason allow-list completeness", () => {
+  it("keeps ISSUE_WAKE_DIAGNOSTIC_KNOWN_REASONS in sync with every reason literal written to agentWakeupRequests", () => {
+    const knownReasons = extractKnownReasons();
+    const literals = collectWakeupReasonLiterals();
+    const missing = literals.filter((entry) => !knownReasons.has(entry.reason));
+
+    expect(
+      missing,
+      missing.length === 0
+        ? undefined
+        : `Reason(s) written to agentWakeupRequests but missing from ISSUE_WAKE_DIAGNOSTIC_KNOWN_REASONS ` +
+            `in server/src/routes/issues.ts (they will render as "other" in /diagnostics/wakes):\n` +
+            missing.map((entry) => `  "${entry.reason}" (${entry.files.join(", ")})`).join("\n"),
+    ).toEqual([]);
+  });
+});

--- a/server/src/__tests__/wake-diagnostics-reason-allowlist.test.ts
+++ b/server/src/__tests__/wake-diagnostics-reason-allowlist.test.ts
@@ -90,6 +90,91 @@ function buildStringConstantMap(): Map<string, string> {
   return constMap;
 }
 
+/** Splits an argument list on top-level commas, ignoring nested brackets and strings. */
+function splitTopLevelArgs(argList: string): string[] {
+  const inner = argList.replace(/^\(/, "").replace(/\)$/, "");
+  const parts: string[] = [];
+  let depth = 0;
+  let quote: string | null = null;
+  let current = "";
+  for (let i = 0; i < inner.length; i++) {
+    const ch = inner[i];
+    if (quote) {
+      if (ch === quote && inner[i - 1] !== "\\") quote = null;
+    } else if (ch === '"' || ch === "'" || ch === "`") {
+      quote = ch;
+    } else if ("([{".includes(ch)) {
+      depth++;
+    } else if (")]}".includes(ch)) {
+      depth--;
+    } else if (ch === "," && depth === 0) {
+      parts.push(current.trim());
+      current = "";
+      continue;
+    }
+    current += ch;
+  }
+  if (current.trim()) parts.push(current.trim());
+  return parts;
+}
+
+/** True when the text has a `reason` used as a property key, not as some other key's value. */
+function hasReasonProperty(text: string): boolean {
+  return /(?:^|[{,])\s*reason\s*[:,}]/.test(text);
+}
+
+/**
+ * Resolves the reason carried by a spread of a caller-supplied object, such as
+ * `.set({ status, ...patch })`.
+ *
+ * The spread hides whatever the caller passed, so the guard cannot read the write
+ * site alone. This finds the parameter the spread came from, locates that
+ * parameter's position in the enclosing helper, and reads the matching argument at
+ * every call site.
+ *
+ * Returns the literals it proved, or null when any call site passes something this
+ * scan cannot inspect — a variable, a spread, or a call. The caller then reports the
+ * site as unresolved, so an unprovable spread fails the test instead of passing.
+ */
+function resolveSpreadReasonFromCallSites(
+  text: string,
+  writeSiteIndex: number,
+  spreadName: string,
+): { literals: string[] } | null {
+  const before = text.slice(0, writeSiteIndex);
+  const declRe = /(?:async\s+)?function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(/g;
+  let decl: RegExpExecArray | null;
+  let helperName: string | null = null;
+  let declIndex = -1;
+  while ((decl = declRe.exec(before))) {
+    helperName = decl[1];
+    declIndex = decl.index + decl[0].length - 1;
+  }
+  if (!helperName || declIndex < 0) return null;
+
+  // Which parameter position does the spread variable occupy?
+  const params = splitTopLevelArgs(extractBalancedParens(text, declIndex));
+  const paramIndex = params.findIndex((param) =>
+    new RegExp(`^${spreadName}\\b`).test(param.replace(/^\.\.\./, "")),
+  );
+  if (paramIndex === -1) return null;
+
+  const literals = new Set<string>();
+  const callRe = new RegExp(`\\b${helperName}\\s*\\(`, "g");
+  let call: RegExpExecArray | null;
+  while ((call = callRe.exec(text))) {
+    const openIdx = call.index + call[0].length - 1;
+    if (openIdx === declIndex) continue;
+    const args = splitTopLevelArgs(extractBalancedParens(text, openIdx));
+    const arg = args[paramIndex];
+    if (arg === undefined) continue; // optional parameter omitted -- carries no reason
+    if (!arg.startsWith("{")) return null; // a variable or call -- cannot prove absence
+    if (!hasReasonProperty(arg)) continue; // inline object, provably no reason
+    for (const q of arg.matchAll(/reason\s*:\s*"([^"]+)"/g)) literals.add(q[1]);
+  }
+  return { literals: [...literals] };
+}
+
 /**
  * Resolves a wake `reason` that is a parameter of a file-local helper.
  *
@@ -176,18 +261,38 @@ function collectWakeupReasonLiterals(): { reason: string; files: string[] }[] {
         const shorthand = /[{,]\s*reason\s*[,}]/.test(block);
         const spread = /\.\.\.[A-Za-z_][A-Za-z0-9_]*/.test(block);
         if (!shorthand && !spread) continue;
-        const traced = resolveReasonFromHelperCallSites(text, m.index, "reason");
-        if (traced) {
-          for (const literal of traced) {
-            if (!found.has(literal)) found.set(literal, new Set());
-            found.get(literal)!.add(relFile);
+        if (shorthand) {
+          const traced = resolveReasonFromHelperCallSites(text, m.index, "reason");
+          if (traced) {
+            for (const literal of traced) {
+              if (!found.has(literal)) found.set(literal, new Set());
+              found.get(literal)!.add(relFile);
+            }
+          } else {
+            // A shorthand write whose helper cannot be traced is a real unknown.
+            if (!unresolved.has("reason (shorthand)")) unresolved.set("reason (shorthand)", new Set());
+            unresolved.get("reason (shorthand)")!.add(relFile);
           }
-        } else if (shorthand) {
-          // A shorthand write whose helper cannot be traced is a real unknown.
-          if (!unresolved.has("reason (shorthand)")) unresolved.set("reason (shorthand)", new Set());
-          unresolved.get("reason (shorthand)")!.add(relFile);
         }
-        // A spread whose call sites never pass `reason` contributes nothing.
+        if (spread) {
+          // Resolve each spread separately. A spread is only safe when every call
+          // site passes an inline object this scan can read; anything else -- a
+          // variable, a nested spread, a call -- is reported rather than skipped.
+          for (const spreadMatch of block.matchAll(/\.\.\.([A-Za-z_][A-Za-z0-9_]*)/g)) {
+            const spreadName = spreadMatch[1];
+            const resolved = resolveSpreadReasonFromCallSites(text, m.index, spreadName);
+            if (!resolved) {
+              const key = `...${spreadName} (unprovable spread)`;
+              if (!unresolved.has(key)) unresolved.set(key, new Set());
+              unresolved.get(key)!.add(relFile);
+              continue;
+            }
+            for (const literal of resolved.literals) {
+              if (!found.has(literal)) found.set(literal, new Set());
+              found.get(literal)!.add(relFile);
+            }
+          }
+        }
         continue;
       }
 

--- a/server/src/__tests__/wake-diagnostics-reason-allowlist.test.ts
+++ b/server/src/__tests__/wake-diagnostics-reason-allowlist.test.ts
@@ -164,10 +164,33 @@ function collectWakeupReasonLiterals(): { reason: string; files: string[] }[] {
       if (!callMatch || callMatch.index === undefined) continue;
       const openIdx = m.index + callMatch.index + callMatch[0].length - 1;
       const block = extractBalancedParens(text, openIdx);
-      const reasonMatch = block.match(/reason\s*:\s*("([^"]+)"|[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)/);
-      if (!reasonMatch) continue;
-
       const relFile = path.relative(REPO_ROOT, file);
+      const reasonMatch = block.match(/reason\s*:\s*("([^"]+)"|[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)/);
+      if (!reasonMatch) {
+        // No `reason:` key. Two shapes reach the column without one, and both
+        // must be resolved rather than skipped, or the guard fails open.
+        //   1. ES2015 shorthand -- `.values({ ..., reason, payload })`
+        //   2. a spread of a caller-supplied object -- `.set({ status, ...patch })`
+        // In both cases the value comes from the enclosing helper, so trace its
+        // call sites. Report the site when the helper cannot be identified.
+        const shorthand = /[{,]\s*reason\s*[,}]/.test(block);
+        const spread = /\.\.\.[A-Za-z_][A-Za-z0-9_]*/.test(block);
+        if (!shorthand && !spread) continue;
+        const traced = resolveReasonFromHelperCallSites(text, m.index, "reason");
+        if (traced) {
+          for (const literal of traced) {
+            if (!found.has(literal)) found.set(literal, new Set());
+            found.get(literal)!.add(relFile);
+          }
+        } else if (shorthand) {
+          // A shorthand write whose helper cannot be traced is a real unknown.
+          if (!unresolved.has("reason (shorthand)")) unresolved.set("reason (shorthand)", new Set());
+          unresolved.get("reason (shorthand)")!.add(relFile);
+        }
+        // A spread whose call sites never pass `reason` contributes nothing.
+        continue;
+      }
+
       if (reasonMatch[2]) {
         if (!found.has(reasonMatch[2])) found.set(reasonMatch[2], new Set());
         found.get(reasonMatch[2])!.add(relFile);

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1186,9 +1186,11 @@ const ISSUE_WAKE_DIAGNOSTIC_KNOWN_REASONS = new Set([
   "heartbeat_timer",
   "issue_monitor_recovery",
   "issue_monitor_recovery_issue",
-  // Recovery sweeps (services/recovery/service.ts).
+  // Recovery sweeps (services/recovery/ and services/heartbeat.ts).
   "issue_disposition_repair",
   "provider_quota_recovery",
+  "finish_successful_run_handoff",
+  "issue_review_path_lost",
 ]);
 
 const ISSUE_WAKE_DIAGNOSTIC_KNOWN_STATUSES = new Set([

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1182,6 +1182,10 @@ const ISSUE_WAKE_DIAGNOSTIC_KNOWN_REASONS = new Set([
   "issue_rewake_throttled",
   "workspace_worktree_requires_project",
   "execution_review_participant_recovery",
+  // Issue monitors and the heartbeat timer (services/heartbeat.ts).
+  "heartbeat_timer",
+  "issue_monitor_recovery",
+  "issue_monitor_recovery_issue",
   // Recovery sweeps (services/recovery/service.ts).
   "issue_disposition_repair",
   "provider_quota_recovery",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1168,6 +1168,23 @@ const ISSUE_WAKE_DIAGNOSTIC_KNOWN_REASONS = new Set([
   "heartbeat.disabled",
   "heartbeat.timer.no_actionable_work",
   "heartbeat.wakeOnDemand.disabled",
+  "heartbeat.worktree_execution_cutoff",
+  // Native status decision committer (services/native-runtime/status-decision-committer.ts).
+  "issue_status_changed",
+  "issue_children_completed",
+  "monitor_due",
+  // Issue execution scheduling (services/heartbeat.ts).
+  "issue_execution_promoted",
+  "issue_execution_deferred",
+  "issue_execution_same_name",
+  "issue_execution_issue_not_found",
+  "issue_state_guard_mismatch",
+  "issue_rewake_throttled",
+  "workspace_worktree_requires_project",
+  "execution_review_participant_recovery",
+  // Recovery sweeps (services/recovery/service.ts).
+  "issue_disposition_repair",
+  "provider_quota_recovery",
 ]);
 
 const ISSUE_WAKE_DIAGNOSTIC_KNOWN_STATUSES = new Set([


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents do not run continuously. A wake request starts each run, and every wake records why it happened
> - When an agent does not run as expected, an operator opens `GET /api/issues/:id/diagnostics/wakes` to see the wake history
> - That endpoint passes each stored reason through an allow-list. It replaces any unlisted reason with `"other"`
> - The allow-list holds 12 reasons, but the server writes 31 distinct reason literals. So 19 real reasons display as `"other"`
> - This hides the cause of a wake exactly when an operator is trying to find it
> - This pull request adds the 19 missing reasons and adds a test that keeps the allow-list in sync
> - The benefit is that wake diagnostics report the true reason, and the gap cannot return silently

## Linked Issues or Issue Description

No existing issue or in-flight PR found. I searched the full set of open issues and pull requests
for the code identifiers this change touches — `ISSUE_WAKE_DIAGNOSTIC_KNOWN_REASONS` and
`projectWakeDiagnosticReason` — and for the affected reason literals (`monitor_due`,
`issue_execution_promoted`, `issue_disposition_repair`). The identifier searches return nothing.
The reason-literal matches are all unrelated reports that happen to mention a reason string.

Problem described below, following `.github/ISSUE_TEMPLATE/bug_report.yml`.

**What happened?**

`GET /api/issues/:id/diagnostics/wakes` reports `"other"` instead of the real wake reason for 19 of the 31 reason values the server writes to `agent_wakeup_requests`.

`projectWakeDiagnosticReason()` in `server/src/routes/issues.ts` maps any reason that is not in `ISSUE_WAKE_DIAGNOSTIC_KNOWN_REASONS` to `"other"`. The set contains 12 reasons. The server writes these 19 additional reasons:

| Reason | Written by |
| --- | --- |
| `issue_status_changed` | `services/native-runtime/status-decision-committer.ts` |
| `issue_children_completed` | `services/native-runtime/status-decision-committer.ts` |
| `monitor_due` | `services/native-runtime/status-decision-committer.ts` |
| `issue_execution_promoted` | `services/heartbeat.ts` |
| `issue_execution_deferred` | `services/heartbeat.ts` |
| `issue_execution_same_name` | `services/heartbeat.ts` |
| `issue_execution_issue_not_found` | `services/heartbeat.ts` |
| `issue_state_guard_mismatch` | `services/heartbeat.ts` |
| `issue_rewake_throttled` | `services/heartbeat.ts` |
| `workspace_worktree_requires_project` | `services/heartbeat.ts` |
| `execution_review_participant_recovery` | `services/heartbeat.ts` |
| `heartbeat.worktree_execution_cutoff` | `services/heartbeat.ts` |
| `issue_disposition_repair` | `services/recovery/service.ts` |
| `provider_quota_recovery` | `services/recovery/service.ts` |
| `heartbeat_timer` | `services/heartbeat.ts` |
| `issue_monitor_recovery` | `services/heartbeat.ts` |
| `issue_monitor_recovery_issue` | `services/heartbeat.ts` |
| `finish_successful_run_handoff` | `services/heartbeat.ts` |
| `issue_review_path_lost` | `services/heartbeat.ts` |

Wake delivery is not affected. Only the diagnostics view is wrong.

**Expected behavior**

The endpoint reports the reason that the server recorded. It reports `"other"` only for a reason the server does not write.

**Steps to reproduce**

1. Start an instance and let the heartbeat scheduler promote an issue for execution. This writes a wake with reason `issue_execution_promoted`.
2. Open `GET /api/issues/:id/diagnostics/wakes` for that issue.
3. Read the `reason` field of the wake event. It shows `"other"`.
4. Read the same row in `agent_wakeup_requests`. It shows `issue_execution_promoted`.

**Paperclip version or commit**

`af3023f1e` (master).

**Deployment mode**

Self-hosted, local development.

## What Changed

- Added the 19 missing reason literals to `ISSUE_WAKE_DIAGNOSTIC_KNOWN_REASONS` in `server/src/routes/issues.ts`, grouped by the subsystem that writes them.
- Added `server/src/__tests__/wake-diagnostics-reason-allowlist.test.ts`. The test scans every `.insert(agentWakeupRequests)` and `.update(agentWakeupRequests)` site under `server/src`, resolves each `reason` to a string literal, and fails when the allow-list does not contain it.
- The test resolves a reason that a write site takes from its enclosing helper, including ES2015 shorthand (`{ ..., reason }`) and a spread of a caller-supplied object (`{ status, ...patch }`), by reading the reason of every call to that helper in the same file.
- Resolution is fail-closed. An expression resolves through a fixed ladder — a double-quoted literal (every branch of a ternary counts), a string constant from the constant map, or an identifier documented in `KNOWN_DYNAMIC_REASON_SOURCES`. One unresolvable identifier fails the whole expression, so a new reason cannot hide behind a sibling literal or an opaque call site.
- The constant map indexes plain string constants, members of a frozen lookup object (`RECOVERY_REASON_KINDS = { ... } as const`), and aliases of such a member. Two of the 19 reasons above (`finish_successful_run_handoff`, `issue_review_path_lost`) reach the column only through those constants and were invisible until the map could read them.
- The test also fails when it finds a reason expression it cannot resolve to a literal. An expression is skipped only when it is listed in `KNOWN_DYNAMIC_REASON_SOURCES` with a comment that records the manual trace. This makes a new dynamic wake site fail loudly instead of passing silently.

## Verification

Run the new test and the endpoint suite:

```bash
pnpm --filter @paperclipai/server exec vitest run \
  src/__tests__/wake-diagnostics-reason-allowlist.test.ts \
  src/__tests__/issue-wake-diagnostics-routes.test.ts
```

Both pass (8 tests).

To confirm the test guards the fix, revert the `server/src/routes/issues.ts` change and run it again. It fails and names every missing reason with the file that writes it.

Typecheck is clean:

```bash
cd server && tsc --noEmit
```

## Risks

Low risk.

- The change adds strings to an allow-list that is only read by one display function. It does not change wake delivery, scheduling, or storage.
- The endpoint now returns reason values it did not return before. A client that treats the reason as a closed set must accept these values. The API type `IssueWakeDiagnosticWakeReason` already permits them.
- No database migration. No telemetry change. No run-log event change.
- The new test reads files from disk and uses no database.

## Model Used

Claude Opus 5 (Anthropic), model id `claude-opus-5`, 1M context window, extended thinking enabled, with tool use and code execution. The change was verified by running the test suites and the typechecker locally.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes — no documentation describes the wake diagnostics endpoint or enumerates wake reasons, so there is nothing to update. The allow-list itself now carries a comment naming the subsystem that writes each group.
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups