### PR TITLE
fix: keep runner traceability inputs in Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -37,3 +37,11 @@ packages/paperclip-runner/scripts/*-smoke.mjs
 # now guards this in PR CI.
 !packages/paperclip-runner/generated/**
 !packages/paperclip-runner/docs/capability-contract.md
+!packages/paperclip-runner/src/backends/harness-driver-backend.test.ts
+!packages/paperclip-runner/src/contracts/native-execution.test.ts
+!packages/paperclip-runner/src/drivers/acpx/codex-acpx-driver.test.ts
+!packages/paperclip-runner/src/drivers/acpx/runtime-host.test.ts
+!packages/paperclip-runner/src/drivers/opencode/mcp-bridge.test.ts
+!packages/paperclip-runner/src/drivers/opencode/opencode-server-driver.test.ts
+!packages/paperclip-runner/src/native-session-runtime.test.ts
+!packages/paperclip-runner/src/protocol/result-normalization.test.ts

--- a/.dockerignore
+++ b/.dockerignore
@@ -34,7 +34,9 @@ packages/paperclip-runner/scripts/*-smoke.mjs
 # survive the slimming above. 2026-09-04: the *.md rule stripped the
 # committed capability contract out of the context and every image build
 # on master failed its drift check — .github/docker-context-checks.Dockerfile
-# now guards this in PR CI.
+# now guards this in PR CI. The workflow-traceability build check also reads
+# each regression test named by its manifest, so retain the eight runner-local
+# test files below without restoring the other runner test suites.
 !packages/paperclip-runner/generated/**
 !packages/paperclip-runner/docs/capability-contract.md
 !packages/paperclip-runner/src/backends/harness-driver-backend.test.ts

--- a/.github/docker-context-checks.Dockerfile
+++ b/.github/docker-context-checks.Dockerfile
@@ -30,7 +30,8 @@ COPY . .
 RUN test -f packages/paperclip-runner/generated/capability/semantic-tool-contracts.json \
  && test -f packages/paperclip-runner/generated/semantic-action-catalog.json \
  && test -f packages/paperclip-runner/spec/evals/stress-workflow-traceability.json \
- && test -d packages/paperclip-runner/protocol/fixtures/replay
+ && test -d packages/paperclip-runner/protocol/fixtures/replay \
+ && node -e "const fs=require('node:fs');const path=require('node:path');const root='packages/paperclip-runner';const manifest=JSON.parse(fs.readFileSync(path.join(root,'spec/evals/stress-workflow-traceability.json'),'utf8'));for(const finding of manifest.findings){for(const regressionTest of finding.regressionTests){fs.accessSync(path.resolve(root,regressionTest));}}"
 # ajv is installed in an isolated directory (the runner's own package.json
 # uses workspace: ranges npm cannot install from) and symlinked in so ESM
 # resolution finds it from the scripts' location.

--- a/.github/scripts/tests/docker-context-traceability.test.mjs
+++ b/.github/scripts/tests/docker-context-traceability.test.mjs
@@ -1,0 +1,38 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const repoRoot = resolve(import.meta.dirname, "../../..");
+
+test("Docker context retains every runner-local traceability test", async () => {
+  const runnerRoot = resolve(repoRoot, "packages/paperclip-runner");
+  const manifest = JSON.parse(
+    await readFile(resolve(runnerRoot, "spec/evals/stress-workflow-traceability.json"), "utf8"),
+  );
+  const dockerignore = await readFile(resolve(repoRoot, ".dockerignore"), "utf8");
+  const retainedPaths = new Set(
+    dockerignore
+      .split(/\r?\n/u)
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith("!") && !line.endsWith("/**"))
+      .map((line) => line.slice(1)),
+  );
+
+  const runnerLocalTests = new Set(
+    manifest.findings
+      .flatMap((finding) => finding.regressionTests)
+      .filter((path) => !path.startsWith("../../"))
+      .map((path) => `packages/paperclip-runner/${path}`),
+  );
+  const missing = [...runnerLocalTests].filter((path) => !retainedPaths.has(path));
+
+  assert.deepEqual(missing, []);
+});
+
+test("Docker context probe walks the traceability manifest", async () => {
+  const probe = await readFile(resolve(repoRoot, ".github/docker-context-checks.Dockerfile"), "utf8");
+
+  assert.match(probe, /stress-workflow-traceability\.json/u);
+  assert.match(probe, /finding\.regressionTests/u);
+});

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,4 +10,4 @@ permissions:
 
 jobs:
   ci:
-    uses: paperclipai/paperclip/.github/workflows/pr-trusted.yml@a0a78ee60946a5f79f85b2bd0584fc766fae43bb
+    uses: paperclipai/paperclip/.github/workflows/pr-trusted.yml@0ffc0914733183374288441232c3ec9e48eb226b


### PR DESCRIPTION
## Thinking Path

> - Paperclip ships production and cloud container images from every master commit.
> - The container build runs the paperclip-runner workflow-traceability check.
> - That check verifies every regression-test path named in its manifest.
> - The Docker context excludes runner test files, including eight paths that the check reads.
> - The master cloud-image build therefore fails before it can publish an image.
> - This pull request retains only those eight inputs and makes the context probe validate the complete manifest.
> - The benefit is that image builds work again and the PR gate detects future missing traceability inputs.

## Linked Issues or Issue Description

Refs: #12855

**What happened?**

The Docker workflow for master commit `0ffc0914733183374288441232c3ec9e48eb226b` failed in `check:runner-workflow-traceability`. The build context did not contain `packages/paperclip-runner/src/contracts/native-execution.test.ts`. The same manifest names seven more runner test files that the context also excludes. The failed run is https://github.com/paperclipai/paperclip/actions/runs/33927979700.

**Expected behavior**

The Docker context must include every committed input that an image build reads. The PR context probe must fail before merge when one of those inputs is absent.

**Steps to reproduce**

1. Check out master at `0ffc0914733183374288441232c3ec9e48eb226b`.
2. Run the cloud-image build from the Docker workflow.
3. Observe `ENOENT` for `src/contracts/native-execution.test.ts` during `check:runner-workflow-traceability`.

**Paperclip version or commit**

`0ffc0914733183374288441232c3ec9e48eb226b`

**Deployment mode**

Docker image build in GitHub Actions.

## What Changed

- Retain the eight runner-local regression tests named by the workflow-traceability manifest.
- Keep all other runner test suites excluded from the Docker context.
- Make the Docker-context probe resolve and verify every regression-test path in the manifest.

## Verification

- The manifest probe resolves all 44 traceability references on a full checkout.
- The Docker-context CI job validates the same references after `.dockerignore` is applied.
- The post-merge Docker workflow will verify both production image variants.

## Risks

- Low risk. The build context gains eight source test files and no runtime behavior changes.
- A future traceability reference outside the context will fail the PR probe by design.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex, `gpt-5.6-sol`, agentic reasoning with browser and shell tool use. The runtime does not expose the context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
