### PR TITLE
REVIP-2973: preserve checkout attribution and runtime context

### DIFF
--- a/server/src/__tests__/cross-issue-influence-limit-postgres.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit-postgres.test.ts
@@ -13,6 +13,7 @@ import {
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import {
+  attributeRunSourceIssueOnCheckout,
   CROSS_ISSUE_INFLUENCE_ENFORCE_AT,
   observeCrossIssueInfluence,
 } from "../services/cross-issue-influence-limit.js";
@@ -112,5 +113,40 @@ describeEmbeddedPostgres("cross-issue influence limit PostgreSQL serialization",
       .where(and(eq(activityLog.companyId, companyId), eq(activityLog.runId, runId)));
     expect(recorded.filter((row) => row.action === "issue.cross_issue_influence_observed")).toHaveLength(20);
     expect(recorded.filter((row) => row.action === "issue.cross_issue_influence_cap_rejected")).toHaveLength(1);
+  });
+
+  it("allows an unscoped run to write its own issue after checkout attribution", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({ id: companyId, name: "Paperclip", issuePrefix: `C${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`, defaultResponsibleUserId: "board-user" });
+    await db.insert(agents).values({ id: agentId, companyId, name: "Unscoped Coder", role: "engineer", adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {} });
+    await db.insert(heartbeatRuns).values({ id: runId, companyId, agentId, status: "running", responsibleUserId: "board-user", contextSnapshot: { triggeredBy: "user", actorId: "board-user" } });
+
+    await expect(attributeRunSourceIssueOnCheckout(db, { companyId, runId, agentId, issueId })).resolves.toBe(true);
+    await expect(observeCrossIssueInfluence(db, { companyId, runId, agentId, targetIssueId: issueId, targetIssueIdentifier: "CAP-1", kind: "comment", now: CROSS_ISSUE_INFLUENCE_ENFORCE_AT })).resolves.toBeNull();
+
+    const [run] = await db.select({ contextSnapshot: heartbeatRuns.contextSnapshot }).from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(run?.contextSnapshot).toEqual({ triggeredBy: "user", actorId: "board-user", issueId, taskId: issueId });
+
+    await db.update(heartbeatRuns).set({ status: "succeeded", finishedAt: new Date() }).where(eq(heartbeatRuns.id, runId));
+    await expect(attributeRunSourceIssueOnCheckout(db, { companyId, runId, agentId, issueId: randomUUID() })).resolves.toBe(false);
+  });
+
+  it("does not overwrite scoped runs or attribute a foreign agent", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const sourceIssueId = randomUUID();
+    await db.insert(companies).values({ id: companyId, name: "Paperclip", issuePrefix: `C${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`, defaultResponsibleUserId: "board-user" });
+    await db.insert(agents).values({ id: agentId, companyId, name: "Scoped Coder", role: "engineer", adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {} });
+    await db.insert(heartbeatRuns).values({ id: runId, companyId, agentId, status: "running", responsibleUserId: "board-user", contextSnapshot: { issueId: sourceIssueId, taskId: sourceIssueId, retained: true } });
+
+    await expect(attributeRunSourceIssueOnCheckout(db, { companyId, runId, agentId, issueId: randomUUID() })).resolves.toBe(false);
+    await expect(attributeRunSourceIssueOnCheckout(db, { companyId, runId, agentId: randomUUID(), issueId: randomUUID() })).resolves.toBe(false);
+    const [run] = await db.select({ contextSnapshot: heartbeatRuns.contextSnapshot }).from(heartbeatRuns).where(eq(heartbeatRuns.id, runId));
+    expect(run?.contextSnapshot).toEqual({ issueId: sourceIssueId, taskId: sourceIssueId, retained: true });
   });
 });

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -189,6 +189,7 @@ function registerRouteMocks() {
   }));
 
   vi.doMock("../services/cross-issue-influence-limit.js", () => ({
+    attributeRunSourceIssueOnCheckout: vi.fn().mockResolvedValue(true),
     observeCrossIssueInfluence: mockObserveCrossIssueInfluence,
     crossIssueInfluenceLimitError: vi.fn(),
     crossIssueInfluenceRunContextError: () => new HttpError(

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -259,6 +259,7 @@ import {
 } from "../services/issue-thread-interaction-resolution.js";
 import { resolveSelectedSuggestedTasks } from "../services/issue-thread-interactions.js";
 import {
+  attributeRunSourceIssueOnCheckout,
   crossIssueInfluenceLimitError,
   crossIssueInfluenceRunContextError,
   observeCrossIssueInfluence,
@@ -11622,6 +11623,21 @@ export function issueRoutes(
         return;
       }
       throw error;
+    }
+    if (req.actor.type === "agent" && checkoutRunId) {
+      try {
+        await attributeRunSourceIssueOnCheckout(db, {
+          companyId: issue.companyId,
+          runId: checkoutRunId,
+          agentId: req.body.agentId,
+          issueId: issue.id,
+        });
+      } catch (error) {
+        logger.warn(
+          { error, issueId: issue.id, runId: checkoutRunId },
+          "Failed to enrich heartbeat run context after successful checkout",
+        );
+      }
     }
     const actor = getActorInfo(req);
     if (updated?.harnessKind === "skill_test") {

--- a/server/src/services/cross-issue-influence-limit.ts
+++ b/server/src/services/cross-issue-influence-limit.ts
@@ -1,4 +1,4 @@
-import { and, count, eq } from "drizzle-orm";
+import { and, count, eq, inArray, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { activityLog, heartbeatRuns } from "@paperclipai/db";
 import { isUuidLike, issueWriteDenialResponse } from "@paperclipai/shared";
@@ -41,6 +41,28 @@ function readRunSourceIssueId(contextSnapshot: unknown) {
     if (typeof candidate === "string" && candidate.trim()) return candidate.trim();
   }
   return null;
+}
+
+/** Gives an unscoped heartbeat run its source issue after a successful checkout. */
+export async function attributeRunSourceIssueOnCheckout(
+  db: Db,
+  input: { companyId: string; runId: string; agentId: string; issueId: string },
+) {
+  return db
+    .update(heartbeatRuns)
+    .set({
+      contextSnapshot: sql`coalesce(${heartbeatRuns.contextSnapshot}, '{}'::jsonb) || jsonb_build_object('issueId', ${input.issueId}::text, 'taskId', ${input.issueId}::text)`,
+    })
+    .where(and(
+      eq(heartbeatRuns.id, input.runId),
+      eq(heartbeatRuns.companyId, input.companyId),
+      eq(heartbeatRuns.agentId, input.agentId),
+      inArray(heartbeatRuns.status, ["queued", "running"]),
+      sql`nullif(btrim(coalesce(${heartbeatRuns.contextSnapshot} ->> 'issueId', '')), '') is null`,
+      sql`nullif(btrim(coalesce(${heartbeatRuns.contextSnapshot} ->> 'taskId', '')), '') is null`,
+    ))
+    .returning({ id: heartbeatRuns.id })
+    .then((rows) => rows.length > 0);
 }
 
 export function evaluateCrossIssueInfluenceLimit(input: {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -21014,10 +21014,14 @@ export function heartbeatService(
             combinedRuntimeServices.find((service) =>
               readNonEmptyString(service.url),
             )?.url ?? null;
+          const runtimeContextPatch = {
+            paperclipRuntimeServices: context.paperclipRuntimeServices,
+            paperclipRuntimePrimaryUrl: context.paperclipRuntimePrimaryUrl,
+          };
           await db
             .update(heartbeatRuns)
             .set({
-              contextSnapshot: context,
+              contextSnapshot: sql`coalesce(${heartbeatRuns.contextSnapshot}, '{}'::jsonb) || ${JSON.stringify(runtimeContextPatch)}::jsonb`,
               updatedAt: new Date(),
             })
             .where(eq(heartbeatRuns.id, run.id));


### PR DESCRIPTION
Attribution-Fix aus REVIP-2838 / REVIP-2973. Head b60bcb8c4d7fc8e5b52355193d1d5144a99ee515. Fork-zu-Upstream-PR, kein Merge und kein Deploy angefordert. Automatisch geoeffnet zur Entblockung von REVIP-4970 / REVIP-4980.