### PR TITLE
fix(onboarding): keep the pasted code on screen, and make the auto-copy real

### DIFF
--- a/ui/src/components/AdapterLoginChrome.test.tsx
+++ b/ui/src/components/AdapterLoginChrome.test.tsx
@@ -197,6 +197,40 @@ describe("the displayed code's auto-copy", () => {
     }
   });
 
+  it("asks once while a write is still in flight", async () => {
+    // The success latch is only taken when the write resolves, so it cannot
+    // also mean "already running" — without a separate guard a focus event
+    // arriving mid-write started a second attempt.
+    let settle: () => void = () => {};
+    const writeText = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          settle = resolve;
+        }),
+    );
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    const restore = stubFocus(true);
+    try {
+      await render(<OnboardingLoginCodeRow code="WFK7-4GA3U" autoCopy />);
+      expect(writeText).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        window.dispatchEvent(new Event("focus"));
+        window.dispatchEvent(new Event("focus"));
+      });
+      expect(writeText).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        settle();
+      });
+    } finally {
+      restore();
+    }
+  });
+
   it("waits for the document rather than spending its one attempt unfocused", async () => {
     // A write from an unfocused document is refused, and the first attempt is
     // the most likely to be refused, since it fires while the card is still

--- a/ui/src/components/AdapterLoginChrome.test.tsx
+++ b/ui/src/components/AdapterLoginChrome.test.tsx
@@ -2,12 +2,13 @@
 
 import { createRoot, type Root } from "react-dom/client";
 import { flushSync } from "react-dom";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type React from "react";
 import {
   OnboardingLoginCard,
   OnboardingCardField,
+  OnboardingLoginCodeRow,
   onboardingCardInputClass,
 } from "./AdapterLoginChrome";
 
@@ -139,5 +140,80 @@ describe("the connect step's cards", () => {
 
     expect(waiting).toContain("min-h-(--sz-108px)");
     expect(ready).toContain("min-h-(--sz-108px)");
+  });
+});
+
+/**
+ * The displayed-code card puts the code on the clipboard the moment it is
+ * readable, so the customer can paste it wherever they are being asked for it
+ * without reaching for the button. That convenience is only worth anything if
+ * it actually happened — a card claiming "Copied!" over an empty clipboard is
+ * worse than one that never claimed it, because the customer stops checking.
+ */
+describe("the displayed code's auto-copy", () => {
+  function stubClipboard() {
+    const writeText = vi.fn(async () => {});
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    return writeText;
+  }
+
+  function stubFocus(focused: boolean) {
+    const original = document.hasFocus;
+    document.hasFocus = () => focused;
+    return () => {
+      document.hasFocus = original;
+    };
+  }
+
+  afterEach(() => {
+    Reflect.deleteProperty(navigator, "clipboard");
+  });
+
+  it("writes nothing when there is no code yet", async () => {
+    // The row renders before the server's one-time prompt carries a value on
+    // some paths. The latch used to be taken on that first run, so the copy
+    // that mattered never ran and the clipboard kept whatever it already had.
+    const writeText = stubClipboard();
+    const restore = stubFocus(true);
+    try {
+      await render(<OnboardingLoginCodeRow code="" autoCopy />);
+      expect(writeText).not.toHaveBeenCalled();
+    } finally {
+      restore();
+    }
+  });
+
+  it("copies the code once it arrives", async () => {
+    const writeText = stubClipboard();
+    const restore = stubFocus(true);
+    try {
+      await render(<OnboardingLoginCodeRow code="WFK7-4GA3U" autoCopy />);
+      expect(writeText).toHaveBeenCalledWith("WFK7-4GA3U");
+    } finally {
+      restore();
+    }
+  });
+
+  it("waits for the document rather than spending its one attempt unfocused", async () => {
+    // A write from an unfocused document is refused, and the first attempt is
+    // the most likely to be refused, since it fires while the card is still
+    // arriving. Latching before the attempt made that refusal permanent.
+    const writeText = stubClipboard();
+    const restore = stubFocus(false);
+    try {
+      await render(<OnboardingLoginCodeRow code="WFK7-4GA3U" autoCopy />);
+      expect(writeText).not.toHaveBeenCalled();
+
+      document.hasFocus = () => true;
+      await act(async () => {
+        window.dispatchEvent(new Event("focus"));
+      });
+      expect(writeText).toHaveBeenCalledWith("WFK7-4GA3U");
+    } finally {
+      restore();
+    }
   });
 });

