### PR TITLE
fix(server): require checkout proof before first-write run binding

### DIFF
--- a/server/src/__tests__/cross-issue-influence-limit-postgres.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit-postgres.test.ts
@@ -14,6 +14,7 @@ import {
 } from "./helpers/embedded-postgres.js";
 import {
   CROSS_ISSUE_INFLUENCE_ENFORCE_AT,
+  bindCheckoutRunSourceIssueIfUnset,
   observeCrossIssueInfluence,
 } from "../services/cross-issue-influence-limit.js";
 
@@ -112,5 +113,138 @@ describeEmbeddedPostgres("cross-issue influence limit PostgreSQL serialization",
       .where(and(eq(activityLog.companyId, companyId), eq(activityLog.runId, runId)));
     expect(recorded.filter((row) => row.action === "issue.cross_issue_influence_observed")).toHaveLength(20);
     expect(recorded.filter((row) => row.action === "issue.cross_issue_influence_cap_rejected")).toHaveLength(1);
+  });
+
+  it("binds a run with no recorded source issue to the first write's target, persists it on the row, and caps only writes to a different issue thereafter", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const issueA = randomUUID();
+    const issueB = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `C${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      defaultResponsibleUserId: "board-user",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Unscoped Wake Agent",
+      role: "engineer",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    // The exact shape a plain unscoped-wake heartbeat run starts with: no
+    // issueId/taskId recorded yet.
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      responsibleUserId: "board-user",
+      contextSnapshot: {},
+    });
+
+    // First write of the run's life, against the issue it checked out (A):
+    // must succeed and must not be treated as a cross-issue write.
+    const firstWrite = await observeCrossIssueInfluence(db, {
+      companyId,
+      runId,
+      agentId,
+      targetIssueId: issueA,
+      kind: "comment",
+    });
+    expect(firstWrite).toBeNull();
+
+    const [boundRun] = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId));
+    expect(boundRun?.contextSnapshot).toMatchObject({ issueId: issueA, source: "first_write_bind" });
+
+    // A second write to the same issue A still costs nothing against the cap.
+    const secondWriteSameIssue = await observeCrossIssueInfluence(db, {
+      companyId,
+      runId,
+      agentId,
+      targetIssueId: issueA,
+      kind: "update",
+    });
+    expect(secondWriteSameIssue).toBeNull();
+
+    // A write to a different issue B is gated by the existing cross-issue cap,
+    // not unconditionally rejected — it is allowed here (well under the cap).
+    const crossIssueWrite = await observeCrossIssueInfluence(db, {
+      companyId,
+      runId,
+      agentId,
+      targetIssueId: issueB,
+      kind: "comment",
+      now: CROSS_ISSUE_INFLUENCE_ENFORCE_AT,
+    });
+    expect(crossIssueWrite).toMatchObject({ allowed: true, count: 1 });
+
+    // Re-fetching the row (simulating a process-lost/retried run reusing the
+    // same run id) shows the bind still persisted and no further mutation on
+    // the second same-issue write above.
+    const [runAfter] = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId));
+    expect(runAfter?.contextSnapshot).toMatchObject({ issueId: issueA, source: "first_write_bind" });
+  });
+
+  it("bindCheckoutRunSourceIssueIfUnset binds the calling actor's own run at checkout time, and never overwrites an already-bound run", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const issueA = randomUUID();
+    const issueB = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `C${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      defaultResponsibleUserId: "board-user",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Checkout Binder",
+      role: "engineer",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      responsibleUserId: "board-user",
+      contextSnapshot: null,
+    });
+
+    await bindCheckoutRunSourceIssueIfUnset(db, { companyId, runId, agentId, issueId: issueA });
+
+    const [afterCheckout] = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId));
+    expect(afterCheckout?.contextSnapshot).toMatchObject({ issueId: issueA, source: "issue.checkout" });
+
+    // A later checkout of a different issue by the same run must not clobber
+    // the already-bound source issue.
+    await bindCheckoutRunSourceIssueIfUnset(db, { companyId, runId, agentId, issueId: issueB });
+    const [afterSecondCheckout] = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId));
+    expect(afterSecondCheckout?.contextSnapshot).toMatchObject({ issueId: issueA, source: "issue.checkout" });
   });
 });

--- a/server/src/__tests__/cross-issue-influence-limit-postgres.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit-postgres.test.ts
@@ -247,4 +247,49 @@ describeEmbeddedPostgres("cross-issue influence limit PostgreSQL serialization",
       .where(eq(heartbeatRuns.id, runId));
     expect(afterSecondCheckout?.contextSnapshot).toMatchObject({ issueId: issueA, source: "issue.checkout" });
   });
+
+  it("bindCheckoutRunSourceIssueIfUnset merges into an existing populated contextSnapshot instead of replacing it", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const issueA = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `C${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      defaultResponsibleUserId: "board-user",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Checkout Binder Merge",
+      role: "engineer",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      responsibleUserId: "board-user",
+      contextSnapshot: { wakeReason: "heartbeat_timer", modelProfile: "reasoning-high" },
+    });
+
+    await bindCheckoutRunSourceIssueIfUnset(db, { companyId, runId, agentId, issueId: issueA });
+
+    const [afterCheckout] = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId));
+    expect(afterCheckout?.contextSnapshot).toEqual({
+      wakeReason: "heartbeat_timer",
+      modelProfile: "reasoning-high",
+      issueId: issueA,
+      source: "issue.checkout",
+    });
+  });
 });

--- a/server/src/__tests__/cross-issue-influence-limit-postgres.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit-postgres.test.ts
@@ -7,6 +7,7 @@ import {
   companies,
   createDb,
   heartbeatRuns,
+  issues,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -32,6 +33,7 @@ describeEmbeddedPostgres("cross-issue influence limit PostgreSQL serialization",
 
   afterEach(async () => {
     await db.delete(activityLog);
+    await db.delete(issues);
     await db.delete(heartbeatRuns);
     await db.delete(agents);
     await db.delete(companies);
@@ -148,6 +150,15 @@ describeEmbeddedPostgres("cross-issue influence limit PostgreSQL serialization",
       responsibleUserId: "board-user",
       contextSnapshot: {},
     });
+    await db.insert(issues).values({
+      id: issueA,
+      companyId,
+      title: "Checked-out heartbeat issue",
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      checkoutRunId: runId,
+      executionRunId: runId,
+    });
 
     // First write of the run's life, against the issue it checked out (A):
     // must succeed and must not be treated as a cross-issue write.
@@ -196,6 +207,61 @@ describeEmbeddedPostgres("cross-issue influence limit PostgreSQL serialization",
       .from(heartbeatRuns)
       .where(eq(heartbeatRuns.id, runId));
     expect(runAfter?.contextSnapshot).toMatchObject({ issueId: issueA, source: "first_write_bind" });
+  });
+
+  it("refuses to bind an unscoped run to a target it has not checked out", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const uncheckedIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `C${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      defaultResponsibleUserId: "board-user",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Unscoped Wake Agent",
+      role: "engineer",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      responsibleUserId: "board-user",
+      contextSnapshot: {},
+    });
+    await db.insert(issues).values({
+      id: uncheckedIssueId,
+      companyId,
+      title: "Unclaimed target",
+      status: "todo",
+    });
+
+    await expect(observeCrossIssueInfluence(db, {
+      companyId,
+      runId,
+      agentId,
+      targetIssueId: uncheckedIssueId,
+      kind: "comment",
+    })).rejects.toMatchObject({
+      status: 403,
+      details: { code: "cross_issue_influence_run_context_required" },
+    });
+
+    const [runAfter] = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId));
+    expect(runAfter?.contextSnapshot).toEqual({});
   });
 
   it("bindCheckoutRunSourceIssueIfUnset binds the calling actor's own run at checkout time, and never overwrites an already-bound run", async () => {

--- a/server/src/__tests__/cross-issue-influence-limit-postgres.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit-postgres.test.ts
@@ -15,7 +15,6 @@ import {
 } from "./helpers/embedded-postgres.js";
 import {
   CROSS_ISSUE_INFLUENCE_ENFORCE_AT,
-  bindCheckoutRunSourceIssueIfUnset,
   observeCrossIssueInfluence,
 } from "../services/cross-issue-influence-limit.js";
 
@@ -264,98 +263,4 @@ describeEmbeddedPostgres("cross-issue influence limit PostgreSQL serialization",
     expect(runAfter?.contextSnapshot).toEqual({});
   });
 
-  it("bindCheckoutRunSourceIssueIfUnset binds the calling actor's own run at checkout time, and never overwrites an already-bound run", async () => {
-    const companyId = randomUUID();
-    const agentId = randomUUID();
-    const runId = randomUUID();
-    const issueA = randomUUID();
-    const issueB = randomUUID();
-
-    await db.insert(companies).values({
-      id: companyId,
-      name: "Paperclip",
-      issuePrefix: `C${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
-      defaultResponsibleUserId: "board-user",
-    });
-    await db.insert(agents).values({
-      id: agentId,
-      companyId,
-      name: "Checkout Binder",
-      role: "engineer",
-      adapterType: "codex_local",
-      adapterConfig: {},
-      runtimeConfig: {},
-      permissions: {},
-    });
-    await db.insert(heartbeatRuns).values({
-      id: runId,
-      companyId,
-      agentId,
-      status: "running",
-      responsibleUserId: "board-user",
-      contextSnapshot: null,
-    });
-
-    await bindCheckoutRunSourceIssueIfUnset(db, { companyId, runId, agentId, issueId: issueA });
-
-    const [afterCheckout] = await db
-      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
-      .from(heartbeatRuns)
-      .where(eq(heartbeatRuns.id, runId));
-    expect(afterCheckout?.contextSnapshot).toMatchObject({ issueId: issueA, source: "issue.checkout" });
-
-    // A later checkout of a different issue by the same run must not clobber
-    // the already-bound source issue.
-    await bindCheckoutRunSourceIssueIfUnset(db, { companyId, runId, agentId, issueId: issueB });
-    const [afterSecondCheckout] = await db
-      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
-      .from(heartbeatRuns)
-      .where(eq(heartbeatRuns.id, runId));
-    expect(afterSecondCheckout?.contextSnapshot).toMatchObject({ issueId: issueA, source: "issue.checkout" });
-  });
-
-  it("bindCheckoutRunSourceIssueIfUnset merges into an existing populated contextSnapshot instead of replacing it", async () => {
-    const companyId = randomUUID();
-    const agentId = randomUUID();
-    const runId = randomUUID();
-    const issueA = randomUUID();
-
-    await db.insert(companies).values({
-      id: companyId,
-      name: "Paperclip",
-      issuePrefix: `C${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
-      defaultResponsibleUserId: "board-user",
-    });
-    await db.insert(agents).values({
-      id: agentId,
-      companyId,
-      name: "Checkout Binder Merge",
-      role: "engineer",
-      adapterType: "codex_local",
-      adapterConfig: {},
-      runtimeConfig: {},
-      permissions: {},
-    });
-    await db.insert(heartbeatRuns).values({
-      id: runId,
-      companyId,
-      agentId,
-      status: "running",
-      responsibleUserId: "board-user",
-      contextSnapshot: { wakeReason: "heartbeat_timer", modelProfile: "reasoning-high" },
-    });
-
-    await bindCheckoutRunSourceIssueIfUnset(db, { companyId, runId, agentId, issueId: issueA });
-
-    const [afterCheckout] = await db
-      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
-      .from(heartbeatRuns)
-      .where(eq(heartbeatRuns.id, runId));
-    expect(afterCheckout?.contextSnapshot).toEqual({
-      wakeReason: "heartbeat_timer",
-      modelProfile: "reasoning-high",
-      issueId: issueA,
-      source: "issue.checkout",
-    });
-  });
 });

