### PR TITLE
fix(adapter-utils): strip DATABASE_URL and BETTER_AUTH_SECRET from inherited agent env

### DIFF
--- a/packages/adapter-utils/src/server-utils-env.test.ts
+++ b/packages/adapter-utils/src/server-utils-env.test.ts
@@ -12,4 +12,17 @@ describe("sanitizeInheritedPaperclipEnv", () => {
       PATH: "/usr/bin",
     });
   });
+
+  it("drops server-only secrets while keeping unrelated and runtime keys", () => {
+    expect(sanitizeInheritedPaperclipEnv({
+      DATABASE_URL: "postgres://paperclip:secret@127.0.0.1:5432/paperclip",
+      BETTER_AUTH_SECRET: "top-secret",
+      PAPERCLIP_AGENT_JWT_SECRET: "also-secret",
+      PAPERCLIP_RUNTIME_API_URL: "http://127.0.0.1:3100",
+      HOME: "/home/agent",
+    })).toEqual({
+      PAPERCLIP_RUNTIME_API_URL: "http://127.0.0.1:3100",
+      HOME: "/home/agent",
+    });
+  });
 });

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -2417,6 +2417,10 @@ export function refreshPaperclipWorkspaceEnvForExecution(input: {
 export function sanitizeInheritedPaperclipEnv(baseEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...baseEnv };
   delete env.PAPERCLIPAI_CMD;
+  // Server-only secrets: never inherited by an agent process. An adapter that
+  // genuinely needs a database URL passes one explicitly through its `env`.
+  delete env.DATABASE_URL;
+  delete env.BETTER_AUTH_SECRET;
   for (const key of Object.keys(env)) {
     if (!key.startsWith("PAPERCLIP_")) continue;
     if (key === "PAPERCLIP_RUNTIME_API_URL") continue;


### PR DESCRIPTION
## Thinking Path
> - Self-hosted instances run the server with `DATABASE_URL` and `BETTER_AUTH_SECRET` in its environment.
> - `runProcess` builds the agent env from `sanitizeInheritedPaperclipEnv(process.env)`, which only strips `PAPERCLIPAI_CMD` and `PAPERCLIP_*`.
> - Both server-only secrets therefore reach every legacy-lane agent and land in run logs whenever an agent dumps its env.
> - #12387 closed this for the ACP lane with an allowlist projection; `runProcess` never got the equivalent.
> - Smallest safe change: add the two keys to the existing sanitizer. Explicit adapter `env` is merged afterwards, so intentional pass-through keeps working.

## Linked Issues or Issue Description
Fixes: #12869

## What Changed
- `sanitizeInheritedPaperclipEnv` now also deletes `DATABASE_URL` and `BETTER_AUTH_SECRET`.
- Test added in `server-utils-env.test.ts` covering both keys and confirming `PAPERCLIP_RUNTIME_API_URL` and unrelated keys are preserved.

## Verification
- `npx vitest run packages/adapter-utils/src/server-utils-env.test.ts` passes (2 tests).
- Manual: server started with both variables set, an agent run that prints `env`; neither key appears in the run log.

## Risks
- An adapter that relied on implicitly inheriting the server's `DATABASE_URL` stops seeing it. That inheritance was never a documented contract; explicit adapter `env` is the supported path and still works.

## Model Used
Claude Fable 5.1 (Anthropic, `claude-fable-5-1`) with extended thinking and tool use; change reviewed by a human before submission.

## Checklist
- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
