### PR TITLE
feat(teams-catalog): add opt-in software SDLC template pack

### DIFF
--- a/packages/teams-catalog/catalog/optional/software-development/software-sdlc/LICENSE.md
+++ b/packages/teams-catalog/catalog/optional/software-development/software-sdlc/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Paperclip AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/teams-catalog/catalog/optional/software-development/software-sdlc/TEAM.md
+++ b/packages/teams-catalog/catalog/optional/software-development/software-sdlc/TEAM.md
@@ -1,0 +1,85 @@
+---
+name: Software SDLC
+description: An opt-in software delivery team with reusable requirements, architecture, implementation, testing, security review, release, and retrospective templates.
+schema: agentcompanies/v1
+slug: software-sdlc
+category: software-development
+key: paperclipai/optional/software-development/software-sdlc
+manager: agents/delivery-lead/AGENTS.md
+includes:
+  - agents/implementer/AGENTS.md
+  - agents/test-reviewer/AGENTS.md
+  - agents/security-reviewer/AGENTS.md
+  - projects/software-sdlc/PROJECT.md
+  - skills/software-sdlc/SKILL.md
+defaultInstall: false
+recommendedForCompanyTypes:
+  - software
+  - startup
+  - product
+tags:
+  - sdlc
+  - requirements
+  - architecture
+  - testing
+  - security-review
+  - release
+requiredSkills:
+  - software-sdlc
+  - paperclipai/bundled/software-development/github-pr-workflow
+  - paperclipai/bundled/quality/qa-acceptance
+  - paperclipai/bundled/paperclip-operations/task-planning
+---
+
+# Software SDLC
+
+A reusable delivery method for a software team. This is a content pack, not a
+workflow engine or a command runner. It does not enforce gates in server code.
+
+## Install and start
+
+1. Preview this team in the Teams catalog.
+2. Choose the parent manager and review agent and skill changes.
+3. Choose an adapter for each agent. This pack does not set models or credentials.
+4. Apply the import through the normal governed team installation flow.
+5. Assign a delivery request to the Delivery Lead. Include the project workspace,
+   scope, acceptance criteria, budget, and the person who can authorize release.
+
+Installation creates no starter tasks or routines. It does not start a delivery
+cycle or grant hiring, release, or approval permissions.
+
+## Contents
+
+- Delivery Lead: requirements, architecture, coordination, and release preparation.
+- Implementer: scoped code changes and their tests.
+- Test Reviewer: independent acceptance and regression evidence.
+- Security Reviewer: threat analysis and security findings.
+- Software SDLC project: a home for delivery requests.
+- Software SDLC skill: a reusable seven-phase method and artifact templates.
+
+For an existing team, reuse the skill and map phase owners to existing agents.
+Do not create extra agents only to match these role names.
+
+## Flow and interface
+
+The skill uses normal issues, blocker relations, revisioned documents, artifacts,
+and typed review stages. Those objects keep Paperclip's existing layout and
+approval controls. Each delivery cycle has its own parent issue and artifact
+revisions. See [the skill](skills/software-sdlc/SKILL.md) for the dependency flow.
+
+Workflow-template work is tracked in
+[#3950](https://github.com/paperclipai/paperclip/issues/3950) and
+[#3951](https://github.com/paperclipai/paperclip/pull/3951). This pack neither
+replaces that work nor requires its unmerged API. A future invocation layer can
+reuse the phase inputs, outputs, and acceptance criteria here.
+
+## License and limitations
+
+This pack is original contribution content under [Paperclip's MIT license](LICENSE.md). It
+does not vendor ECC prompts or scripts. External tools and dependencies retain
+their own licenses.
+
+The templates are instructions. A model can fail to follow them. Deterministic
+test execution, verified evidence ingestion, and server-side completion
+enforcement are separate capabilities. A completed checklist is not proof of a
+passing build, a secure system, or an authorized release.

--- a/packages/teams-catalog/catalog/optional/software-development/software-sdlc/agents/delivery-lead/AGENTS.md
+++ b/packages/teams-catalog/catalog/optional/software-development/software-sdlc/agents/delivery-lead/AGENTS.md
@@ -1,0 +1,20 @@
+---
+name: Delivery Lead
+slug: delivery-lead
+title: Delivery Lead
+role: engineering-manager
+reportsTo: null
+skills:
+  - software-sdlc
+  - task-planning
+  - github-pr-workflow
+---
+
+# Delivery Lead
+
+Own intake, requirements, architecture, handoffs, release preparation, and the retrospective. Map existing agents to phase owners before proposing hires. Keep the parent plan and artifact revision links current. Request independent review of work you produce. Do not approve your own release on behalf of the board.
+
+Follow the Paperclip heartbeat contract and the Software SDLC skill. Honor the
+assigned company, workspace, budget, checkout, and approval boundaries. Never
+commit secrets or treat a template as permission to run commands or change
+production. When blocked, record the missing evidence, next owner, and action.

--- a/packages/teams-catalog/catalog/optional/software-development/software-sdlc/agents/implementer/AGENTS.md
+++ b/packages/teams-catalog/catalog/optional/software-development/software-sdlc/agents/implementer/AGENTS.md
@@ -1,0 +1,19 @@
+---
+name: Implementer
+slug: implementer
+title: Implementer
+role: engineer
+reportsTo: delivery-lead
+skills:
+  - software-sdlc
+  - github-pr-workflow
+---
+
+# Implementer
+
+Implement the accepted scope in the assigned workspace. Add tests for the behavior changed. Record the candidate revision and actual check results. Address review findings and request new verification after changes. Do not mark independent reviews or release approval as passed yourself.
+
+Follow the Paperclip heartbeat contract and the Software SDLC skill. Honor the
+assigned company, workspace, budget, checkout, and approval boundaries. Never
+commit secrets or treat a template as permission to run commands or change
+production. When blocked, record the missing evidence, next owner, and action.

--- a/packages/teams-catalog/catalog/optional/software-development/software-sdlc/agents/security-reviewer/AGENTS.md
+++ b/packages/teams-catalog/catalog/optional/software-development/software-sdlc/agents/security-reviewer/AGENTS.md
@@ -1,0 +1,18 @@
+---
+name: Security Reviewer
+slug: security-reviewer
+title: Security Reviewer
+role: engineer
+reportsTo: delivery-lead
+skills:
+  - software-sdlc
+---
+
+# Security Reviewer
+
+Review trust boundaries, input handling, authorization, secrets, dependencies, and changes to sensitive data. Start threat analysis during architecture and verify the final candidate. Record severity, evidence, remediation, and residual risk. Do not claim compliance certification or authorize intrusive testing. Submit verdicts through the assigned native review stage; escalate risk acceptance to its authorized owner.
+
+Follow the Paperclip heartbeat contract and the Software SDLC skill. Honor the
+assigned company, workspace, budget, checkout, and approval boundaries. Never
+commit secrets or treat a template as permission to run commands or change
+production. When blocked, record the missing evidence, next owner, and action.

--- a/packages/teams-catalog/catalog/optional/software-development/software-sdlc/agents/test-reviewer/AGENTS.md
+++ b/packages/teams-catalog/catalog/optional/software-development/software-sdlc/agents/test-reviewer/AGENTS.md
@@ -1,0 +1,19 @@
+---
+name: Test Reviewer
+slug: test-reviewer
+title: Test Reviewer
+role: qa
+reportsTo: delivery-lead
+skills:
+  - software-sdlc
+  - qa-acceptance
+---
+
+# Test Reviewer
+
+Verify acceptance criteria and regression behavior against the named candidate revision. Run only authorized project checks. Record reproducible failures and missing evidence. Treat missing tools, skipped tests, timeouts, and stale reports as incomplete. Return the verdict through the assigned native review stage.
+
+Follow the Paperclip heartbeat contract and the Software SDLC skill. Honor the
+assigned company, workspace, budget, checkout, and approval boundaries. Never
+commit secrets or treat a template as permission to run commands or change
+production. When blocked, record the missing evidence, next owner, and action.

--- a/packages/teams-catalog/catalog/optional/software-development/software-sdlc/projects/software-sdlc/PROJECT.md
+++ b/packages/teams-catalog/catalog/optional/software-development/software-sdlc/projects/software-sdlc/PROJECT.md
@@ -1,0 +1,16 @@
+---
+name: Software SDLC
+slug: software-sdlc
+description: Delivery cycles with linked requirements, design decisions, code, verification evidence, and release records.
+owner: delivery-lead
+---
+
+# Software SDLC
+
+Create a separate parent issue for each approved delivery request. Record the
+actual target repository and workspace on that request. Do not assume this
+project points at Paperclip's own repository.
+
+Use the Software SDLC skill to plan phase owners and artifact handoffs. Keep
+unapproved work in planning. A project or team installation is not permission
+to deploy, spend money, or change production data.

--- a/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/SKILL.md
+++ b/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: software-sdlc
+description: Use for a software delivery request that needs requirements, architecture, implementation, independent testing, security review, release, and a retrospective with inspectable artifacts.
+---
+
+# Software SDLC
+
+Apply this method within the assigned issue's scope and the normal Paperclip
+heartbeat contract. It does not expand permissions or override user instructions.
+
+## Intake and approval
+
+Inspect the existing parent issue, plan, children, and artifacts before creating
+work. Ask for missing scope, target workspace, acceptance criteria, budget,
+phase owners, and release authority through the normal question interaction.
+Do not guess an executable command, production target, credential, or approver.
+
+Write a revisioned plan with the phase mapping below. Request approval when the
+task or company policy requires it. Keep implementation in planning until the
+current plan is accepted. A plan approval does not grant hiring or deployment
+permission. If an owner is unavailable, record the missing owner and request the
+normal governed hire or reassignment; do not bypass a permission refusal.
+
+## Reusable phase map
+
+| Phase | Suggested owner | Requires accepted output from | Artifact template |
+| --- | --- | --- | --- |
+| Requirements | Delivery Lead | Approved intake | [requirements](references/requirements.md) |
+| Architecture | Delivery Lead | Requirements | [architecture](references/architecture.md) |
+| Implementation | Implementer | Architecture | [implementation](references/implementation.md) |
+| Testing | Test Reviewer | Implementation | [testing](references/testing.md) |
+| Security review | Security Reviewer | Implementation | [security review](references/security-review.md) |
+| Release | Delivery Lead | Testing and security review | [release](references/release.md) |
+| Retrospective | Delivery Lead | Release outcome or explicit cancellation | [retrospective](references/retrospective.md) |
+
+Testing and security review may run in parallel against the same candidate
+revision. Start threat analysis during architecture; the later security phase
+verifies the implementation. A rejected review returns work to implementation.
+Both reviews must cover the new candidate after a change.
+
+## Issues, dependencies, and review
+
+- Use one parent issue per delivery cycle. Map phases to child issues only when
+  they need independent ownership or a durable handoff; small changes may use
+  one issue with the same artifact headings.
+- Reuse existing phase issues on retry. Record their IDs in the parent plan.
+  Inspect that mapping before creating children. If concurrent work leaves the
+  mapping uncertain, reconcile it before creating more issues.
+- Use blocker relations for required handoffs. Parent-child structure alone
+  does not prevent a child from running. Add dependencies before waking owners.
+- For an independent verdict, use the issue's native execution-policy review
+  stage with a named eligible participant. Do not replace it with a comment,
+  a self-checked box, or a separate review task that can be ignored.
+- The testing and security phase issues produce evidence; they do not substitute
+  for typed review approval on the implementation or release issue.
+- Leave a live owner, durable wait, or explicit escalation at every handoff.
+  A pending human response needs a persisted interaction, not a polling loop.
+- An unavailable or denied operation is a blocker. Do not mark it done or grant
+  yourself more authority to proceed.
+
+## Artifact contract
+
+Read only the template for the current phase and its prerequisite outputs.
+Copy its headings into the issue's revisioned document. Fill placeholders from
+evidence; use "not yet verified" when evidence is missing. Do not edit the
+installed templates for a single run.
+
+Every output records the cycle's parent issue, producer, source revision,
+upstream artifact revisions, checks performed, findings, and next owner.
+Link documents and attach file deliverables through Paperclip's artifact flow.
+Do not use a local file path as the only delivery record.
+
+## Evidence and completion
+
+A reported pass needs the exact candidate commit, command or external check
+identity, environment, exit status, and an inspectable result. Missing tools,
+timeouts, skipped checks, stale reports, and partial output are not passes.
+Do not treat a language model's summary as test execution.
+
+Record tests, lint, build, coverage, and security checks separately. A project
+owner selects commands and thresholds. Never claim a universal coverage target
+or no-vulnerability result merely because the template lists a check.
+
+Release stays blocked until required evidence and native reviews are accepted
+and the authorized release actor approves the exact target and revision.
+The template itself cannot authorize or enforce release.

--- a/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/architecture.md
+++ b/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/architecture.md
@@ -36,6 +36,18 @@ Accepted requirements and an inspected target repository.
 - Rollback strategy:
 - Unresolved risks:
 
+## Checks performed and findings
+
+- Checks performed:
+- Findings:
+- Evidence links:
+
+Summarize this phase's checks and findings, or link to its detailed results
+above. For planning phases, include document reviews and consistency checks;
+do not imply that runtime tests were executed. If no check was performed,
+record "not yet verified" and the reason. Use "none found" only for completed
+checks with evidence.
+
 ## Exit criteria
 
 The design addresses acceptance criteria, compatibility, failure handling, and trust boundaries. Record the review decision. Do not begin implementation on an unapproved design where approval is required.

--- a/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/architecture.md
+++ b/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/architecture.md
@@ -1,0 +1,47 @@
+# Architecture
+
+## Inputs
+
+Accepted requirements and an inspected target repository.
+
+## Provenance
+
+- Parent delivery issue:
+- Phase issue:
+- Producer:
+- Source revision:
+- Upstream artifact revisions:
+
+## Existing system
+
+- Relevant components and contracts:
+- Existing conventions to preserve:
+- Affected data and trust boundaries:
+
+## Design decision
+
+- Proposed change:
+- Alternatives and tradeoffs:
+- API and data model changes:
+- Migration and compatibility plan:
+- Failure handling and recovery:
+- Security and privacy considerations:
+- Test strategy linked to acceptance criteria:
+
+## Delivery plan
+
+- Implementation slices and owners:
+- Dependencies and external services:
+- Reviewers and approvals required:
+- Rollback strategy:
+- Unresolved risks:
+
+## Exit criteria
+
+The design addresses acceptance criteria, compatibility, failure handling, and trust boundaries. Record the review decision. Do not begin implementation on an unapproved design where approval is required.
+
+## Handoff
+
+- Artifact document or attachment:
+- Next owner:
+- Required decision or blocker:

--- a/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/implementation.md
+++ b/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/implementation.md
@@ -38,6 +38,18 @@ still an open release consideration, not an automatic waiver.
 - Security reviewer:
 - Native review request:
 
+## Checks performed and findings
+
+- Checks performed:
+- Findings:
+- Evidence links:
+
+Summarize this phase's checks and findings, or link to its detailed results
+above. For planning phases, include document reviews and consistency checks;
+do not imply that runtime tests were executed. If no check was performed,
+record "not yet verified" and the reason. Use "none found" only for completed
+checks with evidence.
+
 ## Exit criteria
 
 The scoped changes and tests exist at the recorded commit. Relevant checks have inspectable results. Testing and security reviewers receive the same candidate revision; no independent review is self-approved.

--- a/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/implementation.md
+++ b/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/implementation.md
@@ -1,0 +1,49 @@
+# Implementation
+
+## Inputs
+
+Accepted architecture, assigned workspace, and approved scope.
+
+## Provenance
+
+- Parent delivery issue:
+- Phase issue:
+- Producer:
+- Source revision:
+- Upstream artifact revisions:
+
+## Change record
+
+- Branch and candidate commit:
+- Files and contracts changed:
+- Acceptance criteria addressed:
+- Deliberate deviations from the design:
+- Migration and configuration changes:
+
+## Checks actually performed
+
+| Check | Exact command or check ID | Candidate revision | Result and exit status | Evidence |
+| --- | --- | --- | --- | --- |
+| [check] | [command] | [commit] | [pass/fail/incomplete] | [artifact link] |
+
+Separate new failures from verified baseline failures. A baseline failure is
+still an open release consideration, not an automatic waiver.
+
+## Review handoff
+
+- Test cases added or changed:
+- Known failures and limitations:
+- Manual verification steps:
+- Test reviewer:
+- Security reviewer:
+- Native review request:
+
+## Exit criteria
+
+The scoped changes and tests exist at the recorded commit. Relevant checks have inspectable results. Testing and security reviewers receive the same candidate revision; no independent review is self-approved.
+
+## Handoff
+
+- Artifact document or attachment:
+- Next owner:
+- Required decision or blocker:

--- a/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/release.md
+++ b/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/release.md
@@ -1,0 +1,52 @@
+# Release
+
+## Inputs
+
+Accepted testing and security evidence for the exact release candidate.
+
+## Provenance
+
+- Parent delivery issue:
+- Phase issue:
+- Producer:
+- Source revision:
+- Upstream artifact revisions:
+
+## Candidate and target
+
+- Candidate commit and artifact digest:
+- Upstream test and security report revisions:
+- Target environment:
+- Release owner:
+- Authorized approver:
+- Scope of approval and approval record:
+
+## Readiness
+
+- Required checks and native reviews:
+- Release notes and documentation:
+- Configuration and migration plan:
+- Backup and rollback plan:
+- Monitoring and success criteria:
+- Rollback trigger and owner:
+
+## Execution record
+
+- Actual release action and timestamp:
+- Deployed version or artifact identity:
+- Post-release checks and evidence:
+- Observed outcome:
+- Incident or rollback record, if any:
+
+If release authority is absent, stop at a prepared release. Do not interpret a
+plan approval, imported role, or passing test as deployment permission.
+
+## Exit criteria
+
+The authorized actor approved the exact target and candidate. Record the actual release or explicit cancellation outcome. Post-release checks and rollback ownership are inspectable before closing the cycle.
+
+## Handoff
+
+- Artifact document or attachment:
+- Next owner:
+- Required decision or blocker:

--- a/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/release.md
+++ b/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/release.md
@@ -41,6 +41,18 @@ Accepted testing and security evidence for the exact release candidate.
 If release authority is absent, stop at a prepared release. Do not interpret a
 plan approval, imported role, or passing test as deployment permission.
 
+## Checks performed and findings
+
+- Checks performed:
+- Findings:
+- Evidence links:
+
+Summarize this phase's checks and findings, or link to its detailed results
+above. For planning phases, include document reviews and consistency checks;
+do not imply that runtime tests were executed. If no check was performed,
+record "not yet verified" and the reason. Use "none found" only for completed
+checks with evidence.
+
 ## Exit criteria
 
 The authorized actor approved the exact target and candidate. Record the actual release or explicit cancellation outcome. Post-release checks and rollback ownership are inspectable before closing the cycle.

--- a/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/requirements.md
+++ b/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/requirements.md
@@ -1,0 +1,48 @@
+# Requirements
+
+## Inputs
+
+Approved intake with a target user, problem, target repository, and decision owner.
+
+## Provenance
+
+- Parent delivery issue:
+- Phase issue:
+- Producer:
+- Source revision:
+- Upstream artifact revisions:
+
+## Problem and scope
+
+- User and current problem:
+- Desired measurable outcome:
+- In scope:
+- Out of scope:
+- Constraints and budget:
+- Unknowns and who will resolve them:
+
+## Acceptance criteria
+
+| ID | User behavior or requirement | Observable pass condition | Verification method |
+| --- | --- | --- | --- |
+| AC-1 | [behavior] | [measurable condition] | [test or inspection] |
+
+Include failure paths, accessibility, data handling, and performance requirements
+where relevant. Separate founder or stakeholder claims from verified facts.
+
+## Decisions
+
+- Open questions:
+- Options considered:
+- Scope decision and authorized decision maker:
+- Approval record for this revision:
+
+## Exit criteria
+
+Each in-scope requirement has an observable acceptance condition. The owner has resolved or explicitly deferred open questions. The approved requirements revision is linked in the architecture handoff.
+
+## Handoff
+
+- Artifact document or attachment:
+- Next owner:
+- Required decision or blocker:

--- a/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/requirements.md
+++ b/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/requirements.md
@@ -37,6 +37,18 @@ where relevant. Separate founder or stakeholder claims from verified facts.
 - Scope decision and authorized decision maker:
 - Approval record for this revision:
 
+## Checks performed and findings
+
+- Checks performed:
+- Findings:
+- Evidence links:
+
+Summarize this phase's checks and findings, or link to its detailed results
+above. For planning phases, include document reviews and consistency checks;
+do not imply that runtime tests were executed. If no check was performed,
+record "not yet verified" and the reason. Use "none found" only for completed
+checks with evidence.
+
 ## Exit criteria
 
 Each in-scope requirement has an observable acceptance condition. The owner has resolved or explicitly deferred open questions. The approved requirements revision is linked in the architecture handoff.

--- a/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/retrospective.md
+++ b/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/retrospective.md
@@ -1,0 +1,55 @@
+# Retrospective
+
+## Inputs
+
+A recorded release, rollback, or explicit cancellation outcome.
+
+## Provenance
+
+- Parent delivery issue:
+- Phase issue:
+- Producer:
+- Source revision:
+- Upstream artifact revisions:
+
+## Outcome
+
+- Intended outcome:
+- Observed result and evidence:
+- Release or cancellation record:
+- Acceptance criteria met and missed:
+
+## Learning
+
+- What worked:
+- What failed or took longer than expected:
+- Process gaps and contributing factors:
+- Unproven assumptions:
+- Checks that missed defects:
+- Cost or effort compared with the approved budget:
+
+## Follow-up
+
+| Improvement | Evidence | Owner | Next action | Issue |
+| --- | --- | --- | --- | --- |
+| [improvement] | [link] | [owner] | [action] | [issue] |
+
+Propose reusable method changes separately. Do not silently modify company-wide
+rules or installed skills during a retrospective. Avoid adding unsupported
+claims to future templates.
+
+## Cycle closure
+
+- Remaining work and its live owners:
+- Stakeholder summary:
+- Closure decision:
+
+## Exit criteria
+
+The outcome is evidence-backed. Actionable follow-ups have owners and issue links, or an explicit decision to defer them. The summary distinguishes measured results from assumptions.
+
+## Handoff
+
+- Artifact document or attachment:
+- Next owner:
+- Required decision or blocker:

--- a/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/retrospective.md
+++ b/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/retrospective.md
@@ -44,6 +44,18 @@ claims to future templates.
 - Stakeholder summary:
 - Closure decision:
 
+## Checks performed and findings
+
+- Checks performed:
+- Findings:
+- Evidence links:
+
+Summarize this phase's checks and findings, or link to its detailed results
+above. For planning phases, include document reviews and consistency checks;
+do not imply that runtime tests were executed. If no check was performed,
+record "not yet verified" and the reason. Use "none found" only for completed
+checks with evidence.
+
 ## Exit criteria
 
 The outcome is evidence-backed. Actionable follow-ups have owners and issue links, or an explicit decision to defer them. The summary distinguishes measured results from assumptions.

--- a/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/security-review.md
+++ b/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/security-review.md
@@ -46,6 +46,18 @@ tests against external or production systems without explicit authorization.
 - Any risk acceptance, authorized actor, and scope:
 - Native review decision:
 
+## Checks performed and findings
+
+- Checks performed:
+- Findings:
+- Evidence links:
+
+Summarize this phase's checks and findings, or link to its detailed results
+above. For planning phases, include document reviews and consistency checks;
+do not imply that runtime tests were executed. If no check was performed,
+record "not yet verified" and the reason. Use "none found" only for completed
+checks with evidence.
+
 ## Exit criteria
 
 Required security checks have inspectable evidence for the candidate revision. Blocking findings are resolved or handled through an explicitly authorized risk decision. No findings is not a guarantee of security or certification.

--- a/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/security-review.md
+++ b/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/security-review.md
@@ -1,0 +1,57 @@
+# Security review
+
+## Inputs
+
+Requirements, architecture threat analysis, and the exact implementation candidate.
+
+## Provenance
+
+- Parent delivery issue:
+- Phase issue:
+- Producer:
+- Source revision:
+- Upstream artifact revisions:
+
+## Review scope
+
+- Candidate commit:
+- Components and interfaces reviewed:
+- Data classification:
+- Trust boundaries and threat scenarios:
+- Authorized test scope and tools:
+
+## Checks
+
+- Authentication and authorization:
+- Company or tenant isolation:
+- Input and output handling:
+- Secrets and logging:
+- Dependency and license review:
+- Sensitive data retention and deletion:
+- Deployment and migration risks:
+
+For each applicable check, record the method and evidence. Do not run intrusive
+tests against external or production systems without explicit authorization.
+
+## Findings
+
+| Finding | Severity | Evidence | Required change | Owner | State |
+| --- | --- | --- | --- | --- | --- |
+| [finding] | [severity] | [link] | [remediation] | [owner] | [open/resolved] |
+
+## Verdict
+
+- Checks not performed and why:
+- Residual risks:
+- Any risk acceptance, authorized actor, and scope:
+- Native review decision:
+
+## Exit criteria
+
+Required security checks have inspectable evidence for the candidate revision. Blocking findings are resolved or handled through an explicitly authorized risk decision. No findings is not a guarantee of security or certification.
+
+## Handoff
+
+- Artifact document or attachment:
+- Next owner:
+- Required decision or blocker:

--- a/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/testing.md
+++ b/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/testing.md
@@ -44,6 +44,18 @@ skipped cases and timeouts. Reject reports that describe a different revision.
 - Residual risk:
 - Verdict and native review decision:
 
+## Checks performed and findings
+
+- Checks performed:
+- Findings:
+- Evidence links:
+
+Summarize this phase's checks and findings, or link to its detailed results
+above. For planning phases, include document reviews and consistency checks;
+do not imply that runtime tests were executed. If no check was performed,
+record "not yet verified" and the reason. Use "none found" only for completed
+checks with evidence.
+
 ## Exit criteria
 
 Every required check has current evidence and every acceptance criterion has a result. Unresolved failures or missing evidence block a pass. Changes after review require fresh verification.

--- a/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/testing.md
+++ b/packages/teams-catalog/catalog/optional/software-development/software-sdlc/skills/software-sdlc/references/testing.md
@@ -1,0 +1,55 @@
+# Testing
+
+## Inputs
+
+A fixed candidate revision, requirements acceptance criteria, and implementation handoff.
+
+## Provenance
+
+- Parent delivery issue:
+- Phase issue:
+- Producer:
+- Source revision:
+- Upstream artifact revisions:
+
+## Test environment
+
+- Candidate commit and clean/dirty workspace state:
+- Runtime and tool versions:
+- Test data and environment:
+- Authorized check configuration:
+
+## Acceptance matrix
+
+| Criterion | Test or inspection | Expected result | Actual result | Evidence |
+| --- | --- | --- | --- | --- |
+| AC-1 | [test] | [expected] | [actual] | [artifact] |
+
+## Quality checks
+
+| Kind | Command or check ID | Exit status | Result | Report |
+| --- | --- | --- | --- | --- |
+| Tests | [configured check] | [code] | [pass/fail/incomplete] | [link] |
+| Lint | [configured check] | [code] | [pass/fail/incomplete] | [link] |
+| Build | [configured check] | [code] | [pass/fail/incomplete] | [link] |
+| Coverage | [configured check and agreed threshold] | [code] | [pass/fail/incomplete] | [link] |
+
+Use "not applicable" only with a reason and an explicit owner decision. Record
+skipped cases and timeouts. Reject reports that describe a different revision.
+
+## Findings and verdict
+
+- Reproducible failures:
+- Missing evidence:
+- Residual risk:
+- Verdict and native review decision:
+
+## Exit criteria
+
+Every required check has current evidence and every acceptance criterion has a result. Unresolved failures or missing evidence block a pass. Changes after review require fresh verification.
+
+## Handoff
+
+- Artifact document or attachment:
+- Next owner:
+- Required decision or blocker:

--- a/packages/teams-catalog/generated/catalog.json
+++ b/packages/teams-catalog/generated/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "packageName": "@paperclipai/teams-catalog",
   "packageVersion": "0.1.0",
-  "generatedAt": "2026-06-04T18:03:41.262Z",
+  "generatedAt": "2026-09-05T08:52:03.975Z",
   "teams": [
     {
       "id": "paperclipai:bundled:company-defaults:core-exec-team",
@@ -462,6 +462,195 @@
       "trustLevel": "markdown_only",
       "compatibility": "compatible",
       "contentHash": "sha256:06822cec5f2b6910cb37ba0ebd5e04ed5c7e34f77225564ddddc2470779cdaa6"
+    },
+    {
+      "id": "paperclipai:optional:software-development:software-sdlc",
+      "key": "paperclipai/optional/software-development/software-sdlc",
+      "kind": "optional",
+      "category": "software-development",
+      "slug": "software-sdlc",
+      "name": "Software SDLC",
+      "description": "An opt-in software delivery team with reusable requirements, architecture, implementation, testing, security review, release, and retrospective templates.",
+      "path": "catalog/optional/software-development/software-sdlc",
+      "entrypoint": "TEAM.md",
+      "schema": "agentcompanies/v1",
+      "defaultInstall": false,
+      "recommendedForCompanyTypes": [
+        "software",
+        "startup",
+        "product"
+      ],
+      "tags": [
+        "sdlc",
+        "requirements",
+        "architecture",
+        "testing",
+        "security-review",
+        "release"
+      ],
+      "counts": {
+        "agents": 4,
+        "projects": 1,
+        "tasks": 0,
+        "routines": 0,
+        "localSkills": 1,
+        "catalogSkills": 3,
+        "externalSkillSources": 0
+      },
+      "rootAgentSlugs": [
+        "delivery-lead"
+      ],
+      "agentSlugs": [
+        "delivery-lead",
+        "implementer",
+        "security-reviewer",
+        "test-reviewer"
+      ],
+      "projectSlugs": [
+        "software-sdlc"
+      ],
+      "requiredSkills": [
+        {
+          "type": "catalog",
+          "ref": "github-pr-workflow",
+          "agentSlugs": [
+            "delivery-lead",
+            "implementer"
+          ],
+          "resolved": true,
+          "catalogSkillId": "paperclipai:bundled:software-development:github-pr-workflow",
+          "catalogSkillKey": "paperclipai/bundled/software-development/github-pr-workflow"
+        },
+        {
+          "type": "catalog",
+          "ref": "qa-acceptance",
+          "agentSlugs": [
+            "test-reviewer"
+          ],
+          "resolved": true,
+          "catalogSkillId": "paperclipai:bundled:quality:qa-acceptance",
+          "catalogSkillKey": "paperclipai/bundled/quality/qa-acceptance"
+        },
+        {
+          "type": "catalog",
+          "ref": "task-planning",
+          "agentSlugs": [
+            "delivery-lead"
+          ],
+          "resolved": true,
+          "catalogSkillId": "paperclipai:bundled:paperclip-operations:task-planning",
+          "catalogSkillKey": "paperclipai/bundled/paperclip-operations/task-planning"
+        },
+        {
+          "type": "local",
+          "ref": "software-sdlc",
+          "agentSlugs": [
+            "delivery-lead",
+            "implementer",
+            "security-reviewer",
+            "test-reviewer"
+          ],
+          "resolved": true,
+          "localPath": "skills/software-sdlc/SKILL.md"
+        }
+      ],
+      "envInputs": [],
+      "sourceRefs": [],
+      "files": [
+        {
+          "path": "TEAM.md",
+          "kind": "team",
+          "sizeBytes": 3430,
+          "sha256": "ab23dfed7c931a6fb775d3f798745c9eb17dbe170474dc4a7432bc85cb2d8074"
+        },
+        {
+          "path": "agents/delivery-lead/AGENTS.md",
+          "kind": "agent",
+          "sizeBytes": 824,
+          "sha256": "067b9c06f4e7f9d92c4de613b881c21a50b537d8eba8e10af63faf58f8927386"
+        },
+        {
+          "path": "agents/implementer/AGENTS.md",
+          "kind": "agent",
+          "sizeBytes": 768,
+          "sha256": "0aeaecfa99b214f14ca216526fcfaf6c3d9d0b6cf44f519c1dc4aaf491c91fb3"
+        },
+        {
+          "path": "agents/security-reviewer/AGENTS.md",
+          "kind": "agent",
+          "sizeBytes": 902,
+          "sha256": "4fb36affe85bac7b7340219377dcd1ca5051c80b8e344e4ccfdb1049eddcb9d8"
+        },
+        {
+          "path": "agents/test-reviewer/AGENTS.md",
+          "kind": "agent",
+          "sizeBytes": 793,
+          "sha256": "c300a5c5fdbe6d1c322b4e4cbfeaaf4082a68d0154e6795a346cc55cdc222579"
+        },
+        {
+          "path": "LICENSE.md",
+          "kind": "markdown",
+          "sizeBytes": 1069,
+          "sha256": "7f8a27f0979bded50e240caa8c8c29f3088ddf87032cb83e5a9732bff91d18b4"
+        },
+        {
+          "path": "projects/software-sdlc/PROJECT.md",
+          "kind": "project",
+          "sizeBytes": 616,
+          "sha256": "344f0d643ff37dc0a479553ad6df95c04f54ea2e8a347b9aead81065540b9819"
+        },
+        {
+          "path": "skills/software-sdlc/references/architecture.md",
+          "kind": "markdown",
+          "sizeBytes": 1078,
+          "sha256": "42e94f2dea63f5dadb795e7e696e647989338a89818f745e948af87726498a91"
+        },
+        {
+          "path": "skills/software-sdlc/references/implementation.md",
+          "kind": "markdown",
+          "sizeBytes": 1279,
+          "sha256": "ffa361239f1628e5225cde781f05fbdffb191b3176a997aeb1ba2d4a89d302f3"
+        },
+        {
+          "path": "skills/software-sdlc/references/release.md",
+          "kind": "markdown",
+          "sizeBytes": 1314,
+          "sha256": "daa4955651b769df9a91ab215bd332572f8781bceae096c6a7076caa949f5d06"
+        },
+        {
+          "path": "skills/software-sdlc/references/requirements.md",
+          "kind": "markdown",
+          "sizeBytes": 1225,
+          "sha256": "8bbff91a9948f3f0a42705fd46d29e8b4ad5ffe23e61cb29a53fbce9a989287d"
+        },
+        {
+          "path": "skills/software-sdlc/references/retrospective.md",
+          "kind": "markdown",
+          "sizeBytes": 1309,
+          "sha256": "2ebfa16acd3a518ee3f538adcc6cf037e69063bc9aa34ca590d2e2476f9f027d"
+        },
+        {
+          "path": "skills/software-sdlc/references/security-review.md",
+          "kind": "markdown",
+          "sizeBytes": 1488,
+          "sha256": "94c6eada3afc8d6f1790decb0bfcf5328e7c6911dabe74d56f3e6f488263c6dc"
+        },
+        {
+          "path": "skills/software-sdlc/references/testing.md",
+          "kind": "markdown",
+          "sizeBytes": 1608,
+          "sha256": "9342ee999f39cd1c363e8f69328c370c3a35d87dff8cd6d5bcbd6dd8f6416e46"
+        },
+        {
+          "path": "skills/software-sdlc/SKILL.md",
+          "kind": "skill",
+          "sizeBytes": 4839,
+          "sha256": "9a74472df7f1401c32822abd97934a62d7d1ffc025266fa1c4519cb0a418fcf4"
+        }
+      ],
+      "trustLevel": "markdown_only",
+      "compatibility": "compatible",
+      "contentHash": "sha256:0ecfe9eac9be709828ead7b164314ab26d15621c0a5c85197b92433db250d8a8"
     }
   ]
 }

--- a/packages/teams-catalog/generated/catalog.json
+++ b/packages/teams-catalog/generated/catalog.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "packageName": "@paperclipai/teams-catalog",
   "packageVersion": "0.1.0",
-  "generatedAt": "2026-09-05T08:52:03.975Z",
+  "generatedAt": "2026-09-05T10:06:51.996Z",
   "teams": [
     {
       "id": "paperclipai:bundled:company-defaults:core-exec-team",
@@ -602,44 +602,44 @@
         {
           "path": "skills/software-sdlc/references/architecture.md",
           "kind": "markdown",
-          "sizeBytes": 1078,
-          "sha256": "42e94f2dea63f5dadb795e7e696e647989338a89818f745e948af87726498a91"
+          "sizeBytes": 1491,
+          "sha256": "c8b82ae1263a4b65a7175afa2c51fca38146190db60c11956019fa7d25e51969"
         },
         {
           "path": "skills/software-sdlc/references/implementation.md",
           "kind": "markdown",
-          "sizeBytes": 1279,
-          "sha256": "ffa361239f1628e5225cde781f05fbdffb191b3176a997aeb1ba2d4a89d302f3"
+          "sizeBytes": 1692,
+          "sha256": "92facfe07622fe0c790d7aa58a3d18974cc7b78bf594dc7e6213c99e18995c3e"
         },
         {
           "path": "skills/software-sdlc/references/release.md",
           "kind": "markdown",
-          "sizeBytes": 1314,
-          "sha256": "daa4955651b769df9a91ab215bd332572f8781bceae096c6a7076caa949f5d06"
+          "sizeBytes": 1727,
+          "sha256": "8ee4b706a222dd67c51e55ed4ff13e2a45b870cb45fe838e3da89876f0268c25"
         },
         {
           "path": "skills/software-sdlc/references/requirements.md",
           "kind": "markdown",
-          "sizeBytes": 1225,
-          "sha256": "8bbff91a9948f3f0a42705fd46d29e8b4ad5ffe23e61cb29a53fbce9a989287d"
+          "sizeBytes": 1638,
+          "sha256": "c79b8bc54bb232dcbfc8e8fb1b28e96ded78bb4b4881c1e034832d0fdf90259d"
         },
         {
           "path": "skills/software-sdlc/references/retrospective.md",
           "kind": "markdown",
-          "sizeBytes": 1309,
-          "sha256": "2ebfa16acd3a518ee3f538adcc6cf037e69063bc9aa34ca590d2e2476f9f027d"
+          "sizeBytes": 1722,
+          "sha256": "6a28d4f0353a48f984dd29758ccc357244182ead44f6c28f292c5493949512d2"
         },
         {
           "path": "skills/software-sdlc/references/security-review.md",
           "kind": "markdown",
-          "sizeBytes": 1488,
-          "sha256": "94c6eada3afc8d6f1790decb0bfcf5328e7c6911dabe74d56f3e6f488263c6dc"
+          "sizeBytes": 1901,
+          "sha256": "95d993905ba2b4a75b7fcfb8cb6d7940b76ce4f44f6973e29f6bd5cb4bd5fe70"
         },
         {
           "path": "skills/software-sdlc/references/testing.md",
           "kind": "markdown",
-          "sizeBytes": 1608,
-          "sha256": "9342ee999f39cd1c363e8f69328c370c3a35d87dff8cd6d5bcbd6dd8f6416e46"
+          "sizeBytes": 2021,
+          "sha256": "6d18bbfb8a12731698f7697db62f9b947e4ed29d1e831646cf32651385adb864"
         },
         {
           "path": "skills/software-sdlc/SKILL.md",
@@ -650,7 +650,7 @@
       ],
       "trustLevel": "markdown_only",
       "compatibility": "compatible",
-      "contentHash": "sha256:0ecfe9eac9be709828ead7b164314ab26d15621c0a5c85197b92433db250d8a8"
+      "contentHash": "sha256:646431e9837ac95283d5ff988fb3a36ea811da4812a19bc54756d85774918a46"
     }
   ]
 }

--- a/packages/teams-catalog/src/shipped-catalog.test.ts
+++ b/packages/teams-catalog/src/shipped-catalog.test.ts
@@ -14,6 +14,7 @@ const EXPECTED_BUNDLED_KEYS = [
 
 const EXPECTED_OPTIONAL_KEYS = [
   "paperclipai/optional/content/content-machine",
+  "paperclipai/optional/software-development/software-sdlc",
 ];
 
 const PACKAGE_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");

--- a/packages/teams-catalog/src/software-sdlc.test.ts
+++ b/packages/teams-catalog/src/software-sdlc.test.ts
@@ -1,0 +1,75 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parseFrontmatterMarkdown } from "./frontmatter.js";
+import { resolveCatalogTeamRef } from "./index.js";
+
+const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const team = resolveCatalogTeamRef("software-sdlc")!;
+const phases = [
+  "requirements", "architecture", "implementation", "testing",
+  "security-review", "release", "retrospective",
+];
+
+function read(relativePath: string) {
+  return fs.readFileSync(path.join(packageDir, team.path, relativePath), "utf8");
+}
+
+describe("software-sdlc team pack", () => {
+  it("is opt-in content without starter work, executables, or external sources", () => {
+    expect(team).toMatchObject({
+      kind: "optional",
+      defaultInstall: false,
+      trustLevel: "markdown_only",
+      compatibility: "compatible",
+      counts: { agents: 4, projects: 1, tasks: 0, routines: 0, localSkills: 1, externalSkillSources: 0 },
+      envInputs: [],
+      sourceRefs: [],
+    });
+    expect(team.files.every((file) => file.path.endsWith(".md"))).toBe(true);
+    expect(team.rootAgentSlugs).toEqual(["delivery-lead"]);
+  });
+
+  it("resolves the local delivery method for every role", () => {
+    const method = team.requiredSkills.find((skill) => skill.type === "local");
+    expect(method).toMatchObject({
+      ref: "software-sdlc",
+      resolved: true,
+      localPath: "skills/software-sdlc/SKILL.md",
+      agentSlugs: [...team.agentSlugs].sort(),
+    });
+    for (const slug of team.agentSlugs) {
+      const { frontmatter } = parseFrontmatterMarkdown(read(`agents/${slug}/AGENTS.md`));
+      expect(frontmatter.skills).toContain("software-sdlc");
+      expect(frontmatter).not.toHaveProperty("permissions");
+      expect(frontmatter).not.toHaveProperty("adapterConfig");
+    }
+  });
+
+  it.each(phases)("ships a linked %s artifact with provenance and an exit contract", (phase) => {
+    const ref = `references/${phase}.md`;
+    expect(read("skills/software-sdlc/SKILL.md")).toContain(`](${ref})`);
+    const content = read(`skills/software-sdlc/${ref}`);
+    for (const heading of ["## Inputs", "## Provenance", "## Exit criteria", "## Handoff"]) {
+      expect(content).toContain(heading);
+    }
+    expect(content).toContain("Source revision:");
+    expect(content).toContain("Upstream artifact revisions:");
+    expect(content).toContain("Next owner:");
+  });
+
+  it("keeps every relative Markdown link within the pack and in the manifest", () => {
+    const inventory = new Set(team.files.map((file) => file.path));
+    for (const file of team.files) {
+      const content = read(file.path);
+      for (const match of content.matchAll(/\]\(([^)]+)\)/g)) {
+        const target = match[1]!;
+        if (/^https:\/\//.test(target)) continue;
+        const normalized = path.posix.normalize(path.posix.join(path.posix.dirname(file.path), target));
+        expect(normalized.startsWith("../")).toBe(false);
+        expect(inventory.has(normalized), `${file.path} -> ${target}`).toBe(true);
+      }
+    }
+  });
+});

