### PR TITLE
test(server): remove a concurrent-import race in the approval routes suite

### DIFF
--- a/server/src/__tests__/approval-routes-idempotency.test.ts
+++ b/server/src/__tests__/approval-routes-idempotency.test.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import request from "supertest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { hoistModuleGraph } from "./helpers/hoist-module-graph.js";
 
 const mockApprovalService = vi.hoisted(() => ({
   list: vi.fn(),
@@ -43,11 +44,14 @@ function registerModuleMocks() {
   }));
 }
 
+const routeModules = hoistModuleGraph(registerModuleMocks, async () => {
+  const { errorHandler } = await import("../middleware/index.js");
+  const { approvalRoutes } = await import("../routes/approvals.js");
+  return { errorHandler, approvalRoutes };
+});
+
 async function createApp(actorOverrides: Record<string, unknown> = {}) {
-  const [{ errorHandler }, { approvalRoutes }] = await Promise.all([
-    import("../middleware/index.js"),
-    import("../routes/approvals.js"),
-  ]);
+  const { errorHandler, approvalRoutes } = routeModules.value;
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
@@ -87,10 +91,7 @@ function createRouteDb(contextSnapshot: Record<string, unknown> = {}, runId = "r
 }
 
 async function createAgentApp(options: { runId?: string; contextSnapshot?: Record<string, unknown> } = {}) {
-  const [{ errorHandler }, { approvalRoutes }] = await Promise.all([
-    import("../middleware/index.js"),
-    import("../routes/approvals.js"),
-  ]);
+  const { errorHandler, approvalRoutes } = routeModules.value;
   const app = express();
   app.use(express.json());
   app.use((req, _res, next) => {
@@ -111,12 +112,6 @@ async function createAgentApp(options: { runId?: string; contextSnapshot?: Recor
 
 describe("approval routes idempotent retries", () => {
   beforeEach(() => {
-    vi.resetModules();
-    vi.doUnmock("../services/index.js");
-    vi.doUnmock("../routes/approvals.js");
-    vi.doUnmock("../routes/authz.js");
-    vi.doUnmock("../middleware/index.js");
-    registerModuleMocks();
     vi.clearAllMocks();
     mockApprovalService.list.mockReset();
     mockApprovalService.getById.mockReset();


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Approval routes use server tests to protect access and idempotency behavior
> - The approval routes test suite loaded mocked modules at the same time
> - Concurrent module loading could lose a service mock and produce a false test failure
> - This pull request loads the shared module graph once and reuses it across the suite
> - The benefit is stable approval route tests with unchanged coverage

## Linked Issues or Issue Description

**What happened?**

The approval routes test suite loaded two mocked modules in one concurrent import. A module interleaving could remove the approval service mock. The route then returned HTTP 404 instead of the expected HTTP 403.

**Expected behavior**

The suite must keep the approval service mock when it loads the route modules. The access test must return HTTP 403 on every run.

**Steps to reproduce**

1. Run `npx vitest run server/src/__tests__/approval-routes-idempotency.test.ts`.
2. Repeat the test command while the test runner loads the module graph.
3. Observe a false HTTP 404 result when the module mock interleaves.

**Paperclip version or commit**

Current `master` at the base commit of this pull request.

**Deployment mode**

Built from source with the server test runner.

## What Changed

- Reused the existing `hoistModuleGraph` helper for the approval route modules.
- Loaded the route modules once in sequence instead of in one concurrent import.
- Kept per-test mock behavior, Express app setup, database doubles, test names, and assertions unchanged.

## Verification

- `npx vitest run server/src/__tests__/approval-routes-idempotency.test.ts` — 11 of 11 tests passed.
- Ten repeat runs passed.
- `npx tsc --noEmit -p server` produced no new errors against the base branch.
- All Paperclip CI checks passed.
- Greptile reported 5/5 with no open findings.

## Risks

This change affects test module setup only. It does not change production code or test coverage. Risk is low.

## Model Used

OpenAI Codex with the `gpt-5` model family. The serving snapshot and context-window size are not exposed. The agent used reasoning, repository tools, code execution, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and found no duplicate for this test race
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge