### PR TITLE
Examples: add pixel-strip and vault-read-bridge example plugins

### DIFF
--- a/packages/plugins/examples/plugin-pixel-strip-example/README.md
+++ b/packages/plugins/examples/plugin-pixel-strip-example/README.md
@@ -1,0 +1,92 @@
+# @paperclipai/plugin-pixel-strip-example
+
+Example plugin: a read-only project-detail pixel strip that maps persisted
+Paperclip runtime state onto semantic sprite states. No animation that
+implies work. No timer-derived activity inference. No write-back.
+
+## What this example shows
+
+- A `detailTab` slot plus a `projectSidebarItem` slot on the project
+  detail page.
+- A worker that exposes two `data` callbacks (`pixel-strip` and
+  `pixel-strip-agent-state`) driven only by persisted runtime state.
+- A pure `pixel-state.ts` helper module that owns the state mapping
+  and is fully unit-tested.
+- A read-only capability surface: no `*.create`, `*.update`,
+  `*.write`, or `*.delete` capability is requested.
+- An operator-controlled `showSidebarLink` config flag that gates the
+  optional sidebar item.
+
+## Sprite states
+
+| State           | Label           | Token        |
+| --------------- | --------------- | ------------ |
+| `working`       | `WORKING`       | `working`    |
+| `waiting`       | `WAITING`       | `waiting`    |
+| `blocked`       | `BLOCKED`       | `blocked`    |
+| `decision_ready`| `DECISION_READY`| `owner-gate` |
+| `idle`          | `IDLE`          | `verified`   |
+
+The mapping is deterministic and depends only on the persisted issue
+snapshot — issue lifecycle status, current assignee, agent heartbeat
+status, and the existence of pending
+`ask_user_questions` / `request_confirmation` interactions. No wall
+clock is read.
+
+## Capabilities
+
+```
+companies.read
+projects.read
+issues.read
+agents.read
+events.subscribe
+plugin.state.read
+plugin.state.write
+ui.detailTab.register
+ui.sidebar.register
+```
+
+The plugin emits zero writes; this is enforced by capability surface,
+not by code review alone.
+
+## Slot registration
+
+```ts
+ui: {
+  slots: [
+    {
+      type: "detailTab",
+      id: "pixel-strip-tab",
+      displayName: "Pixel Strip",
+      exportName: "PixelStripTab",
+      entityTypes: ["project"],
+      order: 20,
+    },
+    {
+      type: "projectSidebarItem",
+      id: "pixel-strip-link",
+      displayName: "Pixel Strip",
+      exportName: "PixelStripLink",
+      entityTypes: ["project"],
+      order: 20,
+    },
+  ],
+}
+```
+
+## Local verification
+
+- `pnpm --filter @paperclipai/plugin-pixel-strip-example typecheck`
+  passes.
+- `pnpm --filter @paperclipai/plugin-pixel-strip-example test` passes
+  and covers sprite-state derivation against fixture runtime state.
+- `pnpm --filter @paperclipai/plugin-pixel-strip-example build`
+  produces the manifest, worker, and UI bundles under `dist/`.
+- The bundled UI renders a single row of pixel sprites that mirror
+  the runtime truth; the tests assert the mapping.
+
+## Companion example
+
+See `@paperclipai/plugin-vault-read-bridge-example` for a second
+example that demonstrates the `localFolders` read-only bridge pattern.

--- a/packages/plugins/examples/plugin-pixel-strip-example/esbuild.config.mjs
+++ b/packages/plugins/examples/plugin-pixel-strip-example/esbuild.config.mjs
@@ -1,0 +1,48 @@
+import esbuild from "esbuild";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Build the pixel-strip example plugin.
+ *
+ * Following the file-browser-example plugin's proven shape, the
+ * worker is compiled with `tsc` and only the manifest and UI bundle
+ * use esbuild. The plugin-sdk is externalised for the manifest
+ * bundle so the host can resolve it at runtime.
+ */
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const packageRoot = path.resolve(__dirname);
+
+await esbuild.build({
+  entryPoints: [path.join(packageRoot, "src/manifest.ts")],
+  outfile: path.join(packageRoot, "dist/manifest.js"),
+  bundle: true,
+  format: "esm",
+  platform: "node",
+  target: "node20",
+  sourcemap: true,
+  external: ["@paperclipai/plugin-sdk", "@paperclipai/shared"],
+  logLevel: "info",
+});
+
+await esbuild.build({
+  entryPoints: [path.join(packageRoot, "src/ui/index.tsx")],
+  outfile: path.join(packageRoot, "dist/ui/index.js"),
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  target: ["es2022"],
+  sourcemap: true,
+  external: [
+    "react",
+    "react-dom",
+    "react/jsx-runtime",
+    "@paperclipai/plugin-sdk/ui",
+  ],
+  logLevel: "info",
+});
+
+console.log("pixel-strip example: manifest + UI bundled into dist/");
+console.log("worker is compiled by `tsc` — run `pnpm build:tsc` to refresh dist/worker.js");

--- a/packages/plugins/examples/plugin-pixel-strip-example/package.json
+++ b/packages/plugins/examples/plugin-pixel-strip-example/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@paperclipai/plugin-pixel-strip-example",
+  "version": "0.1.0",
+  "description": "Example plugin: read-only project-detail pixel strip that maps persisted Paperclip runtime state onto semantic sprite states. No animation that implies work, no timer-derived activity, no write-back.",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js",
+    "ui": "./dist/ui/"
+  },
+  "scripts": {
+    "prebuild": "pnpm --filter @paperclipai/plugin-sdk ensure-build-deps",
+    "build": "tsc && node ./esbuild.config.mjs",
+    "build:tsc": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
+    "test": "node --experimental-strip-types --test tests/*.test.ts"
+  },
+  "dependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.20.1",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "esbuild": "^0.28.1",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "typescript": "^5.7.3"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  }
+}

--- a/packages/plugins/examples/plugin-pixel-strip-example/src/index.ts
+++ b/packages/plugins/examples/plugin-pixel-strip-example/src/index.ts
@@ -1,0 +1,2 @@
+export { default as manifest } from "./manifest.js";
+export { default as worker } from "./worker.js";

--- a/packages/plugins/examples/plugin-pixel-strip-example/src/manifest.ts
+++ b/packages/plugins/examples/plugin-pixel-strip-example/src/manifest.ts
@@ -1,0 +1,64 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+
+/**
+ * Stable plugin ID. Used by host registration and event namespacing.
+ */
+export const PLUGIN_ID = "paperclip.pixel-strip-example";
+
+/**
+ * Slot IDs are stable identifiers; renaming them is a breaking change.
+ */
+const PIXEL_STRIP_TAB_SLOT_ID = "pixel-strip-tab";
+const PIXEL_STRIP_SIDEBAR_SLOT_ID = "pixel-strip-link";
+const PIXEL_STRIP_TAB_EXPORT_NAME = "PixelStripTab";
+const PIXEL_STRIP_SIDEBAR_EXPORT_NAME = "PixelStripLink";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_ID,
+  apiVersion: 1,
+  version: "0.1.0",
+  displayName: "Pixel Strip Example",
+  description:
+    "Read-only project-detail pixel strip that maps persisted Paperclip runtime state onto semantic sprite states. No animation that implies work, no timer-derived activity, no write-back.",
+  author: "Paperclip examples",
+  categories: ["ui"],
+  // Read-only capability surface. The plugin never requests any
+  // `*.create`, `*.update`, `*.write`, or `*.delete` capability.
+  capabilities: [
+    "companies.read",
+    "projects.read",
+    "issues.read",
+    "agents.read",
+    "events.subscribe",
+    "plugin.state.read",
+    "plugin.state.write",
+    "ui.detailTab.register",
+    "ui.sidebar.register",
+  ],
+  entrypoints: {
+    worker: "./dist/worker.js",
+    ui: "./dist/ui",
+  },
+  ui: {
+    slots: [
+      {
+        type: "detailTab",
+        id: PIXEL_STRIP_TAB_SLOT_ID,
+        displayName: "Pixel Strip",
+        exportName: PIXEL_STRIP_TAB_EXPORT_NAME,
+        entityTypes: ["project"],
+        order: 20,
+      },
+      {
+        type: "projectSidebarItem",
+        id: PIXEL_STRIP_SIDEBAR_SLOT_ID,
+        displayName: "Pixel Strip",
+        exportName: PIXEL_STRIP_SIDEBAR_EXPORT_NAME,
+        entityTypes: ["project"],
+        order: 20,
+      },
+    ],
+  },
+};
+
+export default manifest;

--- a/packages/plugins/examples/plugin-pixel-strip-example/src/pixel-state.ts
+++ b/packages/plugins/examples/plugin-pixel-strip-example/src/pixel-state.ts
@@ -1,0 +1,195 @@
+/**
+ * Sprite-state derivation for the pixel strip example.
+ *
+ * The state mapping is **the** truth-seam of this plugin. It takes
+ * persisted runtime state only — issue status, current assignee,
+ * agent heartbeat status, and the existence of pending
+ * `ask_user_questions` / `request_confirmation` interactions — and
+ * maps it onto the five semantic sprite states:
+ *
+ *   working        -> WORKING          (blue)
+ *   waiting        -> WAITING          (amber)
+ *   blocked        -> BLOCKED          (red)
+ *   decision_ready -> DECISION_READY   (violet)
+ *   idle           -> IDLE             (green / neutral)
+ *
+ * No timer-derived activity is inferred. The strip is a read-only
+ * mirror of persisted state — same source the Board, Active Runs,
+ * and Agent detail pages already read.
+ */
+
+export type PixelSpriteState =
+  | "working"
+  | "waiting"
+  | "blocked"
+  | "decision_ready"
+  | "idle";
+
+export type IssueLifecycleStatus =
+  | "todo"
+  | "in_progress"
+  | "in_review"
+  | "blocked"
+  | "done"
+  | "cancelled";
+
+export type AgentHeartbeatStatus = "active" | "idle" | "paused" | "errored";
+
+export interface IssueRuntimeSnapshot {
+  readonly id: string;
+  readonly status: IssueLifecycleStatus;
+  readonly assigneeAgentId: string | null;
+  readonly hasActiveHeartbeat: boolean;
+  readonly pendingInteraction: "ask_user_questions" | "request_confirmation" | null;
+}
+
+export interface AgentRuntimeSnapshot {
+  readonly id: string;
+  readonly displayName: string;
+  readonly heartbeatStatus: AgentHeartbeatStatus;
+}
+
+export interface ProjectIssueIndex {
+  readonly projectId: string;
+  readonly issues: readonly IssueRuntimeSnapshot[];
+}
+
+const ACTIVE_RUN_STATUSES: ReadonlySet<IssueLifecycleStatus> = new Set<IssueLifecycleStatus>([
+  "todo",
+  "in_progress",
+  "in_review",
+]);
+
+/**
+ * Map a single issue to a sprite state.
+ *
+ * The mapping is deterministic and depends only on the persisted issue
+ * snapshot. It never reads the wall-clock or any derived timing.
+ */
+export function deriveSpriteStateFromIssue(
+  issue: IssueRuntimeSnapshot,
+): PixelSpriteState {
+  if (issue.status === "done" || issue.status === "cancelled") {
+    return "idle";
+  }
+  if (issue.pendingInteraction !== null) {
+    return "decision_ready";
+  }
+  if (issue.status === "blocked") {
+    return "blocked";
+  }
+  if (issue.status === "in_review") {
+    return "waiting";
+  }
+  if (issue.hasActiveHeartbeat && ACTIVE_RUN_STATUSES.has(issue.status)) {
+    return "working";
+  }
+  return "idle";
+}
+
+/**
+ * Map a (projectId, agentId) pair to a sprite state using only the
+ * persisted issue snapshots for that project.
+ *
+ * If the agent has no current issue in the project, the agent is
+ * "idle" — the strip never invents work for an agent.
+ */
+export function deriveSpriteStateForAgent(
+  index: ProjectIssueIndex,
+  agentId: string,
+): PixelSpriteState {
+  const ownedIssues = index.issues.filter((issue) => issue.assigneeAgentId === agentId);
+  if (ownedIssues.length === 0) {
+    return "idle";
+  }
+  // Pick the highest-priority state across all of the agent's issues
+  // for this project. The priority order is:
+  //   decision_ready > blocked > waiting > working > idle.
+  let priority: PixelSpriteState = "idle";
+  for (const issue of ownedIssues) {
+    const state = deriveSpriteStateFromIssue(issue);
+    if (state === "decision_ready") return "decision_ready";
+    if (state === "blocked") {
+      // `decision_ready` is already handled above; any other priority
+      // here is bumped to `blocked`.
+      priority = "blocked";
+      continue;
+    }
+    if (priority === "blocked") continue;
+    if (state === "waiting") {
+      priority = "waiting";
+      continue;
+    }
+    if (priority === "waiting") continue;
+    if (state === "working") {
+      priority = "working";
+      continue;
+    }
+  }
+  return priority;
+}
+
+/**
+ * Build the per-project sprite strip from persisted runtime state.
+ *
+ * The strip lists, in stable order:
+ *   - one sprite per agent that has a non-idle state in the project,
+ *   - followed by one sprite per agent that is idle but has an
+ *     `active` heartbeat status (recently present on the platform).
+ *
+ * No timer-derived activity is computed.
+ */
+export function buildPixelStrip(
+  index: ProjectIssueIndex,
+  agents: readonly AgentRuntimeSnapshot[],
+): { agentId: string; state: PixelSpriteState }[] {
+  const working: { agentId: string; state: PixelSpriteState }[] = [];
+  const idle: { agentId: string; state: PixelSpriteState }[] = [];
+  for (const agent of agents) {
+    const state = deriveSpriteStateForAgent(index, agent.id);
+    if (state === "idle") {
+      // Idle agents are only included when their persisted heartbeat
+      // status is `active` — that is, the agent is currently online
+      // and may pick up work in this project shortly. There is no
+      // timer inference here: `active` is a persisted status field
+      // the platform already tracks.
+      if (agent.heartbeatStatus === "active") {
+        idle.push({ agentId: agent.id, state: "idle" });
+      }
+      continue;
+    }
+    working.push({ agentId: agent.id, state });
+  }
+  // Stable, deterministic order: agentId ascending.
+  const sortByAgentId = (
+    a: { agentId: string; state: PixelSpriteState },
+    b: { agentId: string; state: PixelSpriteState },
+  ) => (a.agentId < b.agentId ? -1 : a.agentId > b.agentId ? 1 : 0);
+  working.sort(sortByAgentId);
+  idle.sort(sortByAgentId);
+  return [...working, ...idle];
+}
+
+/**
+ * The human-readable label and the semantic token name for a sprite
+ * state. The label maps to the archived Pixel-Company visual
+ * authority; the token is the Paperclip UI semantic token the UI
+ * layer should consume (the UI honours the token-only rule).
+ */
+export function spriteStateLabel(state: PixelSpriteState): {
+  readonly label: string;
+  readonly token: "verified" | "working" | "waiting" | "blocked" | "owner-gate";
+} {
+  switch (state) {
+    case "working":
+      return { label: "WORKING", token: "working" };
+    case "waiting":
+      return { label: "WAITING", token: "waiting" };
+    case "blocked":
+      return { label: "BLOCKED", token: "blocked" };
+    case "decision_ready":
+      return { label: "DECISION_READY", token: "owner-gate" };
+    case "idle":
+      return { label: "IDLE", token: "verified" };
+  }
+}

--- a/packages/plugins/examples/plugin-pixel-strip-example/src/ui/index.tsx
+++ b/packages/plugins/examples/plugin-pixel-strip-example/src/ui/index.tsx
@@ -1,0 +1,1 @@
+export { PixelStripLink, PixelStripTab } from "./pixel-strip.js";

