### PR TITLE
feat: add soft-delete trash system for issues, agents, projects, and goals

### DIFF
--- a/packages/db/src/migrations/0047_soft_delete_trash.sql
+++ b/packages/db/src/migrations/0047_soft_delete_trash.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "agents" ADD COLUMN "deleted_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "goals" ADD COLUMN "deleted_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "projects" ADD COLUMN "deleted_at" timestamp with time zone;--> statement-breakpoint
+CREATE INDEX "agents_company_deleted_idx" ON "agents" ("company_id") WHERE "deleted_at" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX "goals_company_deleted_idx" ON "goals" ("company_id") WHERE "deleted_at" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX "projects_company_deleted_idx" ON "projects" ("company_id") WHERE "deleted_at" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX "issues_company_deleted_idx" ON "issues" ("company_id") WHERE "hidden_at" IS NOT NULL;

--- a/packages/db/src/migrations/0240_soft_delete_trash.sql
+++ b/packages/db/src/migrations/0240_soft_delete_trash.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "agents" ADD COLUMN "deleted_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "goals" ADD COLUMN "deleted_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "projects" ADD COLUMN "deleted_at" timestamp with time zone;--> statement-breakpoint
+CREATE INDEX "agents_company_deleted_idx" ON "agents" ("company_id") WHERE "deleted_at" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX "goals_company_deleted_idx" ON "goals" ("company_id") WHERE "deleted_at" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX "projects_company_deleted_idx" ON "projects" ("company_id") WHERE "deleted_at" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX "issues_company_deleted_idx" ON "issues" ("company_id") WHERE "hidden_at" IS NOT NULL;

--- a/packages/db/src/migrations/meta/_journal.json
+++ b/packages/db/src/migrations/meta/_journal.json
@@ -1667,6 +1667,13 @@
       "when": 1788557575279,
       "tag": "0239_sturdy_santa_claus",
       "breakpoints": true
+    },
+    {
+      "idx": 240,
+      "version": "7",
+      "when": 1775200800000,
+      "tag": "0240_soft_delete_trash",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/agents.ts
+++ b/packages/db/src/schema/agents.ts
@@ -35,6 +35,7 @@ export const agents = pgTable(
     permissions: jsonb("permissions").$type<Record<string, unknown>>().notNull().default({}),
     lastHeartbeatAt: timestamp("last_heartbeat_at", { withTimezone: true }),
     metadata: jsonb("metadata").$type<Record<string, unknown>>(),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/db/src/schema/goals.ts
+++ b/packages/db/src/schema/goals.ts
@@ -20,6 +20,7 @@ export const goals = pgTable(
     status: text("status").notNull().default("planned"),
     parentId: uuid("parent_id").references((): AnyPgColumn => goals.id),
     ownerAgentId: uuid("owner_agent_id").references(() => agents.id),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/packages/db/src/schema/projects.ts
+++ b/packages/db/src/schema/projects.ts
@@ -22,6 +22,7 @@ export const projects = pgTable(
     pausedAt: timestamp("paused_at", { withTimezone: true }),
     executionWorkspacePolicy: jsonb("execution_workspace_policy").$type<Record<string, unknown>>(),
     archivedAt: timestamp("archived_at", { withTimezone: true }),
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -81,6 +81,7 @@ import { llmRoutes } from "./routes/llms.js";
 import { authRoutes } from "./routes/auth.js";
 import { assetRoutes } from "./routes/assets.js";
 import { accessRoutes } from "./routes/access.js";
+import { trashRoutes } from "./routes/trash.js";
 import { pluginRoutes } from "./routes/plugins.js";
 import { mcpGatewayProtocolRoutes, toolGatewayRoutes } from "./routes/tool-gateway.js";
 import {
@@ -534,6 +535,7 @@ export async function createApp(
   }));
   api.use(executionWorkspaceRoutes(db, { pluginWorkerManager: workerManager }));
   api.use(goalRoutes(db));
+  api.use(trashRoutes(db, opts.storageService));
   api.use(onboardingSeedRoutes(db));
   api.use(boardChatRoutes(db, { deploymentMode: opts.deploymentMode }));
   api.use(approvalRoutes(db, { pluginWorkerManager: workerManager }));

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -5015,22 +5015,40 @@ export function agentRoutes(
     if (!(await getAccessibleAgent(req, res, id))) {
       return;
     }
-    const agent = await svc.remove(id);
-    if (!agent) {
-      res.status(404).json({ error: "Agent not found" });
-      return;
+
+    const permanent = req.query.permanent === "true";
+
+    if (permanent) {
+      const agent = await svc.remove(id);
+      if (!agent) {
+        res.status(404).json({ error: "Agent not found" });
+        return;
+      }
+      await logActivity(db, {
+        companyId: agent.companyId,
+        actorType: "user",
+        actorId: req.actor.userId ?? "board",
+        action: "agent.permanently_deleted",
+        entityType: "agent",
+        entityId: agent.id,
+      });
+      res.json({ ok: true });
+    } else {
+      const agent = await svc.softDelete(id);
+      if (!agent) {
+        res.status(404).json({ error: "Agent not found" });
+        return;
+      }
+      await logActivity(db, {
+        companyId: agent.companyId,
+        actorType: "user",
+        actorId: req.actor.userId ?? "board",
+        action: "agent.trashed",
+        entityType: "agent",
+        entityId: agent.id,
+      });
+      res.json(agent);
     }
-
-    await logActivity(db, {
-      companyId: agent.companyId,
-      actorType: "user",
-      actorId: req.actor.userId ?? "board",
-      action: "agent.deleted",
-      entityType: "agent",
-      entityId: agent.id,
-    });
-
-    res.json({ ok: true });
   });
 
   router.get("/agents/:id/keys", async (req, res) => {

--- a/server/src/routes/goals.ts
+++ b/server/src/routes/goals.ts
@@ -76,24 +76,44 @@ export function goalRoutes(db: Db) {
     const id = req.params.id as string;
     const existing = await getAccessibleResource(req, res, svc.getById(id), "Goal not found");
     if (!existing) return;
-    const goal = await svc.remove(id);
-    if (!goal) {
-      res.status(404).json({ error: "Goal not found" });
-      return;
+
+    const permanent = req.query.permanent === "true";
+
+    if (permanent) {
+      const goal = await svc.remove(id);
+      if (!goal) {
+        res.status(404).json({ error: "Goal not found" });
+        return;
+      }
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId: goal.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        action: "goal.permanently_deleted",
+        entityType: "goal",
+        entityId: goal.id,
+      });
+      res.json(goal);
+    } else {
+      const goal = await svc.softDelete(id);
+      if (!goal) {
+        res.status(404).json({ error: "Goal not found" });
+        return;
+      }
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId: goal.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        action: "goal.trashed",
+        entityType: "goal",
+        entityId: goal.id,
+      });
+      res.json(goal);
     }
-
-    const actor = getActorInfo(req);
-    await logActivity(db, {
-      companyId: goal.companyId,
-      actorType: actor.actorType,
-      actorId: actor.actorId,
-      agentId: actor.agentId,
-      action: "goal.deleted",
-      entityType: "goal",
-      entityId: goal.id,
-    });
-
-    res.json(goal);
   });
 
   return router;

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -11516,37 +11516,56 @@ export function issueRoutes(
     const existing = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
     if (!existing) return;
     if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
-    const attachments = await svc.listAttachments(id);
 
-    const issue = await svc.remove(id);
-    if (!issue) {
-      res.status(404).json({ error: "Issue not found" });
-      return;
-    }
+    const permanent = req.query.permanent === "true";
 
-    for (const attachment of attachments) {
-      try {
-        await storage.deleteObject(attachment.companyId, attachment.objectKey);
-      } catch (err) {
-        logger.warn({ err, issueId: id, attachmentId: attachment.id }, "failed to delete attachment object during issue delete");
+    if (permanent) {
+      const attachments = await svc.listAttachments(id);
+      const issue = await svc.remove(id);
+      if (!issue) {
+        res.status(404).json({ error: "Issue not found" });
+        return;
       }
+      for (const attachment of attachments) {
+        try {
+          await storage.deleteObject(attachment.companyId, attachment.objectKey);
+        } catch (err) {
+          logger.warn({ err, issueId: id, attachmentId: attachment.id }, "failed to delete attachment object during issue delete");
+        }
+      }
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId: issue.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        agentApiKeyId: actor.agentApiKeyId,
+        action: "issue.permanently_deleted",
+        entityType: "issue",
+        entityId: issue.id,
+      });
+      await queueTaskWatchdogEvaluation(existing, actor.runId);
+      res.json(issue);
+    } else {
+      const issue = await svc.softDelete(id);
+      if (!issue) {
+        res.status(404).json({ error: "Issue not found" });
+        return;
+      }
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId: issue.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: "issue.trashed",
+        entityType: "issue",
+        entityId: issue.id,
+      });
+      res.json(issue);
     }
-
-    const actor = getActorInfo(req);
-    await logActivity(db, {
-      companyId: issue.companyId,
-      actorType: actor.actorType,
-      actorId: actor.actorId,
-      agentId: actor.agentId,
-      runId: actor.runId,
-      agentApiKeyId: actor.agentApiKeyId,
-      action: "issue.deleted",
-      entityType: "issue",
-      entityId: issue.id,
-    });
-
-    await queueTaskWatchdogEvaluation(existing, actor.runId);
-    res.json(issue);
   });
 
   router.post("/issues/:id/checkout", validate(checkoutIssueSchema), async (req, res) => {

--- a/server/src/routes/projects.ts
+++ b/server/src/routes/projects.ts
@@ -710,24 +710,44 @@ export function projectRoutes(db: Db) {
     const id = req.params.id as string;
     const existing = await getAccessibleResource(req, res, svc.getById(id), "Project not found");
     if (!existing) return;
-    const project = await svc.remove(id);
-    if (!project) {
-      res.status(404).json({ error: "Project not found" });
-      return;
+
+    const permanent = req.query.permanent === "true";
+
+    if (permanent) {
+      const project = await svc.remove(id);
+      if (!project) {
+        res.status(404).json({ error: "Project not found" });
+        return;
+      }
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId: project.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        action: "project.permanently_deleted",
+        entityType: "project",
+        entityId: project.id,
+      });
+      res.json(project);
+    } else {
+      const project = await svc.softDelete(id);
+      if (!project) {
+        res.status(404).json({ error: "Project not found" });
+        return;
+      }
+      const actor = getActorInfo(req);
+      await logActivity(db, {
+        companyId: project.companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        action: "project.trashed",
+        entityType: "project",
+        entityId: project.id,
+      });
+      res.json(project);
     }
-
-    const actor = getActorInfo(req);
-    await logActivity(db, {
-      companyId: project.companyId,
-      actorType: actor.actorType,
-      actorId: actor.actorId,
-      agentId: actor.agentId,
-      action: "project.deleted",
-      entityType: "project",
-      entityId: project.id,
-    });
-
-    res.json(project);
   });
 
   return router;

