### PR TITLE
adapters: make the configured agent cwd an unconditional pin, with a test

### DIFF
--- a/packages/adapter-utils/src/agent-cwd-pin.test.ts
+++ b/packages/adapter-utils/src/agent-cwd-pin.test.ts
@@ -1,0 +1,149 @@
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The configured agent cwd is an UNCONDITIONAL pin.
+ *
+ * Every local adapter resolves its working directory through
+ * `useConfiguredInsteadOfAgentHome`. That flag must depend only on whether a cwd was
+ * configured:
+ *
+ *     const useConfiguredInsteadOfAgentHome = configuredCwd.length > 0;
+ *
+ * It once read `workspaceSource === "agent_home" && configuredCwd.length > 0`, which makes
+ * the configured cwd the last arm of a fallback chain: `project_primary` and `task_session`
+ * both win first, so an agent with an explicitly configured cwd silently runs somewhere
+ * else. Agent state that is keyed by the runtime cwd — Claude's auto-memory store, for one —
+ * then collapses into a single directory shared by every agent on the project.
+ *
+ * That conjunct was removed once before, in a commit with no test. It was reintroduced by a
+ * later merge and went unnoticed for roughly three weeks. This test is the missing guard.
+ *
+ * It asserts EQUALITY against the pinned expression rather than the absence of the old
+ * conjunct. A battery of negative regexes never terminates: a guard that only looks for
+ * `workspaceSource` passes `useConfiguredInsteadOfAgentHome = configuredCwd.length > 0 &&
+ * runSource === "agent_home"`. Equality on a fixed one-line expression does terminate.
+ */
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "..", "..", "..");
+const ADAPTERS_DIR = path.join(REPO_ROOT, "packages", "adapters");
+
+const SYMBOL = "useConfiguredInsteadOfAgentHome";
+const PINNED_EXPRESSION = "configuredCwd.length > 0";
+const ASSIGNMENT = new RegExp(`\\b${SYMBOL}\\s*=\\s*([^;]*);`);
+
+/**
+ * Adapters known to resolve a configured cwd, and how many assignment sites each one had
+ * when this guard was written. Present so the suite cannot pass vacuously: if a rename,
+ * a refactor, or a bad merge removes a site, the count drops and this goes red instead of
+ * quietly checking nothing. New adapters do not need to be listed — they are covered by the
+ * expression check below the moment they declare the symbol.
+ */
+const KNOWN_SITES: Record<string, number> = {
+  "claude-local": 2,
+  "codex-local": 1,
+  "cursor-local": 1,
+  "gemini-local": 1,
+  "grok-local": 1,
+  "kimi-local": 1,
+  "opencode-local": 1,
+  "pi-local": 1,
+};
+
+interface Site {
+  adapter: string;
+  file: string;
+  line: number;
+  expression: string;
+}
+
+function assignmentSites(source: string, adapter: string, file: string): Site[] {
+  const sites: Site[] = [];
+  source.split("\n").forEach((text, index) => {
+    const match = ASSIGNMENT.exec(text);
+    if (match) {
+      sites.push({ adapter, file, line: index + 1, expression: match[1].trim() });
+    }
+  });
+  return sites;
+}
+
+function collectSites(): Site[] {
+  const sites: Site[] = [];
+  for (const adapter of readdirSync(ADAPTERS_DIR).sort()) {
+    const file = path.join(ADAPTERS_DIR, adapter, "src", "server", "execute.ts");
+    if (!existsSync(file)) continue;
+    sites.push(...assignmentSites(readFileSync(file, "utf8"), adapter, file));
+  }
+  return sites;
+}
+
+describe("configured agent cwd is an unconditional pin", () => {
+  const sites = collectSites();
+
+  it("finds the adapters it claims to guard", () => {
+    // A zero-site run is a blind run, not a passing one.
+    expect(sites.length).toBeGreaterThan(0);
+
+    const perAdapter = new Map<string, number>();
+    for (const site of sites) {
+      perAdapter.set(site.adapter, (perAdapter.get(site.adapter) ?? 0) + 1);
+    }
+    for (const [adapter, expected] of Object.entries(KNOWN_SITES)) {
+      expect(
+        perAdapter.get(adapter) ?? 0,
+        `${adapter}/src/server/execute.ts should assign ${SYMBOL} ${expected} time(s)`,
+      ).toBeGreaterThanOrEqual(expected);
+    }
+  });
+
+  it.each(collectSites().map((site) => [`${site.adapter}:${site.line}`, site] as const))(
+    "%s pins the cwd unconditionally",
+    (_label, site) => {
+      expect(
+        site.expression,
+        `${path.relative(REPO_ROOT, site.file)}:${site.line} conditions the configured cwd ` +
+          `on something other than whether it was configured. A run whose workspace does not ` +
+          `resolve to agent_home would ignore the agent's cwd.`,
+      ).toBe(PINNED_EXPRESSION);
+    },
+  );
+
+  it("rejects the regressions it exists to catch", () => {
+    // Negative fixtures. Without these the assertion above could be inert and nobody
+    // would know. Each mutation is one that has shipped or could plausibly ship.
+    const mutations = [
+      // The historical regression, verbatim.
+      `workspaceSource === "agent_home" && ${PINNED_EXPRESSION}`,
+      // Same conjunct, other order.
+      `${PINNED_EXPRESSION} && workspaceSource === "agent_home"`,
+      // Widened rather than narrowed: passes any absence-of-conjunct check.
+      `${PINNED_EXPRESSION} || workspaceSource === "agent_home"`,
+      // Renamed source field, same defect.
+      `runSource === "agent_home" && ${PINNED_EXPRESSION}`,
+      // Silently disabled.
+      "false",
+    ];
+
+    for (const mutation of mutations) {
+      const mutated = `  const ${SYMBOL} = ${mutation};`;
+      const found = assignmentSites(mutated, "fixture", "fixture.ts");
+      expect(found, `fixture not parsed: ${mutation}`).toHaveLength(1);
+      expect(found[0].expression, `mutation would survive the guard: ${mutation}`).not.toBe(
+        PINNED_EXPRESSION,
+      );
+    }
+
+    // ...and the pinned form itself must still be accepted, or the guard is red always.
+    const clean = assignmentSites(
+      `  const ${SYMBOL} = ${PINNED_EXPRESSION};`,
+      "fixture",
+      "fixture.ts",
+    );
+    expect(clean).toHaveLength(1);
+    expect(clean[0].expression).toBe(PINNED_EXPRESSION);
+  });
+});

