### PR TITLE
fix(watchdogs): do not wake a task watchdog the platform will refuse

### DIFF
--- a/server/src/__tests__/task-watchdogs-classifier.test.ts
+++ b/server/src/__tests__/task-watchdogs-classifier.test.ts
@@ -388,10 +388,10 @@ describe("task watchdog subtree classifier", () => {
     expect(result.state).toBe("not_applicable");
   });
 
-  // LUN-7052 hypothesis check. That ticket assumed a child's pending card masks
-  // a dead parent as `live` forever. It does not: waits are material state that
-  // feeds the stop fingerprint, and only a run or a queued wake yields `live`.
-  // Pinned so the assumption cannot come back as a "fix".
+  // Hypothesis check. A plausible reading of the refusal is that a child's
+  // pending card masks a dead parent as `live` forever. It does not: waits are
+  // material state that feeds the stop fingerprint, and only a run or a queued
+  // wake yields `live`. Pinned so the assumption cannot come back as a "fix".
   it("does not read a parent as live because children carry pending interactions", () => {
     const otherChildId = "child-2";
     const result = classify({

--- a/server/src/__tests__/task-watchdogs-classifier.test.ts
+++ b/server/src/__tests__/task-watchdogs-classifier.test.ts
@@ -387,4 +387,44 @@ describe("task watchdog subtree classifier", () => {
 
     expect(result.state).toBe("not_applicable");
   });
+
+  // LUN-7052 hypothesis check. That ticket assumed a child's pending card masks
+  // a dead parent as `live` forever. It does not: waits are material state that
+  // feeds the stop fingerprint, and only a run or a queued wake yields `live`.
+  // Pinned so the assumption cannot come back as a "fix".
+  it("does not read a parent as live because children carry pending interactions", () => {
+    const otherChildId = "child-2";
+    const result = classify({
+      issues: [
+        issue({ status: "in_progress" }),
+        issue({ id: childId, identifier: "PAP-2", parentId: sourceId, status: "in_progress" }),
+        issue({ id: otherChildId, identifier: "PAP-3", parentId: sourceId, status: "in_progress" }),
+      ],
+      pendingInteractions: [
+        { companyId, issueId: childId, id: "interaction-1", kind: "ask_user_questions", status: "pending" },
+        { companyId, issueId: otherChildId, id: "interaction-2", kind: "request_confirmation", status: "pending" },
+      ],
+    });
+
+    expect(result.state).toBe("stopped");
+  });
+
+  it("names the issue and the signal that make the subtree live", () => {
+    const result = classify({
+      issues: [
+        issue(),
+        issue({ id: childId, identifier: "PAP-2", parentId: sourceId, status: "todo" }),
+      ],
+      activeRuns: [{ companyId, issueId: sourceId, agentId: "agent-1", status: "running" }],
+      queuedWakeRequests: [{ companyId, issueId: childId, agentId: "agent-1", status: "queued" }],
+    });
+
+    expect(result.state).toBe("live");
+    if (result.state !== "live") return;
+    expect(result.liveSignals).toEqual([
+      { issueId: childId, identifier: "PAP-2", kind: "queued_wake_request", status: "queued" },
+      { issueId: sourceId, identifier: "PAP-1", kind: "active_run", status: "running" },
+    ]);
+    expect(result.reason).toContain("PAP-1 has a active_run in status running");
+  });
 });

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -685,7 +685,7 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     });
 
     expect(revalidated.allowed).toBe(false);
-    // LUN-7052: the refusal has to name which issue is live and what makes it
+    // The refusal has to name which issue is live and what makes it
     // live. `GET /api/live-runs` is scoped to the caller, so a watchdog run
     // cannot otherwise see another agent's run on the watched issue, and the
     // bare "subtree is live" verdict reads as a platform bug.
@@ -797,7 +797,7 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     expect(watchdogIssues).toHaveLength(1);
   });
 