--- a/ui/src/components/AdapterLoginChrome.tsx
+++ b/ui/src/components/AdapterLoginChrome.tsx
@@ -247,19 +247,46 @@ export function OnboardingLoginCodeRow({
   }, []);
 
   useEffect(() => {
-    if (!autoCopy || autoCopiedRef.current) return;
-    autoCopiedRef.current = true;
-    void copyTextToClipboard(code)
-      .then(() => {
-        // Written now, said later: the clipboard should be ready the instant
-        // the code is readable, but the claim waits for the rest of the card to
-        // stop moving — see COPIED_REVEAL_DELAY_MS.
-        if (timeoutRef.current) clearTimeout(timeoutRef.current);
-        timeoutRef.current = setTimeout(() => setCopied(true), COPIED_REVEAL_DELAY_MS);
-      })
-      .catch(() => {
-        // Refused, most likely for want of user activation. The button stays.
-      });
+    // An empty code is not a code. The row renders before the server's one-time
+    // prompt has a value on some paths, and the previous version latched on
+    // that first run — so the copy that mattered never ran, and the card said
+    // "Copied!" over an empty clipboard.
+    if (!autoCopy || autoCopiedRef.current || !code) return;
+
+    let cancelled = false;
+
+    const attempt = () => {
+      if (cancelled || autoCopiedRef.current) return;
+      // A write from an unfocused document is refused, and worse, some engines
+      // resolve it without writing. Wait for focus rather than spend the one
+      // attempt on it.
+      if (typeof document !== "undefined" && !document.hasFocus()) return;
+      void copyTextToClipboard(code)
+        .then(() => {
+          if (cancelled) return;
+          // Latched on success, not before it. Latching up front made the first
+          // refusal permanent — and the first attempt is the one most likely to
+          // be refused, since it fires while the card is still arriving.
+          autoCopiedRef.current = true;
+          window.removeEventListener("focus", attempt);
+          // Written now, said later: the clipboard should be ready the instant
+          // the code is readable, but the claim waits for the rest of the card
+          // to stop moving — see COPIED_REVEAL_DELAY_MS.
+          if (timeoutRef.current) clearTimeout(timeoutRef.current);
+          timeoutRef.current = setTimeout(() => setCopied(true), COPIED_REVEAL_DELAY_MS);
+        })
+        .catch(() => {
+          // Refused. The listener gives it another go when the document comes
+          // back, and the button is there the whole time regardless.
+        });
+    };
+
+    attempt();
+    window.addEventListener("focus", attempt);
+    return () => {
+      cancelled = true;
+      window.removeEventListener("focus", attempt);
+    };
   }, [autoCopy, code]);
 
   return (

--- a/ui/src/components/AdapterLoginChrome.tsx
+++ b/ui/src/components/AdapterLoginChrome.tsx
@@ -254,13 +254,19 @@ export function OnboardingLoginCodeRow({
     if (!autoCopy || autoCopiedRef.current || !code) return;
 
     let cancelled = false;
+    // The success latch is taken when the write resolves, so it cannot also
+    // stand in for "a write is already running" — a focus event landing while
+    // one was in flight started a second. Same text either way, but it doubles
+    // the reveal timers and there is no reason to ask twice.
+    let inFlight = false;
 
     const attempt = () => {
-      if (cancelled || autoCopiedRef.current) return;
+      if (cancelled || autoCopiedRef.current || inFlight) return;
       // A write from an unfocused document is refused, and worse, some engines
       // resolve it without writing. Wait for focus rather than spend the one
       // attempt on it.
       if (typeof document !== "undefined" && !document.hasFocus()) return;
+      inFlight = true;
       void copyTextToClipboard(code)
         .then(() => {
           if (cancelled) return;
@@ -278,6 +284,9 @@ export function OnboardingLoginCodeRow({
         .catch(() => {
           // Refused. The listener gives it another go when the document comes
           // back, and the button is there the whole time regardless.
+        })
+        .finally(() => {
+          inFlight = false;
         });
     };
 

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -2862,9 +2862,21 @@ function SubmittedBrowserCodeLoginPanel({
   const handleSubmit = () => {
     if (!canSubmit) return;
     submitCode.mutate(trimmedCode);
-    // Clear the browser code right after submit, so the secret never lingers in
-    // the input.
-    setBrowserCode("");
+    // Onboarding keeps the code on screen; the panel still clears it.
+    //
+    // Clearing emptied the input in the same frame the paste landed, so on the
+    // connect step the only feedback for the seconds that followed was a field
+    // that had just gone blank — reported from staging as the paste looking
+    // dropped, or the step looking stuck. There the field is disabled from here
+    // on and the step's own button carries the status, so the code can stay:
+    // `resetLocalState` clears it whenever a session starts, resumes or is
+    // cleared, the value dies with the panel moments later, and the code is
+    // single-use and already spent.
+    //
+    // The panel is not that. It sits in a form that stays open long after the
+    // login, with its own status area doing the reporting — so there the code
+    // does have somewhere to linger, and clearing it remains right.
+    if (chrome !== "onboarding") setBrowserCode("");
   };
 
   // Start once, on mount, when the caller has already taken the press, and

--- a/ui/src/components/OnboardingWizard.test.tsx
+++ b/ui/src/components/OnboardingWizard.test.tsx
@@ -2228,6 +2228,11 @@ describe("OnboardingWizard restore-gate (stale localStorage across accounts)", (
         "claude-session-1",
         "Q2RJ-E1YIF-authorization-code",
       );
+      // And it stays on screen. Clearing the field on submit emptied it in the
+      // same frame the paste landed, so the only feedback for the seconds that
+      // followed was an input that had just gone blank — reported from staging
+      // as the paste looking dropped, or the step looking stuck.
+      expect(field!.value).toBe("Q2RJ-E1YIF-authorization-code");
 
       await act(async () => root.unmount());
     });

--- a/ui/src/components/onboarding/OnboardingPrimitives.tsx
+++ b/ui/src/components/onboarding/OnboardingPrimitives.tsx
@@ -36,7 +36,9 @@ export function OnboardingHeading({
 }) {
   return (
     <div className={cn("space-y-2", center && "text-center")}>
-      <h1 className="text-4xl font-semibold tracking-tight text-foreground">{title}</h1>
+      <h1 className="text-(length:--text-onboarding-title) font-semibold leading-(--leading-onboarding-title) tracking-tight text-foreground">
+        {title}
+      </h1>
       {lede ? (
         <p className="text-base leading-relaxed text-muted-foreground">{lede}</p>
       ) : null}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2332,6 +2332,14 @@ span.paperclip-mention-chip[data-mention-kind="external-object"] {
   --text-nano: 10px;
   --text-micro: 11px;
   --text-compact: 13px;
+  /* The onboarding arc's question. A quarter larger than the 36px it was, so
+     the step's one question carries the screen it is alone on. Off Tailwind's
+     scale (text-4xl is 36, text-5xl 48), hence a token rather than a step. */
+  --text-onboarding-title: 45px;
+  /* Its own leading, because `text-(length:…)` sets only the size: the 36px
+     step carried 40px of line height with it, and inheriting the body's would
+     have loosened a question that wraps onto two lines. */
+  --leading-onboarding-title: 1.1;
   --tracking-label: 0.08em;
   --tracking-eyebrow: 0.14em;
   --tracking-caps: 0.2em;


### PR DESCRIPTION
## Thinking Path

Three items from a staging pass over the connect step shipped in #12863. Two are defects in the sign-in itself, one is a type-size change.

The first was reported as "the dots quickly flashed but disappeared and so wasn't sure if it got stuck". Tracing it, the Claude panel's `handleSubmit` cleared the field in the same frame it submitted — so the code appeared and vanished together, and the several seconds that followed had no feedback at all. The clearing was deliberate hygiene, but on this screen it removed the only thing telling the customer their paste had landed.

The second was "the openai option actually copies the code to clipboard, it didn't work". The auto-copy had two independent faults, either of which produces exactly that: it took its latch *before* the attempt, so the first refusal was permanent; and it ran with an empty string on the paths where the row renders before the server's one-time prompt carries a value — writing nothing and then claiming "Copied!" over whatever the clipboard already held.

The third is the arc's question at a quarter larger.

**Scope.** This is the tenant half of a batch of six. The other three — the account header appearing during the wizard, the URL row and its tooltip, and the invite step's label spacing — are in `paperclip-cloud`'s signup wizard and follow in a separate PR there.

## Linked Issues or Issue Description

No tracking issue — described inline, per CONTRIBUTING.md. All three reported from staging (canary `2026.905.0-canary.10`).

**1. The pasted code vanishes.** Sign in with Claude, paste the authorization code. Expected: some sign it was accepted. Actual: the field empties instantly and nothing else changes until the step advances seconds later.

**2. The OpenAI code is not on the clipboard.** Pick OpenAI, then paste. Expected: the code. Actual: whatever was there before, sometimes under a card reading "Copied!".

**3. The question is too small** relative to the screen it is alone on.

## What Changed

**The code stays in the field.** Clearing moved out of `handleSubmit` for the onboarding chrome only. It stays for the panel chrome, which is a different situation: that form remains open long after the login and has its own status area, so a code there does have somewhere to linger. An existing test pins that behaviour and still passes untouched.

Nothing lingers on the onboarding side either — `resetLocalState` clears the field whenever a session starts, resumes or is cleared, the value dies with the panel moments later, and the code is single-use and already spent by the time it is on screen.

**The auto-copy latches on success, not before it**, skips an attempt while the document is unfocused rather than spending its only try on a write that will be refused, retries when focus returns, and does not run at all on an empty code.

**The arc's question is 45px, from 36.** A token rather than a Tailwind step, since 45 sits between `text-4xl` and `text-5xl` and Gate 2 forbids arbitrary bracket values. It carries its own leading token, because `text-(length:…)` sets only the size and the 36px step had been supplying 40px of line height.

## Verification

**5479 tests / 559 files green**, `tsc --noEmit` clean, all four token gates clean.

Three new tests, each checked against the fault it describes rather than trusted:

| test | fails on the original with |
|---|---|
| the pasted code survives the submit | `expected '' to be 'Q2RJ-E1YIF-authorization-code'` |
| writes nothing when there is no code yet | the empty-code write |
| waits for the document rather than spending its one attempt unfocused | no write at all |

Worth recording that my first revert-check on the clipboard tests was **invalid** — the patch left the new closure in place, so it short-circuited instead of reproducing the original, and two tests failed for the wrong reason. Redone against the true original, the two that fail are exactly the two faults, and "copies the code once it arrives" passes on the original, correctly, since that path always worked.

**Not verified visually:** the 45px question. Both sizes wrap to two lines in the 480px column by measurement, but I have not put eyes on it — the preview harness opens on the connect step, whose heading is short enough not to exercise the wrap.

## Risks

- **The code is now on screen for a few seconds longer.** It is a single-use authorization code, already spent, on a screen the customer is looking at. The panel chrome's stricter behaviour is unchanged.
- **The auto-copy can still be refused** — it is a clipboard write the customer did not ask for by pressing anything. It now retries on focus instead of giving up, and "Copied!" still appears only on a write that resolved. The button beside it always works.
- The focus listener is removed on success and on unmount.
- The heading token is new and used in one place; nothing else moves.

## Model Used

Anthropic Claude — Opus 5, model ID `claude-opus-5`, run through Claude Code. Extended thinking enabled; tool use for repo inspection, `vitest`, `tsc`, and the token gates.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

Follows #12863 and #12902.

🤖 Generated with [Claude Code](https://claude.com/claude-code)