### PR TITLE
fix(opencode): ignore intermediate tool use errors

### DIFF
--- a/packages/adapters/opencode-local/src/server/parse.test.ts
+++ b/packages/adapters/opencode-local/src/server/parse.test.ts
@@ -69,6 +69,166 @@ describe("parseOpenCodeJsonl", () => {
     expect(parsed.toolErrors).toEqual(["File not found: e2b-adapter-result.txt"]);
   });
 
+  it("ignores tool_use errors so they do not fail the run", () => {
+    const stdout = [
+      JSON.stringify({
+        type: "tool_use",
+        sessionID: "session_123",
+        part: {
+          name: "edit",
+          state: {
+            status: "error",
+            error: "Error: Could not find oldString in the file.",
+          },
+        },
+      }),
+      JSON.stringify({
+        type: "tool_use",
+        sessionID: "session_123",
+        part: {
+          name: "read",
+          state: {
+            status: "error",
+            error: "Error: Please read the file again before modifying it.",
+          },
+        },
+      }),
+    ].join("\n");
+
+    const parsed = parseOpenCodeJsonl(stdout);
+    expect(parsed.errorMessage).toBeNull();
+  });
+
+  it("collects fatal errors even if preceded by tool_use errors", () => {
+    const stdout = [
+      JSON.stringify({
+        type: "tool_use",
+        sessionID: "session_123",
+        part: {
+          name: "edit",
+          state: {
+            status: "error",
+            error: "Error: Could not find oldString in the file.",
+          },
+        },
+      }),
+      JSON.stringify({
+        type: "error",
+        sessionID: "session_123",
+        error: { message: "fatal connection error" },
+      }),
+    ].join("\n");
+
+    const parsed = parseOpenCodeJsonl(stdout);
+    expect(parsed.errorMessage).toContain("fatal connection error");
+    expect(parsed.errorMessage).not.toContain("oldString");
+  });
+
+  it("skips tool_use events regardless of status", () => {
+    const stdout = [
+      JSON.stringify({
+        type: "tool_use",
+        sessionID: "session_456",
+        part: {
+          name: "bash",
+          state: {
+            status: "completed",
+            result: "build succeeded",
+          },
+        },
+      }),
+      JSON.stringify({
+        type: "text",
+        sessionID: "session_456",
+        part: { text: "All tasks completed successfully" },
+      }),
+      JSON.stringify({
+        type: "step_finish",
+        sessionID: "session_456",
+        part: {
+          reason: "done",
+          cost: 0.001,
+          tokens: {
+            input: 80,
+            output: 20,
+            reasoning: 5,
+            cache: { read: 10, write: 0 },
+          },
+        },
+      }),
+    ].join("\n");
+
+    const parsed = parseOpenCodeJsonl(stdout);
+    expect(parsed.errorMessage).toBeNull();
+    expect(parsed.summary).toBe("All tasks completed successfully");
+    expect(parsed.usage).toEqual({
+      inputTokens: 80,
+      cachedInputTokens: 10,
+      outputTokens: 25,
+    });
+  });
+
+  it("realistic happy path with tool errors followed by successful completion", () => {
+    const stdout = [
+      JSON.stringify({
+        type: "tool_use",
+        sessionID: "session_789",
+        part: {
+          name: "edit",
+          state: {
+            status: "error",
+            error: "Error: Could not find oldString in the file.",
+          },
+        },
+      }),
+      JSON.stringify({
+        type: "text",
+        sessionID: "session_789",
+        part: { text: "Fixed the issue" },
+      }),
+      JSON.stringify({
+        type: "step_finish",
+        sessionID: "session_789",
+        part: {
+          reason: "done",
+          cost: 0.005,
+          tokens: {
+            input: 200,
+            output: 60,
+            reasoning: 15,
+            cache: { read: 50, write: 0 },
+          },
+        },
+      }),
+    ].join("\n");
+
+    const parsed = parseOpenCodeJsonl(stdout);
+    expect(parsed.errorMessage).toBeNull();
+    expect(parsed.summary).toBe("Fixed the issue");
+    expect(parsed.usage.inputTokens).toBeGreaterThan(0);
+    expect(parsed.costUsd).toBeGreaterThan(0);
+  });
+
+  it("fails the run on permission auto-rejection tool errors", () => {
+    const stdout = [
+      JSON.stringify({
+        type: "tool_use",
+        sessionID: "session_999",
+        part: {
+          name: "bash",
+          state: {
+            status: "error",
+            error: "Error: permission requested: external_directory (/home/mja311/*); auto-rejecting",
+          },
+        },
+      }),
+    ].join("\n");
+
+    const parsed = parseOpenCodeJsonl(stdout);
+    expect(parsed.errorMessage).toContain("permission requested");
+    expect(parsed.errorMessage).toContain("auto-rejecting");
+  });
+
   it("detects unknown session errors", () => {
     expect(isOpenCodeUnknownSessionError("Session not found: s_123", "")).toBe(true);
     expect(isOpenCodeUnknownSessionError("", "unknown session id")).toBe(true);

--- a/packages/adapters/opencode-local/src/server/parse.ts
+++ b/packages/adapters/opencode-local/src/server/parse.ts
@@ -62,11 +62,17 @@ export function parseOpenCodeJsonl(stdout: string) {
     }
 
     if (type === "tool_use") {
+      // Tool errors are part of the normal LLM interaction loop and should not
+      // cause the entire adapter run to fail with 'adapter_failed'.
+      // Exception: Permission auto-rejections indicate a hard configuration error.
       const part = parseObject(event.part);
       const state = parseObject(part.state);
       if (asString(state.status, "") === "error") {
         const text = asString(state.error, "").trim();
         if (text) toolErrors.push(text);
+        if (text.includes("permission requested") && text.includes("auto-rejecting")) {
+          errors.push(text);
+        }
       }
       continue;
     }


### PR DESCRIPTION
## Summary
- ignore recoverable intermediate `tool_use` errors in the OpenCode JSONL parser
- preserve fatal top-level errors
- keep permission auto-rejection errors fatal
- add regression tests for recovery, fatal events, and permission rejection

Fixes #1607