### PR TITLE
fix(server): let a pending interaction outrank a missing successful-run disposition

### DIFF
--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -920,6 +920,51 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     });
   });
 
+  it("prefers a pending interaction over an escalated successful-run handoff", async () => {
+    const { companyId, agentId } = await createCompany("PIP");
+    const issueId = await insertIssue({
+      companyId,
+      identifier: "PIP-1",
+      title: "Escalated handoff with a pending ask",
+      status: "in_progress",
+      assigneeAgentId: agentId,
+    });
+    await db.insert(activityLog).values({
+      companyId,
+      actorType: "system",
+      actorId: "system",
+      action: "issue.successful_run_handoff_escalated",
+      entityType: "issue",
+      entityId: issueId,
+      agentId,
+      details: { sourceRunId: randomUUID() },
+    });
+
+    const maskedRows = await svc.list(companyId, { attention: "blocked" });
+    expect(maskedRows.find((row) => row.id === issueId)?.blockedInboxAttention).toMatchObject({
+      state: "missing_disposition",
+      reason: "missing_successful_run_disposition",
+    });
+
+    const interactionId = randomUUID();
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId,
+      kind: "request_confirmation",
+      status: "pending",
+      payload: { version: 1, title: "Confirm", prompt: "Confirm the plan." },
+    });
+
+    const unmaskedRows = await svc.list(companyId, { attention: "blocked" });
+    expect(unmaskedRows.find((row) => row.id === issueId)?.blockedInboxAttention).toMatchObject({
+      state: "awaiting_decision",
+      reason: "pending_board_decision",
+      owner: { type: "board" },
+      interactionId,
+    });
+  });
+
   it("applies assigneeAgentId='null' as an IS NULL filter on the blocked-inbox path", async () => {
     const { companyId, agentId } = await createCompany("BAN");
     const unassignedParentId = await insertIssue({

--- a/server/src/__tests__/issue-blocker-attention.test.ts
+++ b/server/src/__tests__/issue-blocker-attention.test.ts
@@ -965,6 +965,41 @@ describeEmbeddedPostgres("issue blocker attention", () => {
     });
   });
 
+  it("keeps recovery attention ahead of a pending interaction", async () => {
+    const { companyId, agentId } = await createCompany("ROI");
+    const sourceId = await insertIssue({
+      companyId,
+      identifier: "ROI-1",
+      title: "Stranded source",
+      status: "blocked",
+    });
+    const recoveryId = await insertIssue({
+      companyId,
+      identifier: "ROI-2",
+      title: "Recovery issue",
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      originKind: "stranded_issue_recovery",
+      originId: sourceId,
+    });
+    const interactionId = randomUUID();
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId: recoveryId,
+      kind: "request_confirmation",
+      status: "pending",
+      payload: { version: 1, title: "Confirm", prompt: "Confirm the recovery." },
+    });
+
+    const rows = await svc.list(companyId, { attention: "blocked" });
+    expect(rows.find((row) => row.id === recoveryId)?.blockedInboxAttention).toMatchObject({
+      state: "recovery_open",
+      reason: "open_recovery_issue",
+      recoveryIssue: { id: recoveryId },
+    });
+  });
+
   it("applies assigneeAgentId='null' as an IS NULL filter on the blocked-inbox path", async () => {
     const { companyId, agentId } = await createCompany("BAN");
     const unassignedParentId = await insertIssue({

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -4044,7 +4044,8 @@ async function listIssueBlockedInboxAttentionMap(
       (handoff?.state === "required" || handoff?.state === "escalated")
       && (liveHandoffRunIssueIds.has(row.id) || liveHandoffWakeIssueIds.has(row.id))
     );
-    if (handoff && !hasLiveHandoffContinuation && (handoff.required || handoff.state === "escalated")) {
+    const hasPendingInteraction = interactionByIssueId.has(row.id);
+    if (handoff && !hasLiveHandoffContinuation && !hasPendingInteraction && (handoff.required || handoff.state === "escalated")) {
       result.set(row.id, attentionBase({
         state: "missing_disposition",
         reason: "missing_successful_run_disposition",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The blocked inbox is the surface that tells a person which stopped issues need them
> - `listIssueBlockedInboxAttentionMap` gives each row one attention state from a priority chain, and every branch ends in `continue`
> - The successful-run handoff branch runs before the pending-interaction branch
> - An issue that has both an escalated handoff and a pending interaction is therefore classified as `missing_disposition`, and its `interactionId` is dropped
> - The person sees "an agent owes a disposition" and never sees the question that waits for them to answer it
> - This pull request adds one term to the handoff guard, so a pending interaction lets the row fall through to `awaiting_decision`
> - The benefit is that a decision which waits on a person is shown as a decision

## Linked Issues or Issue Description

Refs #10628. Please read that pull request first. It fixes this same defect as part of a larger change that also propagates interaction coverage up the blocker graph. It is green and it is broader than this one. If #10628 merges, this pull request is unnecessary and I will close it. I opened this one because #10628 has waited 5 weeks for a review, and a 2-line change may be easier to land. Your call which one you want.

No public issue exists for the defect. I use path B and follow `.github/ISSUE_TEMPLATE/bug_report.yml`.

**What happened?**

The blocked inbox hides a pending issue-thread interaction when the same issue has an escalated successful-run handoff. The row shows `state: missing_disposition` at `severity: high` with `interactionId: null`. The pending question is never offered as a decision.

In `server/src/services/issues.ts`, the handoff branch claims the row and calls `continue`:

```js
const hasLiveHandoffContinuation = Boolean(
  (handoff?.state === "required" || handoff?.state === "escalated")
  && (liveHandoffRunIssueIds.has(row.id) || liveHandoffWakeIssueIds.has(row.id))
);
if (handoff && !hasLiveHandoffContinuation && (handoff.required || handoff.state === "escalated")) {
```

A live run or a queued wake already lets a row through. A pending interaction does not, so the interaction branch further down is never reached.

The two subsystems disagree. `decideSuccessfulRunHandoff` receives `hasPendingInteractionOrApproval` and declines to re-arm the handoff while an interaction is pending, because a pending ask is a live path. The inbox builder ignores the interaction and reports that an agent owes a disposition. The heartbeat is the half that is right.

This is durable, not transient. The handoff state is derived from the newest handoff activity row. The only writer of the resolved state requires the derived state to be `required`, so a row in `escalated` cannot be discharged through it. On one self-hosted deployment, 4 rows sat in this state, and the oldest held for 10 days. A correct disposition in the thread and a status change both left the row unchanged.

**Expected behavior**

A pending interaction should count as a live continuation, exactly as a live run and a queued wake already do. The row should report `awaiting_decision` and carry the interaction id, so the person can answer the question.

**Steps to reproduce**

1. Take an issue that is assigned to an agent.
2. Write an `issue.successful_run_handoff_escalated` activity row for it.
3. Confirm the blocked inbox reports `missing_disposition`.
4. Create a pending `request_confirmation` interaction on the same issue.
5. Read the blocked inbox again.

Result: the row still reports `missing_disposition` and `interactionId` stays null.
Expected: the row reports `awaiting_decision` and carries the interaction id.

The added test in `server/src/__tests__/issue-blocker-attention.test.ts` performs these steps.

**Paperclip version or commit**

`f2349990ccfdaa0fc8ae33754b6695c2bdeb60e1` on `master`. The defect is present at that commit.

**Agent adapter(s) involved**

Not adapter-specific (core bug).

## What Changed

- `server/src/services/issues.ts`: add `hasPendingInteraction` to the successful-run handoff guard, so a row with a pending interaction falls through to the `awaiting_decision` branch. `interactionByIssueId` is already built before the loop, so this needs no new query.
- `server/src/__tests__/issue-blocker-attention.test.ts`: add a regression test for the precedence.

## Verification

```
cd server
npx vitest run src/__tests__/issue-blocker-attention.test.ts
```

| run | result |
|---|---|
| full file, with the change | 26 passed |
| new test only, with the change | 1 passed |
| new test only, source change reverted | 1 failed |

The third row shows the test is not vacuous. Reverted, it fails with `missing_disposition` where `awaiting_decision` is expected.

## Risks

Low. The change is read-time only. `blockedInboxAttention` is computed on every read and is not stored, so rows that are already pending correct themselves on the next read. No migration is needed.

One behavior change deserves attention. A row that has both an escalated handoff and a pending interaction now reports `awaiting_decision` only. The disposition prompt is not shown for that row while the interaction is open. I believe this is right, because answering the interaction is what releases the disposition, but it is a judgement and you may prefer a combined state.

The change does not affect a row with an escalated handoff and no interaction. That row still reports `missing_disposition`. The existing tests cover this and still pass.

## Model Used

Claude Opus 5 (`claude-opus-5`), extended thinking, with tool use for repository search, patch application, and test runs.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no documentation describes this branch order, so nothing needed an update
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — not yet run on this branch
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — not yet run
- [x] I will address all Greptile and reviewer comments before requesting merge