-  // LUN-7052. Measured on LUN-6807: a board comment enqueued an
+  // Measured on a live instance: a board comment enqueued an
   // `issue_commented` wake on the watched issue at 17:24:52.431Z and the
   // watchdog wake was enqueued 13 ms later, from a liveness snapshot taken
   // before that run existed. The watchdog then ran for ~9 minutes against a
@@ -817,7 +817,7 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     // DDL cannot carry bind parameters, and these ids are locally generated
     // UUIDs, so raw interpolation is safe here.
     await db.execute(sql.raw(`
-      CREATE FUNCTION public.lun7052_race() RETURNS trigger AS $fn$
+      CREATE FUNCTION public.watchdog_enqueue_race() RETURNS trigger AS $fn$
       BEGIN
         INSERT INTO heartbeat_runs (company_id, agent_id, status, invocation_source, context_snapshot)
         VALUES ('${companyId}'::uuid, '${agentId}'::uuid, 'running', 'assignment',
@@ -827,9 +827,9 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
       $fn$ LANGUAGE plpgsql;
     `));
     await db.execute(sql.raw(`
-      CREATE TRIGGER lun7052_race AFTER INSERT ON issues
+      CREATE TRIGGER watchdog_enqueue_race AFTER INSERT ON issues
       FOR EACH ROW WHEN (NEW.origin_kind = 'task_watchdog')
-      EXECUTE FUNCTION public.lun7052_race();
+      EXECUTE FUNCTION public.watchdog_enqueue_race();
     `));
 
     try {
@@ -837,8 +837,27 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
       expect(result).toMatchObject({ checked: 1, triggered: 0, live: 1 });
       expect(wakes).toHaveLength(0);
     } finally {
-      await db.execute(sql.raw("DROP TRIGGER lun7052_race ON issues; DROP FUNCTION public.lun7052_race();"));
+      await db.execute(sql.raw(
+        "DROP TRIGGER watchdog_enqueue_race ON issues; DROP FUNCTION public.watchdog_enqueue_race();",
+      ));
     }
+
+    // The review issue was published before the race was observed, so it exists
+    // in `todo` with nobody woken for it. It must not stay pinned to that stop
+    // fingerprint: a pinned artifact reads as an open same-fingerprint review
+    // and would suppress the trigger the stopped state still deserves, forever.
+    const [published] = await db
+      .select({ id: issues.id, originFingerprint: issues.originFingerprint })
+      .from(issues)
+      .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "task_watchdog")));
+    expect(published.originFingerprint).toMatch(/^task_watchdog_untriggered:/);
+
+    // Once the racing run is gone, the next pass triggers on the same stopped
+    // state instead of reading its own leftover artifact as a done review.
+    await db.delete(heartbeatRuns).where(eq(heartbeatRuns.companyId, companyId));
+    const retry = await service.reconcileTaskWatchdogs({ companyId });
+    expect(retry).toMatchObject({ checked: 1, triggered: 1 });
+    expect(wakes).toHaveLength(1);
   });
 
   it("handles an armed cutoff when no watchdogs are active", async () => {

--- a/server/src/__tests__/task-watchdogs-scheduler.test.ts
+++ b/server/src/__tests__/task-watchdogs-scheduler.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   activityLog,
@@ -685,8 +685,17 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
     });
 
     expect(revalidated.allowed).toBe(false);
-    expect(revalidated.reason).toContain("now has a live");
+    // LUN-7052: the refusal has to name which issue is live and what makes it
+    // live. `GET /api/live-runs` is scoped to the caller, so a watchdog run
+    // cannot otherwise see another agent's run on the watched issue, and the
+    // bare "subtree is live" verdict reads as a platform bug.
+    expect(revalidated.reason).toContain("has a live path");
+    expect(revalidated.reason).toContain("WDOG-LIVE-REVALIDATE");
+    expect(revalidated.reason).toContain("active_run");
     expect(revalidated.classification?.state).toBe("live");