--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -200,7 +200,7 @@ async function buildClaudeRuntimeConfig(input: ClaudeExecutionInput): Promise<Cl
     : [];
   const runtimePrimaryUrl = asString(context.paperclipRuntimePrimaryUrl, "");
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const useConfiguredInsteadOfAgentHome = configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
   const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
   const executionTargetIsRemote = adapterExecutionTargetIsRemote(executionTarget);
@@ -450,7 +450,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       )
     : [];
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const useConfiguredInsteadOfAgentHome = configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
   const hasExplicitClaudeConfigDir =
     typeof configEnv.CLAUDE_CONFIG_DIR === "string" && configEnv.CLAUDE_CONFIG_DIR.trim().length > 0;

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -625,7 +625,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   });
   const targetWorkspaceRealization = executionTarget?.workspaceRealization ?? null;
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const useConfiguredInsteadOfAgentHome = configuredCwd.length > 0;
   const effectiveWorkspaceCwd = targetWorkspaceRealization?.mode === "in_place"
     ? targetWorkspaceRealization.authoritativeRoot
     : useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;

--- a/packages/adapters/cursor-local/src/server/execute.ts
+++ b/packages/adapters/cursor-local/src/server/execute.ts
@@ -225,7 +225,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       )
     : [];
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const useConfiguredInsteadOfAgentHome = configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
   const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);

--- a/packages/adapters/gemini-local/src/server/execute.ts
+++ b/packages/adapters/gemini-local/src/server/execute.ts
@@ -250,7 +250,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     )
     : [];
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const useConfiguredInsteadOfAgentHome = configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
   const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);

--- a/packages/adapters/grok-local/src/server/execute.ts
+++ b/packages/adapters/grok-local/src/server/execute.ts
@@ -229,7 +229,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       )
     : [];
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const useConfiguredInsteadOfAgentHome = configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
   const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);

--- a/packages/adapters/kimi-local/src/server/execute.ts
+++ b/packages/adapters/kimi-local/src/server/execute.ts
@@ -227,7 +227,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     )
     : [];
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const useConfiguredInsteadOfAgentHome = configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
   const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);

--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -248,7 +248,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       )
     : [];
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const useConfiguredInsteadOfAgentHome = configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
   const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);

--- a/packages/adapters/pi-local/src/server/execute.ts
+++ b/packages/adapters/pi-local/src/server/execute.ts
@@ -251,7 +251,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       )
     : [];
   const configuredCwd = asString(config.cwd, "");
-  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const useConfiguredInsteadOfAgentHome = configuredCwd.length > 0;
   const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
   const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
   let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);


### PR DESCRIPTION
`useConfiguredInsteadOfAgentHome` is gated on `workspaceSource === "agent_home"` at all 9 assignment sites across 8 local adapters. That conjunct makes the configured cwd the **last arm of a fallback chain** — `heartbeat.ts` resolves `project_primary`, then `task_session`, then `agent_home` — so an agent with an explicit `config.cwd` silently runs in the shared project checkout instead of its own.

Anything keyed by the runtime cwd then collapses across agents. Claude's auto-memory store is a slug of the runtime cwd, so on our instance eight agents configured with eight distinct cwds shared one memory directory. Every project-attached issue defaults to `project_primary`, so the pin was inert for essentially every real run — and the bug was invisible to any measurement taken on a project-less issue, which is why it survived.

**This is the second time.** The conjunct was removed once before in a commit that carried no test, was reintroduced by a later merge, and the regression ran unnoticed for about three weeks.

## What changed

- 8 files, 9 sites: `const useConfiguredInsteadOfAgentHome = configuredCwd.length > 0;`
- `packages/adapter-utils/src/agent-cwd-pin.test.ts` — the missing guard.

Agents with `cwd: null` are unaffected; they still resolve the workspace cwd.

## About the test

It asserts the assignment expression **equals** `configuredCwd.length > 0`, rather than merely lacking the old conjunct. A guard built from negative regexes does not terminate — `configuredCwd.length > 0 && runSource === "agent_home"` passes any check that greps for `workspaceSource`. Equality on a fixed one-line expression does terminate.

It also pins a per-adapter site count, so a rename or a bad merge that drops a site turns it red instead of quietly checking nothing. New adapters do not need to be listed: they are covered the moment they declare the symbol.

## Verification

- Reintroducing the conjunct at each of the 9 sites **individually**: red 9/9.
- Deleting an adapter's `execute.ts` entirely: red — it cannot pass vacuously.
- Clean tree: 11 passed.

Mutation runs were done against a scratch mirror of the adapter tree, not the live source.