### PR TITLE
fix(onboarding): hide the probe's diagnostics while the hire is in flight

### DIFF
--- a/ui/src/components/OnboardingWizard.test.tsx
+++ b/ui/src/components/OnboardingWizard.test.tsx
@@ -2323,6 +2323,66 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
       await act(async () => root.unmount());
     });
 
+    it("shows no probe diagnostics between the sign-in succeeding and the step advancing", async () => {
+      // Reported from staging: a block of amber diagnostics flashed up right
+      // after a successful sign-in. They are the identity and target INFO
+      // checks every run reports, which make the result a `warn` without
+      // blocking anything — so they rendered for the window between the probe
+      // returning and the step advancing, reading as an error thrown by the
+      // sign-in that had just succeeded.
+      mockAgentsApi.getAdapterAuthSignal.mockResolvedValue({ status: "absent" });
+      mockAgentsApi.getClaudeSetupTokenLoginStatus.mockResolvedValue({
+        sessionId: "claude-session-1",
+        status: "authenticated",
+        expiresAt: new Date(Date.now() + 600_000).toISOString(),
+      });
+      mockAgentsApi.testEnvironment.mockResolvedValue({
+        adapterType: "claude_local",
+        status: "warn",
+        checks: [
+          {
+            code: "environment_identity",
+            level: "info",
+            message: 'Environment test identity for "Paperclip Computer".',
+            detail: "paperclipLeaseId=ff9e58e9; provider=daytona",
+          },
+        ],
+        testedAt: new Date().toISOString(),
+      });
+      // Hold the hire open, which is the window the diagnostics appeared in:
+      // the probe has returned but `loading` is not cleared until the `finally`
+      // that runs after the step advances.
+      let finishHire: (v: { agent: { id: string }; approval: null }) => void = () => {};
+      mockAgentsApi.hire.mockReturnValue(
+        new Promise((resolve) => {
+          finishHire = resolve;
+        }),
+      );
+
+      const { root } = await openStep4({ adapterType: "claude_local" });
+      await pickSource(/Claude/);
+      for (let i = 0; i < 8; i++) await flushReact();
+
+      // Past the deliberate hold, so the hire is running and its probe is done.
+      await act(async () => {
+        await new Promise((resolve) => window.setTimeout(resolve, CONNECTED_HOLD_MS + 400));
+      });
+      for (let i = 0; i < 8; i++) await flushReact();
+
+      expect(mockAgentsApi.hire).toHaveBeenCalled();
+      expect(document.body.textContent).not.toContain("Environment test identity");
+      expect(document.body.textContent).not.toContain("Warnings");
+      // And the button goes on saying what is happening rather than going quiet.
+      expect(
+        [...document.body.querySelectorAll("button")].pop()?.textContent?.trim(),
+      ).toBe("Connecting");
+
+      await act(async () => finishHire({ agent: { id: "agent-1" }, approval: null }));
+      for (let i = 0; i < 6; i++) await flushReact();
+
+      await act(async () => root.unmount());
+    });
+
     it("starts no login when Back interrupts the collapse", async () => {
       // Backing out before the card has opened has nothing to close. Unwinding
       // through the card beat regardless mounted the panel — which starts a

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -3189,7 +3189,20 @@ function OnboardingWizardInner({
                       step, so this block renders only when a probe has actually
                       found something: the checks the blocking error tells the
                       customer to fix have to be visible somewhere. */}
-                  {isLocalAdapter && (adapterEnvError || (adapterEnvResult && adapterEnvResult.status !== "pass")) && (
+                  {/* Not while the hire is in flight. The probe's result lands
+                      before the hire it gates has finished, so a warn that does
+                      not block — the identity and target INFO checks, which
+                      every run reports — rendered a block of diagnostics for the
+                      moment between the probe returning and the step advancing.
+                      It read as an error thrown up by a sign-in that had just
+                      succeeded.
+
+                      `loading` is the right gate rather than the connect phase:
+                      it is false again by the time a blocking result has stopped
+                      the hire, because `handleGiveHeartbeat` clears it in its
+                      `finally` after the early return — so a genuine block still
+                      shows its checks, which is the whole reason this is here. */}
+                  {isLocalAdapter && !loading && (adapterEnvError || (adapterEnvResult && adapterEnvResult.status !== "pass")) && (
                     <div className="space-y-2 rounded-md border border-border p-3">
                       {adapterEnvError && (
                         <div className="rounded-md border border-destructive/30 bg-destructive/10 px-2.5 py-2 text-(length:--text-micro) text-destructive">


### PR DESCRIPTION
## Thinking Path

Reported from staging against the connect sequence shipped in #12863: after signing in with either Claude or OpenAI, a block of amber diagnostics flashes up and then disappears as the step advances.

Tracing it, the block is not an error at all. It is `AdapterEnvironmentResult` rendering the environment probe's checks, and the checks in question are the identity and target `INFO` lines that every run reports — the ones naming the lease and sandbox ids. Their presence makes the result a `warn` rather than a `pass`, and the step renders any non-pass result, so they appear the moment the probe returns.

What makes it a flash rather than a permanent state is the ordering inside `handleGiveHeartbeat`: the probe returns, the hire is then awaited, and `setLoading(false)` only runs in the `finally` after `setStep(5)`. So the diagnostics own the screen for exactly the gap between those two, which is precisely when the customer has just succeeded and is least expecting to see amber.

## Linked Issues or Issue Description

No tracking issue — described inline, per CONTRIBUTING.md. Reported on staging (canary `2026.905.0-canary.5`).

**Steps.** Onboarding → Connect a model → pick Claude or OpenAI → complete the sign-in.

**Expected.** The button reads "Connecting" and the step advances.

**Actual.** The button reads "Connecting", and a block of amber diagnostics appears under the card for a moment first — `Warnings`, a timestamp, and `INFO · Environment test identity for "Paperclip Computer"` with lease and sandbox ids — then vanishes.

## What Changed

One condition. The diagnostics block is now gated on the hire not being in flight:

```diff
-{isLocalAdapter && (adapterEnvError || (adapterEnvResult && adapterEnvResult.status !== "pass")) && (
+{isLocalAdapter && !loading && (adapterEnvError || (adapterEnvResult && adapterEnvResult.status !== "pass")) && (
```

**Why `loading` and not the connect phase.** The phase would hide the block for the whole sequence, including when a result genuinely stops the hire — and showing those checks is the entire reason this block exists. `loading` draws the line in the right place on its own: a blocking result returns early from `handleGiveHeartbeat`, whose `finally` clears `loading`, so the checks are visible again by the time the customer is looking at a stopped hire. A hire still running shows nothing.

**The button needed no change.** Step 4 already forces the footer's `loading` to `false` and takes its label from `connectCta`, which reads "Connecting" from `onConnected` until the step advances. Verified rather than assumed — the new test asserts it.

## Verification

New test drives the reported path: sign-in succeeds, the probe returns a non-blocking `warn` carrying an identity `INFO` check, and the hire is held open on a pending promise — which is the exact window the flash lived in. It asserts the diagnostics are absent and the button still reads "Connecting".

Checked against the fault rather than trusted: with the `!loading` removed the test fails on `expected '…' not to contain 'Environment test identity'`.

The existing coverage for the case this block exists for still passes untouched — "blocks the hire on a warn result that holds adapter_auth_missing, and shows the returned checks" — which is the evidence that a genuine block is not being hidden.

**5462 tests / 559 files green**, `tsc --noEmit` clean, all four token gates clean.

## Risks

- **The one thing to get wrong here is hiding a real failure.** The blocking path is what the existing adapter_auth_missing test covers, and it passes: `loading` is already false by the time a blocked hire is on screen.
- Diagnostics from a previous attempt now disappear while a retry runs, rather than sitting stale under a probe that is re-running. That is a behaviour change, and the better of the two.
- No change to the probe, the hire, the sequence, or the button.

## Model Used

Anthropic Claude — Opus 5, model ID `claude-opus-5`, run through Claude Code. Extended thinking enabled; tool use for repo inspection, `vitest`, `tsc`, and the token gates.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

Follows #12863.

🤖 Generated with [Claude Code](https://claude.com/claude-code)