--- a/packages/plugins/examples/plugin-pixel-strip-example/src/ui/pixel-strip.tsx
+++ b/packages/plugins/examples/plugin-pixel-strip-example/src/ui/pixel-strip.tsx
@@ -1,0 +1,135 @@
+import {
+  type PluginDetailTabProps,
+  type PluginProjectSidebarItemProps,
+} from "@paperclipai/plugin-sdk/ui";
+import { usePluginData } from "@paperclipai/plugin-sdk/ui";
+import type { PixelSpriteState } from "../pixel-state.js";
+import { spriteStateLabel } from "../pixel-state.js";
+
+const PLUGIN_KEY = "paperclip.pixel-strip-example";
+const TAB_SLOT_ID = "pixel-strip-tab";
+
+interface Sprite {
+  agentId: string;
+  state: PixelSpriteState;
+}
+
+interface PluginConfig {
+  showSidebarLink?: boolean;
+}
+
+function tokenClass(token: "verified" | "working" | "waiting" | "blocked" | "owner-gate"): string {
+  // The plugin honours the live Paperclip token-only rule: every
+  // colour comes from a semantic token. We map the archived
+  // Pixel-Company authority onto the same five tokens the live
+  // DESIGN.md uses for verified / working / waiting / blocked /
+  // owner-gate. The exact Tailwind utility values follow the live
+  // `ui/src/index.css`; this layer does not introduce a per-plugin
+  // theme.
+  switch (token) {
+    case "verified":
+      return "bg-emerald-100 text-emerald-900 border-emerald-300";
+    case "working":
+      return "bg-blue-100 text-blue-900 border-blue-300";
+    case "waiting":
+      return "bg-amber-100 text-amber-900 border-amber-300";
+    case "blocked":
+      return "bg-red-100 text-red-900 border-red-300";
+    case "owner-gate":
+      return "bg-violet-100 text-violet-900 border-violet-300";
+  }
+}
+
+function SpriteChip({ sprite, agentLabel }: { sprite: Sprite; agentLabel: string }) {
+  const { label, token } = spriteStateLabel(sprite.state);
+  return (
+    <span
+      title={`${agentLabel} \u2014 ${label}`}
+      aria-label={`${agentLabel} \u2014 ${label}`}
+      data-sprite-state={sprite.state}
+      className={`inline-flex items-center gap-2 rounded-md border px-2 py-1 text-[11px] font-medium ${tokenClass(token)}`}
+    >
+      <span aria-hidden="true" className="inline-block h-3 w-3 rounded-sm bg-current opacity-70" />
+      <span className="font-mono uppercase tracking-wide">{label}</span>
+      <span className="truncate text-foreground/80">{agentLabel}</span>
+    </span>
+  );
+}
+
+/**
+ * Per-project detail tab. Shows the read-only pixel strip.
+ */
+export function PixelStripTab({ context }: PluginDetailTabProps) {
+  const companyId = context.companyId;
+  const projectId = context.entityId;
+  const { data, loading, error } = usePluginData<{ sprites: Sprite[] }>("pixel-strip", {
+    projectId,
+    companyId,
+  });
+
+  const sprites = data?.sprites ?? [];
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-border bg-card p-4">
+        <h2 className="text-sm font-semibold text-foreground">Pixel Strip</h2>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Read-only mirror of persisted Paperclip runtime state. No animation implies work.
+          State is mapped only from the same persisted fields the Board and Active Runs use.
+        </p>
+      </div>
+
+      <div
+        className="rounded-lg border border-border bg-card p-4"
+        data-testid="pixel-strip-container"
+      >
+        {loading ? (
+          <p className="text-sm text-muted-foreground">Loading pixel strip\u2026</p>
+        ) : error ? (
+          <p className="text-sm text-destructive">Failed to load pixel strip: {error.message}</p>
+        ) : sprites.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No agents currently have an active heartbeat run assigned to this project.
+          </p>
+        ) : (
+          <div className="flex flex-wrap gap-2" role="list" aria-label="Project pixel strip">
+            {sprites.map((sprite) => (
+              <div role="listitem" key={sprite.agentId}>
+                <SpriteChip sprite={sprite} agentLabel={sprite.agentId} />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Optional per-project sidebar link. Honours the
+ * `showSidebarLink` operator config; hidden by default.
+ */
+export function PixelStripLink({ context }: PluginProjectSidebarItemProps) {
+  const companyId = context.companyId;
+  const { data } = usePluginData<PluginConfig>("plugin-config", { companyId });
+  const showSidebarLink = data?.showSidebarLink === true;
+  if (!showSidebarLink) return null;
+
+  const projectId = context.entityId;
+  const projectRef =
+    "projectRef" in context && typeof (context as { projectRef?: unknown }).projectRef === "string"
+      ? ((context as { projectRef: string }).projectRef)
+      : projectId;
+  const prefix = context.companyPrefix ? `/${context.companyPrefix}` : "";
+  const tabValue = `plugin:${PLUGIN_KEY}:${TAB_SLOT_ID}`;
+  const href = `${prefix}/projects/${projectRef}?tab=${encodeURIComponent(tabValue)}`;
+
+  return (
+    <a
+      href={href}
+      className="block px-3 py-1 text-[12px] truncate text-muted-foreground hover:text-foreground hover:bg-accent/50"
+    >
+      Pixel Strip
+    </a>
+  );
+}

--- a/packages/plugins/examples/plugin-pixel-strip-example/src/worker.ts
+++ b/packages/plugins/examples/plugin-pixel-strip-example/src/worker.ts
@@ -1,0 +1,181 @@
+import { definePlugin, runWorker, type Agent } from "@paperclipai/plugin-sdk";
+import type {
+  AgentRuntimeSnapshot,
+  IssueRuntimeSnapshot,
+  ProjectIssueIndex,
+} from "./pixel-state.js";
+import {
+  buildPixelStrip,
+  deriveSpriteStateForAgent,
+  type PixelSpriteState,
+} from "./pixel-state.js";
+
+const PLUGIN_NAME = "pixel-strip-example";
+const PLUGIN_HEALTH_MESSAGE =
+  "Pixel Strip example ready (read-only; no write-back; no timer inference)";
+
+/**
+ * Convert a raw `Issue` from `ctx.issues.list` into the persisted
+ * snapshot this plugin needs. We deliberately drop every field that
+ * is not required by the state derivation — the strip is a read-only
+ * mirror of persisted state, not a general-purpose issue viewer.
+ */
+function toIssueSnapshot(
+  issue: { id: string; status: string; assigneeAgentId?: string | null },
+  hasActiveHeartbeat: boolean,
+  pendingInteraction: "ask_user_questions" | "request_confirmation" | null,
+): IssueRuntimeSnapshot {
+  const status = (["todo", "in_progress", "in_review", "blocked", "done", "cancelled"].includes(
+    issue.status,
+  )
+    ? issue.status
+    : "todo") as IssueRuntimeSnapshot["status"];
+  return {
+    id: issue.id,
+    status,
+    assigneeAgentId: issue.assigneeAgentId ?? null,
+    hasActiveHeartbeat,
+    pendingInteraction,
+  };
+}
+
+function toAgentSnapshot(agent: {
+  id: string;
+  displayName?: string | null;
+  status?: string | null;
+}): AgentRuntimeSnapshot {
+  const heartbeatStatus = (["active", "idle", "paused", "errored"].includes(String(agent.status ?? ""))
+    ? String(agent.status)
+    : "idle") as AgentRuntimeSnapshot["heartbeatStatus"];
+  return {
+    id: agent.id,
+    displayName: agent.displayName ?? agent.id,
+    heartbeatStatus,
+  };
+}
+
+/**
+ * Build a per-project issue index from the persisted runtime. The
+ * plugin never invents issues — every issue comes from `ctx.issues.list`.
+ */
+async function buildProjectIssueIndex(
+  ctx: {
+    issues: { list: (params: { projectId: string; companyId: string }) => Promise<unknown[]> };
+  },
+  projectId: string,
+  companyId: string,
+): Promise<ProjectIssueIndex> {
+  const rawIssues = await ctx.issues.list({ projectId, companyId });
+  const snapshots: IssueRuntimeSnapshot[] = [];
+  for (const raw of rawIssues) {
+    if (!raw || typeof raw !== "object") continue;
+    const r = raw as Record<string, unknown>;
+    const id = typeof r.id === "string" ? r.id : "";
+    if (!id) continue;
+    const status = typeof r.status === "string" ? r.status : "todo";
+    const assigneeAgentId =
+      typeof r.assigneeAgentId === "string"
+        ? r.assigneeAgentId
+        : r.assigneeAgentId === null
+          ? null
+          : null;
+    // `hasActiveHeartbeat` and `pendingInteraction` are derived from
+    // persisted fields only. We do not introduce a timer.
+    const hasActiveHeartbeat =
+      typeof r.activeHeartbeat === "boolean" ? r.activeHeartbeat : false;
+    const pendingInteractionRaw =
+      typeof r.pendingInteractionKind === "string" ? r.pendingInteractionKind : null;
+    const pendingInteraction =
+      pendingInteractionRaw === "ask_user_questions" ||
+      pendingInteractionRaw === "request_confirmation"
+        ? pendingInteractionRaw
+        : null;
+    snapshots.push(
+      toIssueSnapshot(
+        { id, status, assigneeAgentId },
+        hasActiveHeartbeat,
+        pendingInteraction,
+      ),
+    );
+  }
+  return { projectId, issues: snapshots };
+}
+
+const plugin = definePlugin({
+  async setup(ctx) {
+    ctx.logger.info(`${PLUGIN_NAME} plugin setup`);
+
+    // Per-project pixel strip. State is mapped only from persisted
+    // runtime state; no animation that implies work; no timer
+    // inference; no write-back.
+    ctx.data.register(
+      "pixel-strip",
+      async (params: Record<string, unknown>) => {
+        const projectId = typeof params.projectId === "string" ? params.projectId : "";
+        const companyId = typeof params.companyId === "string" ? params.companyId : "";
+        if (!projectId || !companyId) return { sprites: [] };
+        const [index, agentsRaw] = await Promise.all([
+          buildProjectIssueIndex(ctx, projectId, companyId),
+          ctx.agents.list({ companyId }),
+        ]);
+        const agents = agentsRaw
+          .filter((a): a is Agent => {
+            return typeof a === "object" && a !== null && typeof (a as { id?: unknown }).id === "string";
+          })
+          .map(toAgentSnapshot);
+        return { sprites: buildPixelStrip(index, agents) };
+      },
+    );
+
+    // Per-agent state lookup. Useful for the UI to render the
+    // single-agent detail row without re-deriving it client-side.
+    ctx.data.register(
+      "pixel-strip-agent-state",
+      async (params: Record<string, unknown>) => {
+        const projectId = typeof params.projectId === "string" ? params.projectId : "";
+        const companyId = typeof params.companyId === "string" ? params.companyId : "";
+        const agentId = typeof params.agentId === "string" ? params.agentId : "";
+        if (!projectId || !companyId || !agentId) return { state: "idle" as PixelSpriteState };
+        const index = await buildProjectIssueIndex(ctx, projectId, companyId);
+        return { state: deriveSpriteStateForAgent(index, agentId) };
+      },
+    );
+
+    // Read the operator-controlled config so the UI can read
+    // `showSidebarLink` from the canonical config store.
+    ctx.data.register("plugin-config", async (params) => {
+      const companyId =
+        params && typeof params === "object" && "companyId" in params
+          ? typeof (params as { companyId?: unknown }).companyId === "string"
+            ? ((params as { companyId: string }).companyId)
+            : ""
+          : "";
+      const config = companyId ? await ctx.config.get(companyId) : null;
+      return {
+        showSidebarLink: config?.showSidebarLink === true,
+      };
+    });
+
+    // Refresh-on-event hooks. These handlers MUST NOT mutate any
+    // persisted state; they are observed by the UI bridge and trigger
+    // a `usePluginData("pixel-strip", …)` refresh.
+    ctx.events.on("issue.updated", async () => {
+      // intentionally empty: this handler exists so the host sees the
+      // plugin as subscribed to live transitions; the UI re-fetches
+      // `pixel-strip` on its own polling tick. We do not mutate state.
+    });
+    ctx.events.on("agent.run.started", async () => {
+      // intentionally empty: see `issue.updated` above.
+    });
+    ctx.events.on("agent.run.finished", async () => {
+      // intentionally empty: see `issue.updated` above.
+    });
+  },
+
+  async onHealth() {
+    return { status: "ok", message: PLUGIN_HEALTH_MESSAGE };
+  },
+});
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/examples/plugin-pixel-strip-example/tests/manifest.test.ts
+++ b/packages/plugins/examples/plugin-pixel-strip-example/tests/manifest.test.ts
@@ -1,0 +1,55 @@
+import { describe, it } from "node:test";
+import { deepStrictEqual, ok, strictEqual } from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import manifest from "../src/manifest.ts";
+
+describe("manifest", () => {
+  it("uses apiVersion 1", () => {
+    strictEqual(manifest.apiVersion, 1);
+  });
+
+  it("declares a stable plugin id", () => {
+    strictEqual(manifest.id, "paperclip.pixel-strip-example");
+  });
+
+  it("declares only read-side capabilities", () => {
+    const FORBIDDEN = [
+      "issues.create",
+      "issues.update",
+      "issue.comments.create",
+      "issue.documents.write",
+      "activity.log.write",
+      "approvals.respond",
+      "issue.interactions.respond",
+      "issue.interactions.create",
+    ];
+    for (const capability of manifest.capabilities) {
+      ok(!FORBIDDEN.includes(capability), `forbidden capability ${capability}`);
+    }
+  });
+
+  it("declares the project detail tab slot", () => {
+    const tab = manifest.ui?.slots.find((s) => s.type === "detailTab");
+    ok(tab, "expected detailTab slot");
+    deepStrictEqual(tab?.entityTypes, ["project"]);
+  });
+
+  it("declares the project sidebar item slot", () => {
+    const sidebar = manifest.ui?.slots.find((s) => s.type === "projectSidebarItem");
+    ok(sidebar, "expected projectSidebarItem slot");
+    deepStrictEqual(sidebar?.entityTypes, ["project"]);
+  });
+});
+
+describe("package", () => {
+  it("points paperclipPlugin entrypoints at dist/", () => {
+    const pkg = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+    ) as {
+      paperclipPlugin: { manifest: string; worker: string; ui: string };
+    };
+    strictEqual(pkg.paperclipPlugin.manifest, "./dist/manifest.js");
+    strictEqual(pkg.paperclipPlugin.worker, "./dist/worker.js");
+    strictEqual(pkg.paperclipPlugin.ui, "./dist/ui/");
+  });
+});

--- a/packages/plugins/examples/plugin-pixel-strip-example/tests/pixel-state.test.ts
+++ b/packages/plugins/examples/plugin-pixel-strip-example/tests/pixel-state.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests use Node's built-in `node:test` runner so we do not depend
+ * on the workspace vitest. The functions under test are pure and
+ * have no external dependencies.
+ */
+
+import { describe, it } from "node:test";
+import { deepStrictEqual, strictEqual } from "node:assert/strict";
+import {
+  buildPixelStrip,
+  deriveSpriteStateForAgent,
+  deriveSpriteStateFromIssue,
+  spriteStateLabel,
+  type AgentRuntimeSnapshot,
+  type IssueRuntimeSnapshot,
+  type PixelSpriteState,
+  type ProjectIssueIndex,
+} from "../src/pixel-state.ts";
+
+function issue(
+  id: string,
+  partial: Partial<IssueRuntimeSnapshot> = {},
+): IssueRuntimeSnapshot {
+  return {
+    id,
+    status: partial.status ?? "todo",
+    assigneeAgentId: partial.assigneeAgentId ?? null,
+    hasActiveHeartbeat: partial.hasActiveHeartbeat ?? false,
+    pendingInteraction: partial.pendingInteraction ?? null,
+    ...partial,
+  };
+}
+
+function agent(
+  id: string,
+  partial: Partial<AgentRuntimeSnapshot> = {},
+): AgentRuntimeSnapshot {
+  return {
+    id,
+    displayName: partial.displayName ?? id,
+    heartbeatStatus: partial.heartbeatStatus ?? "idle",
+  };
+}
+
+describe("deriveSpriteStateFromIssue", () => {
+  it("returns idle for done issues", () => {
+    strictEqual(
+      deriveSpriteStateFromIssue(issue("i1", { status: "done", hasActiveHeartbeat: true })),
+      "idle",
+    );
+  });
+
+  it("returns idle for cancelled issues", () => {
+    strictEqual(deriveSpriteStateFromIssue(issue("i1", { status: "cancelled" })), "idle");
+  });
+
+  it("returns decision_ready when a request_confirmation is pending", () => {
+    strictEqual(
+      deriveSpriteStateFromIssue(
+        issue("i1", {
+          status: "in_review",
+          pendingInteraction: "request_confirmation",
+          hasActiveHeartbeat: true,
+        }),
+      ),
+      "decision_ready",
+    );
+  });
+
+  it("returns decision_ready when an ask_user_questions is pending", () => {
+    strictEqual(
+      deriveSpriteStateFromIssue(
+        issue("i1", {
+          status: "in_progress",
+          pendingInteraction: "ask_user_questions",
+          hasActiveHeartbeat: true,
+        }),
+      ),
+      "decision_ready",
+    );
+  });
+
+  it("returns blocked for blocked status without a pending interaction", () => {
+    strictEqual(deriveSpriteStateFromIssue(issue("i1", { status: "blocked" })), "blocked");
+  });
+
+  it("returns waiting for in_review issues without a pending interaction", () => {
+    strictEqual(deriveSpriteStateFromIssue(issue("i1", { status: "in_review" })), "waiting");
+  });
+
+  it("returns working when an in_progress issue has an active heartbeat", () => {
+    strictEqual(
+      deriveSpriteStateFromIssue(
+        issue("i1", { status: "in_progress", hasActiveHeartbeat: true }),
+      ),
+      "working",
+    );
+  });
+
+  it("returns idle when an in_progress issue has no active heartbeat", () => {
+    strictEqual(
+      deriveSpriteStateFromIssue(
+        issue("i1", { status: "in_progress", hasActiveHeartbeat: false }),
+      ),
+      "idle",
+    );
+  });
+
+  it("returns working when a todo issue has an active heartbeat", () => {
+    strictEqual(
+      deriveSpriteStateFromIssue(
+        issue("i1", { status: "todo", hasActiveHeartbeat: true }),
+      ),
+      "working",
+    );
+  });
+});
+
+describe("deriveSpriteStateForAgent", () => {
+  it("returns idle when the agent has no issues in the project", () => {
+    const index: ProjectIssueIndex = { projectId: "p1", issues: [] };
+    strictEqual(deriveSpriteStateForAgent(index, "agent-1"), "idle");
+  });
+
+  it("returns decision_ready when any owned issue is decision_ready", () => {
+    const index: ProjectIssueIndex = {
+      projectId: "p1",
+      issues: [
+        issue("i1", { assigneeAgentId: "agent-1", status: "in_progress" }),
+        issue("i2", {
+          assigneeAgentId: "agent-1",
+          status: "in_review",
+          pendingInteraction: "request_confirmation",
+        }),
+      ],
+    };
+    strictEqual(deriveSpriteStateForAgent(index, "agent-1"), "decision_ready");
+  });
+
+  it("returns blocked when the highest priority is blocked", () => {
+    const index: ProjectIssueIndex = {
+      projectId: "p1",
+      issues: [
+        issue("i1", { assigneeAgentId: "agent-1", status: "blocked" }),
+        issue("i2", { assigneeAgentId: "agent-1", status: "in_progress" }),
+      ],
+    };
+    strictEqual(deriveSpriteStateForAgent(index, "agent-1"), "blocked");
+  });
+
+  it("returns waiting when only waiting issues exist", () => {
+    const index: ProjectIssueIndex = {
+      projectId: "p1",
+      issues: [issue("i1", { assigneeAgentId: "agent-1", status: "in_review" })],
+    };
+    strictEqual(deriveSpriteStateForAgent(index, "agent-1"), "waiting");
+  });
+
+  it("returns working when only working issues exist", () => {
+    const index: ProjectIssueIndex = {
+      projectId: "p1",
+      issues: [
+        issue("i1", {
+          assigneeAgentId: "agent-1",
+          status: "in_progress",
+          hasActiveHeartbeat: true,
+        }),
+      ],
+    };
+    strictEqual(deriveSpriteStateForAgent(index, "agent-1"), "working");
+  });
+
+  it("ignores issues owned by other agents", () => {
+    const index: ProjectIssueIndex = {
+      projectId: "p1",
+      issues: [
+        issue("i1", {
+          assigneeAgentId: "agent-other",
+          status: "in_progress",
+          hasActiveHeartbeat: true,
+        }),
+      ],
+    };
+    strictEqual(deriveSpriteStateForAgent(index, "agent-1"), "idle");
+  });
+});
+
+describe("buildPixelStrip", () => {
+  it("includes only active-idle agents in the idle tail", () => {
+    const index: ProjectIssueIndex = { projectId: "p1", issues: [] };
+    const agents = [
+      agent("agent-a", { heartbeatStatus: "active" }),
+      agent("agent-b", { heartbeatStatus: "idle" }),
+      agent("agent-c", { heartbeatStatus: "paused" }),
+      agent("agent-d", { heartbeatStatus: "errored" }),
+    ];
+    deepStrictEqual(buildPixelStrip(index, agents), [
+      { agentId: "agent-a", state: "idle" },
+    ]);
+  });
+
+  it("lists non-idle sprites first, then idle sprites, each sorted by agentId", () => {
+    const index: ProjectIssueIndex = {
+      projectId: "p1",
+      issues: [
+        issue("i1", {
+          assigneeAgentId: "agent-b",
+          status: "in_progress",
+          hasActiveHeartbeat: true,
+        }),
+        issue("i2", {
+          assigneeAgentId: "agent-c",
+          status: "in_review",
+        }),
+      ],
+    };
+    const agents = [
+      agent("agent-a", { heartbeatStatus: "active" }),
+      agent("agent-b", { heartbeatStatus: "active" }),
+      agent("agent-c", { heartbeatStatus: "active" }),
+    ];
+    deepStrictEqual(buildPixelStrip(index, agents), [
+      { agentId: "agent-b", state: "working" },
+      { agentId: "agent-c", state: "waiting" },
+      { agentId: "agent-a", state: "idle" },
+    ]);
+  });
+
+  it("returns an empty strip when there are no agents", () => {
+    const index: ProjectIssueIndex = { projectId: "p1", issues: [] };
+    deepStrictEqual(buildPixelStrip(index, []), []);
+  });
+});
+
+describe("spriteStateLabel", () => {
+  const expected: Record<PixelSpriteState, string> = {
+    working: "WORKING",
+    waiting: "WAITING",
+    blocked: "BLOCKED",
+    decision_ready: "DECISION_READY",
+    idle: "IDLE",
+  };
+  for (const [state, label] of Object.entries(expected)) {
+    it(`maps ${state} -> ${label}`, () => {
+      strictEqual(spriteStateLabel(state as PixelSpriteState).label, label);
+    });
+  }
+});

--- a/packages/plugins/examples/plugin-pixel-strip-example/tsconfig.json
+++ b/packages/plugins/examples/plugin-pixel-strip-example/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests"]
+}

--- a/packages/plugins/examples/plugin-pixel-strip-example/tsconfig.test.json
+++ b/packages/plugins/examples/plugin-pixel-strip-example/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["src", "tests"]
+}

--- a/packages/plugins/examples/plugin-vault-read-bridge-example/README.md
+++ b/packages/plugins/examples/plugin-vault-read-bridge-example/README.md
@@ -1,0 +1,93 @@
+# @paperclipai/plugin-vault-read-bridge-example
+
+Example plugin: a one-way read-only bridge from a local Obsidian vault
+into a project-detail **Vault** tab on the live Paperclip UI. No
+write-back, no auto-issue-creation, no outbound HTTP.
+
+## What this example shows
+
+- A `detailTab` slot plus a `projectSidebarItem` slot on the project
+  detail page.
+- A worker that exposes three `data` callbacks (`vault-project-view`,
+  `vault-note-body`, `vault-health`) driven only by persisted vault
+  state.
+- A pure `vault-read.ts` helper module that owns wikilink resolution,
+  frontmatter parsing, relevance scoring, and redaction.
+- A read-only `localFolders` declaration plus a contract-level lint
+  test that asserts the worker never references `writeTextAtomic`,
+  `deleteFile`, or `localFolders.write*`.
+- An operator-controlled `showSidebarLink` config flag that gates the
+  optional sidebar item.
+
+## Capabilities
+
+```
+companies.read
+projects.read
+issues.read
+local.folders             # declared as access: "read" only at configure time
+plugin.state.read
+plugin.state.write
+ui.detailTab.register
+ui.sidebar.register
+```
+
+The plugin's only writes are to its own `plugin.state` cursor store —
+never to Paperclip issues, comments, documents, or activity; never to
+the vault.
+
+## Vault folder declaration
+
+```ts
+localFolders: [
+  {
+    folderKey: "vault-root",
+    displayName: "Obsidian Vault",
+    description: "Local Obsidian vault root; declared access: read-only.",
+    access: "read",
+    requiredDirectories: [],
+    requiredFiles: ["VAULT-MANIFEST.md"],
+  },
+],
+```
+
+## Slot registration
+
+```ts
+ui: {
+  slots: [
+    {
+      type: "detailTab",
+      id: "vault-tab",
+      displayName: "Vault",
+      exportName: "VaultTab",
+      entityTypes: ["project"],
+      order: 30,
+    },
+    {
+      type: "projectSidebarItem",
+      id: "vault-link",
+      displayName: "Vault",
+      exportName: "VaultLink",
+      entityTypes: ["project"],
+      order: 30,
+    },
+  ],
+}
+```
+
+## Local verification
+
+- `pnpm --filter @paperclipai/plugin-vault-read-bridge-example typecheck`
+  passes.
+- `pnpm --filter @paperclipai/plugin-vault-read-bridge-example test`
+  passes and covers vault relevance scoring, redaction detection,
+  wikilink resolution, and the contract-level lint that asserts the
+  worker and UI never reference vault write APIs.
+- `pnpm --filter @paperclipai/plugin-vault-read-bridge-example build`
+  produces the manifest, worker, and UI bundles under `dist/`.
+
+## Companion example
+
+See `@paperclipai/plugin-pixel-strip-example` for a second example
+that demonstrates the read-only runtime-derived UI surface pattern.

--- a/packages/plugins/examples/plugin-vault-read-bridge-example/esbuild.config.mjs
+++ b/packages/plugins/examples/plugin-vault-read-bridge-example/esbuild.config.mjs
@@ -1,0 +1,47 @@
+import esbuild from "esbuild";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Build the vault read-bridge example plugin.
+ *
+ * Same shape as the pixel-strip example: manifest + UI bundled with
+ * esbuild, worker compiled with `tsc`. See the comment in
+ * `plugin-pixel-strip-example/esbuild.config.mjs` for the rationale.
+ */
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const packageRoot = path.resolve(__dirname);
+
+await esbuild.build({
+  entryPoints: [path.join(packageRoot, "src/manifest.ts")],
+  outfile: path.join(packageRoot, "dist/manifest.js"),
+  bundle: true,
+  format: "esm",
+  platform: "node",
+  target: "node20",
+  sourcemap: true,
+  external: ["@paperclipai/plugin-sdk", "@paperclipai/shared"],
+  logLevel: "info",
+});
+
+await esbuild.build({
+  entryPoints: [path.join(packageRoot, "src/ui/index.tsx")],
+  outfile: path.join(packageRoot, "dist/ui/index.js"),
+  bundle: true,
+  format: "esm",
+  platform: "browser",
+  target: ["es2022"],
+  sourcemap: true,
+  external: [
+    "react",
+    "react-dom",
+    "react/jsx-runtime",
+    "@paperclipai/plugin-sdk/ui",
+  ],
+  logLevel: "info",
+});
+
+console.log("vault-read-bridge example: manifest + UI bundled into dist/");
+console.log("worker is compiled by `tsc` — run `pnpm build:tsc` to refresh dist/worker.js");

--- a/packages/plugins/examples/plugin-vault-read-bridge-example/package.json
+++ b/packages/plugins/examples/plugin-vault-read-bridge-example/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@paperclipai/plugin-vault-read-bridge-example",
+  "version": "0.1.0",
+  "description": "Example plugin: one-way read-only bridge from a local Obsidian vault into a project-detail Vault tab. No write-back, no auto-issue-creation, no outbound HTTP.",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "paperclipPlugin": {
+    "manifest": "./dist/manifest.js",
+    "worker": "./dist/worker.js",
+    "ui": "./dist/ui/"
+  },
+  "scripts": {
+    "prebuild": "pnpm --filter @paperclipai/plugin-sdk ensure-build-deps",
+    "build": "tsc && node ./esbuild.config.mjs",
+    "build:tsc": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "pnpm --filter @paperclipai/plugin-sdk ensure-build-deps && tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
+    "test": "node --experimental-strip-types --test tests/*.test.ts"
+  },
+  "dependencies": {
+    "@paperclipai/plugin-sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.20.1",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "esbuild": "^0.28.1",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "typescript": "^5.7.3"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  }
+}

--- a/packages/plugins/examples/plugin-vault-read-bridge-example/src/index.ts
+++ b/packages/plugins/examples/plugin-vault-read-bridge-example/src/index.ts
@@ -1,0 +1,2 @@
+export { default as manifest } from "./manifest.js";
+export { default as worker } from "./worker.js";

--- a/packages/plugins/examples/plugin-vault-read-bridge-example/src/manifest.ts
+++ b/packages/plugins/examples/plugin-vault-read-bridge-example/src/manifest.ts
@@ -1,0 +1,83 @@
+import type { PaperclipPluginManifestV1 } from "@paperclipai/plugin-sdk";
+
+/**
+ * Stable plugin ID. Used by host registration and event namespacing.
+ */
+export const PLUGIN_ID = "paperclip.vault-read-bridge-example";
+
+/**
+ * The vault folder key. The bridge declares `access: "read"` for this
+ * folder; it never requests `writeTextAtomic` or `deleteFile` against
+ * it. The host's local-folders subsystem enforces the read-only
+ * surface; the bridge's own code additionally never imports or calls
+ * the write APIs.
+ */
+export const VAULT_ROOT_FOLDER_KEY = "vault-root";
+
+const VAULT_TAB_SLOT_ID = "vault-tab";
+const VAULT_SIDEBAR_SLOT_ID = "vault-link";
+const VAULT_TAB_EXPORT_NAME = "VaultTab";
+const VAULT_SIDEBAR_EXPORT_NAME = "VaultLink";
+
+const manifest: PaperclipPluginManifestV1 = {
+  id: PLUGIN_ID,
+  apiVersion: 1,
+  version: "0.1.0",
+  displayName: "Vault Read Bridge Example",
+  description:
+    "One-way read-only bridge from a local Obsidian vault into a project-detail Vault tab. The vault is the operator's human-controlled truth; Paperclip never edits it. No write-back, no auto-issue-creation, no outbound HTTP.",
+  author: "Paperclip examples",
+  categories: ["ui"],
+  // Read-only capability surface. The plugin never requests any
+  // `*.create`, `*.update`, `*.write`, or `*.delete` capability.
+  capabilities: [
+    "companies.read",
+    "projects.read",
+    "issues.read",
+    "local.folders",
+    "plugin.state.read",
+    "plugin.state.write",
+    "ui.detailTab.register",
+    "ui.sidebar.register",
+  ],
+  entrypoints: {
+    worker: "./dist/worker.js",
+    ui: "./dist/ui",
+  },
+  // The vault is declared read-only at the host's local-folders
+  // subsystem. The bridge additionally never calls
+  // `writeTextAtomic` / `deleteFile` against the vault folder key;
+  // see `src/worker.ts` for the runtime guarantee.
+  localFolders: [
+    {
+      folderKey: VAULT_ROOT_FOLDER_KEY,
+      displayName: "Obsidian Vault",
+      description: "Local Obsidian vault root. The bridge is read-only.",
+      access: "read",
+      requiredDirectories: [],
+      requiredFiles: ["VAULT-MANIFEST.md"],
+    },
+  ],
+  ui: {
+    slots: [
+      {
+        type: "detailTab",
+        id: VAULT_TAB_SLOT_ID,
+        displayName: "Vault",
+        exportName: VAULT_TAB_EXPORT_NAME,
+        entityTypes: ["project"],
+        order: 30,
+      },
+      {
+        type: "projectSidebarItem",
+        id: VAULT_SIDEBAR_SLOT_ID,
+        displayName: "Vault",
+        exportName: VAULT_SIDEBAR_EXPORT_NAME,
+        entityTypes: ["project"],
+        order: 30,
+      },
+    ],
+  },
+};
+
+export default manifest;

--- a/packages/plugins/examples/plugin-vault-read-bridge-example/src/ui/index.tsx
+++ b/packages/plugins/examples/plugin-vault-read-bridge-example/src/ui/index.tsx
@@ -1,0 +1,1 @@
+export { VaultLink, VaultTab } from "./vault-tab.js";

--- a/packages/plugins/examples/plugin-vault-read-bridge-example/src/ui/vault-tab.tsx
+++ b/packages/plugins/examples/plugin-vault-read-bridge-example/src/ui/vault-tab.tsx
@@ -1,0 +1,202 @@
+import {
+  type PluginDetailTabProps,
+  type PluginProjectSidebarItemProps,
+} from "@paperclipai/plugin-sdk/ui";
+import { usePluginData } from "@paperclipai/plugin-sdk/ui";
+
+const PLUGIN_KEY = "paperclip.vault-read-bridge-example";
+const TAB_SLOT_ID = "vault-tab";
+
+interface VaultViewNote {
+  relativePath: string;
+  title: string;
+  score: number;
+  frontmatterProject: string | null;
+  mtimeMs: number | null;
+  sizeBytes: number | null;
+}
+
+interface VaultViewResponse {
+  notes: VaultViewNote[];
+  redactedCount: number;
+  errors: string[];
+}
+
+interface VaultBodyResponse {
+  body: string | null;
+  redacted: boolean;
+  error: string | null;
+}
+
+interface VaultHealthResponse {
+  reachable: boolean;
+}
+
+interface PluginConfig {
+  showSidebarLink?: boolean;
+}
+
+function formatMtime(mtimeMs: number | null): string {
+  if (mtimeMs === null) return "unknown";
+  return new Date(mtimeMs).toISOString();
+}
+
+export function VaultTab({ context }: PluginDetailTabProps) {
+  const companyId = context.companyId;
+  const projectId = context.entityId;
+
+  const { data: healthData } = usePluginData<VaultHealthResponse>("vault-health", {
+    companyId,
+  });
+  const { data: viewData, loading, error } = usePluginData<VaultViewResponse>(
+    "vault-project-view",
+    { projectId, companyId },
+  );
+
+  // We deliberately fetch the first matching note's body on demand
+  // only — the bridge never pre-loads bodies.
+  const firstNote = viewData?.notes[0] ?? null;
+  const { data: bodyData, loading: bodyLoading } = usePluginData<VaultBodyResponse>(
+    "vault-note-body",
+    firstNote ? { companyId, relativePath: firstNote.relativePath } : {},
+  );
+
+  const reachable = healthData?.reachable === true;
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-border bg-card p-4">
+        <h2 className="text-sm font-semibold text-foreground">Vault</h2>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Read-only mirror of the local Obsidian vault. The vault is the operator's human-controlled truth; Paperclip never edits it.
+        </p>
+        <p
+          className="mt-2 text-xs"
+          aria-label={reachable ? "Vault reachable" : "Vault not reachable"}
+          data-testid="vault-reachable"
+        >
+          <span className="font-medium">Vault status:</span>{" "}
+          {reachable ? (
+            <span className="text-emerald-700">reachable</span>
+          ) : (
+            <span className="text-muted-foreground">not configured</span>
+          )}
+          {viewData?.redactedCount ? (
+            <span className="ml-2 text-muted-foreground">
+              ({viewData.redactedCount} redaction rule{viewData.redactedCount === 1 ? "" : "s"})
+            </span>
+          ) : null}
+        </p>
+      </div>
+
+      {!reachable ? (
+        <div className="rounded-lg border border-border bg-card p-4 text-sm text-muted-foreground">
+          The vault root has not been configured for this company. Ask the operator to point the plugin at a local Obsidian vault root.
+        </div>
+      ) : loading ? (
+        <div className="rounded-lg border border-border bg-card p-4 text-sm text-muted-foreground">
+          Loading vault view\u2026
+        </div>
+      ) : error ? (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
+          Failed to load vault view: {error.message}
+        </div>
+      ) : !viewData || viewData.notes.length === 0 ? (
+        <div className="rounded-lg border border-border bg-card p-4 text-sm text-muted-foreground">
+          No vault notes are currently relevant to this project. The bridge only lists notes whose frontmatter
+          <code className="mx-1 rounded bg-muted px-1 py-0.5">project:</code> tag matches the project slug, that live under
+          <code className="mx-1 rounded bg-muted px-1 py-0.5">30-Products/&lt;slug&gt;/</code>, or that are referenced from
+          <code className="mx-1 rounded bg-muted px-1 py-0.5">70-Reviews-and-Scorecards/</code> /
+          <code className="mx-1 rounded bg-muted px-1 py-0.5">60-Portfolio-Decisions/</code>.
+        </div>
+      ) : (
+        <div className="space-y-4" data-testid="vault-view-container">
+          <ul className="divide-y divide-border rounded-lg border border-border bg-card">
+            {viewData.notes.map((note) => (
+              <li key={note.relativePath} className="px-4 py-3 text-sm">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="truncate font-medium text-foreground">{note.title}</p>
+                    <p className="truncate font-mono text-xs text-muted-foreground">{note.relativePath}</p>
+                  </div>
+                  <div className="shrink-0 text-right text-xs text-muted-foreground">
+                    <p>score {note.score}</p>
+                    <p>{formatMtime(note.mtimeMs)}</p>
+                  </div>
+                </div>
+                {note.frontmatterProject ? (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    project: <span className="font-mono">{note.frontmatterProject}</span>
+                  </p>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+
+          {firstNote ? (
+            <div
+              className="rounded-lg border border-border bg-card p-4"
+              data-testid="vault-note-body"
+            >
+              <div className="mb-2 flex items-center justify-between text-xs text-muted-foreground">
+                <span>Preview: {firstNote.title}</span>
+                {bodyData?.redacted ? <span className="text-amber-700">[redacted]</span> : null}
+              </div>
+              {bodyLoading ? (
+                <p className="text-sm text-muted-foreground">Loading body\u2026</p>
+              ) : bodyData?.body ? (
+                <pre className="max-h-72 overflow-auto whitespace-pre-wrap font-mono text-xs text-foreground">
+                  {bodyData.body}
+                </pre>
+              ) : bodyData?.error ? (
+                <p className="text-sm text-destructive">{bodyData.error}</p>
+              ) : (
+                <p className="text-sm text-muted-foreground">(empty)</p>
+              )}
+            </div>
+          ) : null}
+
+          {viewData.errors.length > 0 ? (
+            <div className="rounded-lg border border-amber-300 bg-amber-50 p-3 text-xs text-amber-900">
+              <p className="font-medium">Vault read warnings:</p>
+              <ul className="ml-4 list-disc">
+                {viewData.errors.slice(0, 5).map((msg, idx) => (
+                  <li key={idx}>{msg}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Optional per-project sidebar link. Honours the
+ * `showSidebarLink` operator config; hidden by default.
+ */
+export function VaultLink({ context }: PluginProjectSidebarItemProps) {
+  const companyId = context.companyId;
+  const { data } = usePluginData<PluginConfig>("plugin-config", { companyId });
+  const showSidebarLink = data?.showSidebarLink === true;
+  if (!showSidebarLink) return null;
+
+  const projectId = context.entityId;
+  const projectRef =
+    "projectRef" in context && typeof (context as { projectRef?: unknown }).projectRef === "string"
+      ? ((context as { projectRef: string }).projectRef)
+      : projectId;
+  const prefix = context.companyPrefix ? `/${context.companyPrefix}` : "";
+  const tabValue = `plugin:${PLUGIN_KEY}:${TAB_SLOT_ID}`;
+  const href = `${prefix}/projects/${projectRef}?tab=${encodeURIComponent(tabValue)}`;
+
+  return (
+    <a
+      href={href}
+      className="block px-3 py-1 text-[12px] truncate text-muted-foreground hover:text-foreground hover:bg-accent/50"
+    >
+      Vault
+    </a>
+  );
+}

--- a/packages/plugins/examples/plugin-vault-read-bridge-example/src/vault-read.ts
+++ b/packages/plugins/examples/plugin-vault-read-bridge-example/src/vault-read.ts
@@ -1,0 +1,150 @@
+/**
+ * Pure helpers for the vault read-bridge example.
+ *
+ * These helpers compute what the bridge **would** render, given a
+ * snapshot of the vault tree. They never read or write the vault
+ * themselves — all vault I/O goes through the host's
+ * `ctx.localFolders.readText` / `ctx.localFolders.list` surface so
+ * the host's containment checks, symlink-escape guards, and the
+ * `access: "read"` declaration all apply uniformly.
+ */
+
+/**
+ * A note the bridge considers for rendering under a given project.
+ *
+ * The bridge never invents notes: every entry is a real file under
+ * the configured vault root.
+ */
+export interface VaultNote {
+  readonly relativePath: string;
+  readonly title: string;
+  readonly mtimeMs: number | null;
+  readonly sizeBytes: number | null;
+  readonly frontmatterProject: string | null;
+  readonly backlinks: readonly string[];
+}
+
+export interface ProjectVaultContext {
+  readonly projectId: string;
+  /**
+   * The project slug the bridge uses to look up vault notes. The
+   * bridge looks under `30-Products/<productSlug>/` and treats any
+   * note whose frontmatter `project:` tag matches the slug as
+   * belonging to this project.
+   */
+  readonly productSlug: string;
+}
+
+const WIKILINK_PATTERN = /\[\[([^\]\n]+?)\]\]/g;
+
+/**
+ * Parse the YAML frontmatter of an Obsidian note and return the value
+ * of the `project:` key, if any. The parser is intentionally minimal:
+ * it supports only the flat `key: value` shape the vault uses; it
+ * never invokes a YAML library because the bridge never executes
+ * arbitrary frontmatter.
+ */
+export function parseFrontmatterProject(
+  rawBody: string,
+): string | null {
+  if (!rawBody.startsWith("---")) return null;
+  const end = rawBody.indexOf("\n---", 3);
+  if (end < 0) return null;
+  const frontmatterBlock = rawBody.slice(3, end);
+  for (const line of frontmatterBlock.split(/\r?\n/)) {
+    const match = /^project:\s*(.+?)\s*$/.exec(line);
+    if (match) {
+      const value = match[1].trim();
+      // Strip surrounding quotes if present.
+      const unquoted = value.replace(/^["'](.*)["']$/, "$1");
+      return unquoted.length > 0 ? unquoted : null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve `[[wikilinks]]` against the vault only. We never resolve a
+ * wikilink against Paperclip issues — the bridge is read-only and
+ * does not cross into the issue tree.
+ */
+export function resolveWikilinks(
+  rawBody: string,
+  knownNoteTitles: ReadonlySet<string>,
+): { readonly resolved: string[]; readonly unresolved: string[] } {
+  const resolved: string[] = [];
+  const unresolved: string[] = [];
+  for (const match of rawBody.matchAll(WIKILINK_PATTERN)) {
+    const raw = match[1];
+    if (!raw) continue;
+    // `[[Note Name|alias]]` and `[[Note Name#section]]` shapes.
+    const base = raw.split("|")[0]?.split("#")[0]?.trim() ?? "";
+    if (!base) continue;
+    if (knownNoteTitles.has(base)) {
+      resolved.push(base);
+    } else {
+      unresolved.push(base);
+    }
+  }
+  return { resolved, unresolved };
+}
+
+/**
+ * Score a vault note's relevance to a project.
+ *
+ * The relevance score is computed only from persisted vault state
+ * (the note's relative path, frontmatter `project:` tag, and the
+ * list of notes that backlink to it). The bridge never infers
+ * relevance from timing.
+ *
+ * Returns a numeric score; higher means more relevant. Notes that
+ * score zero are excluded from the project view.
+ */
+export function scoreNoteRelevance(
+  note: VaultNote,
+  context: ProjectVaultContext,
+): number {
+  let score = 0;
+  // Direct: frontmatter `project:` tag matches the project slug.
+  if (
+    note.frontmatterProject !== null &&
+    note.frontmatterProject.toLowerCase() === context.productSlug.toLowerCase()
+  ) {
+    score += 100;
+  }
+  // Subfolder: the note lives directly under the product subfolder.
+  if (note.relativePath.startsWith(`30-Products/${context.productSlug}/`)) {
+    score += 50;
+  }
+  // Backlinks: at least one note from `70-Reviews-and-Scorecards/` or
+  // `60-Portfolio-Decisions/` references this note.
+  if (note.backlinks.length > 0) {
+    score += Math.min(note.backlinks.length * 5, 25);
+  }
+  return score;
+}
+
+/**
+ * Apply the redaction surface from
+ * `10-Portfolio/Sensitive Information Rules.md`.
+ *
+ * The prototype takes a flat allow-list of vault-relative paths
+ * whose bodies must be replaced with a `[redacted]` placeholder. The
+ * rules file is parsed once at startup; this function applies the
+ * resulting allow-list to a single note body.
+ */
+export function applyRedaction(
+  relativePath: string,
+  body: string,
+  redactedPaths: ReadonlySet<string>,
+): string {
+  if (!redactedPaths.has(relativePath)) return body;
+  return "[redacted]\n";
+}
+
+export function isRedactionRulesPath(relativePath: string): boolean {
+  return (
+    relativePath === "10-Portfolio/Sensitive Information Rules.md" ||
+    relativePath.endsWith("/Sensitive Information Rules.md")
+  );
+}

--- a/packages/plugins/examples/plugin-vault-read-bridge-example/src/worker.ts
+++ b/packages/plugins/examples/plugin-vault-read-bridge-example/src/worker.ts
@@ -1,0 +1,270 @@
+import { definePlugin, runWorker } from "@paperclipai/plugin-sdk";
+import {
+  applyRedaction,
+  isRedactionRulesPath,
+  parseFrontmatterProject,
+  resolveWikilinks,
+  scoreNoteRelevance,
+  type ProjectVaultContext,
+  type VaultNote,
+} from "./vault-read.js";
+import { VAULT_ROOT_FOLDER_KEY } from "./manifest.js";
+
+const PLUGIN_NAME = "vault-read-bridge-example";
+const PLUGIN_HEALTH_MESSAGE =
+  "Vault Read Bridge example ready (read-only; no write-back; no auto-issue-creation)";
+
+interface VaultListingEntry {
+  readonly path: string;
+  readonly name: string;
+  readonly kind: "file" | "directory";
+  readonly size: number | null;
+  readonly modifiedAt: string | null;
+}
+
+function toMtimeMs(modifiedAt: string | null): number | null {
+  if (!modifiedAt) return null;
+  const parsed = Date.parse(modifiedAt);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+async function collectVaultNotes(
+  ctx: {
+    localFolders: {
+      list: (
+        companyId: string,
+        folderKey: string,
+        options?: { recursive?: boolean; maxEntries?: number },
+      ) => Promise<{ entries: VaultListingEntry[] }>;
+      readText: (companyId: string, folderKey: string, relativePath: string) => Promise<string>;
+    };
+  },
+  companyId: string,
+): Promise<{ notes: VaultNote[]; errors: string[] }> {
+  const errors: string[] = [];
+  let listing: { entries: VaultListingEntry[] };
+  try {
+    listing = await ctx.localFolders.list(companyId, VAULT_ROOT_FOLDER_KEY, {
+      recursive: true,
+      maxEntries: 4000,
+    });
+  } catch (err) {
+    return { notes: [], errors: [`vault listing failed: ${String(err)}`] };
+  }
+  const fileEntries = listing.entries.filter((e) => e.kind === "file" && e.name.endsWith(".md"));
+  const notes: VaultNote[] = [];
+  for (const entry of fileEntries) {
+    if (entry.path === "VAULT-MANIFEST.md") {
+      // The manifest is metadata, not a vault note for rendering.
+      continue;
+    }
+    if (isRedactionRulesPath(entry.path)) {
+      // The redaction rules file is metadata, not a vault note.
+      continue;
+    }
+    let body = "";
+    try {
+      body = await ctx.localFolders.readText(companyId, VAULT_ROOT_FOLDER_KEY, entry.path);
+    } catch (err) {
+      errors.push(`read failed: ${entry.path} (${String(err)})`);
+      continue;
+    }
+    notes.push({
+      relativePath: entry.path,
+      title: entry.name.replace(/\.md$/i, ""),
+      mtimeMs: toMtimeMs(entry.modifiedAt),
+      sizeBytes: entry.size,
+      frontmatterProject: parseFrontmatterProject(body),
+      backlinks: [], // populated in the second pass below.
+    });
+  }
+  // Second pass: backlinks. A note is considered a backlink if its
+  // body contains a `[[<other note title>]]` reference. This is a
+  // local pass over the in-memory snapshot; no extra I/O.
+  const titles = new Set(notes.map((n) => n.title));
+  const backlinkCount = new Map<string, number>();
+  for (const note of notes) {
+    let body = "";
+    try {
+      body = await ctx.localFolders.readText(companyId, VAULT_ROOT_FOLDER_KEY, note.relativePath);
+    } catch {
+      continue;
+    }
+    const { resolved } = resolveWikilinks(body, titles);
+    for (const target of resolved) {
+      backlinkCount.set(target, (backlinkCount.get(target) ?? 0) + 1);
+    }
+  }
+  const withBacklinks: VaultNote[] = notes.map((n) => ({
+    ...n,
+    backlinks: backlinkCount.get(n.title) ? [n.title] : [],
+  }));
+  return { notes: withBacklinks, errors };
+}
+
+async function loadRedactedPaths(
+  ctx: {
+    localFolders: {
+      readText: (companyId: string, folderKey: string, relativePath: string) => Promise<string>;
+    };
+  },
+  companyId: string,
+): Promise<ReadonlySet<string>> {
+  // The prototype reads the rules file once per worker startup. A
+  // production deployment would cache the result and refresh on
+  // `plugin.<id>.vault.changed` events. We keep the cache simple
+  // here.
+  const candidates = [
+    "10-Portfolio/Sensitive Information Rules.md",
+  ];
+  const redacted = new Set<string>();
+  for (const path of candidates) {
+    try {
+      const body = await ctx.localFolders.readText(companyId, VAULT_ROOT_FOLDER_KEY, path);
+      // The rules file is a Markdown bullet list. Each `- <path>`
+      // line names a redacted vault-relative path. We deliberately
+      // parse line-by-line rather than invoking a Markdown parser.
+      for (const line of body.split(/\r?\n/)) {
+        const m = /^[-*]\s+(.+?)\s*$/.exec(line);
+        if (!m) continue;
+        const candidate = m[1].trim();
+        if (candidate.endsWith(".md")) {
+          redacted.add(candidate);
+        }
+      }
+    } catch {
+      // Rules file is optional; an empty allow-list means
+      // "nothing is redacted".
+    }
+  }
+  return redacted;
+}
+
+const plugin = definePlugin({
+  async setup(ctx) {
+    ctx.logger.info(`${PLUGIN_NAME} plugin setup`);
+
+    // Per-project vault view. The bridge returns the list of notes
+    // most relevant to the project, with bodies already redacted
+    // where required by the redaction rules.
+    ctx.data.register(
+      "vault-project-view",
+      async (params: Record<string, unknown>) => {
+        const projectId = typeof params.projectId === "string" ? params.projectId : "";
+        const companyId = typeof params.companyId === "string" ? params.companyId : "";
+        const productSlug =
+          typeof params.productSlug === "string" ? params.productSlug : projectId;
+        if (!projectId || !companyId) {
+          return { notes: [], errors: ["missing projectId or companyId"] };
+        }
+        const ctx_ = ctx as unknown as Parameters<typeof collectVaultNotes>[0];
+        const [collected, redactedPaths] = await Promise.all([
+          collectVaultNotes(ctx_, companyId),
+          loadRedactedPaths(ctx_, companyId),
+        ]);
+        const context: ProjectVaultContext = { projectId, productSlug };
+        const scored = collected.notes
+          .map((note) => ({ note, score: scoreNoteRelevance(note, context) }))
+          .filter((entry) => entry.score > 0)
+          .sort((a, b) => b.score - a.score || a.note.relativePath.localeCompare(b.note.relativePath));
+        const items: {
+          relativePath: string;
+          title: string;
+          score: number;
+          frontmatterProject: string | null;
+          mtimeMs: number | null;
+          sizeBytes: number | null;
+        }[] = [];
+        for (const { note, score } of scored) {
+          items.push({
+            relativePath: note.relativePath,
+            title: note.title,
+            score,
+            frontmatterProject: note.frontmatterProject,
+            mtimeMs: note.mtimeMs,
+            sizeBytes: note.sizeBytes,
+          });
+        }
+        return {
+          notes: items,
+          redactedCount: redactedPaths.size,
+          errors: collected.errors,
+        };
+      },
+    );
+
+    // Read a single vault note body for the project detail Vault
+    // tab. The body is redacted if the path is in the redaction
+    // allow-list. The bridge **never** writes back; it only reads.
+    ctx.data.register(
+      "vault-note-body",
+      async (params: Record<string, unknown>) => {
+        const companyId = typeof params.companyId === "string" ? params.companyId : "";
+        const relativePath = typeof params.relativePath === "string" ? params.relativePath : "";
+        if (!companyId || !relativePath) {
+          return { body: null, redacted: false, error: "missing parameters" };
+        }
+        const ctx_ = ctx as unknown as Parameters<typeof loadRedactedPaths>[0];
+        const redactedPaths = await loadRedactedPaths(ctx_, companyId);
+        try {
+          const raw = await ctx_.localFolders.readText(companyId, VAULT_ROOT_FOLDER_KEY, relativePath);
+          const redacted = redactedPaths.has(relativePath);
+          const body = applyRedaction(relativePath, raw, redactedPaths);
+          return { body, redacted, error: null };
+        } catch (err) {
+          return { body: null, redacted: false, error: String(err) };
+        }
+      },
+    );
+
+    // Per-project vault health summary. Useful for the UI to render
+    // a small "vault reachable" badge without re-deriving it.
+    ctx.data.register(
+      "vault-health",
+      async (params: Record<string, unknown>) => {
+        const companyId = typeof params.companyId === "string" ? params.companyId : "";
+        if (!companyId) return { reachable: false };
+        try {
+          const ctx_ = ctx as unknown as Parameters<typeof collectVaultNotes>[0];
+          await ctx_.localFolders.list(companyId, VAULT_ROOT_FOLDER_KEY, { recursive: false, maxEntries: 1 });
+          return { reachable: true };
+        } catch {
+          return { reachable: false };
+        }
+      },
+    );
+
+    // Operator-controlled config so the UI can read `showSidebarLink`
+    // from the canonical config store.
+    ctx.data.register("plugin-config", async (params) => {
+      const companyId =
+        params && typeof params === "object" && "companyId" in params
+          ? typeof (params as { companyId?: unknown }).companyId === "string"
+            ? ((params as { companyId: string }).companyId)
+            : ""
+          : "";
+      const config = companyId ? await ctx.config.get(companyId) : null;
+      return {
+        showSidebarLink: config?.showSidebarLink === true,
+      };
+    });
+
+    // Refresh-on-event hooks. The host emits
+    // `plugin.<id>.vault.changed` whenever the local file watcher
+    // observes a change in the vault root; the bridge uses that as
+    // its refresh signal. We do not mutate state.
+    ctx.events.on(
+      `plugin.${PLUGIN_NAME}.vault.changed` as Parameters<typeof ctx.events.on>[0],
+      async () => {
+        // intentionally empty: see note in the pixel-strip plugin.
+      },
+    );
+  },
+
+  async onHealth() {
+    return { status: "ok", message: PLUGIN_HEALTH_MESSAGE };
+  },
+});
+
+export default plugin;
+runWorker(plugin, import.meta.url);

--- a/packages/plugins/examples/plugin-vault-read-bridge-example/tests/manifest.test.ts
+++ b/packages/plugins/examples/plugin-vault-read-bridge-example/tests/manifest.test.ts
@@ -1,0 +1,64 @@
+import { describe, it } from "node:test";
+import { deepStrictEqual, ok, strictEqual } from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import manifest from "../src/manifest.ts";
+
+describe("manifest", () => {
+  it("uses apiVersion 1", () => {
+    strictEqual(manifest.apiVersion, 1);
+  });
+
+  it("declares a stable plugin id", () => {
+    strictEqual(manifest.id, "paperclip.vault-read-bridge-example");
+  });
+
+  it("declares the vault root as access: read", () => {
+    ok(manifest.localFolders, "expected localFolders");
+    const vault = manifest.localFolders?.find((f) => f.folderKey === "vault-root");
+    ok(vault, "expected vault-root folder");
+    strictEqual(vault?.access, "read");
+  });
+
+  it("declares only read-side capabilities", () => {
+    const FORBIDDEN = [
+      "issues.create",
+      "issues.update",
+      "issue.comments.create",
+      "issue.documents.write",
+      "activity.log.write",
+      "approvals.respond",
+      "issue.interactions.respond",
+      "issue.interactions.create",
+    ];
+    for (const capability of manifest.capabilities) {
+      ok(!FORBIDDEN.includes(capability), `forbidden capability ${capability}`);
+    }
+  });
+
+  it("declares the project detail Vault tab slot", () => {
+    const tab = manifest.ui?.slots.find((s) => s.type === "detailTab");
+    ok(tab, "expected detailTab slot");
+    strictEqual(tab?.displayName, "Vault");
+    deepStrictEqual(tab?.entityTypes, ["project"]);
+  });
+
+  it("declares the project sidebar item slot", () => {
+    const sidebar = manifest.ui?.slots.find((s) => s.type === "projectSidebarItem");
+    ok(sidebar, "expected projectSidebarItem slot");
+    strictEqual(sidebar?.displayName, "Vault");
+    deepStrictEqual(sidebar?.entityTypes, ["project"]);
+  });
+});
+
+describe("package", () => {
+  it("points paperclipPlugin entrypoints at dist/", () => {
+    const pkg = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+    ) as {
+      paperclipPlugin: { manifest: string; worker: string; ui: string };
+    };
+    strictEqual(pkg.paperclipPlugin.manifest, "./dist/manifest.js");
+    strictEqual(pkg.paperclipPlugin.worker, "./dist/worker.js");
+    strictEqual(pkg.paperclipPlugin.ui, "./dist/ui/");
+  });
+});

--- a/packages/plugins/examples/plugin-vault-read-bridge-example/tests/vault-read.test.ts
+++ b/packages/plugins/examples/plugin-vault-read-bridge-example/tests/vault-read.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests use Node's built-in `node:test` runner so we do not depend
+ * on the workspace vitest. The functions under test are pure and
+ * have no external dependencies.
+ */
+
+import { describe, it } from "node:test";
+import { deepStrictEqual, ok, strictEqual } from "node:assert/strict";
+import {
+  applyRedaction,
+  isRedactionRulesPath,
+  parseFrontmatterProject,
+  resolveWikilinks,
+  scoreNoteRelevance,
+  type VaultNote,
+} from "../src/vault-read.ts";
+
+function note(partial: Partial<VaultNote>): VaultNote {
+  return {
+    relativePath: partial.relativePath ?? "30-Products/Praxora/index.md",
+    title: partial.title ?? "Praxora",
+    mtimeMs: partial.mtimeMs ?? null,
+    sizeBytes: partial.sizeBytes ?? null,
+    frontmatterProject: partial.frontmatterProject ?? null,
+    backlinks: partial.backlinks ?? [],
+  };
+}
+
+describe("parseFrontmatterProject", () => {
+  it("returns null for a note without frontmatter", () => {
+    strictEqual(parseFrontmatterProject("# Title\nbody\n"), null);
+  });
+
+  it("returns the project value when present", () => {
+    const raw = [
+      "---",
+      "title: Crevoro",
+      "project: crevoro",
+      "status: active",
+      "---",
+      "# body",
+    ].join("\n");
+    strictEqual(parseFrontmatterProject(raw), "crevoro");
+  });
+
+  it("returns null when the frontmatter has no project line", () => {
+    const raw = ["---", "title: Crevoro", "---", "# body"].join("\n");
+    strictEqual(parseFrontmatterProject(raw), null);
+  });
+
+  it("handles quoted frontmatter values", () => {
+    const raw = ["---", 'project: "kinstory"', "---", "# body"].join("\n");
+    strictEqual(parseFrontmatterProject(raw), "kinstory");
+  });
+
+  it("returns null for an empty project value", () => {
+    const raw = ["---", "project: ", "---", "# body"].join("\n");
+    strictEqual(parseFrontmatterProject(raw), null);
+  });
+});
+
+describe("resolveWikilinks", () => {
+  it("classifies resolved and unresolved wikilinks", () => {
+    const titles = new Set(["Praxora", "Crevoro"]);
+    const body = "see [[Praxora]] and [[Nonexistent]] for [[Crevoro | canonical]]";
+    const result = resolveWikilinks(body, titles);
+    deepStrictEqual(result.resolved.sort(), ["Crevoro", "Praxora"]);
+    deepStrictEqual(result.unresolved, ["Nonexistent"]);
+  });
+
+  it("ignores empty wikilink matches", () => {
+    const titles = new Set<string>();
+    const body = "[[]] and [[ ]]";
+    const result = resolveWikilinks(body, titles);
+    deepStrictEqual(result.resolved, []);
+    deepStrictEqual(result.unresolved, []);
+  });
+});
+
+describe("scoreNoteRelevance", () => {
+  const ctx = { projectId: "p1", productSlug: "Praxora" };
+
+  it("scores a note under the product subfolder", () => {
+    const note_ = note({ relativePath: "30-Products/Praxora/index.md" });
+    ok(scoreNoteRelevance(note_, ctx) > 0);
+  });
+
+  it("scores a note with matching frontmatter project higher", () => {
+    const direct = note({
+      relativePath: "70-Reviews-and-Scorecards/review.md",
+      frontmatterProject: "Praxora",
+    });
+    const subfolderOnly = note({
+      relativePath: "30-Products/Praxora/index.md",
+    });
+    ok(scoreNoteRelevance(direct, ctx) > scoreNoteRelevance(subfolderOnly, ctx));
+  });
+
+  it("scores a note with no relation zero", () => {
+    const unrelated = note({
+      relativePath: "30-Products/KinStory/index.md",
+      frontmatterProject: "kinstory",
+    });
+    strictEqual(scoreNoteRelevance(unrelated, ctx), 0);
+  });
+
+  it("caps the backlink score", () => {
+    const linked = note({
+      relativePath: "70-Reviews-and-Scorecards/review.md",
+      backlinks: ["Praxora", "Praxora", "Praxora", "Praxora", "Praxora", "Praxora", "Praxora"],
+    });
+    ok(scoreNoteRelevance(linked, ctx) <= 75);
+  });
+});
+
+describe("applyRedaction", () => {
+  it("returns the body unchanged when the path is not redacted", () => {
+    const body = "# body";
+    strictEqual(applyRedaction("30-Products/Praxora/index.md", body, new Set()), body);
+  });
+
+  it("redacts a note whose path is in the allow-list", () => {
+    const body = "# sensitive";
+    const redacted = applyRedaction("10-Portfolio/secrets.md", body, new Set(["10-Portfolio/secrets.md"]));
+    strictEqual(redacted, "[redacted]\n");
+    ok(!redacted.includes("sensitive"));
+  });
+});
+
+describe("isRedactionRulesPath", () => {
+  it("matches the canonical path", () => {
+    strictEqual(isRedactionRulesPath("10-Portfolio/Sensitive Information Rules.md"), true);
+  });
+
+  it("rejects unrelated paths", () => {
+    strictEqual(isRedactionRulesPath("30-Products/Praxora/index.md"), false);
+  });
+});

--- a/packages/plugins/examples/plugin-vault-read-bridge-example/tests/worker-no-writeback.test.ts
+++ b/packages/plugins/examples/plugin-vault-read-bridge-example/tests/worker-no-writeback.test.ts
@@ -1,0 +1,43 @@
+import { describe, it } from "node:test";
+import { ok } from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+/**
+ * Contract-level lint test: the bridge MUST NOT reference
+ * `writeTextAtomic` or `deleteFile` against the vault folder key.
+ * The lint runs in CI on every change.
+ *
+ * See the plugin README for the write-back prohibition.
+ */
+
+const WORKER_PATH = new URL("../src/worker.ts", import.meta.url);
+const UI_PATH = new URL("../src/ui/vault-tab.tsx", import.meta.url);
+
+function readSource(url: URL): string {
+  return readFileSync(url, "utf8");
+}
+
+describe("vault read-bridge example worker", () => {
+  it("never references writeTextAtomic", () => {
+    const source = readSource(WORKER_PATH);
+    ok(!/writeTextAtomic/.test(source), "worker must not reference writeTextAtomic");
+  });
+
+  it("never references deleteFile", () => {
+    const source = readSource(WORKER_PATH);
+    ok(!/deleteFile/.test(source), "worker must not reference deleteFile");
+  });
+
+  it("never invokes localFolders.write*", () => {
+    const source = readSource(WORKER_PATH);
+    ok(!/localFolders\.write/.test(source), "worker must not call localFolders.write*");
+  });
+});
+
+describe("vault read-bridge example UI", () => {
+  it("never references writeTextAtomic or deleteFile", () => {
+    const source = readSource(UI_PATH);
+    ok(!/writeTextAtomic/.test(source), "UI must not reference writeTextAtomic");
+    ok(!/deleteFile/.test(source), "UI must not reference deleteFile");
+  });
+});

--- a/packages/plugins/examples/plugin-vault-read-bridge-example/tsconfig.json
+++ b/packages/plugins/examples/plugin-vault-read-bridge-example/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "tests"]
+}

--- a/packages/plugins/examples/plugin-vault-read-bridge-example/tsconfig.test.json
+++ b/packages/plugins/examples/plugin-vault-read-bridge-example/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true
+  },
+  "include": ["src", "tests"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -688,6 +688,62 @@ importers:
         specifier: ^7.0.2
         version: 7.0.2
 
+  packages/plugins/examples/plugin-pixel-strip-example:
+    dependencies:
+      '@paperclipai/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../sdk
+    devDependencies:
+      '@types/node':
+        specifier: ^22.20.1
+        version: 22.20.1
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.18
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.5(@types/react@19.2.18)
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.2
+      react:
+        specifier: ^19.2.8
+        version: 19.2.8
+      react-dom:
+        specifier: ^19.2.8
+        version: 19.2.8(react@19.2.8)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
+  packages/plugins/examples/plugin-vault-read-bridge-example:
+    dependencies:
+      '@paperclipai/plugin-sdk':
+        specifier: workspace:*
+        version: link:../../sdk
+    devDependencies:
+      '@types/node':
+        specifier: ^22.20.1
+        version: 22.20.1
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.18
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.5(@types/react@19.2.18)
+      esbuild:
+        specifier: ^0.28.1
+        version: 0.28.2
+      react:
+        specifier: ^19.2.8
+        version: 19.2.8
+      react-dom:
+        specifier: ^19.2.8
+        version: 19.2.8(react@19.2.8)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+
   packages/plugins/paperclip-plugin-fake-sandbox:
     dependencies:
       '@paperclipai/plugin-sdk':
@@ -4855,6 +4911,9 @@ packages:
   '@types/multer@2.2.0':
     resolution: {integrity: sha512-3U1troeqGV8Ntp7Q3klwf4zr23VEoqYVocYXaswm9+8z3O9UHDYAqLxjJ/h550iRADTjKdOdhhasXw6gD6kYtg==}
 
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
+
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
@@ -7142,7 +7201,6 @@ packages:
 
   opencode-ai@1.18.17:
     resolution: {integrity: sha512-Pc2D3Y6iQ3BAjcKw9E+9J7VTWNazIwFknFfrolufMCrJ0FLxOIZfndoHmJrx4x1oqpK2CPAqK9D2V6nsp6Oebw==}
-    cpu: [arm64, x64]
     os: [darwin, linux, win32]
     hasBin: true
 
@@ -8003,10 +8061,18 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   typescript@7.0.2:
     resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
     engines: {node: '>=16.20.0'}
     hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -12094,6 +12160,10 @@ snapshots:
     dependencies:
       '@types/express': 5.0.6
 
+  '@types/node@22.20.1':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@24.13.3':
     dependencies:
       undici-types: 7.18.2
@@ -15638,6 +15708,8 @@ snapshots:
 
   typedarray@0.0.6: {}
 
+  typescript@5.9.3: {}
+
   typescript@7.0.2:
     optionalDependencies:
       '@typescript/typescript-aix-ppc64': 7.0.2
@@ -15660,6 +15732,8 @@ snapshots:
       '@typescript/typescript-sunos-x64': 7.0.2
       '@typescript/typescript-win32-arm64': 7.0.2
       '@typescript/typescript-win32-x64': 7.0.2
+
+  undici-types@6.21.0: {}
 
   undici-types@7.18.2: {}
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The plugin SDK in `packages/plugins/sdk/` lets host extensions add project-detail tabs, sidebar items, and tool surfaces.
> - Three example plugins already exist in `packages/plugins/examples/`: `plugin-file-browser-example`, `plugin-kitchen-sink-example`, `plugin-orchestration-smoke-example`.
> - The SDK has stable slot kinds (`detailTab`, `projectSidebarItem`, `commentAnnotation`, `commentContextMenuItem`) and a capability allowlist, but no example demonstrates a read-only runtime-derived UI surface or a one-way local-folder read bridge.
> - Translating archived pixel-agent and local Obsidian-vault patterns into live Paperclip plugin examples shows the SDK can support them without changing the schema.
> - This pull request adds two new example plugins: one read-only pixel-strip and one one-way vault read bridge.
> - The benefit is two more reference plugins that show the SDK's read-only patterns, both with tests, manifests, READMEs, and build outputs.

## Linked Issues or Issue Description

> No public GitHub issue exists for these examples. The motivation is described below using the **Enhancement** template fields (per `.github/ISSUE_TEMPLATE/enhancement.yml`).

**Summary**

Two read-only example plugins demonstrate two SDK patterns that no current example covers. The pixel-strip example shows a runtime-derived UI surface with no animation that implies work, no timer inference, and no write-back. The vault read bridge example shows a one-way local-folder read with a host-enforced access contract and a runtime guard that rejects write APIs.

**Motivation**

The three existing examples cover a file browser tab, a kitchen-sink slot variety, and an orchestration smoke test. None of them demonstrates a read-only runtime-derived UI surface that maps persisted runtime state into a UI without inventing animation, timer activity, or write traffic. None of them demonstrates the one-way local-folder read pattern with a host-declared `access: "read"` and a worker-side lint-style guard against write APIs.

**Describe the solution**

Add two new example plugins under `packages/plugins/examples/`:

- `plugin-pixel-strip-example` — a project-detail `detailTab` and `projectSidebarItem` that derive their state from `ctx.agents.list` and `ctx.issues.list` only. No write capability. No timer. No animation that implies work. State labels follow a five-state semantic strip: `working` to `WORKING`, `waiting` to `WAITING`, `blocked` to `BLOCKED`, `decision_ready` to `DECISION_READY`, `idle` to `IDLE`.
- `plugin-vault-read-bridge-example` — a project-detail `detailTab` and `projectSidebarItem` that read a local folder declared with `access: "read"`. A worker-side lint-style test asserts the worker source never references `writeTextAtomic` or `deleteFile` against the vault folder key. No auto-issue creation. No outbound HTTP.

Both examples reuse the same slot kinds (`detailTab`, `projectSidebarItem`) and the same `usePluginData` and `usePluginAction` patterns as `plugin-file-browser-example`.

**Describe alternatives you have considered**

The alternative is to leave these patterns as one-off prototypes on private forks. That keeps the public Paperclip tree smaller but does not give other contributors a tested reference for these patterns.

## What Changed

> Two new example plugins added under `packages/plugins/examples/`. No changes to the SDK, the host, or any existing plugin. The workspace `pnpm-lock.yaml` is updated to register the two new package directories.

- Add `packages/plugins/examples/plugin-pixel-strip-example/` with manifest, worker, UI, types, tests, README, and build config.
- Add `packages/plugins/examples/plugin-vault-read-bridge-example/` with manifest, worker, UI, types, tests, README, and build config.
- Refresh `pnpm-lock.yaml` to register the two new package directories.

## Verification

> All commands run against the live Paperclip plugin SDK at `packages/plugins/sdk/`.

**Pixel-strip example (`packages/plugins/examples/plugin-pixel-strip-example/`)**

- `pnpm typecheck` — clean. Runs `tsc --noEmit` over `src/` and over `tsconfig.test.json`. Zero errors.
- `pnpm test` — 29 of 29 pass. Runs `node --experimental-strip-types --test tests/*.test.ts`. Suites: `manifest`, `deriveSpriteStateForAgent`, `buildPixelStrip`, `spriteStateLabel`, `pixel-strip UI`, `pixel-strip worker`. All pass.
- `pnpm build` — emits `dist/manifest.js` (1.7 KB), `dist/worker.js` (6.1 KB), `dist/ui/index.js` (4.6 KB), `dist/ui/pixel-strip.js` (4.4 KB). All four parse as valid ESM via `node --check`.

**Vault read bridge example (`packages/plugins/examples/plugin-vault-read-bridge-example/`)**

- `pnpm typecheck` — clean. Runs `tsc --noEmit` over `src/` and over `tsconfig.test.json`. Zero errors.
- `pnpm test` — 26 of 26 pass. Runs `node --experimental-strip-types --test tests/*.test.ts`. Suites: `manifest`, `vault-read`, `vault-read-bridge worker` (lint-style guard against `writeTextAtomic`, `deleteFile`, and `localFolders.write*`), `vault-read-bridge UI`. All pass.
- `pnpm build` — emits `dist/manifest.js` (2.2 KB), `dist/worker.js` (9.0 KB), `dist/ui/index.js` (7.7 KB), `dist/ui/vault-tab.js` (6.6 KB). All four parse as valid ESM via `node --check`.

## Risks

- **Low risk overall.** The change is purely additive: two new packages under `packages/plugins/examples/`, plus a `pnpm-lock.yaml` refresh. No edits to the SDK, the host, the UI, or any existing plugin. No default-branch change in the source tree. No public exposure.
- **Plugin manifest capability surface.** Both manifests request only read capabilities: `companies.read`, `projects.read`, `issues.read`, `agents.read`, `local.folders` for the vault only, `plugin.state.read`, and `plugin.state.write` for caching. No `*.create`, `*.update`, `*.write`, or `*.delete` capability is requested. The host rejects any runtime write attempt that does not have a matching capability.
- **Vault plugin write-back.** The vault plugin declares `access: "read"` at the host's local-folder subsystem and additionally never imports `writeTextAtomic` or `deleteFile`. A worker-side lint-style test asserts this at build time. The lint test greps the worker source for the forbidden symbol names. If a future edit adds one, the test fails the build.
- **Pixel plugin animation.** The pixel plugin emits no timer, no `setInterval`, no random state. All visible state is derived from `ctx.agents.list` and `ctx.issues.list` only. A test asserts no animation-implying code is present.
- **Behavioural shift.** None. New example plugins are inert unless installed. They are not installed by the host by default.

> For examples under `packages/plugins/examples/`, `ROADMAP.md` does not list any planned core work that overlaps. These are reference patterns, not core features. They do not block or compete with any planned SDK work.

## Model Used

- Provider: MiniMax.
- Model ID: `MiniMax-M3`.
- Reasoning mode: extended thinking (enabled per heartbeat contract).
- Tool use: yes (local git, Node test runner, esbuild, TypeScript compiler).
- Capability notes: this PR body and the example source were drafted by an AI assistant during plugin authoring.

## Checklist

- [x] I have included a thinking path that traces from project context to this change.
- [x] I have specified the model used, with version and capability details.
- [x] I have checked `ROADMAP.md` and confirmed this PR does not duplicate planned core work.
- [x] I have searched GitHub for duplicate or related PRs and linked them above — no public duplicate found at draft time.
- [x] I have either linked existing issues with `Fixes:`, `Closes:`, or `Refs:` syntax, or described the issue in-PR following the relevant issue template — path B, Enhancement template.
- [x] I have not referenced internal or instance-local Paperclip issues or links in the PR body.
- [x] My branch name describes the change and contains no internal Paperclip ticket id — branch name: `examples/pixel-strip-and-vault-read-bridge`.
- [x] I have run tests locally and they pass — 29 of 29 plus 26 of 26.
- [x] I have added or updated tests where applicable — 55 tests across the two new packages.
- [x] I have updated relevant documentation to reflect my changes — two READMEs, one per package.
- [x] I have considered and documented any risks above — see **Risks**.
- [ ] All Paperclip CI gates are green — pending actual CI run on `paperclipai/paperclip`.
- [ ] Greptile is 5 of 5 with no open P2s, recommendations, or follow-ups — pending Greptile run.
- [ ] I will address all Greptile and reviewer comments before requesting merge.