--- a/server/src/__tests__/cross-issue-influence-limit.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit.test.ts
@@ -13,6 +13,7 @@ function counterDb(
 ) {
   let observedCount = initialCount;
   const inserted: Array<Record<string, unknown>> = [];
+  const updated: Array<Record<string, unknown>> = [];
   const tx = {
     select: (selection: Record<string, unknown>) => ({
       from: () => ({
@@ -37,6 +38,13 @@ function counterDb(
         },
       }),
     }),
+    update: () => ({
+      set: (value: Record<string, unknown>) => ({
+        where: async () => {
+          updated.push(value);
+        },
+      }),
+    }),
     insert: () => ({
       values: async (value: Record<string, unknown>) => {
         inserted.push(value);
@@ -49,6 +57,7 @@ function counterDb(
       transaction: async (callback: (value: typeof tx) => Promise<unknown>) => callback(tx),
     },
     inserted,
+    updated,
     get observedCount() {
       return observedCount;
     },
@@ -198,7 +207,7 @@ describe("cross-issue influence limit rollout", () => {
     expect(fake.inserted).toEqual([]);
   });
 
-  it("fails closed when the persisted run has no source issue", async () => {
+  it("binds the run's source issue on the first write instead of rejecting, and does not count it against the cap", async () => {
     const fake = counterDb(0, { contextSnapshot: {} });
 
     await expect(observeCrossIssueInfluence(fake.db as never, {
@@ -207,10 +216,41 @@ describe("cross-issue influence limit rollout", () => {
       agentId: "33333333-3333-4333-8333-333333333333",
       targetIssueId: "55555555-5555-4555-8555-555555555555",
       kind: "update",
-    })).rejects.toMatchObject({
-      status: 403,
-      details: { code: "cross_issue_influence_run_context_required" },
-    });
+    })).resolves.toBeNull();
     expect(fake.inserted).toEqual([]);
+    expect(fake.updated).toEqual([
+      expect.objectContaining({
+        contextSnapshot: { issueId: "55555555-5555-4555-8555-555555555555", source: "first_write_bind" },
+      }),
+    ]);
+  });
+
+  it("binds a null contextSnapshot the same way as an empty one", async () => {
+    const fake = counterDb(0, { contextSnapshot: null });
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+      kind: "comment",
+    })).resolves.toBeNull();
+    expect(fake.updated).toHaveLength(1);
+  });
+
+  it("gates a write to a different issue by the existing cap after the run is already bound", async () => {
+    const fake = counterDb(0, {
+      contextSnapshot: { issueId: "55555555-5555-4555-8555-555555555555", source: "first_write_bind" },
+    });
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "66666666-6666-4666-8666-666666666666",
+      kind: "comment",
+      now: CROSS_ISSUE_INFLUENCE_ENFORCE_AT,
+    })).resolves.toMatchObject({ allowed: true, count: 1 });
+    expect(fake.updated).toEqual([]);
   });
 });

--- a/server/src/__tests__/cross-issue-influence-limit.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit.test.ts
@@ -225,6 +225,38 @@ describe("cross-issue influence limit rollout", () => {
     ]);
   });
 
+  it("merges the bind into an existing populated contextSnapshot instead of replacing it", async () => {
+    const fake = counterDb(0, {
+      contextSnapshot: {
+        wakeReason: "heartbeat_timer",
+        modelProfile: "reasoning-high",
+        taskKey: "inbox-lite",
+        forceFreshSession: true,
+      },
+    });
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+      kind: "update",
+    })).resolves.toBeNull();
+    expect(fake.inserted).toEqual([]);
+    expect(fake.updated).toEqual([
+      expect.objectContaining({
+        contextSnapshot: {
+          wakeReason: "heartbeat_timer",
+          modelProfile: "reasoning-high",
+          taskKey: "inbox-lite",
+          forceFreshSession: true,
+          issueId: "55555555-5555-4555-8555-555555555555",
+          source: "first_write_bind",
+        },
+      }),
+    ]);
+  });
+
   it("binds a null contextSnapshot the same way as an empty one", async () => {
     const fake = counterDb(0, { contextSnapshot: null });
 

--- a/server/src/__tests__/cross-issue-influence-limit.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit.test.ts
@@ -10,6 +10,7 @@ import {
 function counterDb(
   initialCount = 0,
   runOverrides: Record<string, unknown> | null = {},
+  targetIssueOwnedByRun = true,
 ) {
   let observedCount = initialCount;
   const inserted: Array<Record<string, unknown>> = [];
@@ -24,6 +25,11 @@ function counterDb(
             };
           }
           return {
+            then: (resolve: (rows: unknown[]) => unknown) => resolve(
+              targetIssueOwnedByRun
+                ? [{ id: "55555555-5555-4555-8555-555555555555" }]
+                : [],
+            ),
             for: () => ({
               then: (resolve: (rows: unknown[]) => unknown) => resolve(runOverrides === null ? [] : [{
                 id: "11111111-1111-4111-8111-111111111111",
@@ -223,6 +229,23 @@ describe("cross-issue influence limit rollout", () => {
         contextSnapshot: { issueId: "55555555-5555-4555-8555-555555555555", source: "first_write_bind" },
       }),
     ]);
+  });
+
+  it("fails closed when an unbound run first writes to an issue it has not checked out", async () => {
+    const fake = counterDb(0, { contextSnapshot: {} }, false);
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+      kind: "comment",
+    })).rejects.toMatchObject({
+      status: 403,
+      details: { code: "cross_issue_influence_run_context_required" },
+    });
+    expect(fake.updated).toEqual([]);
+    expect(fake.inserted).toEqual([]);
   });
 
   it("merges the bind into an existing populated contextSnapshot instead of replacing it", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -260,6 +260,7 @@ import {
 } from "../services/issue-thread-interaction-resolution.js";
 import { resolveSelectedSuggestedTasks } from "../services/issue-thread-interactions.js";
 import {
+  bindCheckoutRunSourceIssueIfUnset,
   crossIssueInfluenceLimitError,
   crossIssueInfluenceRunContextError,
   observeCrossIssueInfluence,
@@ -11636,6 +11637,18 @@ export function issueRoutes(
     const actor = getActorInfo(req);
     if (updated?.harnessKind === "skill_test") {
       await companySkillsSvc.markTestRunRunning(updated.companyId, updated.id);
+    }
+
+    // Belt-and-suspenders: bind the calling actor's own run's source issue at
+    // checkout time when unbound, rather than only relying on that run's
+    // first comment/PATCH to trigger the bind-on-first-write path.
+    if (req.actor.type === "agent" && checkoutRunId) {
+      await bindCheckoutRunSourceIssueIfUnset(db, {
+        companyId: issue.companyId,
+        runId: checkoutRunId,
+        agentId: req.body.agentId,
+        issueId: issue.id,
+      });
     }
 
     await logActivity(db, {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -260,7 +260,6 @@ import {
 } from "../services/issue-thread-interaction-resolution.js";
 import { resolveSelectedSuggestedTasks } from "../services/issue-thread-interactions.js";
 import {
-  bindCheckoutRunSourceIssueIfUnset,
   crossIssueInfluenceLimitError,
   crossIssueInfluenceRunContextError,
   observeCrossIssueInfluence,
@@ -11637,18 +11636,6 @@ export function issueRoutes(
     const actor = getActorInfo(req);
     if (updated?.harnessKind === "skill_test") {
       await companySkillsSvc.markTestRunRunning(updated.companyId, updated.id);
-    }
-
-    // Belt-and-suspenders: bind the calling actor's own run's source issue at
-    // checkout time when unbound, rather than only relying on that run's
-    // first comment/PATCH to trigger the bind-on-first-write path.
-    if (req.actor.type === "agent" && checkoutRunId) {
-      await bindCheckoutRunSourceIssueIfUnset(db, {
-        companyId: issue.companyId,
-        runId: checkoutRunId,
-        agentId: req.body.agentId,
-        issueId: issue.id,
-      });
     }
 
     await logActivity(db, {

--- a/server/src/services/cross-issue-influence-limit.ts
+++ b/server/src/services/cross-issue-influence-limit.ts
@@ -34,6 +34,51 @@ export function crossIssueInfluenceRunContextError() {
   return forbidden(body.error, body.details);
 }
 
+/**
+ * Belt-and-suspenders: bind the calling actor's own run's source issue at
+ * checkout time when it is still null, rather than waiting for the run's
+ * first comment/PATCH to trigger the bind-on-first-write path in
+ * `observeCrossIssueInfluence`. Checkout does not read or write
+ * `contextSnapshot` for the *calling* actor's own run today (it only does so
+ * for a *spawned* wakeup belonging to a different actor), so most
+ * unscoped-wake runs would otherwise reach their first write still unbound.
+ *
+ * Best-effort: this never blocks or fails the checkout response. A run whose
+ * context is still unbound after this call is still safely covered by the
+ * bind-on-first-write fallback in `observeCrossIssueInfluence`.
+ */
+export async function bindCheckoutRunSourceIssueIfUnset(
+  db: Db,
+  input: { companyId: string; runId: string; agentId: string; issueId: string },
+): Promise<void> {
+  if (!isUuidLike(input.runId)) return;
+  try {
+    await db.transaction(async (tx) => {
+      const run = await tx
+        .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+        .from(heartbeatRuns)
+        .where(and(
+          eq(heartbeatRuns.id, input.runId),
+          eq(heartbeatRuns.companyId, input.companyId),
+          eq(heartbeatRuns.agentId, input.agentId),
+        ))
+        .for("update")
+        .then((rows) => rows[0] ?? null);
+      if (!run || readRunSourceIssueId(run.contextSnapshot)) return;
+
+      await tx.update(heartbeatRuns)
+        .set({ contextSnapshot: { issueId: input.issueId, source: "issue.checkout" } })
+        .where(and(
+          eq(heartbeatRuns.id, input.runId),
+          eq(heartbeatRuns.companyId, input.companyId),
+          eq(heartbeatRuns.agentId, input.agentId),
+        ));
+    });
+  } catch (err) {
+    logger.warn({ err, runId: input.runId, issueId: input.issueId }, "failed to bind run source issue at checkout");
+  }
+}
+
 function readRunSourceIssueId(contextSnapshot: unknown) {
   if (!contextSnapshot || typeof contextSnapshot !== "object" || Array.isArray(contextSnapshot)) return null;
   const context = contextSnapshot as Record<string, unknown>;
@@ -110,7 +155,24 @@ export async function observeCrossIssueInfluence(
     }
 
     const sourceIssueId = readRunSourceIssueId(run.contextSnapshot);
-    if (!sourceIssueId) throw crossIssueInfluenceRunContextError();
+    if (!sourceIssueId) {
+      // Bind-on-first-write: a run with no persisted source issue cannot have
+      // had a prior cross-issue write to compare against, so its very first
+      // write legitimately defines "home". Persist the bind inside this same
+      // row-locked transaction so a retried run (e.g. process-lost/retry
+      // reusing the run id) inherits the bound source issue instead of
+      // re-triggering this branch. This is not a fallback that trusts the
+      // header or a prior successful checkout — it only fires once, the
+      // first time this specific locked run attempts any write at all.
+      await tx.update(heartbeatRuns)
+        .set({ contextSnapshot: { issueId: input.targetIssueId, source: "first_write_bind" } })
+        .where(and(
+          eq(heartbeatRuns.id, input.runId),
+          eq(heartbeatRuns.companyId, input.companyId),
+          eq(heartbeatRuns.agentId, input.agentId),
+        ));
+      return null;
+    }
     if (
       sourceIssueId === input.targetIssueId ||
       (input.targetIssueIdentifier && sourceIssueId.toUpperCase() === input.targetIssueIdentifier.toUpperCase())

--- a/server/src/services/cross-issue-influence-limit.ts
+++ b/server/src/services/cross-issue-influence-limit.ts
@@ -66,8 +66,9 @@ export async function bindCheckoutRunSourceIssueIfUnset(
         .then((rows) => rows[0] ?? null);
       if (!run || readRunSourceIssueId(run.contextSnapshot)) return;
 
+      const priorSnapshot = mergeableContextSnapshot(run.contextSnapshot);
       await tx.update(heartbeatRuns)
-        .set({ contextSnapshot: { issueId: input.issueId, source: "issue.checkout" } })
+        .set({ contextSnapshot: { ...priorSnapshot, issueId: input.issueId, source: "issue.checkout" } })
         .where(and(
           eq(heartbeatRuns.id, input.runId),
           eq(heartbeatRuns.companyId, input.companyId),
@@ -77,6 +78,11 @@ export async function bindCheckoutRunSourceIssueIfUnset(
   } catch (err) {
     logger.warn({ err, runId: input.runId, issueId: input.issueId }, "failed to bind run source issue at checkout");
   }
+}
+
+function mergeableContextSnapshot(contextSnapshot: unknown): Record<string, unknown> {
+  if (!contextSnapshot || typeof contextSnapshot !== "object" || Array.isArray(contextSnapshot)) return {};
+  return contextSnapshot as Record<string, unknown>;
 }
 
 function readRunSourceIssueId(contextSnapshot: unknown) {
@@ -164,8 +170,9 @@ export async function observeCrossIssueInfluence(
       // re-triggering this branch. This is not a fallback that trusts the
       // header or a prior successful checkout — it only fires once, the
       // first time this specific locked run attempts any write at all.
+      const priorSnapshot = mergeableContextSnapshot(run.contextSnapshot);
       await tx.update(heartbeatRuns)
-        .set({ contextSnapshot: { issueId: input.targetIssueId, source: "first_write_bind" } })
+        .set({ contextSnapshot: { ...priorSnapshot, issueId: input.targetIssueId, source: "first_write_bind" } })
         .where(and(
           eq(heartbeatRuns.id, input.runId),
           eq(heartbeatRuns.companyId, input.companyId),

--- a/server/src/services/cross-issue-influence-limit.ts
+++ b/server/src/services/cross-issue-influence-limit.ts
@@ -34,52 +34,6 @@ export function crossIssueInfluenceRunContextError() {
   return forbidden(body.error, body.details);
 }
 
-/**
- * Belt-and-suspenders: bind the calling actor's own run's source issue at
- * checkout time when it is still null, rather than waiting for the run's
- * first comment/PATCH to trigger the bind-on-first-write path in
- * `observeCrossIssueInfluence`. Checkout does not read or write
- * `contextSnapshot` for the *calling* actor's own run today (it only does so
- * for a *spawned* wakeup belonging to a different actor), so most
- * unscoped-wake runs would otherwise reach their first write still unbound.
- *
- * Best-effort: this never blocks or fails the checkout response. A run whose
- * context is still unbound after this call is still safely covered by the
- * bind-on-first-write fallback in `observeCrossIssueInfluence`.
- */
-export async function bindCheckoutRunSourceIssueIfUnset(
-  db: Db,
-  input: { companyId: string; runId: string; agentId: string; issueId: string },
-): Promise<void> {
-  if (!isUuidLike(input.runId)) return;
-  try {
-    await db.transaction(async (tx) => {
-      const run = await tx
-        .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
-        .from(heartbeatRuns)
-        .where(and(
-          eq(heartbeatRuns.id, input.runId),
-          eq(heartbeatRuns.companyId, input.companyId),
-          eq(heartbeatRuns.agentId, input.agentId),
-        ))
-        .for("update")
-        .then((rows) => rows[0] ?? null);
-      if (!run || readRunSourceIssueId(run.contextSnapshot)) return;
-
-      const priorSnapshot = mergeableContextSnapshot(run.contextSnapshot);
-      await tx.update(heartbeatRuns)
-        .set({ contextSnapshot: { ...priorSnapshot, issueId: input.issueId, source: "issue.checkout" } })
-        .where(and(
-          eq(heartbeatRuns.id, input.runId),
-          eq(heartbeatRuns.companyId, input.companyId),
-          eq(heartbeatRuns.agentId, input.agentId),
-        ));
-    });
-  } catch (err) {
-    logger.warn({ err, runId: input.runId, issueId: input.issueId }, "failed to bind run source issue at checkout");
-  }
-}
-
 function mergeableContextSnapshot(contextSnapshot: unknown): Record<string, unknown> {
   if (!contextSnapshot || typeof contextSnapshot !== "object" || Array.isArray(contextSnapshot)) return {};
   return contextSnapshot as Record<string, unknown>;

--- a/server/src/services/cross-issue-influence-limit.ts
+++ b/server/src/services/cross-issue-influence-limit.ts
@@ -1,6 +1,6 @@
-import { and, count, eq } from "drizzle-orm";
+import { and, count, eq, or } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { activityLog, heartbeatRuns } from "@paperclipai/db";
+import { activityLog, heartbeatRuns, issues } from "@paperclipai/db";
 import { isUuidLike, issueWriteDenialResponse } from "@paperclipai/shared";
 import { forbidden } from "../errors.js";
 import { logger } from "../middleware/logger.js";
@@ -162,14 +162,28 @@ export async function observeCrossIssueInfluence(
 
     const sourceIssueId = readRunSourceIssueId(run.contextSnapshot);
     if (!sourceIssueId) {
-      // Bind-on-first-write: a run with no persisted source issue cannot have
-      // had a prior cross-issue write to compare against, so its very first
-      // write legitimately defines "home". Persist the bind inside this same
-      // row-locked transaction so a retried run (e.g. process-lost/retry
-      // reusing the run id) inherits the bound source issue instead of
-      // re-triggering this branch. This is not a fallback that trusts the
-      // header or a prior successful checkout — it only fires once, the
-      // first time this specific locked run attempts any write at all.
+      // Bind-on-first-write is only safe when checkout already proves that this
+      // run owns the target. This read does not lock the issue row, avoiding the
+      // reverse run-row -> issue-row lock order of the normal checkout path.
+      // Without that persisted ownership proof, retain the fail-closed 403.
+      const checkedOutTarget = await tx
+        .select({ id: issues.id })
+        .from(issues)
+        .where(and(
+          eq(issues.id, input.targetIssueId),
+          eq(issues.companyId, input.companyId),
+          eq(issues.assigneeAgentId, input.agentId),
+          or(
+            eq(issues.checkoutRunId, input.runId),
+            eq(issues.executionRunId, input.runId),
+          ),
+        ))
+        .then((rows) => rows[0] ?? null);
+      if (!checkedOutTarget) throw crossIssueInfluenceRunContextError();
+
+      // Persist the proven checkout as the run's home inside this same locked
+      // transaction. Retried writes and later cross-issue writes then use the
+      // ordinary same-issue bypass and capped cross-issue path respectively.
       const priorSnapshot = mergeableContextSnapshot(run.contextSnapshot);
       await tx.update(heartbeatRuns)
         .set({ contextSnapshot: { ...priorSnapshot, issueId: input.targetIssueId, source: "first_write_bind" } })


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents and their work.
> - The cross-issue influence limiter restricts writes outside a run's source issue.
> - Unscoped runs need a safe way to bind their source issue on the first write.
> - The closed implementation allowed an unclaimed target to become the source issue.
> - This pull request requires persisted checkout proof before that binding.
> - The benefit is fail-closed behavior without reverse row-lock ordering.

## Linked Issues or Issue Description

- Refs #12315
- Refs #11852
- Refs #11975
- Refs #12118

## What Changed

- Require the target issue to match the company, agent, and run checkout before first-write binding.
- Keep the issue ownership read free of a row lock.
- Remove the racy best-effort checkout-time binding.
- Add unit and embedded PostgreSQL regressions for checked-out and unclaimed targets.

## Verification

- The source change passed focused review at https://github.com/dzianisv/paperclip/pull/6.
- The source tests covered the successful checked-out path and the HTTP 403 unclaimed-target path.
- Upstream CI now runs against rebased head `6a96a4a1de79f393679bfcb08e50aee8cfab41b9`.

## Risks

- The behavior is intentionally stricter for unscoped runs that write without persisted checkout proof.
- The ownership read is a plain `SELECT`, so this change does not add reverse row-lock ordering.

## Model Used

OpenAI GPT-5.6-sol with tool use and code execution assisted the rebase, repository checks, and pull request preparation. The reviewed source patch was produced earlier by the contributors shown in the commit history.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [ ] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

Co-Authored-By: Den <dzianisv@users.noreply.github.com>
