### PR TITLE
fix(tool-gateway): always label connected MCP tools with their connection

### DIFF
--- a/server/src/__tests__/tool-gateway.test.ts
+++ b/server/src/__tests__/tool-gateway.test.ts
@@ -1334,7 +1334,7 @@ describeEmbeddedPostgres("tool gateway acceptance", () => {
     const connectedTool = tools.find((tool) => tool.providerType === "mcp_remote_http");
     expect(connectedTool).toMatchObject({
       name: expect.stringMatching(/^mcp\.kv-demo-[0-9a-f]{8}:kv-set$/),
-      displayName: "Set KV value",
+      displayName: "Set KV value (KV Demo)",
       providerType: "mcp_remote_http",
       risk: "write",
       applicationId: remoteTool.application.id,
@@ -1541,7 +1541,7 @@ describeEmbeddedPostgres("tool gateway acceptance", () => {
     expect(tools).toEqual(expect.arrayContaining([
       expect.objectContaining({
         name: expectedName,
-        displayName: "Local echo",
+        displayName: "Local echo (Local Demo)",
         providerType: "mcp_local_stdio",
         risk: "read",
         applicationId: localTool.application.id,
@@ -1977,6 +1977,40 @@ rl.on("line", (line) => {
       expect.stringMatching(new RegExp(`^mcp\\.kv-demo-${first.connection.id.replace(/-/g, "").slice(0, 8)}:kv-set$`)),
       expect.stringMatching(new RegExp(`^mcp\\.kv-demo-${second.connection.id.replace(/-/g, "").slice(0, 8)}:kv-set$`)),
     ]));
+  });
+
+  it("labels connected remote MCP tools with their own connection when the same app is connected twice", async () => {
+    const company = await createCompany(db);
+    const agent = await createAgent(db, company.id);
+    const { run } = await createIssueAndRun(db, company.id, agent.id);
+    const first = await createRemoteMcpTool(db, company.id, {
+      applicationKey: "kv-demo",
+      connectionName: "KV Demo Primary",
+      toolName: "kv_set",
+      title: "Set KV value",
+    });
+    const second = await createRemoteMcpTool(db, company.id, {
+      applicationKey: "kv-demo",
+      connectionName: "KV Demo Secondary",
+      toolName: "kv_set",
+      title: "Set KV value",
+    });
+    await allowAllToolsForAgent(db, company.id, agent.id);
+    const gateway = createTestToolGatewayService(db);
+    const session = await gateway.createSession({ companyId: company.id, agentId: agent.id, runId: run.id });
+
+    const connectedTools = (await gateway.listToolsForSession(session.token))
+      .filter((tool) => tool.providerType === "mcp_remote_http");
+    expect(connectedTools).toHaveLength(2);
+
+    const firstTool = connectedTools.find((tool) => tool.connectionId === first.connection.id);
+    const secondTool = connectedTools.find((tool) => tool.connectionId === second.connection.id);
+    // Same upstream title on both connections ("Set KV value") - without the
+    // connection name, an agent with both connections would see two
+    // identically-labeled tools and have no way to tell them apart.
+    expect(firstTool?.displayName).toBe("Set KV value (KV Demo Primary)");
+    expect(secondTool?.displayName).toBe("Set KV value (KV Demo Secondary)");
+    expect(firstTool?.displayName).not.toBe(secondTool?.displayName);
   });
 
   it.each([

--- a/server/src/services/tool-gateway.ts
+++ b/server/src/services/tool-gateway.ts
@@ -1063,8 +1063,16 @@ export function createToolGatewayService(
       };
       return {
         name: gatewayToolName,
-        displayName: catalogEntry.title ?? catalogEntry.toolName,
-        description: catalogEntry.description ?? `Connected MCP tool ${catalogEntry.toolName} from ${connection.name}.`,
+        // Always carry the connection name, not just as a fallback for a
+        // missing upstream title/description. Some MCP servers (e.g. a
+        // remote toolkit's own meta-tools like a "search available tools"
+        // entry) report the identical title/description for every
+        // connection they're proxied through, so without this an agent
+        // with several connections to the same server sees several
+        // identically-labeled tools with no way to tell which connection
+        // each one is scoped to.
+        displayName: `${catalogEntry.title ?? catalogEntry.toolName} (${connection.name})`,
+        description: `${catalogEntry.description ?? `Connected MCP tool ${catalogEntry.toolName}.`} (via connection: ${connection.name})`,
         parametersSchema: inputSchema,
         pluginId: `mcp:${applicationKey ?? application.id}`,
         providerType: connection.transport === "local_stdio" ? "mcp_local_stdio" : "mcp_remote_http",


### PR DESCRIPTION
`connectedMcpToolsForCompany` builds the `displayName`/`description` an agent sees for each connected MCP tool from `catalogEntry.title`/`catalogEntry.description`, which are copied verbatim from the upstream MCP server's own tool descriptor. Some MCP servers (e.g. Composio) expose the same meta-tool (a "search available tools" style entry) through every connection they're proxied through, with an identical title/description each time. When a company has several connections to the same server, the agent ends up with several tool entries that are technically distinct (the internal gateway `name` already embeds the connection id) but look identical to a human or an LLM reading `displayName`/`description`, with nothing indicating which connection each one is scoped to. The existing fallback only added the connection name when the upstream description was empty, so it never helped for tools that do have a (non-distinguishing) description.

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents discover and call tools through the tool gateway, which surfaces every connected MCP tool with a display name and description
> - When a company connects the same external service more than once (e.g. one Composio connection per toolkit: Search Console, Analytics, Ads, ...), each connection's proxied meta-tools can carry an identical upstream-supplied title/description
> - An agent (or the human reviewing its tool list) then cannot tell which of several identically-labeled entries belongs to which connection, and picks one effectively at random
> - This caused a real, repeated production issue: an agent searching one connection's tool index for a different service's tools got silently wrong results, with no error, because it had picked the wrong identically-labeled entry
> - This pull request always appends the Paperclip connection name to the displayed name/description for connected MCP tools, instead of only doing so when the upstream description was empty
> - The benefit is that every connected tool entry is now visibly distinguishable by connection, so agents and humans can reliably pick the right one

## Linked Issues or Issue Description

No public GitHub issue exists for this; found and reproduced against a private/internal Paperclip instance.

**Bug:**
- What happened: A company with multiple connections to the same MCP-proxied service (e.g. several Composio toolkit connections) sees identical `displayName`/`description` for the same meta-tool across every connection. An agent calling that meta-tool through one connection only operates within that connection's own scope, but has no label-based way to tell connections apart.
- What was expected: Each connection's copy of a shared meta-tool should be visibly distinguishable (e.g. by connection name), so an agent or human can pick the correct one for the toolkit/service they actually want.
- Steps to reproduce: Connect the same MCP-proxied service through two or more separate connections (e.g. two Composio toolkit connections) in one company. Compare the `displayName`/`description` of the same meta-tool name across both connections in the agent's tool list.
- Impact: Observed in production as a multi-day, self-perpetuating escalation loop: an agent repeatedly picked the wrong connection's copy of a search tool, got confidently wrong (empty-for-its-purpose) results with no error, concluded the target service was broken, and re-opened the same "fix the connection" task over and over.

## What Changed

- `server/src/services/tool-gateway.ts`: connected MCP tool `displayName` and `description` now always append the Paperclip connection name, instead of only falling back to it when the upstream fields were empty.

## Verification

- [ ] `pnpm --filter server test tool-gateway` (existing focused gateway tests need their exact-name assertions updated for the new always-appended format; tracked as follow-up in this PR)
- [ ] Add a test covering the duplicate-connection scenario: same MCP application connected twice, confirm both connections' tools are labeled distinctly
- Manual: connect the same MCP application twice (two connections), confirm each connection's tools are now labeled distinctly in the agent's tool list

## Risks

Low-to-moderate. This changes the exact string agents and humans see for every connected MCP tool's display name/description (adds a suffix), which is a visible behavior change but not a functional/dispatch change - the internal gateway tool `name` used for actual invocation is untouched. Existing tests that assert exact display-name strings need updating to match (see Verification). No change to authorization, execution, or approval logic.

## Model Used

Claude (Anthropic), Sonnet 5 (claude-sonnet-5), extended/high reasoning effort, with tool use (Read/Grep/Bash) against a local clone of the repository, plus live reproduction against a running Paperclip instance.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (none found; related but independent fix in #12835)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge