### PR TITLE
fix(connection-intents): match Composio-proxied connections by their real service slug

### DIFF
--- a/server/src/__tests__/connection-intents-service.test.ts
+++ b/server/src/__tests__/connection-intents-service.test.ts
@@ -571,6 +571,174 @@ describeEmbeddedPostgres("connectionIntentService", () => {
     }
   });
 
+  async function setUpComposioSlugFixture(companyLabel: string) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const goalId = randomUUID();
+    const issueId = randomUUID();
+    const fixtureRunId = randomUUID();
+    const userId = `${companyLabel}-user-${randomUUID()}`;
+    await db.insert(companies).values({
+      id: companyId,
+      name: `Composio toolkit slug test (${companyLabel})`,
+      issuePrefix: `${companyLabel.slice(0, 4).toUpperCase()}${randomUUID().slice(0, 4).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(companyMemberships).values({
+      companyId,
+      principalType: "user",
+      principalId: userId,
+      status: "active",
+      membershipRole: "member",
+    });
+    await db.insert(goals).values({
+      id: goalId,
+      companyId,
+      title: "Read Gmail via Composio",
+      level: "task",
+      status: "active",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Gmail agent",
+      role: "researcher",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      goalId,
+      title: "Read Gmail",
+      status: "in_progress",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+    await db.insert(heartbeatRuns).values({
+      id: fixtureRunId,
+      companyId,
+      agentId,
+      status: "running",
+      responsibleUserId: userId,
+      contextSnapshot: { issueId },
+    });
+    const fixtureClaims: RuntimeToolsTokenClaims = {
+      sub: agentId,
+      company_id: companyId,
+      run_id: fixtureRunId,
+      responsible_user_id: userId,
+      scope: "connection_intents",
+      iat: 1,
+      exp: 2,
+      instance_id: "test",
+    };
+
+    // The generic Composio app-store entry every proxied connection inherits
+    // applicationId from - not the real first-party "gmail" app definition.
+    const [composioApp] = await db.insert(toolApplications).values({
+      companyId,
+      applicationKey: `composio-${randomUUID()}`,
+      name: "Composio",
+      type: "mcp_http",
+      status: "active",
+      metadata: { sourceTemplateKey: "composio" },
+    }).returning();
+    const [composioGmailChild] = await db.insert(toolConnections).values({
+      companyId,
+      applicationId: composioApp!.id,
+      name: "Gmail (via Composio)",
+      uid: `composio/${randomUUID()}`,
+      transport: "mcp_remote",
+      authKind: "none",
+      credentialPolicy: "shared",
+      status: "active",
+      enabled: true,
+      healthStatus: "ok",
+      config: {
+        provider: "composio",
+        parentConnectionId: randomUUID(),
+        toolkitSlug: "gmail",
+        connectedAccountId: randomUUID(),
+      },
+      transportConfig: {},
+    }).returning();
+    await db.insert(connectionGrants).values({
+      companyId,
+      connectionId: composioGmailChild!.id,
+      kind: "organization",
+      credentialSecretRefs: [],
+      status: "active",
+      isDefault: true,
+    });
+    await db.insert(toolConnectionInstalls).values({
+      companyId,
+      connectionId: composioGmailChild!.id,
+      targetType: "agent",
+      targetId: agentId,
+    });
+
+    return { companyId, fixtureClaims, fixtureRunId, composioGmailChild: composioGmailChild! };
+  }
+
+  it("resolves a Composio-proxied connection for its underlying service slug", async () => {
+    const { fixtureClaims, fixtureRunId, composioGmailChild } = await setUpComposioSlugFixture("solo");
+    const service = connectionIntentService(db);
+
+    const searchResult = await service.search(fixtureClaims, "gmail");
+    expect(searchResult.results).toEqual(expect.arrayContaining([
+      expect.objectContaining({ service: "gmail", state: "ready", connectionId: composioGmailChild.id }),
+    ]));
+
+    const requestResult = await service.request(fixtureClaims, "gmail");
+    expect(requestResult).toMatchObject({
+      state: "ready",
+      connectionId: composioGmailChild.id,
+      interactionId: null,
+    });
+    // No connection_intent card should have been raised - the working
+    // Composio connection was found directly.
+    expect(await db.select().from(issueThreadInteractions).where(
+      eq(issueThreadInteractions.sourceRunId, fixtureRunId),
+    )).toHaveLength(0);
+  });
+
+  it("does not let an archived native connection degrade a ready Composio-proxied match", async () => {
+    const { companyId, fixtureClaims, composioGmailChild } = await setUpComposioSlugFixture("archived");
+
+    const [nativeGmailApp] = await db.insert(toolApplications).values({
+      companyId,
+      applicationKey: `gmail-${randomUUID()}`,
+      name: "Gmail",
+      type: "mcp_http",
+      status: "active",
+      metadata: { sourceTemplateKey: "gmail" },
+    }).returning();
+    await db.insert(toolConnections).values({
+      companyId,
+      applicationId: nativeGmailApp!.id,
+      name: "Legacy Gmail OAuth",
+      uid: `gmail/${randomUUID()}`,
+      transport: "mcp_remote",
+      authKind: "oauth",
+      credentialPolicy: "shared",
+      status: "archived",
+      enabled: false,
+      healthStatus: "error",
+      config: { sourceTemplateKey: "gmail" },
+      transportConfig: { sourceTemplateKey: "gmail" },
+    });
+
+    const service = connectionIntentService(db);
+    const searchResult = await service.search(fixtureClaims, "gmail");
+    expect(searchResult.results).toEqual(expect.arrayContaining([
+      expect.objectContaining({ service: "gmail", state: "ready", connectionId: composioGmailChild.id }),
+    ]));
+  });
+
   it("rejects cross-company claims and tokens after the run ends", async () => {
     const service = connectionIntentService(db);
     await expect(service.search({ ...claims, company_id: randomUUID() }, "notion"))

--- a/server/src/services/connection-intents.ts
+++ b/server/src/services/connection-intents.ts
@@ -42,10 +42,38 @@ function sourceSlugForApplication(application: ToolApplication | undefined) {
   return text(application?.metadata?.sourceTemplateKey) ?? text(application?.metadata?.galleryKey);
 }
 
+// Every Composio-proxied connection (Gmail, Google Search Console, ...) is
+// stored as a child row that shares its parent's applicationId - the single,
+// generic "Composio" app-store entry - regardless of which underlying
+// service it actually proxies (see composioChildConfig in
+// composio-session-manager.ts and syncComposioChild in tool-access.ts,
+// which sets `applicationId: parent.applicationId`). Falling through to
+// sourceSlugForApplication for these rows would always resolve to
+// "composio", never the real service slug, so a company whose only working
+// Gmail connection is a Composio child could never be found by
+// connections_search("gmail")/connection_request("gmail") - those tools
+// would keep pointing an agent at an unrelated or archived native
+// connection instead. Map the Composio toolkit slug to the matching
+// first-party app slug explicitly (not a blind toolkitSlug === app.slug
+// assumption) since several toolkits have no corresponding native app
+// definition at all.
+const COMPOSIO_TOOLKIT_APP_SLUGS: Record<string, string> = {
+  gmail: "gmail",
+};
+
+function composioToolkitSlugFor(connection: ToolConnection): string | null {
+  const config = record(connection.config);
+  if (config?.provider !== "composio") return null;
+  return text(config.toolkitSlug);
+}
+
 function sourceSlugForConnection(
   connection: ToolConnection,
   applications: ReadonlyMap<string, ToolApplication>,
 ) {
+  const composioToolkitSlug = composioToolkitSlugFor(connection);
+  const composioAppSlug = composioToolkitSlug ? COMPOSIO_TOOLKIT_APP_SLUGS[composioToolkitSlug] : undefined;
+  if (composioAppSlug) return composioAppSlug;
   return text(connection.config?.sourceTemplateKey)
     ?? text(connection.transportConfig?.sourceTemplateKey)
     ?? sourceSlugForApplication(applications.get(connection.applicationId));


### PR DESCRIPTION
## Summary

- Every Composio-proxied connection (Gmail, Google Search Console, ...) is stored as a child row that shares its parent's `applicationId` — the single, generic "Composio" app-store entry — regardless of which underlying service it actually proxies (`syncComposioChild` in `tool-access.ts` sets `applicationId: parent.applicationId`).
- `sourceSlugForConnection` in `connection-intents.ts` (the function behind the agent-facing `connections_search`/`connection_request` tools) falls through to `sourceSlugForApplication(applications.get(connection.applicationId))` when neither `connection.config.sourceTemplateKey` nor `connection.transportConfig.sourceTemplateKey` is set — which is always the case for a Composio child row. That resolves to `"composio"`, never the real service slug.
- Result: `connections_search("gmail")` / `connection_request("gmail")` never matches a company's working Composio Gmail connection — only a separate native Gmail connection under the real `"gmail"` app, which may be archived/broken. An agent gets pointed at (or asked to reconnect) a dead connector every time, even though a working Composio connection already exists.

## Change

- Map the known Composio toolkit slugs that have a matching first-party app definition explicitly (currently just `gmail`), before falling through to the existing lookup chain. This is a conservative, explicit allowlist rather than a blind `toolkitSlug === app.slug` assumption, since several Composio toolkits (e.g. Google Search Console, Meta Ads) have no corresponding native app definition at all, and assuming otherwise could unintentionally change matching for those.

## Test plan

- [x] Added a test: an active Composio Gmail child connection makes `search("gmail")`/`request("gmail")` resolve directly to it (`state: "ready"`) instead of raising a new connection request.
- [x] Added a test: an archived native Gmail connection does not degrade that result.
- [x] Verified both tests fail without the fix (`state: "available"`, `connectionId: null`) and pass with it.
- [x] Full `connection-intents-service.test.ts` suite passes (9/9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)