### PR TITLE
perf(e2e): narrow Daytona image cache inputs

### DIFF
--- a/docker/daytona-runner/Dockerfile
+++ b/docker/daytona-runner/Dockerfile
@@ -20,8 +20,27 @@ WORKDIR /workspace
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc tsconfig.base.json ./
 COPY patches ./patches
 COPY scripts/link-plugin-dev-sdk.mjs ./scripts/link-plugin-dev-sdk.mjs
-COPY packages/paperclip-eval-kernel ./packages/paperclip-eval-kernel
-COPY packages/paperclip-runner ./packages/paperclip-runner
+COPY \
+    packages/paperclip-eval-kernel/package.json \
+    packages/paperclip-eval-kernel/tsconfig.json \
+    ./packages/paperclip-eval-kernel/
+COPY packages/paperclip-eval-kernel/src ./packages/paperclip-eval-kernel/src
+COPY \
+    packages/paperclip-runner/package.json \
+    packages/paperclip-runner/styles.css \
+    packages/paperclip-runner/tsconfig.json \
+    packages/paperclip-runner/tsconfig.surfaces.json \
+    ./packages/paperclip-runner/
+COPY packages/paperclip-runner/protocol ./packages/paperclip-runner/protocol
+COPY packages/paperclip-runner/runner/crates/runner-core/src/generated_acpx_sidecar_contract.rs ./packages/paperclip-runner/runner/crates/runner-core/src/generated_acpx_sidecar_contract.rs
+COPY \
+    packages/paperclip-runner/scripts/acpx-sidecar-contract.mjs \
+    packages/paperclip-runner/scripts/build-provider-pack.mjs \
+    packages/paperclip-runner/scripts/build-verified-provider-entrypoints.mjs \
+    packages/paperclip-runner/scripts/generate-acpx-sidecar-contract.mjs \
+    packages/paperclip-runner/scripts/generate-protocol-schema-module.mjs \
+    ./packages/paperclip-runner/scripts/
+COPY packages/paperclip-runner/src ./packages/paperclip-runner/src
 RUN pnpm install --frozen-lockfile --filter '@paperclipai/paperclip-runner...'
 RUN pnpm --filter @paperclipai/paperclip-runner build:typescript \
     && PAPERCLIP_RUNNER_SOURCE_REVISION="${PAPERCLIP_RUNNER_SOURCE_REVISION}" \

--- a/tests/runner-e2e/daytona-image-content.ts
+++ b/tests/runner-e2e/daytona-image-content.ts
@@ -6,13 +6,14 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 const repositoryRoot = path.resolve(import.meta.dirname, "../..");
 
 export const DAYTONA_IMAGE_CONTENT_SCHEMA =
-  "paperclip-daytona-runner-image-content/v4";
+  "paperclip-daytona-runner-image-content/v5";
 export const DAYTONA_IMAGE_PLATFORM = "linux/amd64";
 export const DAYTONA_IMAGE_DOCKERFILE_PATH = "docker/daytona-runner/Dockerfile";
 
-// This is the audited dependency closure of docker/daytona-runner/Dockerfile.
-// Keep it conservative: a false positive only rebuilds the image, while a
-// missing input could incorrectly reuse an incompatible paid-test image.
+// This mirrors the explicit repository-local build inputs copied by
+// docker/daytona-runner/Dockerfile. Broad package-tree COPYs are forbidden by
+// the contract test so development-only files cannot silently enter the image
+// without first changing this content-identity contract.
 export const DAYTONA_IMAGE_INPUT_PATHS = [
   ".dockerignore",
   ".npmrc",
@@ -23,20 +24,25 @@ export const DAYTONA_IMAGE_INPUT_PATHS = [
   "pnpm-workspace.yaml",
   "scripts/link-plugin-dev-sdk.mjs",
   "tsconfig.base.json",
-  "packages/paperclip-eval-kernel",
-  "packages/paperclip-runner",
+  "packages/paperclip-eval-kernel/package.json",
+  "packages/paperclip-eval-kernel/src",
+  "packages/paperclip-eval-kernel/tsconfig.json",
+  "packages/paperclip-runner/package.json",
+  "packages/paperclip-runner/protocol",
+  "packages/paperclip-runner/runner/Cargo.lock",
+  "packages/paperclip-runner/runner/Cargo.toml",
+  "packages/paperclip-runner/runner/crates",
+  "packages/paperclip-runner/scripts/acpx-sidecar-contract.mjs",
+  "packages/paperclip-runner/scripts/build-provider-pack.mjs",
+  "packages/paperclip-runner/scripts/build-verified-provider-entrypoints.mjs",
+  "packages/paperclip-runner/scripts/generate-acpx-sidecar-contract.mjs",
+  "packages/paperclip-runner/scripts/generate-protocol-schema-module.mjs",
+  "packages/paperclip-runner/src",
+  "packages/paperclip-runner/styles.css",
+  "packages/paperclip-runner/tsconfig.json",
+  "packages/paperclip-runner/tsconfig.surfaces.json",
 ] as const;
 
-const ignoredGeneratedDirectoryPaths = new Set([
-  "packages/paperclip-runner/dist",
-  "packages/paperclip-runner/runner/target",
-]);
-
-// These paths do not contribute to the release runnerd binary or the
-// executable/digested provider-pack runtime payload. They are also excluded
-// from the real Docker build context by .dockerignore. Keep the two lists in
-// lockstep: if a future build starts consuming one of these inputs, Docker must
-// fail instead of publishing bytes that the content identity did not hash.
 const ignoredRunnerDevelopmentDirectoryPaths = new Set([
   "packages/paperclip-runner/devtools",
   "packages/paperclip-runner/docs",
@@ -70,7 +76,6 @@ function normalizedRelativePath(value: string): string {
 }
 
 function shouldIgnore(relativePath: string): boolean {
-  if (ignoredGeneratedDirectoryPaths.has(relativePath)) return true;
   return relativePath.split("/").includes("node_modules");
 }
 
@@ -213,7 +218,6 @@ async function hashEntry(
 
   const stats = await lstat(absolutePath);
   if (stats.isDirectory()) {
-    updateRecord(hash, "directory", normalizedPath);
     const entries = await readdir(absolutePath, { withFileTypes: true });
     entries.sort((left, right) => compareNames(left.name, right.name));
     for (const entry of entries) {

--- a/tests/runner-e2e/daytona-image.test.ts
+++ b/tests/runner-e2e/daytona-image.test.ts
@@ -28,8 +28,21 @@ describe("runner E2E Daytona image contract", () => {
         "utf8",
       ),
     ]);
+    const normalizedDockerfile = dockerfile.replace(/\\\r?\n\s*/g, " ");
     expect(dockerfile).toContain("--bin paperclip-runnerd");
     expect(dockerfile).toContain("build-provider-pack.mjs /provider-pack");
+    expect(normalizedDockerfile).not.toContain(
+      "COPY packages/paperclip-eval-kernel ./packages/paperclip-eval-kernel",
+    );
+    expect(normalizedDockerfile).not.toContain(
+      "COPY packages/paperclip-runner ./packages/paperclip-runner",
+    );
+    expect(dockerfile).toContain(
+      "COPY packages/paperclip-eval-kernel/src ./packages/paperclip-eval-kernel/src",
+    );
+    expect(dockerfile).toContain(
+      "COPY packages/paperclip-runner/src ./packages/paperclip-runner/src",
+    );
     expect(dockerfile).toContain(
       "/opt/paperclip-runner/provider-pack/provider-pack.json",
     );
@@ -119,11 +132,19 @@ describe("runner E2E Daytona image contract", () => {
       "docker/daytona-runner/Dockerfile",
       "pnpm-lock.yaml",
       "patches",
-      "packages/paperclip-eval-kernel",
-      "packages/paperclip-runner",
+      "packages/paperclip-eval-kernel/src",
+      "packages/paperclip-runner/package.json",
+      "packages/paperclip-runner/runner/crates",
+      "packages/paperclip-runner/src",
     ]) {
       expect(DAYTONA_IMAGE_INPUT_PATHS).toContain(requiredPath);
     }
+    expect(DAYTONA_IMAGE_INPUT_PATHS).not.toContain(
+      "packages/paperclip-eval-kernel",
+    );
+    expect(DAYTONA_IMAGE_INPUT_PATHS).not.toContain(
+      "packages/paperclip-runner",
+    );
     expect(DAYTONA_IMAGE_DOCKERFILE_PATH).toBe(
       "docker/daytona-runner/Dockerfile",
     );
@@ -132,34 +153,69 @@ describe("runner E2E Daytona image contract", () => {
     expect(contentId).toMatch(/^[0-9a-f]{64}$/);
   });
 
-  it("changes only when an image input, frontend, base, or platform changes", async () => {
+  it("changes for runtime source, package, lockfile, Dockerfile, frontend, base, or platform inputs", async () => {
     const root = await mkdtemp(
       path.join(tmpdir(), "paperclip-daytona-image-id-"),
     );
+    const inputPaths = [
+      "docker/daytona-runner/Dockerfile",
+      "package.json",
+      "pnpm-lock.yaml",
+      "packages/paperclip-runner/package.json",
+      "packages/paperclip-runner/src",
+      "packages/paperclip-runner/runner/crates",
+    ] as const;
+    const options = {
+      repositoryRoot: root,
+      inputPaths,
+      baseImages: [`example.test/base:1@sha256:${"a".repeat(64)}`],
+      frontendDigest: `sha256:${"c".repeat(64)}`,
+    } as const;
     try {
-      await mkdir(path.join(root, "image-input"));
+      await mkdir(path.join(root, "docker/daytona-runner"), {
+        recursive: true,
+      });
+      await mkdir(path.join(root, "packages/paperclip-runner/src"), {
+        recursive: true,
+      });
+      await mkdir(
+        path.join(
+          root,
+          "packages/paperclip-runner/runner/crates/runner-core/src",
+        ),
+        { recursive: true },
+      );
       await writeFile(
-        path.join(root, "image-input", "runner.ts"),
+        path.join(root, "docker/daytona-runner/Dockerfile"),
+        "FROM pinned\n",
+      );
+      await writeFile(path.join(root, "package.json"), '{"private":true}\n');
+      await writeFile(path.join(root, "pnpm-lock.yaml"), "lockfileVersion: 9\n");
+      await writeFile(
+        path.join(root, "packages/paperclip-runner/package.json"),
+        '{"name":"@paperclipai/paperclip-runner"}\n',
+      );
+      await writeFile(
+        path.join(root, "packages/paperclip-runner/src/runner.ts"),
         "version one\n",
       );
-      const baseline = await computeDaytonaImageContentId({
-        repositoryRoot: root,
-        inputPaths: ["image-input"],
-        baseImages: [`example.test/base:1@sha256:${"a".repeat(64)}`],
-        frontendDigest: `sha256:${"c".repeat(64)}`,
-      });
+      await writeFile(
+        path.join(
+          root,
+          "packages/paperclip-runner/runner/crates/runner-core/src/lib.rs",
+        ),
+        'pub const VERSION: &str = "one";\n',
+      );
+      const baseline = await computeDaytonaImageContentId(options);
       expect(
         await computeDaytonaImageContentId({
-          repositoryRoot: root,
-          inputPaths: ["image-input"],
+          ...options,
           baseImages: [`example.test/base:1@sha256:${"b".repeat(64)}`],
-          frontendDigest: `sha256:${"c".repeat(64)}`,
         }),
       ).not.toBe(baseline);
       expect(
         await computeDaytonaImageContentId({
-          repositoryRoot: root,
-          inputPaths: ["image-input"],
+          ...options,
           baseImages: [`example.test/base:1@sha256:${"a".repeat(64)}`],
           frontendDigest: `sha256:${"d".repeat(64)}`,
         }),
@@ -170,33 +226,27 @@ describe("runner E2E Daytona image contract", () => {
         "does not enter the image\n",
       );
       expect(
-        await computeDaytonaImageContentId({
-          repositoryRoot: root,
-          inputPaths: ["image-input"],
-          baseImages: [`example.test/base:1@sha256:${"a".repeat(64)}`],
-          frontendDigest: `sha256:${"c".repeat(64)}`,
-        }),
+        await computeDaytonaImageContentId(options),
       ).toBe(baseline);
 
-      await writeFile(
-        path.join(root, "image-input", "runner.ts"),
-        "version two\n",
-      );
+      for (const relativePath of [
+        "docker/daytona-runner/Dockerfile",
+        "package.json",
+        "pnpm-lock.yaml",
+        "packages/paperclip-runner/package.json",
+        "packages/paperclip-runner/src/runner.ts",
+        "packages/paperclip-runner/runner/crates/runner-core/src/lib.rs",
+      ]) {
+        const absolutePath = path.join(root, relativePath);
+        const original = await readFile(absolutePath, "utf8");
+        await writeFile(absolutePath, `${original}changed\n`);
+        expect(await computeDaytonaImageContentId(options)).not.toBe(baseline);
+        await writeFile(absolutePath, original);
+      }
       expect(
         await computeDaytonaImageContentId({
-          repositoryRoot: root,
-          inputPaths: ["image-input"],
-          baseImages: [`example.test/base:1@sha256:${"a".repeat(64)}`],
-          frontendDigest: `sha256:${"c".repeat(64)}`,
-        }),
-      ).not.toBe(baseline);
-      expect(
-        await computeDaytonaImageContentId({
-          repositoryRoot: root,
-          inputPaths: ["image-input"],
+          ...options,
           platform: "linux/arm64",
-          baseImages: [`example.test/base:1@sha256:${"a".repeat(64)}`],
-          frontendDigest: `sha256:${"c".repeat(64)}`,
         }),
       ).not.toBe(baseline);
     } finally {
@@ -262,6 +312,14 @@ describe("runner E2E Daytona image contract", () => {
       );
 
       const baseline = await computeDaytonaImageContentId(options);
+      await mkdir(path.join(runnerRoot, "src/new-test-only-directory"));
+      await writeFile(
+        path.join(
+          runnerRoot,
+          "src/new-test-only-directory/transport-edge.test.ts",
+        ),
+        "new TypeScript test\n",
+      );
       await writeFile(path.join(runnerRoot, "README.md"), "second readme\n");
       await writeFile(
         path.join(runnerRoot, "docs/local-runner.md"),


### PR DESCRIPTION
## Thinking Path

> - Paperclip uses paid full-stack tests to verify local and Daytona runner behavior.
> - Daytona tests reuse a content-addressed runner image when its runtime inputs match.
> - The prior key covered the full runner package even when Docker excluded development files.
> - Test-only and documentation changes could therefore force an identical image rebuild.
> - This pull request aligns the Docker input closure and content-key closure.
> - The benefit is faster paid-test iteration without unsafe image reuse.

## Linked Issues or Issue Description

**What existing behavior does this improve?**

The Daytona paid-test workflow currently rebuilds its large runner image after changes to runner tests, fixtures, smoke scripts, or documentation. Those files do not enter the image and do not change its runtime bytes.

**Subsystem affected**

The runner full-stack E2E workflow and its Daytona image build contract are affected.

**Current behavior**

The content key hashes the full runner package. A development-only edit changes the key even though the Docker build context excludes that edit.

**Proposed behavior**

The Dockerfile copies an explicit runtime build closure. The content key hashes the same closure and continues to include every source, manifest, lockfile, protocol, toolchain, and pinned image input that can affect runtime bytes.

**Reason and benefit**

The workflow can reuse verified images for test-only changes. A runtime change still creates a new immutable key and image.

**Breaking changes**

None. This changes only paid-test image cache identity and Docker build inputs.

## What Changed

- Replace broad runner and eval package copies with explicit build inputs.
- Advance the Daytona image content schema to version 5.
- Hash the matching explicit TypeScript, protocol, script, manifest, lockfile, and Rust closure.
- Add contract coverage for runtime inputs and development-only exclusions.

## Verification

- Focused Daytona image contract tests passed: 6 of 6.
- Exact-head ordinary CI [run 33913366909](https://github.com/paperclipai/paperclip/actions/runs/33913366909) passed every job.
- The PR policy check passed on [run 33913366951, attempt 2](https://github.com/paperclipai/paperclip/actions/runs/33913366951).
- The one-cell paid [run 33916670340](https://github.com/paperclipai/paperclip/actions/runs/33916670340) passed end to end.
- Image job 101165705592 built the explicit 6.33 MB context from exact source revision `4bcfb3faa7694aad4ceca2193230d9693af6c9e0`.
- The workflow published content key `3a3a8a19d2362263e972bead4427048c82a7da61dc203cd5c83aa40b88d90524` at immutable digest `sha256:a5b6f7517bc020ec2bae8075210d1a3f867284f4733042114528e19150ffac0a`.
- Cosign verified the image and recorded transparency log entry 2715972694.
- The sole `core-compatibility.legacy-codex.daytona.message-marker` cell passed in job 101168063383.
- Campaign aggregation, immutable S3 history publication, and GitHub Pages publication all passed.
- Full local test, build, and typecheck suites were not run.

## Risks

A future Docker build input could be omitted from the explicit closure. Contract tests reject the prior broad copies and check the current required runtime inputs. The real Daytona image build also qualified the closure before merge.

## Model Used

OpenAI Codex GPT-5.6 with agentic reasoning and tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [x] I have run focused tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
