### PR TITLE
fix(heartbeat): trust the adapter's own outcome instead of re-checking exit code

### DIFF
--- a/server/src/services/heartbeat-stop-metadata.test.ts
+++ b/server/src/services/heartbeat-stop-metadata.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildHeartbeatRunStopMetadata,
   mergeHeartbeatRunStopMetadata,
+  resolveAdapterRunOutcome,
   resolveHeartbeatRunTimeoutPolicy,
 } from "./heartbeat-stop-metadata.js";
 
@@ -127,6 +128,44 @@ describe("heartbeat stop metadata", () => {
       timeoutConfigured: true,
       timeoutSource: "default",
       timeoutFired: false,
+    });
+  });
+
+  describe("resolveAdapterRunOutcome", () => {
+    it("trusts the adapter's own verdict over a nonzero exit code left by our own cleanup kill", () => {
+      // Regression for SHIP-1350: terminalResultCleanup SIGTERMs a child after it
+      // already emitted a clean terminal result. The adapter treats that as not
+      // failed (no errorMessage), but the process still exits 143. Gating success
+      // on exitCode === 0 here re-introduces the misclassification the adapter
+      // layer already fixed, and it falls through inferHeartbeatRunStopReason's
+      // fallback to "adapter_failed" for a run that actually completed.
+      expect(
+        resolveAdapterRunOutcome({
+          timedOut: false,
+          exitCode: 143,
+          errorMessage: null,
+        }),
+      ).toBe("succeeded");
+    });
+
+    it("still fails a nonzero exit when the adapter reports an error", () => {
+      expect(
+        resolveAdapterRunOutcome({
+          timedOut: false,
+          exitCode: 1,
+          errorMessage: "Claude exited with code 1",
+        }),
+      ).toBe("failed");
+    });
+
+    it("prefers timed_out over exit code or error message", () => {
+      expect(
+        resolveAdapterRunOutcome({
+          timedOut: true,
+          exitCode: 143,
+          errorMessage: null,
+        }),
+      ).toBe("timed_out");
     });
   });
 });

--- a/server/src/services/heartbeat-stop-metadata.ts
+++ b/server/src/services/heartbeat-stop-metadata.ts
@@ -49,6 +49,23 @@ export function normalizeMaxTurnStopReason(value: unknown): Extract<HeartbeatRun
     : null;
 }
 
+// Decides succeeded/timed_out/failed for a completed adapter run. The adapter
+// is the authority on pass/fail: it already accounts for exit codes that
+// don't mean failure (e.g. a clean result killed by our own
+// terminalResultCleanup once a terminal result was already observed — see
+// RunProcessResult.terminalResultCleanup in server-utils.ts). Gating success
+// on exitCode here as well would override that verdict with the raw exit
+// code of a process we ourselves just SIGTERM'd.
+export function resolveAdapterRunOutcome(input: {
+  timedOut: boolean;
+  exitCode: number | null;
+  errorMessage?: string | null;
+}): Extract<HeartbeatRunOutcome, "succeeded" | "timed_out" | "failed"> {
+  if (input.timedOut) return "timed_out";
+  if (!input.errorMessage) return "succeeded";
+  return "failed";
+}
+
 export function resolveHeartbeatRunTimeoutPolicy(
   adapterType: string,
   adapterConfig: Record<string, unknown> | null | undefined,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -212,6 +212,7 @@ import {
   buildHeartbeatRunStopMetadata,
   mergeHeartbeatRunStopMetadata,
   normalizeMaxTurnStopReason,
+  resolveAdapterRunOutcome,
 } from "./heartbeat-stop-metadata.js";
 import {
   classifyRunLiveness,
@@ -21509,15 +21510,12 @@ export function heartbeatService(
               : nativeTerminal === "cancelled"
                 ? "cancelled"
                 : "failed";
-        } else if (adapterResult.timedOut) {
-          outcome = "timed_out";
-        } else if (
-          (adapterResult.exitCode ?? 0) === 0 &&
-          !adapterResult.errorMessage
-        ) {
-          outcome = "succeeded";
         } else {
-          outcome = "failed";
+          outcome = resolveAdapterRunOutcome({
+            timedOut: adapterResult.timedOut,
+            exitCode: adapterResult.exitCode,
+            errorMessage: adapterResult.errorMessage,
+          });
         }
 
         const nextSessionState = resolveNextSessionState({


### PR DESCRIPTION
## The bug

`terminalResultCleanup` (in `runChildProcess`, `packages/adapter-utils/src/server-utils.ts`) SIGTERMs a child process after it has already emitted a terminal result but kept running. The killed child then typically self-exits nonzero (observed: `exitCode 143, signal null`).

The adapter layer already handles this correctly for `claude-local`: `execute()` computes `failed` from the CLI's own parsed result (`parsedSucceeded`), not raw exit code, so a cleanup-killed-but-successful run correctly produces `errorMessage: null`.

`heartbeatService`'s own outcome derivation in `server/src/services/heartbeat.ts`, however, independently re-checks:

```ts
} else if (
  (adapterResult.exitCode ?? 0) === 0 &&
  !adapterResult.errorMessage
) {
  outcome = "succeeded";
} else {
  outcome = "failed";
}
```

Since `exitCode` is 143, not 0, this forces `outcome = "failed"` even though the adapter already determined the run succeeded (`errorMessage` is `null`). That "failed" outcome then flows into `inferHeartbeatRunStopReason` (`heartbeat-stop-metadata.ts`) with `errorCode: null`, which doesn't match any recognized case, so it falls through to the `"adapter_failed"` fallback — misreporting a run that actually completed cleanly.

## The fix

`errorMessage` is already the single source of truth the adapter layer computes for pass/fail. Re-deriving that from `exitCode` in `heartbeatService` duplicates that decision with stale information (the raw exit code of a process *we* just SIGTERM'd). This drops the redundant exit-code check and extracts the three-way `succeeded` / `timed_out` / `failed` decision into `resolveAdapterRunOutcome()`, colocated with the already-tested `heartbeat-stop-metadata.ts` helpers so it's unit-testable without spinning up `heartbeatService`'s full DB-backed factory.

## Tests

Added to `heartbeat-stop-metadata.test.ts`:
- `resolveAdapterRunOutcome({ timedOut: false, exitCode: 143, errorMessage: null })` must be `"succeeded"` — this is provably red against the exit-code-gated version of the function (i.e. today's `heartbeatService` behavior) before the fix.
- a nonzero exit *with* an adapter-reported error message still fails.
- `timedOut` still takes priority over exit code / error message.

All three pass after the fix; the first fails before it.

## Scope note

I initially assumed (from `inferHeartbeatRunStopReason` already having an `"unmanaged_background_task_stopped"` branch keyed off `errorCode`, and `RunProcessResult.terminalResultCleanup` already carrying `stopReason: UNMANAGED_BACKGROUND_TASK_STOP_REASON` as evidence) that the missing piece was setting that `errorCode` on the `terminalResultCleanup` path in `server-utils.ts`. Tracing the actual reproduction through `claude-local`'s `execute()` shows that path never gets reached for this bug: `execute()` already sets `errorMessage: null` on success regardless of exit code, so `outcome` never becomes `"failed"` in the first place once `heartbeatService` stops overriding it. Wiring `errorCode` through unconditionally looked riskier — it would attach an error code to a *successful* run's result — so I kept this change to the one place that's actually wrong.