### PR TITLE
ci: activate the Docker context integrity gate for PRs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,4 +10,5 @@ permissions:
 
 jobs:
   ci:
-    uses: paperclipai/paperclip/.github/workflows/pr-trusted.yml@a0a78ee60946a5f79f85b2bd0584fc766fae43bb
+    # Pin: #12858 merge — docker context integrity gate + traceability context fix.
+    uses: paperclipai/paperclip/.github/workflows/pr-trusted.yml@03609aa6ecc9a047ed53d6b6469d8be554fbc46d


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Pull request CI runs through `pr.yml`, which pins the reusable `pr-trusted.yml` workflow by commit SHA, so `pr-trusted.yml` changes take effect only when the pin moves.
> - PRs #12855 and #12858 added the `docker_context_integrity` job and wired it into the `verify` aggregate, but the pin still points at a commit from before them.
> - Until the pin moves, a pull request that strips a committed Docker build input still merges green and breaks every post-merge image build.
> - This pull request bumps the pin to the #12858 merge commit, the standard second step of every `pr-trusted.yml` change.
> - The benefit is that the Docker context integrity gate now blocks merges, which closes out the 2026-09-04 image-publishing incident end to end.

## Linked Issues or Issue Description

Refs #12855 and #12858 (the gate this activates) and #12769 (the incident that motivated it).

**What happened?**

The `docker_context_integrity` job exists on master but does not run on pull requests, because `pr.yml` pins `pr-trusted.yml` at `a0a78ee6`, which predates it.

**Expected behavior**

Pull requests run the gate, and the `verify` required check fails when a change strips a committed Docker build input.

**Steps to reproduce**

1. Open any pull request before this change: the ci run shows no "Docker context integrity" job.
2. After this change, the job runs on every full-CI pull request and `verify` requires its result.

**Paperclip version or commit**

Pin moves from `a0a78ee60946a5f79f85b2bd0584fc766fae43bb` to `03609aa6` (the #12858 merge commit).

**Deployment mode**

GitHub Actions pull request CI.

## What Changed

- `.github/workflows/pr.yml`: the `pr-trusted.yml` pin moves to the #12858 merge commit. One line.

## Verification

- The pinned commit is master's current tip and contains the job, the `verify` wiring, and both probe revisions; its own CI (on #12855 and #12858) is fully green.
- This PR's ci run itself executes the newly pinned workflow, so the gate's first live run is visible on this very pull request.

## Risks

- Low. Identical mechanism to every previous pin bump. If the new lane misbehaves on some runner, reverting this one line restores the previous pin.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

Claude Fable 5 (Anthropic, model id `claude-fable-5`), extended thinking, agentic tool use in Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass (one-line pin bump; the pinned workflow's tests ran green on #12855/#12858)
- [x] I have added or updated tests where applicable (covered by the pin tests updated in #12855)
- [x] I have updated relevant documentation to reflect my changes (not applicable to a pin bump)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
