### PR TITLE
fix: reap run-scoped sandbox descendants

### DIFF
--- a/packages/adapter-utils/src/sandbox-callback-bridge.ts
+++ b/packages/adapter-utils/src/sandbox-callback-bridge.ts
@@ -1704,7 +1704,11 @@ export async function startSandboxCallbackBridgeServer(input: {
       [
         `mkdir -p ${shellQuote(directories.requestsDir)} ${shellQuote(directories.responsesDir)} ${shellQuote(directories.logsDir)}`,
         `rm -f ${shellQuote(directories.readyFile)} ${shellQuote(directories.pidFile)}`,
-        `nohup ${shellQuote(nodeCommand)} ${shellQuote(remoteEntrypoint)} ` +
+        // This daemon is owned by the bridge handle and stopped through its
+        // pid-file in `stop()`. Do not inherit the one-shot command's run scope,
+        // otherwise generic run-process cleanup would reap the bridge immediately
+        // after this launcher shell exits, before the readiness probe can observe it.
+        `env PAPERCLIP_RUN_PROCESS_SCOPE= nohup ${shellQuote(nodeCommand)} ${shellQuote(remoteEntrypoint)} ` +
           `>> ${shellQuote(directories.logFile)} 2>&1 < /dev/null &`,
         "pid=$!",
         `printf '%s\\n' \"$pid\" > ${shellQuote(directories.pidFile)}`,

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -595,6 +595,48 @@ describe("runChildProcess", () => {
     ).resolves.toMatchObject({ matchedPids: [] });
   });
 
+  it.skipIf(process.platform === "win32")(
+    "does not signal a recycled direct PID when the persisted start time mismatches",
+    async () => {
+      const runId = randomUUID();
+      const child = spawn(
+        process.execPath,
+        ["-e", "setInterval(() => {}, 1000)"],
+        {
+          detached: true,
+          env: { ...process.env, PAPERCLIP_RUN_PROCESS_SCOPE: runId },
+          stdio: "ignore",
+        },
+      );
+      try {
+        expect(child.pid).toBeGreaterThan(0);
+        const evidence = await terminateRunScopedProcesses({
+          runId,
+          pid: child.pid,
+          processGroupId: child.pid,
+          processStartedAt: "1970-01-01T00:00:00.000Z",
+          graceMs: 10,
+        });
+
+        expect(evidence.directPidStartMismatch).toBe(true);
+        expect(evidence.matchedPids).toEqual([]);
+        expect(evidence.termSignalledPids).toEqual([]);
+        expect(evidence.killSignalledPids).toEqual([]);
+        expect(isPidAlive(child.pid!)).toBe(true);
+      } finally {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // Ignore cleanup races.
+        }
+        await new Promise<void>((resolve) => {
+          child.once("close", () => resolve());
+          if (child.exitCode !== null || child.signalCode !== null) resolve();
+        });
+      }
+    },
+  );
+
   it("waits for onSpawn before sending stdin to the child", async () => {
     const spawnDelayMs = 150;
     const startedAt = Date.now();

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -567,6 +567,34 @@ describe("runChildProcess", () => {
     expect(result.stdout).toBe("done");
   });
 
+  it("completes a no-browser run without creating a scoped browser process", async () => {
+    const runId = randomUUID();
+    const result = await runChildProcess(
+      runId,
+      process.execPath,
+      ["-e", "process.stdout.write('no-browser');"],
+      {
+        cwd: process.cwd(),
+        env: {},
+        timeoutSec: 5,
+        graceSec: 1,
+        onLog: async () => {},
+      },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("no-browser");
+    await expect(
+      terminateRunScopedProcesses({
+        runId,
+        pid: result.pid,
+        processGroupId: result.pid,
+        processStartedAt: result.startedAt,
+        graceMs: 10,
+      }),
+    ).resolves.toMatchObject({ matchedPids: [] });
+  });
+
   it("waits for onSpawn before sending stdin to the child", async () => {
     const spawnDelayMs = 150;
     const startedAt = Date.now();
@@ -612,7 +640,7 @@ describe("runChildProcess", () => {
           "-e",
           [
             "const { spawn } = require('node:child_process');",
-            "const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });",
+            "const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { detached: true, stdio: 'ignore' });",
             "process.stdout.write(String(child.pid));",
             "setInterval(() => {}, 1000);",
           ].join(" "),

--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -25,6 +25,7 @@ import {
   runChildProcess,
   sanitizeSshRemoteEnv,
   signalRunningProcess,
+  terminateRunScopedProcesses,
   shapePaperclipWorkspaceEnvForExecution,
   rewriteWorkspaceCwdEnvVarsForExecution,
   stringifyPaperclipWakePayload,
@@ -631,6 +632,83 @@ describe("runChildProcess", () => {
       expect(Number.isInteger(descendantPid) && descendantPid > 0).toBe(true);
 
       expect(await waitForPidExit(descendantPid!, 2_000)).toBe(true);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "reaps a detached run descendant by scope without touching an unscoped gateway",
+    async () => {
+      const gateway = spawn(
+        process.execPath,
+        ["-e", "setInterval(() => {}, 1000)"],
+        { detached: true, stdio: "ignore" },
+      );
+      gateway.unref();
+      let descendantPid: number | null = null;
+      try {
+        const runId = randomUUID();
+        let observed = "";
+        const resultPromise = runChildProcess(
+          runId,
+          process.execPath,
+          [
+            "-e",
+            [
+              "const { spawn } = require('node:child_process');",
+              "const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { detached: true, stdio: 'ignore' });",
+              "child.unref();",
+              "process.stdout.write(String(child.pid));",
+              "setTimeout(() => process.exit(0), 100);",
+            ].join(" "),
+          ],
+          {
+            cwd: process.cwd(),
+            env: {},
+            timeoutSec: 5,
+            graceSec: 1,
+            onLog: async (_stream, chunk) => {
+              observed += chunk;
+            },
+          },
+        );
+        const pidMatch = await waitForTextMatch(() => observed, /(\d+)/);
+        descendantPid = Number.parseInt(pidMatch?.[1] ?? "", 10);
+        expect(Number.isInteger(descendantPid) && descendantPid > 0).toBe(true);
+        expect(isPidAlive(descendantPid)).toBe(true);
+        expect(gateway.pid && isPidAlive(gateway.pid)).toBe(true);
+
+        const result = await resultPromise;
+        expect(result.exitCode).toBe(0);
+        expect(await waitForPidExit(descendantPid, 2_000)).toBe(true);
+
+        // Teardown is idempotent after the first close-path cleanup. The
+        // process-start metadata also prevents a recycled direct PID from
+        // becoming a valid target.
+        const repeated = await terminateRunScopedProcesses({
+          runId,
+          pid: result.pid,
+          processGroupId: result.pid,
+          processStartedAt: result.startedAt,
+          graceMs: 10,
+        });
+        expect(repeated.matchedPids).toEqual([]);
+        expect(gateway.pid && isPidAlive(gateway.pid)).toBe(true);
+      } finally {
+        if (gateway.pid && isPidAlive(gateway.pid)) {
+          try {
+            process.kill(gateway.pid, "SIGKILL");
+          } catch {
+            // Ignore cleanup races.
+          }
+        }
+        if (descendantPid && isPidAlive(descendantPid)) {
+          try {
+            process.kill(descendantPid, "SIGKILL");
+          } catch {
+            // Ignore cleanup races.
+          }
+        }
+      }
     },
   );
 

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -133,6 +133,220 @@ export function signalRunningProcess(
   }
 }
 
+export const PAPERCLIP_RUN_PROCESS_SCOPE = "PAPERCLIP_RUN_PROCESS_SCOPE";
+
+export interface RunScopedProcessCleanupOptions {
+  runId: string;
+  pid: number | null | undefined;
+  processGroupId: number | null | undefined;
+  processStartedAt: Date | string | null | undefined;
+  graceMs?: number;
+}
+
+export interface RunScopedProcessCleanupEvidence {
+  runId: string;
+  matchedPids: number[];
+  termSignalledPids: number[];
+  killSignalledPids: number[];
+  processGroupSignalled: boolean;
+}
+
+interface LinuxProcessIdentity {
+  pid: number;
+  startTicks: number;
+  processGroupId: number;
+  state: string;
+  scoped: boolean;
+}
+
+const LINUX_CLOCK_TICKS_PER_SECOND = 100;
+
+function parseLinuxProcessStat(stat: string): {
+  startTicks: number;
+  processGroupId: number;
+  state: string;
+} | null {
+  const commandEnd = stat.lastIndexOf(")");
+  if (commandEnd < 0) return null;
+  // `/proc/<pid>/stat` fields 5 and 22 are offsets 2 and 19 after field 3.
+  const fields = stat.slice(commandEnd + 2).trim().split(/\s+/);
+  const state = fields[0];
+  const processGroupId = Number(fields[2]);
+  const startTicks = Number(fields[19]);
+  if (
+    typeof state !== "string" ||
+    !Number.isSafeInteger(processGroupId) ||
+    processGroupId <= 0 ||
+    !Number.isSafeInteger(startTicks) ||
+    startTicks < 0
+  ) {
+    return null;
+  }
+  return { processGroupId, startTicks, state };
+}
+
+async function readLinuxProcessIdentity(
+  pid: number,
+  runId: string,
+): Promise<LinuxProcessIdentity | null> {
+  if (process.platform !== "linux" || !Number.isInteger(pid) || pid <= 0) return null;
+  try {
+    const [stat, environ] = await Promise.all([
+      fs.readFile(`/proc/${pid}/stat`, "utf8"),
+      fs.readFile(`/proc/${pid}/environ`),
+    ]);
+    const parsedStat = parseLinuxProcessStat(stat);
+    if (!parsedStat) return null;
+    return {
+      pid,
+      ...parsedStat,
+      scoped: environ
+        .toString("utf8")
+        .split("\0")
+        .includes(`${PAPERCLIP_RUN_PROCESS_SCOPE}=${runId}`),
+    };
+  } catch {
+    // Processes can exit between /proc reads. Treat that race as already gone.
+    return null;
+  }
+}
+
+function processStartedAtMs(value: Date | string | null | undefined): number | null {
+  if (!value) return null;
+  const timestamp = (value instanceof Date ? value : new Date(value)).getTime();
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+async function readLinuxBootTimeSeconds(): Promise<number | null> {
+  if (process.platform !== "linux") return null;
+  try {
+    const line = (await fs.readFile("/proc/stat", "utf8"))
+      .split("\n")
+      .find((value) => value.startsWith("btime "));
+    const bootSeconds = Number(line?.slice("btime ".length));
+    return Number.isFinite(bootSeconds) ? bootSeconds : null;
+  } catch {
+    return null;
+  }
+}
+
+function matchesPersistedStart(
+  identity: LinuxProcessIdentity,
+  startedAt: Date | string | null | undefined,
+  bootSeconds: number | null,
+) {
+  const expectedMs = processStartedAtMs(startedAt);
+  if (expectedMs === null || bootSeconds === null) return true;
+  const actualMs =
+    (bootSeconds + identity.startTicks / LINUX_CLOCK_TICKS_PER_SECOND) * 1000;
+  return Number.isFinite(actualMs) && Math.abs(actualMs - expectedMs) <= 10_000;
+}
+
+async function listRunScopedProcessIdentities(runId: string) {
+  if (process.platform !== "linux") return [];
+  let entries: Dirent[];
+  try {
+    entries = await fs.readdir("/proc", { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const pids = entries
+    .filter((entry) => entry.isDirectory() && /^\d+$/.test(entry.name))
+    .map((entry) => Number(entry.name))
+    .filter((pid) => Number.isSafeInteger(pid) && pid > 0);
+  const identities = await Promise.all(
+    pids.map((pid) => readLinuxProcessIdentity(pid, runId)),
+  );
+  return identities.filter(
+    (identity): identity is LinuxProcessIdentity =>
+      identity !== null && identity.scoped && identity.state !== "Z" && identity.state !== "X",
+  );
+}
+
+async function signalScopedPid(
+  pid: number,
+  runId: string,
+  expectedStartTicks: number,
+  signal: NodeJS.Signals,
+) {
+  const identity = await readLinuxProcessIdentity(pid, runId);
+  if (!identity || identity.startTicks !== expectedStartTicks) return false;
+  try {
+    process.kill(pid, signal);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Stop one Paperclip run's local process scope, including setsid descendants. */
+export async function terminateRunScopedProcesses(
+  input: RunScopedProcessCleanupOptions,
+): Promise<RunScopedProcessCleanupEvidence> {
+  const evidence: RunScopedProcessCleanupEvidence = {
+    runId: input.runId,
+    matchedPids: [],
+    termSignalledPids: [],
+    killSignalledPids: [],
+    processGroupSignalled: false,
+  };
+  if (process.platform === "win32") return evidence;
+
+  const identities = await listRunScopedProcessIdentities(input.runId);
+  evidence.matchedPids = identities.map((identity) => identity.pid).sort((a, b) => a - b);
+  const bootSeconds = await readLinuxBootTimeSeconds();
+  const direct = identities.find(
+    (identity) =>
+      identity.pid === input.pid &&
+      matchesPersistedStart(identity, input.processStartedAt, bootSeconds),
+  ) ?? null;
+  if (
+    direct !== null &&
+    direct.processGroupId === input.processGroupId &&
+    typeof input.processGroupId === "number" &&
+    Number.isInteger(input.processGroupId) &&
+    input.processGroupId > 0
+  ) {
+    try {
+      process.kill(-input.processGroupId, "SIGTERM");
+      evidence.processGroupSignalled = true;
+    } catch {
+      // The group may have exited between identity validation and signalling.
+    }
+  }
+
+  for (const identity of identities) {
+    if (
+      await signalScopedPid(
+        identity.pid,
+        input.runId,
+        identity.startTicks,
+        "SIGTERM",
+      )
+    ) {
+      evidence.termSignalledPids.push(identity.pid);
+    }
+  }
+
+  const graceMs = Math.max(1, input.graceMs ?? 1_000);
+  if (evidence.termSignalledPids.length > 0 || evidence.processGroupSignalled) {
+    await new Promise((resolve) => setTimeout(resolve, graceMs));
+  }
+  for (const identity of await listRunScopedProcessIdentities(input.runId)) {
+    if (
+      await signalScopedPid(
+        identity.pid,
+        input.runId,
+        identity.startTicks,
+        "SIGKILL",
+      )
+    ) {
+      evidence.killSignalledPids.push(identity.pid);
+    }
+  }
+  return evidence;
+}
+
 export const runningProcesses = new Map<string, RunningProcess>();
 export const MAX_CAPTURE_BYTES = 4 * 1024 * 1024;
 export const MAX_EXCERPT_BYTES = 32 * 1024;
@@ -3474,9 +3688,12 @@ export async function runChildProcess(
     if (opts.localProcessSandbox?.homeDir) {
       mergedEnv.HOME = opts.localProcessSandbox.homeDir;
     }
+    const runScopedRemoteEnv = opts.remoteExecution
+      ? { ...opts.env, [PAPERCLIP_RUN_PROCESS_SCOPE]: runId }
+      : null;
     void resolveSpawnTarget(command, args, opts.cwd, mergedEnv, {
       remoteExecution: opts.remoteExecution ?? null,
-      remoteEnv: opts.remoteExecution ? opts.env : null,
+      remoteEnv: runScopedRemoteEnv,
       localProcessSandbox: opts.localProcessSandbox ?? null,
     })
       .then((target) => {
@@ -3484,6 +3701,9 @@ export async function runChildProcess(
         for (const [key, value] of Object.entries(childEnv)) {
           if (value === undefined) delete childEnv[key];
         }
+        // Every local adapter child carries its exact run scope so descendants
+        // that call setsid() remain discoverable without process-name matching.
+        childEnv[PAPERCLIP_RUN_PROCESS_SCOPE] = runId;
         const child = spawn(target.command, target.args, {
           cwd: target.cwd ?? opts.cwd,
           env: childEnv,
@@ -3502,6 +3722,36 @@ export async function runChildProcess(
             : Promise.resolve();
 
         runningProcesses.set(runId, { child, graceSec: opts.graceSec, processGroupId });
+
+        let scopeCleanupPromise: Promise<RunScopedProcessCleanupEvidence> | null = null;
+        const cleanupRunScope = () => {
+          if (!scopeCleanupPromise) {
+            scopeCleanupPromise = terminateRunScopedProcesses({
+              runId,
+              pid: child.pid,
+              processGroupId,
+              processStartedAt: startedAt,
+              graceMs: Math.max(1, opts.graceSec) * 1000,
+            });
+          }
+          return scopeCleanupPromise;
+        };
+
+        const stopRunScope = (onForceKill?: () => void) => {
+          void cleanupRunScope().then((evidence) => {
+            if (evidence.matchedPids.length > 0) {
+              if (evidence.killSignalledPids.length > 0) onForceKill?.();
+              return;
+            }
+            // Compatibility path for pre-scope runs or non-Linux hosts.
+            signalRunningProcess({ child, processGroupId }, "SIGTERM");
+            terminalCleanupKillTimer = setTimeout(() => {
+              terminalCleanupKillTimer = null;
+              onForceKill?.();
+              signalRunningProcess({ child, processGroupId }, "SIGKILL");
+            }, Math.max(1, opts.graceSec) * 1000);
+          });
+        };
 
         let timedOut = false;
         let stdout = "";
@@ -3551,13 +3801,10 @@ export async function runChildProcess(
             if (terminalCleanupStarted || timedOut) return;
             terminalCleanupStarted = true;
             terminalCleanupSignal = "SIGTERM";
-            signalRunningProcess({ child, processGroupId }, "SIGTERM");
-            terminalCleanupKillTimer = setTimeout(() => {
-              terminalCleanupKillTimer = null;
+            stopRunScope(() => {
               terminalCleanupSignal = "SIGKILL";
               terminalCleanupForceKilled = true;
-              signalRunningProcess({ child, processGroupId }, "SIGKILL");
-            }, Math.max(1, opts.graceSec) * 1000);
+            });
           }, graceMs);
         };
 
@@ -3566,10 +3813,7 @@ export async function runChildProcess(
             ? setTimeout(() => {
                 timedOut = true;
                 clearTerminalCleanupTimers();
-                signalRunningProcess({ child, processGroupId }, "SIGTERM");
-                setTimeout(() => {
-                  signalRunningProcess({ child, processGroupId }, "SIGKILL");
-                }, Math.max(1, opts.graceSec) * 1000);
+                stopRunScope();
               }, opts.timeoutSec * 1000)
             : null;
 
@@ -3637,30 +3881,32 @@ export async function runChildProcess(
           clearTerminalCleanupTimers();
           runningProcesses.delete(runId);
           void logChain.finally(() => {
-            void Promise.resolve()
-              .then(() => target.cleanup?.())
-              .finally(() => {
-              resolve({
-                exitCode: code,
-                signal,
-                timedOut,
-                stdout,
-                stderr,
-                pid: child.pid ?? null,
-                startedAt,
-                terminalResultCleanup: terminalCleanupStarted
-                  ? {
-                    kind: "terminal_result_cleanup",
-                    stopped: true,
-                    stopReason: UNMANAGED_BACKGROUND_TASK_STOP_REASON,
-                    reason: UNMANAGED_BACKGROUND_TASK_LIVENESS_REASON,
-                    terminalResultSeen,
-                    signal: terminalCleanupSignal,
-                    forceKilled: terminalCleanupForceKilled,
-                  }
-                  : null,
-              });
-              });
+            void cleanupRunScope().then(() =>
+              Promise.resolve()
+                .then(() => target.cleanup?.())
+                .finally(() => {
+                  resolve({
+                    exitCode: code,
+                    signal,
+                    timedOut,
+                    stdout,
+                    stderr,
+                    pid: child.pid ?? null,
+                    startedAt,
+                    terminalResultCleanup: terminalCleanupStarted
+                      ? {
+                          kind: "terminal_result_cleanup",
+                          stopped: true,
+                          stopReason: UNMANAGED_BACKGROUND_TASK_STOP_REASON,
+                          reason: UNMANAGED_BACKGROUND_TASK_LIVENESS_REASON,
+                          terminalResultSeen,
+                          signal: terminalCleanupSignal,
+                          forceKilled: terminalCleanupForceKilled,
+                        }
+                      : null,
+                  });
+                }),
+            );
           });
         });
       })

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -83,6 +83,10 @@ interface RunningProcess {
   child: ChildProcess;
   graceSec: number;
   processGroupId: number | null;
+  // Remote targets use this hook to reap their own host-local descendants.
+  // It is memoized at the spawn boundary so cancellation and close cleanup
+  // share one idempotent lease release.
+  cleanup?: () => Promise<void>;
 }
 
 interface SpawnTarget {
@@ -239,7 +243,7 @@ function matchesPersistedStart(
   if (expectedMs === null || bootSeconds === null) return true;
   const actualMs =
     (bootSeconds + identity.startTicks / LINUX_CLOCK_TICKS_PER_SECOND) * 1000;
-  return Number.isFinite(actualMs) && Math.abs(actualMs - expectedMs) <= 10_000;
+  return Number.isFinite(actualMs) && Math.abs(actualMs - expectedMs) <= 2_000;
 }
 
 async function listRunScopedProcessIdentities(runId: string) {
@@ -293,12 +297,20 @@ export async function terminateRunScopedProcesses(
   if (process.platform === "win32") return evidence;
 
   const identities = await listRunScopedProcessIdentities(input.runId);
-  evidence.matchedPids = identities.map((identity) => identity.pid).sort((a, b) => a - b);
   const bootSeconds = await readLinuxBootTimeSeconds();
-  const direct = identities.find(
+  // A persisted direct PID is the only identity vulnerable to PID reuse across
+  // a Paperclip restart. Descendants are selected by the exact opaque run
+  // marker; the direct PID must additionally match its persisted start time.
+  const eligibleIdentities = identities.filter(
     (identity) =>
-      identity.pid === input.pid &&
+      identity.pid !== input.pid ||
       matchesPersistedStart(identity, input.processStartedAt, bootSeconds),
+  );
+  evidence.matchedPids = eligibleIdentities
+    .map((identity) => identity.pid)
+    .sort((a, b) => a - b);
+  const direct = eligibleIdentities.find(
+    (identity) => identity.pid === input.pid,
   ) ?? null;
   if (
     direct !== null &&
@@ -3713,6 +3725,15 @@ export async function runChildProcess(
         }) as ChildProcessWithEvents;
         const startedAt = new Date().toISOString();
         const processGroupId = resolveProcessGroupId(child);
+        let targetCleanupPromise: Promise<void> | null = null;
+        const cleanupTarget = () => {
+          if (!targetCleanupPromise) {
+            targetCleanupPromise = Promise.resolve(target.cleanup?.()).catch((err) => {
+              onLogError(err, runId, "failed to clean up adapter execution target");
+            });
+          }
+          return targetCleanupPromise;
+        };
 
         const spawnPersistPromise =
           typeof child.pid === "number" && child.pid > 0 && opts.onSpawn
@@ -3721,7 +3742,12 @@ export async function runChildProcess(
             })
             : Promise.resolve();
 
-        runningProcesses.set(runId, { child, graceSec: opts.graceSec, processGroupId });
+        runningProcesses.set(runId, {
+          child,
+          graceSec: opts.graceSec,
+          processGroupId,
+          cleanup: cleanupTarget,
+        });
 
         let scopeCleanupPromise: Promise<RunScopedProcessCleanupEvidence> | null = null;
         const cleanupRunScope = () => {
@@ -3738,6 +3764,10 @@ export async function runChildProcess(
         };
 
         const stopRunScope = (onForceKill?: () => void) => {
+          // Local scope cleanup and remote target cleanup are independent. Run
+          // both immediately so killing the SSH transport cannot strand a VDS
+          // descendant while the local process-group grace window is running.
+          void cleanupTarget();
           void cleanupRunScope().then((evidence) => {
             if (evidence.matchedPids.length > 0) {
               if (evidence.killSignalledPids.length > 0) onForceKill?.();
@@ -3862,7 +3892,7 @@ export async function runChildProcess(
           if (timeout) clearTimeout(timeout);
           clearTerminalCleanupTimers();
           runningProcesses.delete(runId);
-          void target.cleanup?.();
+          void cleanupTarget();
           const errno = (err as NodeJS.ErrnoException).code;
           const pathValue = mergedEnv.PATH ?? mergedEnv.Path ?? "";
           const msg =
@@ -3881,32 +3911,30 @@ export async function runChildProcess(
           clearTerminalCleanupTimers();
           runningProcesses.delete(runId);
           void logChain.finally(() => {
-            void cleanupRunScope().then(() =>
-              Promise.resolve()
-                .then(() => target.cleanup?.())
-                .finally(() => {
-                  resolve({
-                    exitCode: code,
-                    signal,
-                    timedOut,
-                    stdout,
-                    stderr,
-                    pid: child.pid ?? null,
-                    startedAt,
-                    terminalResultCleanup: terminalCleanupStarted
-                      ? {
-                          kind: "terminal_result_cleanup",
-                          stopped: true,
-                          stopReason: UNMANAGED_BACKGROUND_TASK_STOP_REASON,
-                          reason: UNMANAGED_BACKGROUND_TASK_LIVENESS_REASON,
-                          terminalResultSeen,
-                          signal: terminalCleanupSignal,
-                          forceKilled: terminalCleanupForceKilled,
-                        }
-                      : null,
-                  });
-                }),
-            );
+            void cleanupRunScope()
+              .then(() => cleanupTarget())
+              .then(() => {
+                resolve({
+                  exitCode: code,
+                  signal,
+                  timedOut,
+                  stdout,
+                  stderr,
+                  pid: child.pid ?? null,
+                  startedAt,
+                  terminalResultCleanup: terminalCleanupStarted
+                    ? {
+                        kind: "terminal_result_cleanup",
+                        stopped: true,
+                        stopReason: UNMANAGED_BACKGROUND_TASK_STOP_REASON,
+                        reason: UNMANAGED_BACKGROUND_TASK_LIVENESS_REASON,
+                        terminalResultSeen,
+                        signal: terminalCleanupSignal,
+                        forceKilled: terminalCleanupForceKilled,
+                      }
+                    : null,
+                });
+              });
           });
         });
       })

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -153,6 +153,9 @@ export interface RunScopedProcessCleanupEvidence {
   termSignalledPids: number[];
   killSignalledPids: number[];
   processGroupSignalled: boolean;
+  // True when persisted direct-child metadata points at a different live
+  // process. Callers must not use the legacy PID/process-group fallback then.
+  directPidStartMismatch: boolean;
 }
 
 interface LinuxProcessIdentity {
@@ -293,11 +296,22 @@ export async function terminateRunScopedProcesses(
     termSignalledPids: [],
     killSignalledPids: [],
     processGroupSignalled: false,
+    directPidStartMismatch: false,
   };
   if (process.platform === "win32") return evidence;
 
   const identities = await listRunScopedProcessIdentities(input.runId);
   const bootSeconds = await readLinuxBootTimeSeconds();
+  const directPidIdentity =
+    typeof input.pid === "number"
+      ? await readLinuxProcessIdentity(input.pid, input.runId)
+      : null;
+  const expectedStartMs = processStartedAtMs(input.processStartedAt);
+  evidence.directPidStartMismatch =
+    directPidIdentity !== null &&
+    expectedStartMs !== null &&
+    bootSeconds !== null &&
+    !matchesPersistedStart(directPidIdentity, input.processStartedAt, bootSeconds);
   // A persisted direct PID is the only identity vulnerable to PID reuse across
   // a Paperclip restart. Descendants are selected by the exact opaque run
   // marker; the direct PID must additionally match its persisted start time.
@@ -327,7 +341,7 @@ export async function terminateRunScopedProcesses(
     }
   }
 
-  for (const identity of identities) {
+  for (const identity of eligibleIdentities) {
     if (
       await signalScopedPid(
         identity.pid,
@@ -344,7 +358,12 @@ export async function terminateRunScopedProcesses(
   if (evidence.termSignalledPids.length > 0 || evidence.processGroupSignalled) {
     await new Promise((resolve) => setTimeout(resolve, graceMs));
   }
-  for (const identity of await listRunScopedProcessIdentities(input.runId)) {
+  const remainingEligibleIdentities = (await listRunScopedProcessIdentities(input.runId)).filter(
+    (identity) =>
+      identity.pid !== input.pid ||
+      matchesPersistedStart(identity, input.processStartedAt, bootSeconds),
+  );
+  for (const identity of remainingEligibleIdentities) {
     if (
       await signalScopedPid(
         identity.pid,

--- a/packages/adapter-utils/src/ssh.ts
+++ b/packages/adapter-utils/src/ssh.ts
@@ -1299,6 +1299,37 @@ export async function buildSshSpawnTarget(input: {
       : `exec ${remoteCommandParts}`,
   ].join(" && ");
 
+  const runScope = input.env["PAPERCLIP_RUN_PROCESS_SCOPE"];
+  const cleanupRemoteRunScope = runScope
+    ? async () => {
+        // Re-read /proc/<pid>/environ immediately before each signal. The
+        // opaque run UUID is the process identity; never match by name.
+        const cleanupScript = [
+          `scope=${shellQuote(runScope)}`,
+          "for signal in TERM KILL; do",
+          "  for proc in /proc/[0-9]*; do",
+          "    pid=${proc##*/}",
+          "    if [ -r \"$proc/environ\" ] && tr '\\0' '\\n' < \"$proc/environ\" | grep -Fqx \"PAPERCLIP_RUN_PROCESS_SCOPE=$scope\"; then",
+          "      kill -$signal \"$pid\" 2>/dev/null || true",
+          "    fi",
+          "  done",
+          "  [ \"$signal\" = KILL ] || sleep 1",
+          "done",
+        ].join("\n");
+        const cleanupArgs = [
+          ...auth.args,
+          "-p",
+          String(input.spec.port),
+          `${input.spec.username}@${input.spec.host}`,
+          `sh -c ${shellQuote(cleanupScript)}`,
+        ];
+        await execFileText("ssh", cleanupArgs, {
+          timeout: 15_000,
+          maxBuffer: 32 * 1024,
+        }).catch(() => undefined);
+      }
+    : null;
+
   sshArgs.push(
     "-p",
     String(input.spec.port),
@@ -1309,7 +1340,10 @@ export async function buildSshSpawnTarget(input: {
   return {
     command: "ssh",
     args: sshArgs,
-    cleanup: auth.cleanup,
+    cleanup: async () => {
+      await cleanupRemoteRunScope?.();
+      await auth.cleanup();
+    },
   };
 }
 

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -288,20 +288,23 @@ async function cancelActiveRunsForCleanup(
   }
 }
 
-async function spawnOrphanedProcessGroup() {
+async function spawnOrphanedProcessGroup(runScope?: string) {
   const leader = spawn(
     process.execPath,
     [
       "-e",
       [
         "const { spawn } = require('node:child_process');",
-        "const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });",
+        `const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { detached: ${runScope ? "true" : "false"}, stdio: 'ignore' });`,
         "process.stdout.write(String(child.pid));",
         "setTimeout(() => process.exit(0), 25);",
       ].join(" "),
     ],
     {
       detached: true,
+      env: runScope
+        ? { ...process.env, PAPERCLIP_RUN_PROCESS_SCOPE: runScope }
+        : undefined,
       stdio: ["ignore", "pipe", "ignore"],
     },
   );
@@ -523,6 +526,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     processLossRetryCount?: number;
     runtimeMode?: "legacy" | "native";
     includeIssue?: boolean;
+    issueStatus?: "in_progress" | "done" | "cancelled";
     runErrorCode?: string | null;
     runError?: string | null;
     contextSnapshot?: Record<string, unknown>;
@@ -595,7 +599,7 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         id: issueId,
         companyId,
         title: "Recover local adapter after lost process",
-        status: "in_progress",
+        status: input?.issueStatus ?? "in_progress",
         priority: "medium",
         assigneeAgentId: agentId,
         checkoutRunId: runId,

--- a/server/src/__tests__/recovery-stale-issue-lock-sweep.test.ts
+++ b/server/src/__tests__/recovery-stale-issue-lock-sweep.test.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { spawn } from "node:child_process";
 import { eq } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
@@ -411,6 +412,64 @@ describeEmbeddedPostgres("recovery sweepStaleIssueLocks", () => {
       .where(eq(heartbeatRuns.id, runningRunId))
       .then((rows) => rows[0]?.status);
     expect(runStatus).toBe("cancelled");
+  });
+
+  it("reaps a run-scoped detached descendant when a terminal issue is recovered after restart", async () => {
+    const { companyId, agentId, runningRunId } = await seed();
+    const runScope = runningRunId;
+    const leader = spawn(
+      process.execPath,
+      [
+        "-e",
+        [
+          "const { spawn } = require('node:child_process');",
+          "const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { detached: true, stdio: 'ignore' });",
+          "process.stdout.write(String(child.pid));",
+          "setTimeout(() => process.exit(0), 25);",
+        ].join(" "),
+      ],
+      {
+        detached: true,
+        env: { ...process.env, PAPERCLIP_RUN_PROCESS_SCOPE: runScope },
+        stdio: ["ignore", "pipe", "ignore"],
+      },
+    );
+    let stdout = "";
+    leader.stdout?.on("data", (chunk) => { stdout += String(chunk); });
+    await new Promise<void>((resolve, reject) => {
+      leader.once("error", reject);
+      leader.once("close", () => resolve());
+    });
+    const descendantPid = Number.parseInt(stdout.trim(), 10);
+    expect(descendantPid).toBeGreaterThan(0);
+    expect(() => process.kill(descendantPid, 0)).not.toThrow();
+
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Terminal issue with detached adapter descendant",
+      status: "done",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: runningRunId,
+      executionRunId: runningRunId,
+      executionLockedAt: new Date(),
+    });
+    await db.update(heartbeatRuns).set({
+      processPid: leader.pid ?? null,
+      processGroupId: leader.pid ?? null,
+    }).where(eq(heartbeatRuns.id, runningRunId));
+
+    try {
+      const result = await heartbeatService(db).sweepStaleIssueLocks();
+      expect(result.terminalizedRunIds).toEqual([runningRunId]);
+      expect(result.cleared).toBe(1);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(() => process.kill(descendantPid, 0)).toThrow();
+    } finally {
+      try { process.kill(descendantPid, "SIGKILL"); } catch { /* already gone */ }
+    }
   });
 
   it("does not terminalize a running run whose process is alive and whose issue is not terminal", async () => {

--- a/server/src/adapters/index.ts
+++ b/server/src/adapters/index.ts
@@ -31,4 +31,4 @@ export type {
   AdapterAgent,
   AdapterRuntime,
 } from "@paperclipai/adapter-utils";
-export { runningProcesses } from "./utils.js";
+export { runningProcesses, terminateRunScopedProcesses } from "./utils.js";

--- a/server/src/adapters/utils.ts
+++ b/server/src/adapters/utils.ts
@@ -15,6 +15,7 @@ type BuildInvocationEnvForLogsOptions = {
 
 export const runningProcesses: Map<string, { child: ChildProcess; graceSec: number; processGroupId: number | null }> =
   serverUtils.runningProcesses;
+export const terminateRunScopedProcesses = serverUtils.terminateRunScopedProcesses;
 export const MAX_CAPTURE_BYTES = serverUtils.MAX_CAPTURE_BYTES;
 export const MAX_EXCERPT_BYTES = serverUtils.MAX_EXCERPT_BYTES;
 export const parseObject = serverUtils.parseObject;

--- a/server/src/adapters/utils.ts
+++ b/server/src/adapters/utils.ts
@@ -13,8 +13,12 @@ type BuildInvocationEnvForLogsOptions = {
   resolvedCommandEnvKey?: string;
 };
 
-export const runningProcesses: Map<string, { child: ChildProcess; graceSec: number; processGroupId: number | null }> =
-  serverUtils.runningProcesses;
+export const runningProcesses: Map<string, {
+  child: ChildProcess;
+  graceSec: number;
+  processGroupId: number | null;
+  cleanup?: () => Promise<void>;
+}> = serverUtils.runningProcesses;
 export const terminateRunScopedProcesses = serverUtils.terminateRunScopedProcesses;
 export const MAX_CAPTURE_BYTES = serverUtils.MAX_CAPTURE_BYTES;
 export const MAX_EXCERPT_BYTES = serverUtils.MAX_EXCERPT_BYTES;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -157,7 +157,11 @@ import {
   providerTraceStore,
   PROVIDER_TRACE_MAX_BYTES,
 } from "./provider-trace-store.js";
-import { getServerAdapter, runningProcesses } from "../adapters/index.js";
+import {
+  getServerAdapter,
+  runningProcesses,
+  terminateRunScopedProcesses,
+} from "../adapters/index.js";
 import type {
   AdapterExecutionResult,
   AdapterInvocationMeta,
@@ -7685,13 +7689,30 @@ export async function persistHeartbeatRunProcessMetadata(
 }
 
 async function terminateHeartbeatRunProcess(input: {
+  runId?: string | null;
   pid: number | null | undefined;
   processGroupId: number | null | undefined;
+  processStartedAt?: Date | string | null;
   graceMs?: number;
 }) {
   const pid = input.pid ?? null;
   const processGroupId = input.processGroupId ?? null;
   if (typeof pid !== "number" && typeof processGroupId !== "number") return;
+
+  if (input.runId) {
+    const scoped = await terminateRunScopedProcesses({
+      runId: input.runId,
+      pid,
+      processGroupId,
+      processStartedAt: input.processStartedAt,
+      graceMs: input.graceMs,
+    });
+    // Runs created before scoped tagging was deployed have no matching
+    // environment marker. Keep the existing process-group fallback for that
+    // compatibility case; newly tagged runs are cleaned through the exact
+    // run scope above.
+    if (scoped.matchedPids.length > 0) return;
+  }
 
   await terminateLocalService(
     {
@@ -12857,8 +12878,10 @@ export function heartbeatService(
         }
         if (running) {
           await terminateHeartbeatRunProcess({
+            runId: run.id,
             pid: running.child.pid,
             processGroupId: running.processGroupId,
+            processStartedAt: run.processStartedAt,
             graceMs: Math.max(1, running.graceSec) * 1000,
           });
         }
@@ -25011,8 +25034,10 @@ export function heartbeatService(
       });
       if (running) {
         await terminateHeartbeatRunProcess({
+          runId: run.id,
           pid: running.child.pid,
           processGroupId: running.processGroupId,
+          processStartedAt: run.processStartedAt,
           graceMs: Math.max(1, running.graceSec) * 1000,
         });
       }
@@ -25133,8 +25158,10 @@ export function heartbeatService(
       const running = runningProcesses.get(run.id);
       if (running) {
         await terminateHeartbeatRunProcess({
+          runId: run.id,
           pid: running.child.pid,
           processGroupId: running.processGroupId,
+          processStartedAt: run.processStartedAt,
           graceMs: Math.max(1, running.graceSec) * 1000,
         });
       }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7694,24 +7694,34 @@ async function terminateHeartbeatRunProcess(input: {
   processGroupId: number | null | undefined;
   processStartedAt?: Date | string | null;
   graceMs?: number;
+  cleanup?: () => Promise<void>;
 }) {
   const pid = input.pid ?? null;
   const processGroupId = input.processGroupId ?? null;
   if (typeof pid !== "number" && typeof processGroupId !== "number") return;
 
   if (input.runId) {
-    const scoped = await terminateRunScopedProcesses({
+    const scopedCleanupPromise = terminateRunScopedProcesses({
       runId: input.runId,
       pid,
       processGroupId,
       processStartedAt: input.processStartedAt,
       graceMs: input.graceMs,
     });
+    // A remote adapter owns processes on the execution host, not in this
+    // server's /proc. Run its exact-scope hook alongside local cleanup so
+    // cancellation cannot strand VDS descendants behind a killed SSH child.
+    const [scoped] = await Promise.all([
+      scopedCleanupPromise,
+      input.cleanup?.(),
+    ]);
     // Runs created before scoped tagging was deployed have no matching
     // environment marker. Keep the existing process-group fallback for that
     // compatibility case; newly tagged runs are cleaned through the exact
     // run scope above.
     if (scoped.matchedPids.length > 0) return;
+  } else {
+    await input.cleanup?.();
   }
 
   await terminateLocalService(
@@ -12883,6 +12893,7 @@ export function heartbeatService(
             processGroupId: running.processGroupId,
             processStartedAt: run.processStartedAt,
             graceMs: Math.max(1, running.graceSec) * 1000,
+            cleanup: running.cleanup,
           });
         }
       } finally {
@@ -25039,6 +25050,7 @@ export function heartbeatService(
           processGroupId: running.processGroupId,
           processStartedAt: run.processStartedAt,
           graceMs: Math.max(1, running.graceSec) * 1000,
+          cleanup: running.cleanup,
         });
       }
     } finally {
@@ -25163,6 +25175,7 @@ export function heartbeatService(
           processGroupId: running.processGroupId,
           processStartedAt: run.processStartedAt,
           graceMs: Math.max(1, running.graceSec) * 1000,
+          cleanup: running.cleanup,
         });
       }
       runningProcesses.delete(run.id);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -7719,7 +7719,7 @@ async function terminateHeartbeatRunProcess(input: {
     // environment marker. Keep the existing process-group fallback for that
     // compatibility case; newly tagged runs are cleaned through the exact
     // run scope above.
-    if (scoped.matchedPids.length > 0) return;
+    if (scoped.matchedPids.length > 0 || scoped.directPidStartMismatch) return;
   } else {
     await input.cleanup?.();
   }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -1455,7 +1455,10 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       // Runs created before scoped tagging was introduced cannot be discovered
       // by the run marker. Preserve the old process-group cleanup only for that
       // compatibility case; newly tagged descendants are handled above.
-      if (scopedCleanup.matchedPids.length === 0) {
+      if (
+        scopedCleanup.matchedPids.length === 0 &&
+        !scopedCleanup.directPidStartMismatch
+      ) {
         await terminateLocalService(
           {
             pid: typeof pid === "number" && Number.isInteger(pid) && pid > 0

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -24,7 +24,10 @@ import {
   nativeRunFinalizations,
 } from "@paperclipai/db";
 import { parseObject, asBoolean, asNumber } from "../../adapters/utils.js";
-import { runningProcesses } from "../../adapters/index.js";
+import {
+  runningProcesses,
+  terminateRunScopedProcesses,
+} from "../../adapters/index.js";
 import { visibleIssueCondition } from "../issue-visibility.js";
 import { forbidden, notFound } from "../../errors.js";
 import { logger } from "../../middleware/logger.js";
@@ -1442,17 +1445,29 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     }
 
     try {
-      await terminateLocalService(
-        {
-          pid: typeof pid === "number" && Number.isInteger(pid) && pid > 0
-            ? pid
-            : (processGroupId ?? 0),
-          processGroupId: typeof processGroupId === "number" && Number.isInteger(processGroupId) && processGroupId > 0
-            ? processGroupId
-            : null,
-        },
-        running ? { forceAfterMs: Math.max(1, running.graceSec) * 1000 } : undefined,
-      );
+      const scopedCleanup = await terminateRunScopedProcesses({
+        runId: input.run.id,
+        pid,
+        processGroupId,
+        processStartedAt: input.run.processStartedAt,
+        graceMs: running ? Math.max(1, running.graceSec) * 1000 : undefined,
+      });
+      // Runs created before scoped tagging was introduced cannot be discovered
+      // by the run marker. Preserve the old process-group cleanup only for that
+      // compatibility case; newly tagged descendants are handled above.
+      if (scopedCleanup.matchedPids.length === 0) {
+        await terminateLocalService(
+          {
+            pid: typeof pid === "number" && Number.isInteger(pid) && pid > 0
+              ? pid
+              : (processGroupId ?? 0),
+            processGroupId: typeof processGroupId === "number" && Number.isInteger(processGroupId) && processGroupId > 0
+              ? processGroupId
+              : null,
+          },
+          running ? { forceAfterMs: Math.max(1, running.graceSec) * 1000 } : undefined,
+        );
+      }
       runningProcesses.delete(input.run.id);
       const stillAlive =
         (typeof pid === "number" && isPidAlive(pid)) ||
@@ -4606,6 +4621,29 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         : "run terminalized by recovery backstop: process and sandbox gone while heartbeat_runs.status stayed live";
 
     const now = new Date();
+    // The issue-terminal authority is allowed to run while the server remains
+    // alive, so it must tear down the adapter scope before releasing the run's
+    // in-memory ownership. This is also the restart-safe path: the persisted
+    // run id scopes the scan even when runningProcesses is empty.
+    if (issueTerminalStatus && (typeof pid === "number" || typeof processGroupId === "number")) {
+      const scopedCleanup = await terminateRunScopedProcesses({
+        runId: run.id,
+        pid,
+        processGroupId,
+        processStartedAt: run.processStartedAt,
+      });
+      if (scopedCleanup.matchedPids.length > 0) {
+        logger.info(
+          {
+            runId: run.id,
+            matchedPids: scopedCleanup.matchedPids,
+            termSignalledPids: scopedCleanup.termSignalledPids,
+            killSignalledPids: scopedCleanup.killSignalledPids,
+          },
+          "cleaned run-scoped adapter processes before terminalizing orphaned run",
+        );
+      }
+    }
     const updated = await db
       .update(heartbeatRuns)
       .set({


### PR DESCRIPTION
## Thinking Path

> - Paperclip is an open source app that manages AI agents for work.
> - The adapter runtime starts local and remote executor processes for agent runs.
> - A run can finish logically while a detached sandbox descendant remains alive.
> - A hung sandbox test can therefore consume CPU after Paperclip reports the run complete.
> - The runtime needs an opaque run marker, process-group cleanup, and a hard timeout boundary.
> - This pull request implements that cleanup and keeps the callback bridge daemon outside one-shot run cleanup.
> - The benefit is bounded executor lifetime without breaking the bridge used by a live sandbox run.

## Linked Issues or Issue Description

Related public prior art: [#10624](https://github.com/paperclipai/paperclip/pull/10624) and [#7282](https://github.com/paperclipai/paperclip/pull/7282). This PR is a separate implementation of run-scoped cleanup and PID-reuse protection.

**What happened?**

A sandbox executor could spawn a detached pytest or agent descendant. Paperclip could close the logical run while the descendant continued running. A hung FastAPI TestClient lifespan made this failure persistent.

**Expected behavior**

Run completion, cancellation, timeout, and recovery must terminate the run-scoped executor tree. Termination must send SIGTERM first and SIGKILL after the configured grace period. A callback bridge daemon must survive the launcher shell and stop through its bridge handle.

**Steps to reproduce**

1. Start a sandbox executor that creates a detached descendant with the Paperclip run marker.
2. Let the logical run complete or time out while the descendant remains alive.
3. Observe that run-scoped cleanup finds the descendant and terminates it without touching an unscoped process.
4. Start the sandbox callback bridge through the same runner and verify readiness after the launcher shell exits.

**Paperclip version or commit**

This pull request targets current upstream `master` at the time of review.

## What Changed

- Add run-scoped process markers to local adapter children and remote execution targets.
- Discover and terminate marked Linux descendants, including descendants that call `setsid()`.
- Guard persisted direct-child PID cleanup with process start identity to prevent recycled-PID kills.
- Apply cleanup on completion, cancellation, timeout, and recovery paths, with SIGTERM then SIGKILL escalation.
- Clear the run marker only for the long-lived callback bridge daemon; its pid-file stop path remains authoritative.
- Add focused tests for detached descendants, process groups, recovery, and PID reuse.

## Verification

- `pnpm --filter @paperclipai/adapter-utils typecheck` — passed. The repository reports its existing Node 22 versus declared >=24.11 engine warning.
- `pnpm exec vitest run packages/adapter-utils/src/execution-target-sandbox.test.ts packages/adapter-utils/src/server-utils.test.ts --testTimeout=30000 -t 'uses the effective adapter timeout when starting the sandbox callback bridge|reaps a detached run descendant by scope|kills descendant processes on timeout via the process group|guard|run scope'` — 6 passed, 223 skipped.
- `git diff --check origin/master...HEAD` — passed.
- A broader two-file run had 15 existing 5-second process-session timeout failures in `execution-target-sandbox.test.ts`; `server-utils.test.ts` passed 104 tests. Those failures are outside this patch and are recorded here.

## Risks

Low to moderate risk. The cleanup is limited to processes carrying the exact opaque run marker. Persisted direct PIDs also require a matching process start time. Non-Linux and pre-marker paths retain the existing direct-child/process-group fallback. The callback bridge explicitly remains outside generic run cleanup and still has an explicit stop path.

## Model Used

OpenAI Codex using `gpt-5.6-luna`, high reasoning effort, with local tool-assisted TypeScript implementation and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