--- a/server/src/routes/trash.ts
+++ b/server/src/routes/trash.ts
@@ -1,0 +1,223 @@
+import { Router } from "express";
+import { and, eq, isNotNull } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { issues, agents, projects, goals } from "@paperclipai/db";
+import type { StorageService } from "../storage/types.js";
+import {
+  agentService,
+  goalService,
+  issueService,
+  projectService,
+  logActivity,
+} from "../services/index.js";
+import { assertBoard, assertCompanyAccess, getActorInfo } from "./authz.js";
+import { logger } from "../middleware/logger.js";
+
+const VALID_ENTITY_TYPES = ["issue", "agent", "project", "goal"] as const;
+type TrashEntityType = (typeof VALID_ENTITY_TYPES)[number];
+
+function isValidEntityType(t: string): t is TrashEntityType {
+  return (VALID_ENTITY_TYPES as readonly string[]).includes(t);
+}
+
+export function trashRoutes(db: Db, storage: StorageService) {
+  const router = Router();
+  const issueSvc = issueService(db);
+  const agentSvc = agentService(db);
+  const projectSvc = projectService(db);
+  const goalSvc = goalService(db);
+
+  // List all trashed items for a company
+  router.get("/companies/:companyId/trash", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    assertBoard(req);
+
+    const entityType = typeof req.query.entityType === "string" ? req.query.entityType : undefined;
+
+    const result: Record<string, unknown[]> = {};
+
+    if (!entityType || entityType === "issue") {
+      result.issues = await db
+        .select()
+        .from(issues)
+        .where(and(eq(issues.companyId, companyId), isNotNull(issues.hiddenAt)));
+    }
+
+    if (!entityType || entityType === "agent") {
+      result.agents = await db
+        .select()
+        .from(agents)
+        .where(and(eq(agents.companyId, companyId), isNotNull(agents.deletedAt)));
+    }
+
+    if (!entityType || entityType === "project") {
+      result.projects = await db
+        .select()
+        .from(projects)
+        .where(and(eq(projects.companyId, companyId), isNotNull(projects.deletedAt)));
+    }
+
+    if (!entityType || entityType === "goal") {
+      result.goals = await db
+        .select()
+        .from(goals)
+        .where(and(eq(goals.companyId, companyId), isNotNull(goals.deletedAt)));
+    }
+
+    res.json(result);
+  });
+
+  // Restore a trashed item
+  router.post("/trash/:entityType/:entityId/restore", async (req, res) => {
+    const { entityType, entityId } = req.params;
+    assertBoard(req);
+
+    if (!isValidEntityType(entityType)) {
+      res.status(400).json({ error: `Invalid entity type: ${entityType}. Valid types: ${VALID_ENTITY_TYPES.join(", ")}` });
+      return;
+    }
+
+    const actor = getActorInfo(req);
+    let restored: unknown = null;
+    let companyId: string | null = null;
+
+    switch (entityType) {
+      case "issue": {
+        const issue = await issueSvc.restore(entityId);
+        if (!issue) {
+          res.status(404).json({ error: "Issue not found" });
+          return;
+        }
+        companyId = issue.companyId;
+        restored = issue;
+        break;
+      }
+      case "agent": {
+        const agent = await agentSvc.restore(entityId);
+        if (!agent) {
+          res.status(404).json({ error: "Agent not found" });
+          return;
+        }
+        companyId = agent.companyId;
+        restored = agent;
+        break;
+      }
+      case "project": {
+        const project = await projectSvc.restore(entityId);
+        if (!project) {
+          res.status(404).json({ error: "Project not found" });
+          return;
+        }
+        companyId = project.companyId;
+        restored = project;
+        break;
+      }
+      case "goal": {
+        const goal = await goalSvc.restore(entityId);
+        if (!goal) {
+          res.status(404).json({ error: "Goal not found" });
+          return;
+        }
+        companyId = goal.companyId;
+        restored = goal;
+        break;
+      }
+    }
+
+    if (companyId) {
+      assertCompanyAccess(req, companyId);
+      await logActivity(db, {
+        companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: `${entityType}.restored`,
+        entityType,
+        entityId,
+      });
+    }
+
+    res.json(restored);
+  });
+
+  // Permanently delete a trashed item
+  router.delete("/trash/:entityType/:entityId", async (req, res) => {
+    const { entityType, entityId } = req.params;
+    assertBoard(req);
+
+    if (!isValidEntityType(entityType)) {
+      res.status(400).json({ error: `Invalid entity type: ${entityType}. Valid types: ${VALID_ENTITY_TYPES.join(", ")}` });
+      return;
+    }
+
+    const actor = getActorInfo(req);
+    let companyId: string | null = null;
+
+    switch (entityType) {
+      case "issue": {
+        const attachments = await issueSvc.listAttachments(entityId);
+        const issue = await issueSvc.remove(entityId);
+        if (!issue) {
+          res.status(404).json({ error: "Issue not found" });
+          return;
+        }
+        companyId = issue.companyId;
+        for (const attachment of attachments) {
+          try {
+            await storage.deleteObject(attachment.companyId, attachment.objectKey);
+          } catch (err) {
+            logger.warn({ err, issueId: entityId, attachmentId: attachment.id }, "failed to delete attachment during trash purge");
+          }
+        }
+        break;
+      }
+      case "agent": {
+        const agent = await agentSvc.remove(entityId);
+        if (!agent) {
+          res.status(404).json({ error: "Agent not found" });
+          return;
+        }
+        companyId = agent.companyId;
+        break;
+      }
+      case "project": {
+        const project = await projectSvc.remove(entityId);
+        if (!project) {
+          res.status(404).json({ error: "Project not found" });
+          return;
+        }
+        companyId = project.companyId;
+        break;
+      }
+      case "goal": {
+        const goal = await goalSvc.remove(entityId);
+        if (!goal) {
+          res.status(404).json({ error: "Goal not found" });
+          return;
+        }
+        companyId = goal.companyId;
+        break;
+      }
+    }
+
+    if (companyId) {
+      assertCompanyAccess(req, companyId);
+      await logActivity(db, {
+        companyId,
+        actorType: actor.actorType,
+        actorId: actor.actorId,
+        agentId: actor.agentId,
+        runId: actor.runId,
+        action: `${entityType}.permanently_deleted`,
+        entityType,
+        entityId,
+      });
+    }
+
+    res.json({ ok: true });
+  });
+
+  return router;
+}

