### PR TITLE
refactor(onboarding): reconcile the arc column's width comment with its width

### DIFF
--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -2508,17 +2508,23 @@ function OnboardingWizardInner({
                 // narrower than the next screen's makes the whole frame jump on
                 // Continue — which is the thing that read as "off" to begin
                 // with, and is more obvious once the buttons match.
-                // 68px sides, so the column inside the 560px frame is 424px —
-                // the measure the design draws every arc step to. It was 40px
-                // (a 480px column), which is wide enough that the two model
-                // tiles stretch and the name field sits under a question far
-                // narrower than itself.
+                // 40px sides, so the column inside the 560px frame is 480px:
+                // the measure the connect sequence is drawn to. The arc shares
+                // one shell, so the other steps take that measure rather than
+                // sitting narrower than the step between them.
+                //
+                // It has been both ways, and the objection that moved it last
+                // time has not been retested since it moved back. A 64px inset
+                // (a 432px column) was chosen because at the wider measure the
+                // two model tiles stretch and the name field sits under a
+                // question far narrower than itself. The connect step is now
+                // drawn to 480px, so the shell followed it. If step 1 or step 3
+                // reads loose, that is the reason and this is the line — but
+                // narrowing the shell again would put the connect step back out
+                // of step with its own design, so the fix would belong in those
+                // steps' own content rather than here.
                 isAgentArcStep || step === 1
-                  ? // 40px inset, not 64: the connect sequence is drawn against
-                    // a 480px column and the arc's other steps share the shell,
-                    // so they widen with it rather than sitting narrower than
-                    // the step between them.
-                    "w-(--sz-560px) max-w-full px-8 py-10 sm:px-10 sm:py-11"
+                  ? "w-(--sz-560px) max-w-full px-8 py-10 sm:px-10 sm:py-11"
                   : "w-full max-w-md px-8 py-12",
               )}
             >


### PR DESCRIPTION
## Thinking Path

#12863 rebuilt the connect step's sign-in as one continuous sequence, and the sequence is drawn against a 480px column. The arc's steps share one shell, so taking that measure meant changing the shell's inset — which reaches steps 1, 3 and 5 as well, none of which asked for it.

That made the shell the first thing to describe when writing a handoff for a session focused on the whole flow end to end, since it is the one change from that PR that lands on every other step. Describing it is what surfaced the problem: the file makes two contradictory arguments about the width, one immediately below the other, and the older of them argues against the value the code now uses.

Checking the history showed the older comment had also drifted independently of #12863 — it describes "68px sides" and a "424px column" while the file had been using `--sz-64px`, a 432px column. So neither comment was accurate on its own, and a reader looking for the reason behind the current width would find an argument against it with no indication of which one won.

This is titled `refactor:` rather than `docs:` at the gate's request, since the file is source. Nothing outside the comment block changes.

## Linked Issues or Issue Description

No tracking issue — described inline, per CONTRIBUTING.md.

**What's wrong.** `OnboardingWizardInner`'s shell carries two adjacent comments arguing opposite things. The older block argues for a 64px inset and states that 40px "is wide enough that the two model tiles stretch and the name field sits under a question far narrower than itself." The newer block, on the very next line, argues for the 40px inset the code uses.

The older one had also drifted from the code before #12863 touched it: it describes "68px sides" and a "424px column", while the file had been using `sm:px-(--sz-64px)` — a 432px column.

**Expected.** One comment, describing the width the code uses and why, keeping the history that is actually useful.

## What Changed

- Replaced both comments with one. It states the current decision — 40px sides, a 480px column inside the 560px frame, the measure the connect sequence is drawn to, shared by the arc so no step sits narrower than the one after it.
- Kept the earlier objection rather than deleting it, and marked it **not retested** since the width moved back. It is the one piece of history a future reader needs, because it is an argument against the current value.
- Added where the fix belongs if it does resurface: step 1 and step 3 inherited this width without changing, and narrowing the shell again would put the connect step out of step with its design — so that would be a content change in those steps, not a shell change here.

Comment-only. No behaviour change, no class change.

## Verification

`tsc --noEmit` clean. No runtime code touched — the diff is entirely inside a comment block, and the class strings on both branches of the ternary are byte-identical to before.

**Not done, deliberately:** I did not re-check whether step 1's name field or step 3's content actually read loose at 480px. That needs eyes on the running flow rather than a comment fix, and pre-empting it here would be guessing at the answer. The comment now says it is untested instead of implying either way.

## Risks

None. Comments only.

## Model Used

Anthropic Claude — Opus 5, model ID `claude-opus-5`, run through Claude Code. Extended thinking enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass — `tsc --noEmit`; no test-observable change
- [x] I have added or updated tests where applicable — n/a, comment-only
- [x] I have updated relevant documentation to reflect my changes — this is the documentation fix
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

Follows #12863.

🤖 Generated with [Claude Code](https://claude.com/claude-code)