--- a/packages/teams-catalog/src/software-sdlc.test.ts
+++ b/packages/teams-catalog/src/software-sdlc.test.ts
@@ -51,12 +51,16 @@ describe("software-sdlc team pack", () => {
     const ref = `references/${phase}.md`;
     expect(read("skills/software-sdlc/SKILL.md")).toContain(`](${ref})`);
     const content = read(`skills/software-sdlc/${ref}`);
-    for (const heading of ["## Inputs", "## Provenance", "## Exit criteria", "## Handoff"]) {
+    for (const heading of ["## Inputs", "## Provenance", "## Checks performed and findings", "## Exit criteria", "## Handoff"]) {
       expect(content).toContain(heading);
     }
-    expect(content).toContain("Source revision:");
-    expect(content).toContain("Upstream artifact revisions:");
-    expect(content).toContain("Next owner:");
+    for (const field of [
+      "Parent delivery issue:", "Producer:", "Source revision:",
+      "Upstream artifact revisions:", "Checks performed:", "Findings:",
+      "Evidence links:", "Next owner:",
+    ]) {
+      expect(content).toContain(field);
+    }
   });
 
   it("keeps every relative Markdown link within the pack and in the manifest", () => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages agent work through company-scoped issues, reviews, and artifacts.
> - Its Teams catalog already installs portable teams and their skills.
> - Software delivery also needs repeatable artifact handoffs across the lifecycle.
> - A small content pack can provide those handoffs without a new workflow engine.
> - This pull request adds an opt-in Software SDLC team and seven artifact templates.
> - The pack uses existing catalog, import, issue, document, and review surfaces.
> - It leaves command execution and mandatory completion enforcement out of scope.

## Linked Issues or Issue Description

Refs #3950. Related implementation: #3951.

I posted a coordination comment on #3950:
https://github.com/paperclipai/paperclip/issues/3950#issuecomment-5550711988

This pack does not close that issue or replace its workflow-template work.
It does not require the unmerged workflow API. The phase contracts can be
reused by a future invocation layer.

Separate proposals: #12880 (selective ECC import) and #12881 (deterministic
project checks). Neither is implemented by this PR.

## What Changed

- Add an optional software-development/software-sdlc team package.
- Add Delivery Lead, Implementer, Test Reviewer, and Security Reviewer roles.
- Add one project and a local Software SDLC skill.
- Add requirements, architecture, implementation, testing, security review,
  release, and retrospective artifact templates.
- Require source revisions, evidence, exit criteria, and named handoffs.
- Document native review use, missing evidence, stale reports, and release authority.
- Include the repository MIT notice in the portable content pack.
- Regenerate the catalog manifest and add ten focused regression tests.
- Add no UI code, dependency, migration, executable, credential, permission
  sidecar, starter task, or routine.

## Verification

Passed locally:

- Catalog manifest generation and validation against the source checkout.
- Teams catalog Vitest suite: 3 files, 20 tests passed.
- Teams catalog TypeScript typecheck and declaration build.
- git diff --check.

The checkout has no installed workspace dependencies. I installed isolated
test tools outside the checkout and copied the catalog package, shared
tsconfig, and skills manifest into that verification directory. The tests used
Node 26.3.0, Vitest 4.0.18, tsx 4.21.0, and TypeScript 5.9.3. No dependency or
lockfile change is included.

Commands to repeat with normal repository dependencies:

```sh
pnpm --filter @paperclipai/teams-catalog build:manifest
pnpm --filter @paperclipai/teams-catalog validate
pnpm --filter @paperclipai/teams-catalog test
pnpm --filter @paperclipai/teams-catalog typecheck
pnpm --filter @paperclipai/teams-catalog build
```

Not run: repository-wide typecheck, test:run, build, or a live install into a
company. These need the full workspace dependency setup. This PR remains a
draft for integration verification and maintainer scope review.

Manual integration steps, still to verify:

1. Open the Teams catalog and search for Software SDLC.
2. Preview installation into an isolated test company.
3. Verify four agents, one project, one local skill, and three catalog skills.
4. Verify the preview has no starter tasks, routines, or requested permission grants.
5. Install and inspect the skill references through the existing interface.
6. Assign a scoped delivery request and verify its owner can use the templates.

## Risks

- This is prompt-based content. It does not provide server-enforced gates.
- Catalog validation does not prove a model will follow every instruction.
- The pack creates four roles when all are selected. Existing teams can reuse
  the skill and map owners instead.
- Live company installation and full-repository integration checks are not
  verified yet.
- Maintainers may prefer a different packaging home or phase contract.

I read ROADMAP.md and CONTRIBUTING.md. This is a catalog-only draft, not
uncoordinated core workflow code. Discord #dev agreement has not been obtained.
I am asking for scope review before any core feature implementation.

## Model Used

- Provider: OpenAI.
- Product/model family: Codex.
- The exact serving model ID, context-window size, and reasoning setting are
  not exposed in this session.
- Assistance: repository inspection, original template authoring, TypeScript
  regression tests, local verification, and contribution preparation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