--- a/server/src/routes/trash.ts
+++ b/server/src/routes/trash.ts
@@ -35,37 +35,49 @@ export function trashRoutes(db: Db, storage: StorageService) {
 
     const entityType = typeof req.query.entityType === "string" ? req.query.entityType : undefined;
 
-    const result: Record<string, unknown[]> = {};
+    const items: { entityType: string; entityId: string; name: string; deletedAt: Date | null }[] = [];
 
     if (!entityType || entityType === "issue") {
-      result.issues = await db
+      const rows = await db
         .select()
         .from(issues)
         .where(and(eq(issues.companyId, companyId), isNotNull(issues.hiddenAt)));
+      for (const row of rows) {
+        items.push({ entityType: "issue", entityId: row.id, name: row.title, deletedAt: row.hiddenAt });
+      }
     }
 
     if (!entityType || entityType === "agent") {
-      result.agents = await db
+      const rows = await db
         .select()
         .from(agents)
         .where(and(eq(agents.companyId, companyId), isNotNull(agents.deletedAt)));
+      for (const row of rows) {
+        items.push({ entityType: "agent", entityId: row.id, name: row.name, deletedAt: row.deletedAt });
+      }
     }
 
     if (!entityType || entityType === "project") {
-      result.projects = await db
+      const rows = await db
         .select()
         .from(projects)
         .where(and(eq(projects.companyId, companyId), isNotNull(projects.deletedAt)));
+      for (const row of rows) {
+        items.push({ entityType: "project", entityId: row.id, name: row.name, deletedAt: row.deletedAt });
+      }
     }
 
     if (!entityType || entityType === "goal") {
-      result.goals = await db
+      const rows = await db
         .select()
         .from(goals)
         .where(and(eq(goals.companyId, companyId), isNotNull(goals.deletedAt)));
+      for (const row of rows) {
+        items.push({ entityType: "goal", entityId: row.id, name: row.title, deletedAt: row.deletedAt });
+      }
     }
 
-    res.json(result);
+    res.json(items);
   });
 
   // Restore a trashed item
@@ -79,65 +91,56 @@ export function trashRoutes(db: Db, storage: StorageService) {
     }
 
     const actor = getActorInfo(req);
-    let restored: unknown = null;
     let companyId: string | null = null;
 
+    // Look up entity first to get companyId, then assert access before mutating
     switch (entityType) {
       case "issue": {
-        const issue = await issueSvc.restore(entityId);
-        if (!issue) {
-          res.status(404).json({ error: "Issue not found" });
-          return;
-        }
-        companyId = issue.companyId;
-        restored = issue;
+        const existing = await issueSvc.getById(entityId);
+        if (!existing) { res.status(404).json({ error: "Issue not found" }); return; }
+        companyId = existing.companyId;
         break;
       }
       case "agent": {
-        const agent = await agentSvc.restore(entityId);
-        if (!agent) {
-          res.status(404).json({ error: "Agent not found" });
-          return;
-        }
-        companyId = agent.companyId;
-        restored = agent;
+        const existing = await agentSvc.getById(entityId);
+        if (!existing) { res.status(404).json({ error: "Agent not found" }); return; }
+        companyId = existing.companyId;
         break;
       }
       case "project": {
-        const project = await projectSvc.restore(entityId);
-        if (!project) {
-          res.status(404).json({ error: "Project not found" });
-          return;
-        }
-        companyId = project.companyId;
-        restored = project;
+        const existing = await projectSvc.getById(entityId);
+        if (!existing) { res.status(404).json({ error: "Project not found" }); return; }
+        companyId = existing.companyId;
         break;
       }
       case "goal": {
-        const goal = await goalSvc.restore(entityId);
-        if (!goal) {
-          res.status(404).json({ error: "Goal not found" });
-          return;
-        }
-        companyId = goal.companyId;
-        restored = goal;
+        const existing = await goalSvc.getById(entityId);
+        if (!existing) { res.status(404).json({ error: "Goal not found" }); return; }
+        companyId = existing.companyId;
         break;
       }
     }
 