+    expect(revalidated.classification).toMatchObject({
+      liveSignals: [{ issueId: sourceId, identifier: "WDOG-LIVE-REVALIDATE", kind: "active_run", status: "running" }],
+    });
   });
 
   it("does not raise a stopped-subtree review while a freshly-created assigned issue's first run is starting", async () => {
@@ -786,6 +795,50 @@ describeEmbeddedPostgres("task watchdog scheduler", () => {
       .from(issues)
       .where(and(eq(issues.companyId, companyId), eq(issues.originKind, "task_watchdog")));
     expect(watchdogIssues).toHaveLength(1);
+  });
+
+  // LUN-7052. Measured on LUN-6807: a board comment enqueued an
+  // `issue_commented` wake on the watched issue at 17:24:52.431Z and the
+  // watchdog wake was enqueued 13 ms later, from a liveness snapshot taken
+  // before that run existed. The watchdog then ran for ~9 minutes against a
+  // source issue that was live the whole time, and every repair it attempted
+  // was refused as stale. Nothing about that run could ever have succeeded, so
+  // it must not be woken at all.
+  it("does not wake the watchdog when the source goes live between classification and enqueue", async () => {
+    const companyId = await seedCompany();
+    const sourceId = await seedIssue(companyId, { identifier: "WDOG-ENQUEUE-RACE", status: "in_progress" });
+    const agentId = await seedAgent(companyId);
+    await seedWatchdog(companyId, sourceId, agentId);
+    const { service, wakes } = createService();
+
+    // Reproduce the interleave deterministically: the source issue acquires a
+    // live run at the moment the trigger writes its reusable watchdog issue,
+    // i.e. strictly after the classification that decided to trigger.
+    // DDL cannot carry bind parameters, and these ids are locally generated
+    // UUIDs, so raw interpolation is safe here.
+    await db.execute(sql.raw(`
+      CREATE FUNCTION public.lun7052_race() RETURNS trigger AS $fn$
+      BEGIN
+        INSERT INTO heartbeat_runs (company_id, agent_id, status, invocation_source, context_snapshot)
+        VALUES ('${companyId}'::uuid, '${agentId}'::uuid, 'running', 'assignment',
+                jsonb_build_object('issueId', '${sourceId}'));
+        RETURN NEW;
+      END;
+      $fn$ LANGUAGE plpgsql;
+    `));
+    await db.execute(sql.raw(`
+      CREATE TRIGGER lun7052_race AFTER INSERT ON issues
+      FOR EACH ROW WHEN (NEW.origin_kind = 'task_watchdog')
+      EXECUTE FUNCTION public.lun7052_race();
+    `));
+
+    try {
+      const result = await service.reconcileTaskWatchdogs({ companyId });
+      expect(result).toMatchObject({ checked: 1, triggered: 0, live: 1 });
+      expect(wakes).toHaveLength(0);
+    } finally {
+      await db.execute(sql.raw("DROP TRIGGER lun7052_race ON issues; DROP FUNCTION public.lun7052_race();"));
+    }
   });
 
   it("handles an armed cutoff when no watchdogs are active", async () => {

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -143,6 +143,13 @@ export type TaskWatchdogStopSnapshot = {
   waitsByIssueId: TaskWatchdogWaitsByIssueId;
 };
 
+export type TaskWatchdogLiveSignal = {
+  issueId: string;
+  identifier: string | null;
+  kind: "active_run" | "queued_wake_request";
+  status: string;
+};
+
 type TaskWatchdogPendingInteractionsByIssueId = Record<string, Array<{
   id: string;
   kind: string | null;
@@ -159,6 +166,9 @@ export type TaskWatchdogClassifierResult =
     reason: string;
     includedIssueIds: string[];
     liveIssueIds: string[];
+    // Which issue carries which live signal. A watchdog that is refused a
+    // repair can only re-check the verdict if the refusal names both.
+    liveSignals: TaskWatchdogLiveSignal[];
   }
   | {
     state: "pending_first_run";
@@ -290,6 +300,50 @@ function pathIssueIds(paths: TaskWatchdogClassifierPath[] | undefined, companyId
   );
 }
 
+// A watchdog that is refused a mutation because the subtree reads `live` cannot
+// verify that verdict unless it is told which issue is live and what makes it
+// live: `GET /api/live-runs` is scoped to the caller, so another agent's run on
+// the watched issue is invisible from the watchdog run.
+function collectLiveSignals(
+  companyId: string,
+  includedIdSet: Set<string>,
+  issuesById: Map<string, TaskWatchdogClassifierIssue>,
+  activeRuns: TaskWatchdogClassifierPath[] | undefined,
+  queuedWakeRequests: TaskWatchdogClassifierPath[] | undefined,
+): TaskWatchdogLiveSignal[] {
+  const signals: TaskWatchdogLiveSignal[] = [];
+  const seen = new Set<string>();
+  const add = (paths: TaskWatchdogClassifierPath[] | undefined, kind: TaskWatchdogLiveSignal["kind"]) => {
+    for (const path of paths ?? []) {
+      if (path.companyId !== companyId) continue;
+      if (typeof path.issueId !== "string" || !includedIdSet.has(path.issueId)) continue;
+      const key = `${kind}:${path.issueId}:${path.status}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      signals.push({
+        issueId: path.issueId,
+        identifier: issuesById.get(path.issueId)?.identifier ?? null,
+        kind,
+        status: path.status,
+      });
+    }
+  };
+  add(activeRuns, "active_run");
+  add(queuedWakeRequests, "queued_wake_request");
+  return signals.sort((left, right) =>
+    left.issueId === right.issueId
+      ? left.kind.localeCompare(right.kind)
+      : left.issueId.localeCompare(right.issueId)
+  );
+}
+
+function describeLiveSignals(signals: TaskWatchdogLiveSignal[]) {
+  if (signals.length === 0) return "no signal could be attributed";
+  return signals
+    .map((signal) => `${signal.identifier ?? signal.issueId} has a ${signal.kind} in status ${signal.status}`)
+    .join("; ");
+}
+
 function waitingPathIds(
   paths: TaskWatchdogClassifierWaitingPath[] | undefined,
   companyId: string,
@@ -414,11 +468,21 @@ export function classifyTaskWatchdogSubtree(input: TaskWatchdogClassifierInput):
   ].filter((issueId) => includedIdSet.has(issueId));
   const uniqueLiveIssueIds = [...new Set(liveIssueIds)].sort();
   if (uniqueLiveIssueIds.length > 0) {
+    const liveSignals = collectLiveSignals(
+      input.watchdog.companyId,
+      includedIdSet,
+      issuesById,
+      input.activeRuns,
+      input.queuedWakeRequests,
+    );
     return {
       state: "live",
-      reason: "At least one issue in the watched subtree has a live run, queued wake, or scheduled retry.",
+      reason: `At least one issue in the watched subtree has a live run, queued wake, or scheduled retry: ${
+        describeLiveSignals(liveSignals)
+      }.`,
       includedIssueIds: includedIds,
       liveIssueIds: uniqueLiveIssueIds,
+      liveSignals,
     };
   }
 
@@ -1502,12 +1566,36 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
       };
     }
 
+    // The liveness read above and the wake enqueued below are not one atomic
+    // step: `collectClassifierInput` snapshots the subtree, then the trigger
+    // does several writes. A wake landing on the watched issue inside that
+    // window (a board comment enqueues one) turns the subtree live before the
+    // watchdog run starts, and `revalidateMutationScope` then refuses every
+    // repair for the whole run. Measured on LUN-6807: the source run and the
+    // watchdog wake were created 13 ms apart, and the watchdog stayed refused
+    // for the ~6 minutes the source run held the issue. Re-read liveness right
+    // before enqueuing so a watchdog run that is guaranteed to be a no-op is
+    // never woken at all.
     const watchdogIssue = await ensureReusableWatchdogIssue({
       watchdog,
       sourceIssue,
       classification,
       runId: opts.runId ?? null,
     });
+
+    const recheck = classifyTaskWatchdogSubtree(
+      await collectClassifierInput(watchdog.companyId, watchdog),
+    );
+    if (recheck.state !== "stopped") {
+      return { state: recheck.state, reason: recheck.reason, classification: recheck };
+    }
+    if (recheck.stopFingerprint !== classification.stopFingerprint) {
+      // Still stopped, but on different material state than the one the wake
+      // would have carried. Let the next reconcile pass trigger on the state
+      // the watchdog would actually be handed.
+      return { state: "stop_fingerprint_changed" as const, reason: recheck.reason, classification: recheck };
+    }
+
     const now = new Date();
     await db
       .update(issueWatchdogs)
@@ -1652,7 +1740,11 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
       allowed: false as const,
       reason: classification.state === "stopped"
         ? "Task-watchdog review is stale because the watched subtree stop fingerprint changed; refresh the source state before mutating it."
-        : "Task-watchdog review is stale because the watched subtree now has a live, waiting, already-reviewed, or not-applicable path; refresh the source state before mutating it.",
+        : classification.state === "live"
+        ? `Task-watchdog review is stale because the watched subtree has a live path: ${
+          describeLiveSignals(classification.liveSignals)
+        }. Wait for that path to finish before mutating the source state.`
+        : "Task-watchdog review is stale because the watched subtree now has a waiting, already-reviewed, or not-applicable path; refresh the source state before mutating it.",
       classification,
     };
   }

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -25,6 +25,11 @@ import { visibleIssueCondition } from "./issue-visibility.js";
 import { TASK_WATCHDOG_ORIGIN_KIND } from "./task-watchdog-scope.js";
 
 const TASK_WATCHDOG_STOP_FINGERPRINT_PREFIX = "task_watchdog_stop:";
+// Stamped on a review issue that was published for a stopped state no watchdog
+// was ever woken for. `origin_fingerprint` is NOT NULL, so the pin is replaced
+// rather than cleared; the prefix differs from a real stop fingerprint, so the
+// row can no longer read as an open same-fingerprint review.
+export const TASK_WATCHDOG_UNTRIGGERED_FINGERPRINT_PREFIX = "task_watchdog_untriggered:";
 const TASK_WATCHDOG_SUBTREE_MAX_DEPTH = 100;
 const TASK_WATCHDOG_LIVE_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const TASK_WATCHDOG_WAKE_REQUEST_STATUSES = ["queued", "deferred_issue_execution"] as const;
@@ -1384,6 +1389,77 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
     return updated ?? watchdog;
   }
 
+  // Re-read the watched subtree and confirm it is still stopped on exactly the
+  // fingerprint the pending wake would carry. Anything else means the wake would
+  // hand the watchdog a state the platform will refuse to let it repair.
+  async function rereadStoppedSubtree(watchdog: IssueWatchdogRow, expectedFingerprint: string) {
+    const recheck = classifyTaskWatchdogSubtree(
+      await collectClassifierInput(watchdog.companyId, watchdog),
+    );
+    if (recheck.state !== "stopped") {
+      return {
+        ok: false as const,
+        recheck,
+        result: { state: recheck.state, reason: recheck.reason, classification: recheck },
+      };
+    }
+    if (recheck.stopFingerprint !== expectedFingerprint) {
+      // Still stopped, but on different material state than the one the wake
+      // would have carried. Let the next reconcile pass trigger on the state
+      // the watchdog would actually be handed.
+      return {
+        ok: false as const,
+        recheck,
+        result: { state: "stop_fingerprint_changed" as const, reason: recheck.reason, classification: recheck },
+      };
+    }
+    return { ok: true as const, recheck };
+  }
+
+  // Drop the fingerprint pin from a review issue that was published but never
+  // woken, so it cannot read as an open same-fingerprint review and suppress the
+  // next trigger for that same stopped state.
+  async function releaseUntriggeredWatchdogReview(input: {
+    watchdog: IssueWatchdogRow;
+    watchdogIssue: IssueRow;
+    sourceIssue: IssueRow;
+    stopFingerprint: string;
+    recheck: TaskWatchdogClassifierResult;
+    runId?: string | null;
+  }) {
+    if (input.watchdogIssue.originFingerprint !== input.stopFingerprint) return;
+    const untriggered = `${TASK_WATCHDOG_UNTRIGGERED_FINGERPRINT_PREFIX}${
+      input.stopFingerprint.slice(TASK_WATCHDOG_STOP_FINGERPRINT_PREFIX.length)
+    }`;
+    await db
+      .update(issues)
+      .set({ originFingerprint: untriggered, updatedAt: new Date() })
+      .where(and(
+        eq(issues.companyId, input.watchdog.companyId),
+        eq(issues.id, input.watchdogIssue.id),
+        eq(issues.originFingerprint, input.stopFingerprint),
+      ));
+    input.watchdogIssue.originFingerprint = untriggered;
+    await logActivity(db, {
+      companyId: input.watchdog.companyId,
+      actorType: "system",
+      actorId: "system",
+      agentId: input.watchdog.watchdogAgentId,
+      runId: input.runId ?? null,
+      action: "issue.task_watchdog_trigger_abandoned",
+      entityType: "issue",
+      entityId: input.sourceIssue.id,
+      details: {
+        source: "task_watchdogs.evaluate",
+        watchdogId: input.watchdog.id,
+        watchdogIssueId: input.watchdogIssue.id,
+        stopFingerprint: input.stopFingerprint,
+        recheckState: input.recheck.state,
+        recheckReason: input.recheck.reason,
+      },
+    });
+  }
+
   async function ensureReusableWatchdogIssue(input: {
     watchdog: IssueWatchdogRow;
     sourceIssue: IssueRow;
@@ -1571,11 +1647,16 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
     // does several writes. A wake landing on the watched issue inside that
     // window (a board comment enqueues one) turns the subtree live before the
     // watchdog run starts, and `revalidateMutationScope` then refuses every
-    // repair for the whole run. Measured on LUN-6807: the source run and the
-    // watchdog wake were created 13 ms apart, and the watchdog stayed refused
-    // for the ~6 minutes the source run held the issue. Re-read liveness right
-    // before enqueuing so a watchdog run that is guaranteed to be a no-op is
-    // never woken at all.
+    // repair for the whole run. Measured on a live instance: the source run and
+    // the watchdog wake were created 13 ms apart, and the watchdog stayed
+    // refused for the ~6 minutes the source run held the issue. So re-read
+    // liveness twice, and never publish state a wake did not carry: once before
+    // the reusable review issue is created or reopened, so the common case
+    // leaves no artifact behind, and once immediately before the enqueue, which
+    // is the last remaining window.
+    const beforePublish = await rereadStoppedSubtree(watchdog, classification.stopFingerprint);
+    if (!beforePublish.ok) return beforePublish.result;
+
     const watchdogIssue = await ensureReusableWatchdogIssue({
       watchdog,
       sourceIssue,
@@ -1583,17 +1664,21 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
       runId: opts.runId ?? null,
     });
 
-    const recheck = classifyTaskWatchdogSubtree(
-      await collectClassifierInput(watchdog.companyId, watchdog),
-    );
-    if (recheck.state !== "stopped") {
-      return { state: recheck.state, reason: recheck.reason, classification: recheck };
-    }
-    if (recheck.stopFingerprint !== classification.stopFingerprint) {
-      // Still stopped, but on different material state than the one the wake
-      // would have carried. Let the next reconcile pass trigger on the state
-      // the watchdog would actually be handed.
-      return { state: "stop_fingerprint_changed" as const, reason: recheck.reason, classification: recheck };
+    const beforeEnqueue = await rereadStoppedSubtree(watchdog, classification.stopFingerprint);
+    if (!beforeEnqueue.ok) {
+      // The review issue now exists in `todo`, pinned to a fingerprint no
+      // watchdog was ever woken for. Left pinned, the next reconcile pass reads
+      // it as an open same-fingerprint review and never enqueues the wake the
+      // stopped state still deserves. Un-pin it so that pass triggers instead.
+      await releaseUntriggeredWatchdogReview({
+        watchdog,
+        watchdogIssue,
+        sourceIssue,
+        stopFingerprint: classification.stopFingerprint,
+        recheck: beforeEnqueue.recheck,
+        runId: opts.runId ?? null,
+      });
+      return beforeEnqueue.result;
     }
 
     const now = new Date();


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Task watchdogs are the subsystem that notices a watched issue subtree has stopped, then wakes a watchdog agent to repair it
> - Two parts of that subsystem disagree. `evaluateWatchdog` decides to wake, and `revalidateMutationScope` decides whether the woken run may write. They read liveness at different moments, so a watchdog can be woken on a stop it is then forbidden to touch
> - The gap is not theoretical. On a live instance a board comment enqueued a run on the watched issue 13 ms before the watchdog wake was enqueued from a snapshot taken before that run existed. The watchdog ran for about nine minutes and every write came back "review is stale"
> - It needs to be addressed because that run is a guaranteed no-op that still costs a full agent run, and because the refusal message names no issue and no signal, so the woken agent cannot check the verdict against anything
> - This pull request re-reads liveness before the wake is enqueued and skips the trigger when the subtree went live, and it makes the refusal name which issue is live and what makes it live
> - The benefit is that no agent run is spent on a repair the platform will refuse, and a refusal that does happen is actionable instead of opaque

## Linked Issues or Issue Description

No public issue exists for this. Description follows `.github/ISSUE_TEMPLATE/bug_report.yml`.

**What happened?**

A task watchdog is woken with `reason: task_watchdog_stopped_subtree` on a stopped subtree. Every mutation it then attempts on the watched issue is refused with `Task-watchdog review is stale because the watched subtree now has a live, waiting, already-reviewed, or not-applicable path`, carrying `currentState: "live"`. The wake and the refusal are two opposite verdicts on the same source state, minutes apart. The refused run cannot verify the claim on its own: `GET /api/live-runs` is scoped to the caller, so another agent's run on the watched issue is invisible from the watchdog run.

**Expected behavior**

A watchdog is woken only for a state it is allowed to act on. When a repair is refused anyway, the error names the issue and the signal that make the subtree live.

**Steps to reproduce**

1. Arm a task watchdog on an issue whose subtree is stopped.
2. Post a board comment on the watched issue, which enqueues an `issue_commented` wake for its assignee.
3. Let the watchdog reconcile pass run in the same window. It reads liveness through `collectClassifierInput`, then performs several writes before it enqueues the wake.
4. The run started in step 2 turns the subtree live before the watchdog run begins.
5. The watchdog run starts and every write it attempts is refused for as long as that run holds the issue.

**Paperclip version or commit**

Reproduced against `master` at the merge base of this branch. Covered by new deterministic tests in `server/src/__tests__/task-watchdogs-scheduler.test.ts`.

**Agent adapter(s) involved**

Not adapter-specific (core bug). The trigger path is server side.

**Additional context**

Two other readings of the symptom were plausible and both are false, so both are now pinned by tests. Pending interactions on children do not make a parent read as live: waits are material state that feeds the stop fingerprint, and only a run or a queued wake yields `live`. A recent agent comment on the watched issue does not make it live either.

## What Changed

- `classifyTaskWatchdogSubtree` now attaches `liveSignals` to a `live` result: for each included issue, which issue id and identifier carries which signal kind (`active_run` or `queued_wake_request`) in which status.
- `revalidateMutationScope` names those signals in the refusal instead of listing four possible causes.
- `evaluateWatchdog` re-reads liveness before it enqueues the wake, and skips the trigger when the subtree went live or moved to a different stop fingerprint. The recheck runs twice: once before the reusable review issue is created or reopened, so the common case leaves no artifact behind, and once immediately before the enqueue.
- When the second recheck loses, the review issue that was already published is re-stamped with a `task_watchdog_untriggered:` fingerprint and an `issue.task_watchdog_trigger_abandoned` activity entry. Without that, the row would read as an open same-fingerprint review on every later pass and the stopped state would never get its wake. `origin_fingerprint` is `NOT NULL`, so the pin is replaced rather than cleared.
- Tests: a deterministic scheduler test that makes the source acquire a run at the moment the review issue is written, then asserts no wake was enqueued, the artifact is not left pinned, and the next pass triggers once the racing run ends. Plus a classifier test pinning that pending child interactions never make a parent live.

## Verification

- `cd server && npx vitest run src/__tests__/task-watchdogs-scheduler.test.ts` — 19 passed.
- `cd server && npx vitest run src/__tests__/task-watchdogs-classifier.test.ts` — 21 passed.
- `cd server && npx vitest run src/__tests__/task-watchdogs-incident-fixture.test.ts src/__tests__/issue-watchdogs-routes.test.ts src/__tests__/issue-agent-mutation-ownership-routes.test.ts` — 100 passed.
- `cd server && npx tsc --noEmit -p tsconfig.json` — no diagnostic in either changed file. The run does report pre-existing errors elsewhere from unbuilt workspace dependencies (`@paperclipai/plugin-sdk`, `@paperclipai/paperclip-runner`).
- The race is reproduced with a temporary Postgres `AFTER INSERT` trigger on `issues`, so the interleave is deterministic rather than timing dependent. The trigger and its function are dropped in a `finally`.

## Risks

- No migration and no schema change. No API shape is removed; `liveSignals` is an added field on the `live` classification.
- Behavioral shift: a reconcile pass can now decide not to trigger where it previously did. That is the intent, and the state it declines is picked up by the next pass. The new scheduler test asserts that retry, because the failure mode of getting it wrong is a watchdog that never fires again for that fingerprint.
- The window is narrowed, not closed. Nothing here is atomic with the enqueue, so a run that starts between the last recheck and the wake insert still produces a refused watchdog. Closing it fully needs the wake insert to carry the liveness predicate, which is a larger change to the wake enqueue contract. The refusal diagnostics in this PR are what make the residual case survivable rather than opaque.
- `task_watchdog_untriggered:` is a new sentinel value in `issues.origin_fingerprint`. It is deliberately outside the `task_watchdog_stop:` prefix that `normalizeStopFingerprint` accepts, so no existing reader treats it as a stop fingerprint.

## Model Used

Claude Opus 5 (`claude-opus-5`, 1M context window), extended thinking, with tool use and code execution. Both commits on this branch were produced with that model.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

Two boxes are left unchecked on purpose.

The branch name carries an instance-local ticket id. It was pushed before that rule was read, and renaming the head branch of an open PR would drop the review history on it, so it is left as is and called out here rather than hidden.

`ci / Build` is red on a Rust test in the runner crate, `acpx_provider_backend::tests::active_turn_recovery_closes_without_starting_the_provider`. This branch touches three TypeScript files under `server/src` and no runner code. Confirmation from a maintainer that this failure is pre-existing on `master` would help, since the last recorded `master` runs in the Actions history are from April and do not cover it.