-    if (companyId) {
-      assertCompanyAccess(req, companyId);
-      await logActivity(db, {
-        companyId,
-        actorType: actor.actorType,
-        actorId: actor.actorId,
-        agentId: actor.agentId,
-        runId: actor.runId,
-        action: `${entityType}.restored`,
-        entityType,
-        entityId,
-      });
+    assertCompanyAccess(req, companyId!);
+
+    let restored: unknown = null;
+    switch (entityType) {
+      case "issue": restored = await issueSvc.restore(entityId); break;
+      case "agent": restored = await agentSvc.restore(entityId); break;
+      case "project": restored = await projectSvc.restore(entityId); break;
+      case "goal": restored = await goalSvc.restore(entityId); break;
     }
+
+    await logActivity(db, {
+      companyId: companyId!,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: `${entityType}.restored`,
+      entityType,
+      entityId,
+    });
 
     res.json(restored);
   });
@@ -155,15 +158,40 @@ export function trashRoutes(db: Db, storage: StorageService) {
     const actor = getActorInfo(req);
     let companyId: string | null = null;
 
+    // Look up entity first to get companyId, then assert access before mutating
+    switch (entityType) {
+      case "issue": {
+        const existing = await issueSvc.getById(entityId);
+        if (!existing) { res.status(404).json({ error: "Issue not found" }); return; }
+        companyId = existing.companyId;
+        break;
+      }
+      case "agent": {
+        const existing = await agentSvc.getById(entityId);
+        if (!existing) { res.status(404).json({ error: "Agent not found" }); return; }
+        companyId = existing.companyId;
+        break;
+      }
+      case "project": {
+        const existing = await projectSvc.getById(entityId);
+        if (!existing) { res.status(404).json({ error: "Project not found" }); return; }
+        companyId = existing.companyId;
+        break;
+      }
+      case "goal": {
+        const existing = await goalSvc.getById(entityId);
+        if (!existing) { res.status(404).json({ error: "Goal not found" }); return; }
+        companyId = existing.companyId;
+        break;
+      }
+    }
+
+    assertCompanyAccess(req, companyId!);
+
     switch (entityType) {
       case "issue": {
         const attachments = await issueSvc.listAttachments(entityId);
-        const issue = await issueSvc.remove(entityId);
-        if (!issue) {
-          res.status(404).json({ error: "Issue not found" });
-          return;
-        }
-        companyId = issue.companyId;
+        await issueSvc.remove(entityId);
         for (const attachment of attachments) {
           try {
             await storage.deleteObject(attachment.companyId, attachment.objectKey);
@@ -173,48 +201,21 @@ export function trashRoutes(db: Db, storage: StorageService) {
         }
         break;
       }
-      case "agent": {
-        const agent = await agentSvc.remove(entityId);
-        if (!agent) {
-          res.status(404).json({ error: "Agent not found" });
-          return;
-        }
-        companyId = agent.companyId;
-        break;
-      }
-      case "project": {
-        const project = await projectSvc.remove(entityId);
-        if (!project) {
-          res.status(404).json({ error: "Project not found" });
-          return;
-        }
-        companyId = project.companyId;
-        break;
-      }
-      case "goal": {
-        const goal = await goalSvc.remove(entityId);
-        if (!goal) {
-          res.status(404).json({ error: "Goal not found" });
-          return;
-        }
-        companyId = goal.companyId;
-        break;
-      }
+      case "agent": await agentSvc.remove(entityId); break;
+      case "project": await projectSvc.remove(entityId); break;
+      case "goal": await goalSvc.remove(entityId); break;
     }
 
-    if (companyId) {
-      assertCompanyAccess(req, companyId);
-      await logActivity(db, {
-        companyId,
-        actorType: actor.actorType,
-        actorId: actor.actorId,
-        agentId: actor.agentId,
-        runId: actor.runId,
-        action: `${entityType}.permanently_deleted`,
-        entityType,
-        entityId,
-      });
-    }
+    await logActivity(db, {
+      companyId: companyId!,
+      actorType: actor.actorType,
+      actorId: actor.actorId,
+      agentId: actor.agentId,
+      runId: actor.runId,
+      action: `${entityType}.permanently_deleted`,
+      entityType,
+      entityId,
+    });
 
     res.json({ ok: true });
   });

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -1,5 +1,5 @@
 import { createHash, randomBytes } from "node:crypto";
-import { and, desc, eq, gte, inArray, lt, ne, or, sql } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, isNull, lt, ne, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   agents,
@@ -777,10 +777,13 @@ export function agentService(db: Db) {
   }
 
   return {
-    list: async (companyId: string, options?: { includeTerminated?: boolean }) => {
+    list: async (companyId: string, options?: { includeTerminated?: boolean; includeDeleted?: boolean }) => {
       const conditions = [eq(agents.companyId, companyId)];
       if (!options?.includeTerminated) {
         conditions.push(ne(agents.status, "terminated"));
+      }
+      if (!options?.includeDeleted) {
+        conditions.push(isNull(agents.deletedAt));
       }
       const [rows, allCompanyRows] = await Promise.all([
         db.select().from(agents).where(and(...conditions)),
@@ -950,6 +953,28 @@ export function agentService(db: Db) {
         .where(eq(agentApiKeys.agentId, id));
 
       return getById(id);
+    },
+
+    softDelete: async (id: string) => {
+      const existing = await getById(id);
+      if (!existing) return null;
+      const updated = await db
+        .update(agents)
+        .set({ deletedAt: new Date(), updatedAt: new Date() })
+        .where(and(eq(agents.id, id), isNull(agents.deletedAt)))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+      return updated ? normalizeAgentRow(updated) : null;
+    },
+
+    restore: async (id: string) => {
+      const updated = await db
+        .update(agents)
+        .set({ deletedAt: null, updatedAt: new Date() })
+        .where(eq(agents.id, id))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+      return updated ? normalizeAgentRow(updated) : null;
     },
 
     remove: async (id: string) => {

--- a/server/src/services/goals.ts
+++ b/server/src/services/goals.ts
@@ -14,6 +14,7 @@ export async function getDefaultCompanyGoal(db: GoalReader, companyId: string) {
         eq(goals.level, "company"),
         eq(goals.status, "active"),
         isNull(goals.parentId),
+        isNull(goals.deletedAt),
       ),
     )
     .orderBy(asc(goals.createdAt))
@@ -28,6 +29,7 @@ export async function getDefaultCompanyGoal(db: GoalReader, companyId: string) {
         eq(goals.companyId, companyId),
         eq(goals.level, "company"),
         isNull(goals.parentId),
+        isNull(goals.deletedAt),
       ),
     )
     .orderBy(asc(goals.createdAt))
@@ -37,14 +39,20 @@ export async function getDefaultCompanyGoal(db: GoalReader, companyId: string) {
   return db
     .select()
     .from(goals)
-    .where(and(eq(goals.companyId, companyId), eq(goals.level, "company")))
+    .where(and(eq(goals.companyId, companyId), eq(goals.level, "company"), isNull(goals.deletedAt)))
     .orderBy(asc(goals.createdAt))
     .then((rows) => rows[0] ?? null);
 }
 
 export function goalService(db: Db) {
   return {
-    list: (companyId: string) => db.select().from(goals).where(eq(goals.companyId, companyId)),
+    list: (companyId: string, options?: { includeDeleted?: boolean }) => {
+      const conditions = [eq(goals.companyId, companyId)];
+      if (!options?.includeDeleted) {
+        conditions.push(isNull(goals.deletedAt));
+      }
+      return db.select().from(goals).where(and(...conditions));
+    },
 
     getById: (id: string) =>
       db
@@ -69,6 +77,26 @@ export function goalService(db: Db) {
         .where(eq(goals.id, id))
         .returning()
         .then((rows) => rows[0] ?? null),
+
+    softDelete: async (id: string) => {
+      const updated = await db
+        .update(goals)
+        .set({ deletedAt: new Date(), updatedAt: new Date() })
+        .where(and(eq(goals.id, id), isNull(goals.deletedAt)))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+      return updated;
+    },
+
+    restore: async (id: string) => {
+      const updated = await db
+        .update(goals)
+        .set({ deletedAt: null, updatedAt: new Date() })
+        .where(eq(goals.id, id))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+      return updated;
+    },
 
     remove: (id: string) =>
       db

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -8254,6 +8254,30 @@ export function issueService(db: Db) {
       return cleared;
     },
 
+    softDelete: async (id: string) => {
+      const updated = await db
+        .update(issues)
+        .set({ hiddenAt: new Date(), updatedAt: new Date() })
+        .where(and(eq(issues.id, id), isNull(issues.hiddenAt)))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+      if (!updated) return null;
+      const [enriched] = await withIssueLabels(db, [updated]);
+      return enriched;
+    },
+
+    restore: async (id: string) => {
+      const updated = await db
+        .update(issues)
+        .set({ hiddenAt: null, updatedAt: new Date() })
+        .where(eq(issues.id, id))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+      if (!updated) return null;
+      const [enriched] = await withIssueLabels(db, [updated]);
+      return enriched;
+    },
+
     remove: (id: string) =>
       db.transaction(async (tx) => {
         const attachmentAssetIds = await tx

--- a/server/src/services/projects.ts
+++ b/server/src/services/projects.ts
@@ -620,17 +620,21 @@ export function projectService(db: Db) {
   };
 
   return {
-    list: async (companyId: string, opts: { includeArchived?: boolean } = {}): Promise<ProjectWithGoals[]> => {
+    list: async (companyId: string, opts: { includeArchived?: boolean; includeDeleted?: boolean } = {}): Promise<ProjectWithGoals[]> => {
       // NOTE: this service default is intentionally the inverse of the HTTP route default.
       // The route (`GET /companies/:companyId/projects`) defaults `includeArchived` to `false`
       // (active-only) for its callers, but the service defaults to `true` so that existing
       // server-internal callers that pass no opts keep their pre-existing "return everything,
       // including archived" behaviour. Pass `{ includeArchived: false }` explicitly for active-only.
       const includeArchived = opts.includeArchived ?? true;
-      const where = includeArchived
-        ? eq(projects.companyId, companyId)
-        : and(eq(projects.companyId, companyId), isNull(projects.archivedAt));
-      const rows = await db.select().from(projects).where(where);
+      const conditions = [eq(projects.companyId, companyId)];
+      if (!includeArchived) {
+        conditions.push(isNull(projects.archivedAt));
+      }
+      if (!opts.includeDeleted) {
+        conditions.push(isNull(projects.deletedAt));
+      }
+      const rows = await db.select().from(projects).where(and(...conditions));
       const withGoals = await attachGoals(db, rows);
       const withWorkspaces = await attachWorkspaces(db, withGoals);
       return attachListMetrics(db, companyId, withWorkspaces);
@@ -897,6 +901,28 @@ export function projectService(db: Db) {
       }
 
       return cleared;
+    },
+
+    softDelete: async (id: string) => {
+      const row = await db
+        .update(projects)
+        .set({ deletedAt: new Date(), updatedAt: new Date() })
+        .where(and(eq(projects.id, id), isNull(projects.deletedAt)))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+      if (!row) return null;
+      return { ...row, urlKey: deriveProjectUrlKey(row.name, row.id) };
+    },
+
+    restore: async (id: string) => {
+      const row = await db
+        .update(projects)
+        .set({ deletedAt: null, updatedAt: new Date() })
+        .where(eq(projects.id, id))
+        .returning()
+        .then((rows) => rows[0] ?? null);
+      if (!row) return null;
+      return { ...row, urlKey: deriveProjectUrlKey(row.name, row.id) };
     },
 
     remove: (id: string) =>

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -93,6 +93,8 @@ import { CliAuthPage } from "./pages/CliAuth";
 import { InviteLandingPage } from "./pages/InviteLanding";
 import { JoinRequestQueue } from "./pages/JoinRequestQueue";
 import { NotFoundPage } from "./pages/NotFound";
+import { TrashPage } from "./pages/TrashPage";
+import { queryKeys } from "./lib/queryKeys";
 import { useCompany } from "./context/CompanyContext";
 import { useDialogActions, useDialogState } from "./context/DialogContext";
 import { loadLastInboxTab } from "./lib/inbox";
@@ -413,6 +415,7 @@ function boardRoutes(streamlinedUiEnabled: boolean) {
       <Route path="inbox/all" element={<Inbox />} />
       <Route path="inbox/requests" element={<JoinRequestQueue />} />
       <Route path="inbox/new" element={<Navigate to="/inbox/mine" replace />} />
+      <Route path="trash" element={<TrashPage />} />
       <Route path="u/:userSlug" element={<UserProfile />} />
       <Route path="design-guide" element={<DesignGuide />} />
       <Route path="instance/settings/adapters" element={<AdapterManager />} />

--- a/ui/src/api/index.ts
+++ b/ui/src/api/index.ts
@@ -21,3 +21,5 @@ export { sidebarPreferencesApi } from "./sidebarPreferences";
 export { resourceMembershipsApi } from "./resourceMemberships";
 export { inboxDismissalsApi } from "./inboxDismissals";
 export { companySkillsApi } from "./companySkills";
+export { trashApi } from "./trash";
+export type { TrashItem, TrashEntityType } from "./trash";

--- a/ui/src/api/trash.ts
+++ b/ui/src/api/trash.ts
@@ -1,0 +1,21 @@
+import { api } from "./client";
+
+export type TrashEntityType = "issue" | "agent" | "project" | "goal";
+
+export interface TrashItem {
+  entityType: TrashEntityType;
+  entityId: string;
+  name: string;
+  deletedAt: string;
+}
+
+export const trashApi = {
+  list: (companyId: string, entityType?: TrashEntityType) => {
+    const qs = entityType ? `?entityType=${entityType}` : "";
+    return api.get<TrashItem[]>(`/companies/${companyId}/trash${qs}`);
+  },
+  restore: (entityType: TrashEntityType, entityId: string) =>
+    api.post<{ ok: true }>(`/trash/${entityType}/${entityId}/restore`, {}),
+  deletePermanently: (entityType: TrashEntityType, entityId: string) =>
+    api.delete<{ ok: true }>(`/trash/${entityType}/${entityId}`),
+};

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -21,6 +21,7 @@ import {
   GanttChartSquare,
   LayoutGrid,
   Users,
+  Trash2,
 } from "lucide-react";
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
@@ -260,6 +261,7 @@ export function Sidebar() {
               <SidebarNavItem to="/costs" label="Costs" icon={DollarSign} />
               <SidebarNavItem to="/activity" label="Activity" icon={History} />
               <SidebarNavItem to="/company/settings" label="Settings" icon={Settings} />
+              <SidebarNavItem to="/trash" label="Trash" icon={Trash2} />
             </SidebarSection>
           </>
         )}

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -684,6 +684,9 @@ export const queryKeys = {
   skills: {
     available: ["skills", "available"] as const,
   },
+  trash: {
+    list: (companyId: string, entityType?: string) => ["trash", companyId, entityType ?? "all"] as const,
+  },
   plugins: {
     all: ["plugins"] as const,
     examples: ["plugins", "examples"] as const,

--- a/ui/src/pages/TrashPage.tsx
+++ b/ui/src/pages/TrashPage.tsx
@@ -1,0 +1,193 @@
+import { useEffect, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Trash2, RotateCcw, CircleDot, Bot, FolderKanban, Target } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { trashApi } from "../api/trash";
+import type { TrashEntityType, TrashItem } from "../api/trash";
+import { useCompany } from "../context/CompanyContext";
+import { useBreadcrumbs } from "../context/BreadcrumbContext";
+import { queryKeys } from "../lib/queryKeys";
+import { EmptyState } from "../components/EmptyState";
+import { PageSkeleton } from "../components/PageSkeleton";
+import { Button } from "@/components/ui/button";
+import { cn } from "../lib/utils";
+
+const ENTITY_LABELS: Record<TrashEntityType, string> = {
+  issue: "Issue",
+  agent: "Agent",
+  project: "Project",
+  goal: "Goal",
+};
+
+const ENTITY_ICONS: Record<TrashEntityType, LucideIcon> = {
+  issue: CircleDot,
+  agent: Bot,
+  project: FolderKanban,
+  goal: Target,
+};
+
+const FILTER_OPTIONS: Array<{ value: TrashEntityType | "all"; label: string }> = [
+  { value: "all", label: "Todos" },
+  { value: "issue", label: "Issues" },
+  { value: "agent", label: "Agents" },
+  { value: "project", label: "Projects" },
+  { value: "goal", label: "Goals" },
+];
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString("pt-BR", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+export function TrashPage() {
+  const { selectedCompanyId } = useCompany();
+  const { setBreadcrumbs } = useBreadcrumbs();
+  const queryClient = useQueryClient();
+  const [filter, setFilter] = useState<TrashEntityType | "all">("all");
+  const [confirmDelete, setConfirmDelete] = useState<TrashItem | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setBreadcrumbs([{ label: "Lixeira" }]);
+  }, [setBreadcrumbs]);
+
+  const entityTypeParam = filter === "all" ? undefined : filter;
+
+  const { data: items, isLoading, error } = useQuery({
+    queryKey: queryKeys.trash.list(selectedCompanyId!, filter),
+    queryFn: () => trashApi.list(selectedCompanyId!, entityTypeParam),
+    enabled: !!selectedCompanyId,
+  });
+
+  const restoreMutation = useMutation({
+    mutationFn: (item: TrashItem) => trashApi.restore(item.entityType, item.entityId),
+    onSuccess: () => {
+      setActionError(null);
+      queryClient.invalidateQueries({ queryKey: queryKeys.trash.list(selectedCompanyId!, filter) });
+    },
+    onError: (err) => {
+      setActionError(err instanceof Error ? err.message : "Falha ao restaurar item");
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (item: TrashItem) => trashApi.deletePermanently(item.entityType, item.entityId),
+    onSuccess: () => {
+      setActionError(null);
+      setConfirmDelete(null);
+      queryClient.invalidateQueries({ queryKey: queryKeys.trash.list(selectedCompanyId!, filter) });
+    },
+    onError: (err) => {
+      setActionError(err instanceof Error ? err.message : "Falha ao excluir item");
+    },
+  });
+
+  if (!selectedCompanyId) {
+    return <EmptyState icon={Trash2} message="Selecione uma empresa para ver a lixeira." />;
+  }
+
+  if (isLoading) {
+    return <PageSkeleton variant="list" />;
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Filter tabs */}
+      <div className="flex items-center gap-1 border-b border-border pb-1">
+        {FILTER_OPTIONS.map((opt) => (
+          <button
+            key={opt.value}
+            onClick={() => setFilter(opt.value)}
+            className={cn(
+              "px-3 py-1.5 text-sm font-medium transition-colors",
+              filter === opt.value
+                ? "text-foreground border-b-2 border-foreground -mb-[5px]"
+                : "text-muted-foreground hover:text-foreground"
+            )}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+
+      {error && <p className="text-sm text-destructive">{error.message}</p>}
+      {actionError && <p className="text-sm text-destructive">{actionError}</p>}
+
+      {items && items.length === 0 && (
+        <EmptyState icon={Trash2} message="A lixeira está vazia." />
+      )}
+
+      {items && items.length > 0 && (
+        <div className="divide-y divide-border rounded-lg border border-border">
+          {items.map((item) => {
+            const Icon = ENTITY_ICONS[item.entityType];
+            return (
+              <div key={`${item.entityType}-${item.entityId}`} className="flex items-center gap-3 px-4 py-3">
+                <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium truncate">{item.name}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {ENTITY_LABELS[item.entityType]} · Excluído em {formatDate(item.deletedAt)}
+                  </p>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => restoreMutation.mutate(item)}
+                    disabled={restoreMutation.isPending}
+                  >
+                    <RotateCcw className="h-3.5 w-3.5 mr-1.5" />
+                    Restaurar
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    onClick={() => setConfirmDelete(item)}
+                    disabled={deleteMutation.isPending}
+                  >
+                    <Trash2 className="h-3.5 w-3.5 mr-1.5" />
+                    Excluir
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Confirmation dialog */}
+      {confirmDelete && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="rounded-lg border border-border bg-card p-6 max-w-sm w-full mx-4 shadow-lg">
+            <h2 className="text-base font-semibold mb-2">Excluir permanentemente?</h2>
+            <p className="text-sm text-muted-foreground mb-4">
+              <span className="font-medium text-foreground">{confirmDelete.name}</span> será excluído permanentemente e não poderá ser recuperado.
+            </p>
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setConfirmDelete(null)}
+                disabled={deleteMutation.isPending}
+              >
+                Cancelar
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() => deleteMutation.mutate(confirmDelete)}
+                disabled={deleteMutation.isPending}
+              >
+                Excluir permanentemente
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements a complete trash/soft-delete system for Paperclip (resolves [VIS-12](https://github.com/paperclipai/paperclip) — feature request from the Visionarium company instance).

### What this adds

- **Soft-delete** for issues, agents, projects, and goals (sets `deletedAt`/`hiddenAt` instead of hard-deleting)
- **Trash API**: `GET /api/companies/:companyId/trash` — list trashed items (filter by `?entityType=issue|agent|project|goal`)
- **Restore**: `POST /api/trash/:entityType/:entityId/restore`
- **Permanent delete**: `DELETE /api/trash/:entityType/:entityId`
- **Backward-compatible DELETE routes**: all existing `DELETE /issues/:id`, `DELETE /agents/:id`, etc. now do soft-delete by default; add `?permanent=true` for hard delete
- **Trash UI page**: accessible at `/trash` in the sidebar

### DB changes

- Migration `0240_soft_delete_trash.sql`: adds `deleted_at` column to `agents`, `goals`, `projects` tables with partial indices
- Issues reuse the existing `hidden_at` column (already filtered in queries)

### Activity log actions

- `*.trashed` — moved to trash
- `*.restored` — restored from trash  
- `*.permanently_deleted` — purged permanently

Co-Authored-By: Paperclip <noreply@paperclip.ing>