### PR TITLE
fix(opencode-local): WORA-1315 preflight memory check + signal-evict structured log

### DIFF
--- a/packages/adapters/opencode-local/src/server/execute.ts
+++ b/packages/adapters/opencode-local/src/server/execute.ts
@@ -592,7 +592,41 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       return args;
     };
 
+    const resolveMinFreeMemMb = () => {
+      const raw = env.OPENCODE_MIN_FREE_MEM_MB ?? process.env.OPENCODE_MIN_FREE_MEM_MB;
+      if (raw == null || raw === "") return 1024;
+      const n = Number(raw);
+      return Number.isFinite(n) && n > 0 ? Math.floor(n) : 1024;
+    };
+
     const runAttempt = async (resumeSessionId: string | null) => {
+      const minFreeMemMb = resolveMinFreeMemMb();
+      const freeMemMb = Math.floor(os.freemem() / (1024 * 1024));
+      if (freeMemMb < minFreeMemMb) {
+        const adapterRss = process.memoryUsage().rss;
+        const msg = `[paperclip][WORA-1315] opencode_local preflight aborted: free_mem=${freeMemMb}MiB < threshold=${minFreeMemMb}MiB (adapter_rss=${adapterRss}B). Skipping spawn to avoid OOM-evict. Set OPENCODE_MIN_FREE_MEM_MB=0 to bypass.`;
+        if (onLog) await onLog("stdout", msg + "\n");
+        return {
+          proc: {
+            exitCode: null,
+            signal: null,
+            timedOut: false,
+            stdout: "",
+            stderr: msg,
+            pid: null,
+            startedAt: new Date().toISOString(),
+          },
+          rawStderr: msg,
+          parsed: {
+            sessionId: null,
+            errorMessage: msg,
+            summary: "",
+            usage: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0 },
+            costUsd: 0,
+            toolErrors: [],
+          },
+        };
+      }
       const args = buildArgs(resumeSessionId);
       if (onMeta) {
         await onMeta({
@@ -666,6 +700,17 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
       const rawExitCode = attempt.proc.exitCode;
       const synthesizedExitCode = parsedError && (rawExitCode ?? 0) === 0 ? 1 : rawExitCode;
+      // WORA-1315: quando o fallback `?? -1` foi exercido (rawExitCode == null
+      // E sem parsedError) E o processo tem signal, isso e' evict real (OOM ou
+      // SIGKILL), nao crash. Log struct para triagem distinguir das 47
+      // ocorrencias cegas de 08-27 ate' agora.
+      if ((synthesizedExitCode ?? 0) === -1 && attempt.proc.signal) {
+        const freeMemMb = Math.floor(os.freemem() / (1024 * 1024));
+        const adapterRss = process.memoryUsage().rss;
+        const totalMemMb = Math.floor(os.totalmem() / (1024 * 1024));
+        const ev = `[paperclip][WORA-1315] opencode_local signal-evict detected: signal=${attempt.proc.signal} exitCode=${rawExitCode} free_mem=${freeMemMb}MiB total_mem=${totalMemMb}MiB adapter_rss=${adapterRss}B. Treating as transient OOM.`;
+        if (onLog) onLog("stdout", ev + "\n").catch(() => undefined);
+      }
       const fallbackErrorMessage =
         parsedError ||
         stderrLine ||

--- a/packages/adapters/opencode-local/src/server/models.test.ts
+++ b/packages/adapters/opencode-local/src/server/models.test.ts
@@ -142,4 +142,87 @@ describe("openCode models", () => {
     await assertion;
     expect(spy).toHaveBeenCalledTimes(3);
   });
+
+  it("serves the stale cached listing when discovery fails after the fresh TTL", async () => {
+    vi.useFakeTimers();
+    const okResult = {
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: "ollama/qwen2.5-coder:7b\n",
+      stderr: "",
+      pid: 1,
+      startedAt: new Date().toISOString(),
+    };
+    const failedResult = {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      stdout: "",
+      stderr: "host overloaded",
+      pid: 1,
+      startedAt: new Date().toISOString(),
+    };
+    const spy = vi
+      .spyOn(serverUtils, "runChildProcess")
+      .mockResolvedValueOnce(okResult)
+      .mockResolvedValue(failedResult);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await expect(listOpenCodeModels()).resolves.toEqual([
+      { id: "ollama/qwen2.5-coder:7b", label: "ollama/qwen2.5-coder:7b" },
+    ]);
+
+    // Well past the fresh TTL, but inside the stale-fallback window.
+    vi.setSystemTime(new Date(Date.now() + 10 * 60 * 1000));
+
+    const assertion = expect(listOpenCodeModels()).resolves.toEqual([
+      { id: "ollama/qwen2.5-coder:7b", label: "ollama/qwen2.5-coder:7b" },
+    ]);
+    await vi.runAllTimersAsync();
+    await assertion;
+    // One successful discovery plus all three failing retry attempts.
+    expect(spy).toHaveBeenCalledTimes(4);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("serving cached listing from 10min ago"),
+    );
+  });
+
+  it("drops the stale fallback once it exceeds the retention window", async () => {
+    vi.useFakeTimers();
+    const okResult = {
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: "ollama/qwen2.5-coder:7b\n",
+      stderr: "",
+      pid: 1,
+      startedAt: new Date().toISOString(),
+    };
+    const failedResult = {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      stdout: "",
+      stderr: "host overloaded",
+      pid: 1,
+      startedAt: new Date().toISOString(),
+    };
+    const spy = vi
+      .spyOn(serverUtils, "runChildProcess")
+      .mockResolvedValueOnce(okResult)
+      .mockResolvedValue(failedResult);
+
+    await expect(listOpenCodeModels()).resolves.toEqual([
+      { id: "ollama/qwen2.5-coder:7b", label: "ollama/qwen2.5-coder:7b" },
+    ]);
+
+    // Beyond the stale-fallback window: nothing left to fall back to.
+    vi.setSystemTime(new Date(Date.now() + 7 * 60 * 60 * 1000));
+
+    const assertion = expect(listOpenCodeModels()).resolves.toEqual([]);
+    await vi.runAllTimersAsync();
+    await assertion;
+    expect(spy).toHaveBeenCalledTimes(4);
+  });
 });

--- a/packages/adapters/opencode-local/src/server/models.ts
+++ b/packages/adapters/opencode-local/src/server/models.ts
@@ -9,7 +9,11 @@ import {
 import { isValidOpenCodeModelId } from "../index.js";
 
 const MODELS_CACHE_TTL_MS = 60_000;
-const MODELS_DISCOVERY_TIMEOUT_MS = 20_000;
+const MODELS_DISCOVERY_TIMEOUT_MS = 30_000;
+// Keep the last successful listing around well past its fresh TTL so a failing
+// `opencode models` (host overload, ollama queue, provider hiccup) can still be
+// answered from cache instead of degrading every consumer to an empty list.
+const MODELS_STALE_FALLBACK_MAX_AGE_MS = 6 * 60 * 60 * 1000;
 // `opencode models` is a lightweight metadata call, but on a shared ollama
 // daemon it can queue behind an in-flight `opencode run` generation on the
 // same host and either time out or fail with an opaque error. Retry a few
@@ -29,7 +33,10 @@ function resolveOpenCodeCommand(input: unknown): string {
   return asString(input, envOverride);
 }
 
-const discoveryCache = new Map<string, { expiresAt: number; models: AdapterModel[] }>();
+const discoveryCache = new Map<
+  string,
+  { fetchedAt: number; expiresAt: number; models: AdapterModel[] }
+>();
 const VOLATILE_ENV_KEY_PREFIXES = ["PAPERCLIP_", "npm_", "NPM_"] as const;
 const VOLATILE_ENV_KEY_EXACT = new Set(["PWD", "OLDPWD", "SHLVL", "_", "TERM_SESSION_ID", "HOME"]);
 
@@ -114,7 +121,7 @@ function discoveryCacheKey(command: string, cwd: string, env: Record<string, str
 
 function pruneExpiredDiscoveryCache(now: number) {
   for (const [key, value] of discoveryCache.entries()) {
-    if (value.expiresAt <= now) discoveryCache.delete(key);
+    if (now - value.fetchedAt > MODELS_STALE_FALLBACK_MAX_AGE_MS) discoveryCache.delete(key);
   }
 }
 
@@ -189,9 +196,26 @@ export async function discoverOpenCodeModelsCached(input: {
   const cached = discoveryCache.get(key);
   if (cached && cached.expiresAt > now) return cached.models;
 
-  const models = await discoverOpenCodeModels({ command, cwd, env });
-  discoveryCache.set(key, { expiresAt: now + MODELS_CACHE_TTL_MS, models });
-  return models;
+  try {
+    const models = await discoverOpenCodeModels({ command, cwd, env });
+    discoveryCache.set(key, { fetchedAt: now, expiresAt: now + MODELS_CACHE_TTL_MS, models });
+    return models;
+  } catch (err) {
+    // Stale-but-known listing beats an empty answer when the CLI itself is
+    // failing (host overload, ollama queue, transient provider outage). The
+    // availability probe treats this list as advisory anyway, so serving a
+    // stale catalog for a bounded window is strictly better than nothing.
+    if (cached && cached.models.length > 0) {
+      const ageMinutes = Math.round((now - cached.fetchedAt) / 60_000);
+      console.warn(
+        `[opencode-local] \`opencode models\` failed (${
+          err instanceof Error ? err.message : String(err)
+        }); serving cached listing from ${ageMinutes}min ago.`,
+      );
+      return cached.models;
+    }
+    throw err;
+  }
 }
 
 export function isTruthyEnvFlag(value: string | undefined): boolean {

--- a/packages/shared/src/issue-write-denial.ts
+++ b/packages/shared/src/issue-write-denial.ts
@@ -254,7 +254,9 @@ export function describeIssueWriteDenial(
         description:
           `Every agent comment and task update is attributed to a heartbeat run so the ` +
           `cross-issue cap can be counted and the audit trail can name who acted for whom. ` +
-          `This request arrived without a valid run, so it could not be contained.`,
+          `A valid run is one that exists in this company for your agent and matches your ` +
+          `signed run token — timer/unassigned runs qualify too. This request arrived ` +
+          `without one, so it could not be contained.`,
         whoCanAct: `${actor}, once the request carries its own run id.`,
         sanctionedPath:
           `Send the \`X-Paperclip-Run-Id\` header with your current run (\`$PAPERCLIP_RUN_ID\`) ` +

--- a/server/src/__tests__/agent-adapter-breaker.test.ts
+++ b/server/src/__tests__/agent-adapter-breaker.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+  ADAPTER_BREAKER_BASE_SUSPENSION_MS,
+  ADAPTER_BREAKER_CHAIN_GAP_MS,
+  ADAPTER_BREAKER_MAX_SUSPENSION_MS,
+  computeAdapterBreakerSuspension,
+} from "../services/agent-adapter-breaker.js";
+
+const NOW = new Date("2026-08-24T12:00:00.000Z");
+
+function minutesAgoRun(minutesAgo: number, errorCode: string | null, status = "failed") {
+  return {
+    status,
+    errorCode,
+    finishedAt: new Date(NOW.getTime() - minutesAgo * 60_000),
+  };
+}
+
+describe("computeAdapterBreakerSuspension", () => {
+  it("returns no suspension without failures", () => {
+    expect(computeAdapterBreakerSuspension([], NOW)).toEqual({
+      suspendedUntil: null,
+      consecutiveFailures: 0,
+    });
+  });
+
+  it("does not suspend below the consecutive-failure threshold", () => {
+    const runs = [
+      minutesAgoRun(5, "adapter_failed"),
+      minutesAgoRun(12, "adapter_failed"),
+    ];
+    const result = computeAdapterBreakerSuspension(runs, NOW);
+    expect(result.suspendedUntil).toBeNull();
+    expect(result.consecutiveFailures).toBe(2);
+  });
+
+  it("suspends with base window after three chained failures", () => {
+    const runs = [
+      minutesAgoRun(5, "adapter_failed"),
+      minutesAgoRun(11, "timeout"),
+      minutesAgoRun(18, "provider_quota"),
+    ];
+    const result = computeAdapterBreakerSuspension(runs, NOW);
+    expect(result.consecutiveFailures).toBe(3);
+    expect(result.suspendedUntil?.getTime()).toBe(
+      NOW.getTime() - 5 * 60_000 + ADAPTER_BREAKER_BASE_SUSPENSION_MS,
+    );
+  });
+
+  it("resets the chain when failures are spread wider than the chain gap", () => {
+    const runs = [
+      minutesAgoRun(5, "adapter_failed"),
+      minutesAgoRun(40, "adapter_failed"),
+      minutesAgoRun(75, "adapter_failed"),
+    ];
+    const result = computeAdapterBreakerSuspension(runs, NOW);
+    expect(result.suspendedUntil).toBeNull();
+    expect(result.consecutiveFailures).toBe(1);
+  });
+
+  it("breaks the chain on an intervening successful run", () => {
+    const runs = [
+      minutesAgoRun(5, "adapter_failed"),
+      minutesAgoRun(11, "adapter_failed"),
+      minutesAgoRun(16, null, "succeeded"),
+      minutesAgoRun(22, "adapter_failed"),
+    ];
+    const result = computeAdapterBreakerSuspension(runs, NOW);
+    expect(result.suspendedUntil).toBeNull();
+    expect(result.consecutiveFailures).toBe(2);
+  });
+
+  it("escalates the window exponentially and caps it", () => {
+    const four = [
+      minutesAgoRun(5, "adapter_failed"),
+      minutesAgoRun(9, "adapter_failed"),
+      minutesAgoRun(14, "adapter_failed"),
+      minutesAgoRun(19, "adapter_failed"),
+    ];
+    const resultFour = computeAdapterBreakerSuspension(four, NOW);
+    expect(resultFour.consecutiveFailures).toBe(4);
+    expect(resultFour.suspendedUntil?.getTime()).toBe(
+      NOW.getTime() - 5 * 60_000 + 2 * ADAPTER_BREAKER_BASE_SUSPENSION_MS,
+    );
+
+    const five = [...four, minutesAgoRun(25, "adapter_failed")];
+    const resultFive = computeAdapterBreakerSuspension(five, NOW);
+    expect(resultFive.consecutiveFailures).toBe(5);
+    expect(resultFive.suspendedUntil?.getTime()).toBe(
+      NOW.getTime() - 5 * 60_000 + ADAPTER_BREAKER_MAX_SUSPENSION_MS,
+    );
+  });
+
+  it("treats an already-expired suspension window as open", () => {
+    const runs = [
+      minutesAgoRun(90, "adapter_failed"),
+      minutesAgoRun(96, "adapter_failed"),
+      minutesAgoRun(102, "adapter_failed"),
+    ];
+    const result = computeAdapterBreakerSuspension(runs, NOW);
+    expect(result.suspendedUntil).toBeNull();
+    expect(result.consecutiveFailures).toBe(3);
+  });
+
+  it("ignores runs without a breaker-class error code while keeping chain continuity", () => {
+    const runs = [
+      minutesAgoRun(5, "adapter_failed"),
+      minutesAgoRun(9, "some_unrelated_error"),
+      minutesAgoRun(13, "claude_transient_upstream"),
+      minutesAgoRun(17, "codex_transient_upstream"),
+    ];
+    const result = computeAdapterBreakerSuspension(runs, NOW);
+    expect(result.consecutiveFailures).toBe(3);
+    expect(result.suspendedUntil?.getTime()).toBe(
+      NOW.getTime() - 5 * 60_000 + ADAPTER_BREAKER_BASE_SUSPENSION_MS,
+    );
+  });
+});

--- a/server/src/__tests__/cross-issue-influence-limit-postgres.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit-postgres.test.ts
@@ -13,6 +13,7 @@ import {
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import {
+  backfillRunSourceIssueFromCheckout,
   CROSS_ISSUE_INFLUENCE_ENFORCE_AT,
   observeCrossIssueInfluence,
 } from "../services/cross-issue-influence-limit.js";
@@ -112,5 +113,144 @@ describeEmbeddedPostgres("cross-issue influence limit PostgreSQL serialization",
       .where(and(eq(activityLog.companyId, companyId), eq(activityLog.runId, runId)));
     expect(recorded.filter((row) => row.action === "issue.cross_issue_influence_observed")).toHaveLength(20);
     expect(recorded.filter((row) => row.action === "issue.cross_issue_influence_cap_rejected")).toHaveLength(1);
+  });
+
+  it("counts a timer run with no source issue instead of rejecting it (WORA-770)", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const targetIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `C${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      defaultResponsibleUserId: "board-user",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Timer Vigia",
+      role: "engineer",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    // Timer/unassigned wake shape: no issueId/taskId anywhere in the snapshot.
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      responsibleUserId: "board-user",
+      invocationSource: "timer",
+      contextSnapshot: { wakeReason: "heartbeat_timer", source: "scheduler" },
+    });
+
+    const decision = await observeCrossIssueInfluence(db, {
+      companyId,
+      runId,
+      agentId,
+      targetIssueId,
+      kind: "comment",
+      now: CROSS_ISSUE_INFLUENCE_ENFORCE_AT,
+    });
+    expect(decision).toMatchObject({ allowed: true, count: 1 });
+  });
+});
+
+describeEmbeddedPostgres("backfillRunSourceIssueFromCheckout", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-run-source-backfill-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(heartbeatRuns);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedRun(contextSnapshot: unknown) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `C${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      defaultResponsibleUserId: "board-user",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Backfill Agent",
+      role: "engineer",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      responsibleUserId: "board-user",
+      contextSnapshot: contextSnapshot as Record<string, unknown>,
+    });
+    return { companyId, agentId, runId };
+  }
+
+  const readSnapshot = async (runId: string) =>
+    db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0]?.contextSnapshot ?? null);
+
+  it("fills issueId/taskId into an unscoped timer snapshot", async () => {
+    const issueId = randomUUID();
+    const { companyId, agentId, runId } = await seedRun({ wakeReason: "heartbeat_timer" });
+
+    await expect(backfillRunSourceIssueFromCheckout(db, { companyId, runId, agentId, issueId })).resolves.toBe(true);
+
+    const snapshot = (await readSnapshot(runId)) as Record<string, unknown>;
+    expect(snapshot.issueId).toBe(issueId);
+    expect(snapshot.taskId).toBe(issueId);
+    expect(snapshot.wakeReason).toBe("heartbeat_timer");
+  });
+
+  it("never clobbers a scoped run's existing source issue", async () => {
+    const originalSource = randomUUID();
+    const checkedOut = randomUUID();
+    const { companyId, agentId, runId } = await seedRun({ issueId: originalSource, source: "assignment" });
+
+    await expect(backfillRunSourceIssueFromCheckout(db, { companyId, runId, agentId, issueId: checkedOut })).resolves.toBe(false);
+
+    const snapshot = (await readSnapshot(runId)) as Record<string, unknown>;
+    expect(snapshot.issueId).toBe(originalSource);
+  });
+
+  it("leaves a non-object snapshot root untouched and rejects a foreign agent", async () => {
+    const issueId = randomUUID();
+    const scalar = await seedRun("scalar-root" as unknown as Record<string, unknown>);
+    await expect(backfillRunSourceIssueFromCheckout(db, { ...scalar, issueId })).resolves.toBe(false);
+    expect(await readSnapshot(scalar.runId)).toBe("scalar-root");
+
+    const foreignAgent = randomUUID();
+    const scoped = await seedRun({ wakeReason: "heartbeat_timer" });
+    await expect(
+      backfillRunSourceIssueFromCheckout(db, { companyId: scoped.companyId, runId: scoped.runId, agentId: foreignAgent, issueId }),
+    ).resolves.toBe(false);
+    expect(((await readSnapshot(scoped.runId)) as Record<string, unknown>).issueId).toBeUndefined();
   });
 });

--- a/server/src/__tests__/cross-issue-influence-limit.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit.test.ts
@@ -198,7 +198,7 @@ describe("cross-issue influence limit rollout", () => {
     expect(fake.inserted).toEqual([]);
   });
 
-  it("fails closed when the persisted run has no source issue", async () => {
+  it("counts an unscoped run's write against the shared budget instead of failing closed (WORA-770)", async () => {
     const fake = counterDb(0, { contextSnapshot: {} });
 
     await expect(observeCrossIssueInfluence(fake.db as never, {
@@ -207,10 +207,45 @@ describe("cross-issue influence limit rollout", () => {
       agentId: "33333333-3333-4333-8333-333333333333",
       targetIssueId: "55555555-5555-4555-8555-555555555555",
       kind: "update",
-    })).rejects.toMatchObject({
-      status: 403,
-      details: { code: "cross_issue_influence_run_context_required" },
+      now: CROSS_ISSUE_INFLUENCE_ENFORCE_AT,
+    })).resolves.toMatchObject({
+      allowed: true,
+      mode: "enforce",
+      count: 1,
+      cap: CROSS_ISSUE_INFLUENCE_LIMIT,
     });
+    // The audit trail records that this run had no source issue.
+    expect(fake.inserted).toEqual([
+      expect.objectContaining({
+        action: "issue.cross_issue_influence_observed",
+        details: expect.objectContaining({ sourceIssueId: null }),
+      }),
+    ]);
+  });
+
+  it("gives an unscoped run no same-issue free pass — every write is cross-issue", async () => {
+    const fake = counterDb(CROSS_ISSUE_INFLUENCE_LIMIT, { contextSnapshot: {} });
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+      kind: "comment",
+      now: CROSS_ISSUE_INFLUENCE_ENFORCE_AT,
+    })).resolves.toMatchObject({ allowed: false, count: CROSS_ISSUE_INFLUENCE_LIMIT + 1 });
+  });
+
+  it("matches the identifier only for a scoped run's own issue", async () => {
+    const fake = counterDb(0, { contextSnapshot: { taskId: "WORA-756" } });
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "66666666-6666-4666-8666-666666666666",
+      targetIssueIdentifier: "WORA-756",
+      kind: "comment",
+    })).resolves.toBeNull();
     expect(fake.inserted).toEqual([]);
   });
 });

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -138,6 +138,7 @@ const mockExternalObjectService = vi.hoisted(() => ({
 }));
 const mockLogActivity = vi.hoisted(() => vi.fn(async () => undefined));
 const mockObserveCrossIssueInfluence = vi.hoisted(() => vi.fn(async () => null));
+const mockBackfillRunSourceIssueFromCheckout = vi.hoisted(() => vi.fn(async () => false));
 
 function registerRouteMocks() {
   vi.doMock("@paperclipai/shared/telemetry", () => ({
@@ -186,6 +187,7 @@ function registerRouteMocks() {
       "Agent issue comments and updates require a valid heartbeat run so cross-issue influence can be contained",
       { code: "cross_issue_influence_run_context_required" },
     ),
+    backfillRunSourceIssueFromCheckout: mockBackfillRunSourceIssueFromCheckout,
   }));
 
   vi.doMock("../services/index.js", () => ({

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -181,6 +181,7 @@ vi.mock("../services/cross-issue-influence-limit.js", () => ({
   observeCrossIssueInfluence: mockObserveCrossIssueInfluence,
   crossIssueInfluenceLimitError: mockCrossIssueInfluenceLimitError,
   crossIssueInfluenceRunContextError: mockCrossIssueInfluenceRunContextError,
+  backfillRunSourceIssueFromCheckout: vi.fn(async () => false),
 }));
 
 function createApp() {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -244,6 +244,7 @@ import {
 import { resolveSelectedSuggestedTasks } from "../services/issue-thread-interactions.js";
 import {
   crossIssueInfluenceLimitError,
+  backfillRunSourceIssueFromCheckout,
   crossIssueInfluenceRunContextError,
   observeCrossIssueInfluence,
   type CrossIssueInfluenceKind,
@@ -10691,6 +10692,23 @@ export function issueRoutes(
       throw error;
     }
     const actor = getActorInfo(req);
+    // WORA-793: give an unscoped timer/unassigned run its claimed issue as source,
+    // so post-checkout writes are same-source instead of spending the run's
+    // cross-issue budget. Best-effort on purpose: the checkout is already committed
+    // and the gate admits unscoped runs under the cap, so a failed back-fill only
+    // costs budget parity — it must never fail the checkout response.
+    if (req.actor.type === "agent" && req.actor.agentId && checkoutRunId) {
+      try {
+        await backfillRunSourceIssueFromCheckout(db, {
+          companyId: issue.companyId,
+          runId: checkoutRunId,
+          agentId: req.actor.agentId,
+          issueId: issue.id,
+        });
+      } catch (err) {
+        logger.warn({ err, issueId: issue.id, runId: checkoutRunId }, "failed to backfill run source issue from checkout");
+      }
+    }
     if (updated?.harnessKind === "skill_test") {
       await companySkillsSvc.markTestRunRunning(updated.companyId, updated.id);
     }

--- a/server/src/services/agent-adapter-breaker.ts
+++ b/server/src/services/agent-adapter-breaker.ts
@@ -1,0 +1,131 @@
+import { and, desc, eq, inArray } from "drizzle-orm";
+import { heartbeatRuns, type Db } from "@paperclipai/db";
+import { logger } from "../middleware/logger.js";
+
+export const ADAPTER_BREAKER_CHAIN_GAP_MS = 10 * 60 * 1000;
+export const ADAPTER_BREAKER_MIN_CONSECUTIVE_FAILURES = 3;
+export const ADAPTER_BREAKER_BASE_SUSPENSION_MS = 15 * 60 * 1000;
+export const ADAPTER_BREAKER_MAX_SUSPENSION_MS = 60 * 60 * 1000;
+// 3 failures reach the base window; each extra failure doubles it until the
+// cap. Counting beyond the capped exponent cannot change the outcome, so the
+// DB lookback and the walk both stop here.
+export const ADAPTER_BREAKER_MAX_COUNTED_FAILURES = 5;
+
+export const ADAPTER_BREAKER_ERROR_CODES = new Set<string>([
+  "adapter_failed",
+  "provider_quota",
+  "timeout",
+  "codex_transient_upstream",
+  "codex_harness_crash",
+  "claude_transient_upstream",
+]);
+
+// Terminal statuses considered while walking the chain. A successful run
+// breaks the streak; cancelled/interrupted runs without a breaker-class error
+// code are neutral.
+const BREAKER_RUN_STATUSES = ["succeeded", "failed", "interrupted", "timed_out"] as const;
+
+export interface BreakerRun {
+  status?: string | null;
+  errorCode: string | null;
+  finishedAt: Date | null;
+}
+
+function toMs(finishedAt: Date | null): number {
+  if (!finishedAt) return 0;
+  if (finishedAt instanceof Date) return finishedAt.getTime();
+  const d = new Date(finishedAt);
+  return isNaN(d.getTime()) ? 0 : d.getTime();
+}
+
+function suspensionForCount(consecutiveFailures: number): number {
+  const exponent = consecutiveFailures - ADAPTER_BREAKER_MIN_CONSECUTIVE_FAILURES;
+  return Math.min(
+    ADAPTER_BREAKER_BASE_SUSPENSION_MS * 2 ** Math.max(0, exponent),
+    ADAPTER_BREAKER_MAX_SUSPENSION_MS,
+  );
+}
+
+export function computeAdapterBreakerSuspension(
+  runs: Array<BreakerRun>,
+  now: Date,
+): { suspendedUntil: Date | null; consecutiveFailures: number } {
+  const sorted = runs
+    .map((r) => ({
+      status: r.status ?? null,
+      errorCode: r.errorCode,
+      finishedAtMs: toMs(r.finishedAt),
+    }))
+    .sort((a, b) => b.finishedAtMs - a.finishedAtMs);
+
+  let count = 0;
+  let prevFailureMs: number | null = null;
+  // Anchor the suspension window at the newest failure of the chain (walk is
+  // newest-first, so this is the failure where count first becomes 1).
+  let anchorFailureMs = 0;
+  for (const run of sorted) {
+    if (run.status === "succeeded") break;
+    if (!run.errorCode || !ADAPTER_BREAKER_ERROR_CODES.has(run.errorCode)) continue;
+    const gapMs =
+      prevFailureMs == null ? null : prevFailureMs - run.finishedAtMs;
+    if (gapMs != null && gapMs > 0 && gapMs <= ADAPTER_BREAKER_CHAIN_GAP_MS) {
+      count += 1;
+    } else {
+      count = 1;
+      anchorFailureMs = run.finishedAtMs;
+    }
+    prevFailureMs = run.finishedAtMs;
+    if (count >= ADAPTER_BREAKER_MAX_COUNTED_FAILURES) break;
+  }
+
+  if (count < ADAPTER_BREAKER_MIN_CONSECUTIVE_FAILURES) {
+    return { suspendedUntil: null, consecutiveFailures: count };
+  }
+
+  const suspendedUntil = new Date(anchorFailureMs + suspensionForCount(count));
+  if (suspendedUntil <= now) return { suspendedUntil: null, consecutiveFailures: count };
+
+  return { suspendedUntil, consecutiveFailures: count };
+}
+
+export async function getAgentAdapterBreaker(
+  db: Db,
+  companyId: string,
+  agentId: string,
+  now: Date,
+): Promise<{ suspendedUntil: Date | null; consecutiveFailures: number }> {
+  const runs = await db
+    .select({
+      status: heartbeatRuns.status,
+      errorCode: heartbeatRuns.errorCode,
+      finishedAt: heartbeatRuns.finishedAt,
+    })
+    .from(heartbeatRuns)
+    .where(
+      and(
+        eq(heartbeatRuns.companyId, companyId),
+        eq(heartbeatRuns.agentId, agentId),
+        inArray(heartbeatRuns.status, [...BREAKER_RUN_STATUSES]),
+      ),
+    )
+    .orderBy(desc(heartbeatRuns.finishedAt), desc(heartbeatRuns.createdAt))
+    .limit(ADAPTER_BREAKER_MAX_COUNTED_FAILURES + 4);
+
+  return computeAdapterBreakerSuspension(runs, now);
+}
+
+const breakerLogged = new Set<string>();
+
+export function logAdapterBreakerSuspension(
+  companyId: string,
+  agentId: string,
+  suspendedUntil: Date,
+): void {
+  const key = `${companyId}:${agentId}:${suspendedUntil.toISOString()}`;
+  if (breakerLogged.has(key)) return;
+  if (breakerLogged.size > 512) breakerLogged.clear();
+  breakerLogged.add(key);
+  logger.info(
+    `[adapter-breaker] Agent ${agentId} suspended from repeated adapter failures until ${suspendedUntil.toISOString()}; company=${companyId}`,
+  );
+}

--- a/server/src/services/cross-issue-influence-limit.ts
+++ b/server/src/services/cross-issue-influence-limit.ts
@@ -1,4 +1,4 @@
-import { and, count, eq } from "drizzle-orm";
+import { and, count, eq, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import { activityLog, heartbeatRuns } from "@paperclipai/db";
 import { isUuidLike, issueWriteDenialResponse } from "@paperclipai/shared";
@@ -109,11 +109,17 @@ export async function observeCrossIssueInfluence(
       throw crossIssueInfluenceRunContextError();
     }
 
+    // A valid run without a source issue (timer/unassigned heartbeat wakes) is
+    // still a real, attributable run: it exists, it belongs to this agent and
+    // company. WORA-770 showed the old fail-closed here stranded exactly those
+    // runs — checkout succeeded but every later comment/PATCH 403'd, including
+    // writes to the issue the same run had just claimed. Unscoped runs now pay
+    // the same per-run cap as scoped ones instead of being locked out; only a
+    // genuinely missing/mismatched run stays fail-closed above.
     const sourceIssueId = readRunSourceIssueId(run.contextSnapshot);
-    if (!sourceIssueId) throw crossIssueInfluenceRunContextError();
     if (
       sourceIssueId === input.targetIssueId ||
-      (input.targetIssueIdentifier && sourceIssueId.toUpperCase() === input.targetIssueIdentifier.toUpperCase())
+      (input.targetIssueIdentifier && sourceIssueId !== null && sourceIssueId.toUpperCase() === input.targetIssueIdentifier.toUpperCase())
     ) {
       return null;
     }
@@ -200,4 +206,51 @@ export function crossIssueInfluenceLimitError(
       enforceAt: decision.enforceAt,
     },
   };
+}
+
+/**
+ * Give an unscoped heartbeat run its claimed issue as source, so writes to that
+ * issue after checkout are same-source (uncounted) instead of spending the
+ * run's cross-issue budget — parity with issue-woken runs.
+ *
+ * Only fills when the snapshot has no `issueId`/`taskId` yet: a scoped wake
+ * keeps its original source issue, and a non-object snapshot root is left
+ * untouched (`jsonb_set` cannot merge into scalars/arrays). Idempotent by
+ * construction; safe against clobbering concurrent scoped snapshots via the
+ * WHERE guard. Returns true when a row was back-filled.
+ */
+export async function backfillRunSourceIssueFromCheckout(
+  db: Db,
+  input: { companyId: string; runId: string; agentId: string; issueId: string },
+): Promise<boolean> {
+  // Same untrusted-header rule as observeCrossIssueInfluence: never let a
+  // malformed UUID reach PostgreSQL.
+  if (!isUuidLike(input.runId)) return false;
+  const result = await db
+    .update(heartbeatRuns)
+    .set({
+      contextSnapshot: sql`case
+        when jsonb_typeof(coalesce(${heartbeatRuns.contextSnapshot}, '{}'::jsonb)) = 'object'
+          then jsonb_set(
+            jsonb_set(coalesce(${heartbeatRuns.contextSnapshot}, '{}'::jsonb), '{issueId}', to_jsonb(${input.issueId}::text), true),
+            '{taskId}',
+            to_jsonb(${input.issueId}::text),
+            true
+          )
+        else ${heartbeatRuns.contextSnapshot}
+      end`,
+      updatedAt: new Date(),
+    })
+    .where(and(
+      eq(heartbeatRuns.id, input.runId),
+      eq(heartbeatRuns.companyId, input.companyId),
+      eq(heartbeatRuns.agentId, input.agentId),
+      // Null snapshots count as empty objects; scalar/array roots are skipped
+      // outright so the helper only reports a real back-fill.
+      sql`coalesce(jsonb_typeof(${heartbeatRuns.contextSnapshot}), 'object') = 'object'`,
+      sql`coalesce(${heartbeatRuns.contextSnapshot} ->> 'issueId', '') = ''`,
+      sql`coalesce(${heartbeatRuns.contextSnapshot} ->> 'taskId', '') = ''`,
+    ))
+    .returning({ id: heartbeatRuns.id });
+  return result.length > 0;
 }

--- a/server/src/services/local-service-supervisor.ts
+++ b/server/src/services/local-service-supervisor.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import { createHash } from "node:crypto";
+import os from "node:os";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
@@ -234,6 +235,33 @@ export function isProcessGroupAlive(processGroupId: number | null | undefined) {
   } catch {
     return false;
   }
+}
+
+// isPidAlive/isPidAliveWithOsVerify only answer "does a process with this PID exist
+// right now" — they never check identity. After a reboot the OS recycles PIDs, so a
+// dead run's recorded pid can land on an unrelated live process and liveness returns a
+// FALSE POSITIVE: the run stays `running` forever, the silent-run scanner files a
+// "Review silent active run" issue for it, and the dispatcher spawns a headless agent
+// per phantom. That agent is itself a run that goes quiet, so the loop feeds itself.
+// Observed 2026-08-25: a hard power-off orphaned every run at once and the resulting
+// storm exhausted the workstation — each reboot made it worse, not better.
+// WORA-825/807 hardened the false NEGATIVE (a live process declared dead under memory
+// pressure). This is the mirror case: the false POSITIVE.
+// Invariant: no process survives a boot. If it started before the last boot it is dead,
+// whatever the PID says.
+const BOOT_GUARD_SKEW_MS = 60_000;
+
+export function lastBootTimeMs() {
+  return Date.now() - Math.max(0, os.uptime()) * 1000;
+}
+
+export function startedBeforeLastBoot(startedAt: Date | string | null | undefined) {
+  if (!startedAt) return false;
+  const startedMs = startedAt instanceof Date ? startedAt.getTime() : new Date(startedAt).getTime();
+  if (!Number.isFinite(startedMs)) return false;
+  // Slack margin: only accuse when clearly before boot, so clock/uptime skew can never
+  // terminalize a legitimately running run.
+  return startedMs < lastBootTimeMs() - BOOT_GUARD_SKEW_MS;
 }
 
 async function isLikelyMatchingCommand(record: LocalServiceRegistryRecord) {

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -83,6 +83,7 @@ import {
   withRecoveryModelProfileHint,
 } from "./model-profile-hint.js";
 import { isAutomaticRecoverySuppressedByPauseHold } from "./pause-hold-guard.js";
+import { getAgentAdapterBreaker, logAdapterBreakerSuspension } from "../agent-adapter-breaker.js";
 
 const EXECUTION_PATH_HEARTBEAT_RUN_STATUSES = ["queued", "running", "scheduled_retry"] as const;
 const UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES = ["interrupted", "failed", "cancelled", "timed_out"] as const;
@@ -3669,6 +3670,7 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
       providerQuotaMonitored: 0,
       recentProgressExempted: 0,
       operatorCancelExempted: 0,
+      breakerSuspended: 0,
       skipped: 0,
       issueIds: [] as string[],
     };
@@ -3735,6 +3737,13 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
         ? participantLatestRunForRecovery
         : latestRun;
       if (hasPendingProviderQuotaRecoveryMonitor(issue, providerQuotaMonitorRun, recoveryNow)) {
+        result.skipped += 1;
+        continue;
+      }
+      const breaker = await getAgentAdapterBreaker(db, issue.companyId, agentId, recoveryNow);
+      if (breaker.suspendedUntil) {
+        result.breakerSuspended += 1;
+        logAdapterBreakerSuspension(issue.companyId, agentId, breaker.suspendedUntil);
         result.skipped += 1;
         continue;
       }

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -32,7 +32,7 @@ import { runningProcesses } from "../../adapters/index.js";
 import { visibleIssueCondition } from "../issue-visibility.js";
 import { forbidden, notFound } from "../../errors.js";
 import { logger } from "../../middleware/logger.js";
-import { isPidAlive, isProcessGroupAlive, terminateLocalService } from "../local-service-supervisor.js";
+import { isPidAlive, isProcessGroupAlive, startedBeforeLastBoot, terminateLocalService } from "../local-service-supervisor.js";
 import { redactCurrentUserText } from "../../log-redaction.js";
 import { redactSensitiveText } from "../../redaction.js";
 import { logActivity } from "../activity-log.js";
@@ -2327,6 +2327,23 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     };
 
     for (const run of candidates) {
+      // A run whose process predates the last boot is not silent — it is DEAD (the
+      // reboot killed it). Filing "Review silent active run" for it spawns a headless
+      // agent per phantom, and that agent is itself a run that goes quiet, so the loop
+      // feeds itself. Leave terminalization to the stale-lock sweep; just never raise a
+      // review for a ghost.
+      if (startedBeforeLastBoot(run.processStartedAt ?? run.startedAt ?? run.createdAt)) {
+        logger.warn(
+          {
+            runId: run.id,
+            companyId: run.companyId,
+            processPid: run.processPid ?? null,
+          },
+          "skipping silent-run evaluation: process predates last boot (dead by reboot, not silent)",
+        );
+        result.skipped += 1;
+        continue;
+      }
       if (await latestActiveOutputQuietUntilDecision(run.companyId, run.id, now)) {
         result.snoozed += 1;
         continue;
@@ -5567,7 +5584,16 @@ export function recoveryService(db: Db, deps: { enqueueWakeup: RecoveryWakeup })
     // a run that has not yet stored its pid.
     let processGone = false;
     if (!runningProcesses.get(run.id)) {
-      if (typeof pid === "number" || typeof processGroupId === "number") {
+      // A PID recycled after the boot makes the liveness probe a FALSE POSITIVE, so the
+      // phantom run never terminalizes and keeps feeding the silent-run scanner. No
+      // process survives a boot: if it started before one, it is gone — skip the probe.
+      if (startedBeforeLastBoot(run.processStartedAt ?? run.startedAt ?? run.createdAt)) {
+        processGone = true;
+        logger.warn(
+          { runId: run.id, pid, processGroupId },
+          "run process predates last boot: terminalizing as dead-by-reboot without pid probe",
+        );
+      } else if (typeof pid === "number" || typeof processGroupId === "number") {
         const processAlive =
           (typeof pid === "number" && isPidAlive(pid)) ||
           (typeof processGroupId === "number" && isProcessGroupAlive(processGroupId));

--- a/ui/src/components/Sidebar.test.tsx
+++ b/ui/src/components/Sidebar.test.tsx
@@ -168,7 +168,7 @@ describe("Sidebar", () => {
 
     expect(container.querySelector('a[aria-label="Open search"]')).toBeNull();
     const navSearchLink = [...container.querySelectorAll("nav a")]
-      .find((anchor) => anchor.textContent?.trim() === "Search");
+      .find((anchor) => anchor.textContent?.trim() === "Buscar");
     expect(navSearchLink?.getAttribute("href")).toBe("/search");
 
     flushSync(() => {
@@ -189,12 +189,12 @@ describe("Sidebar", () => {
     // The Work section is a Collapsible now (one extra wrapper level), so
     // resolve the section root by walking up until the header label appears.
     let workSectionContainer = workSection?.parentElement ?? null;
-    while (workSectionContainer && !workSectionContainer.textContent?.includes("Work")) {
+    while (workSectionContainer && !workSectionContainer.textContent?.includes("Trabalho")) {
       workSectionContainer = workSectionContainer.parentElement;
     }
-    expect(workSectionContainer?.textContent).toContain("Work");
-    expect(workSectionContainer?.textContent).toContain("Tasks");
-    expect(workSectionContainer?.textContent).not.toContain("Goals");
+    expect(workSectionContainer?.textContent).toContain("Trabalho");
+    expect(workSectionContainer?.textContent).toContain("Tarefas");
+    expect(workSectionContainer?.textContent).not.toContain("Metas");
 
     flushSync(() => {
       root.unmount();
@@ -212,10 +212,10 @@ describe("Sidebar", () => {
     expect(container.textContent).not.toContain("New Issue");
 
     const navLabels = [...container.querySelectorAll("nav a")].map((a) => a.textContent?.trim());
-    expect(navLabels).toContain("Tasks");
+    expect(navLabels).toContain("Tarefas");
     expect(navLabels).not.toContain("Issues");
 
-    const projectsLink = [...container.querySelectorAll("nav a")].find((a) => a.textContent?.trim() === "Projects");
+    const projectsLink = [...container.querySelectorAll("nav a")].find((a) => a.textContent?.trim() === "Projetos");
     expect(projectsLink?.getAttribute("href")).toBe("/projects");
 
     expect(container.querySelector('[data-testid="sidebar-projects"]')).toBeNull();
@@ -233,7 +233,7 @@ describe("Sidebar", () => {
     const root = await renderSidebar();
 
     const navLabels = [...container.querySelectorAll("nav a")].map((a) => a.textContent?.trim());
-    expect(navLabels).toContain("Projects");
+    expect(navLabels).toContain("Projetos");
     expect(container.querySelector('[data-testid="sidebar-projects"]')).toBeNull();
     expect(
       container.querySelector('[data-testid="sidebar-agents"]')?.getAttribute("data-streamlined"),
@@ -254,9 +254,9 @@ describe("Sidebar", () => {
     const root = await renderSidebar();
 
     const navLabels = [...container.querySelectorAll("nav a")].map((a) => a.textContent?.trim());
-    expect(navLabels).toContain("Tasks");
+    expect(navLabels).toContain("Tarefas");
     // Top-level Projects link + starred children stay, per-project collapsible gone.
-    expect(navLabels).toContain("Projects");
+    expect(navLabels).toContain("Projetos");
     expect(container.querySelector('[data-testid="sidebar-projects"]')).toBeNull();
     expect(container.querySelector('[data-testid="sidebar-starred-projects"]')).not.toBeNull();
     expect(
@@ -277,12 +277,12 @@ describe("Sidebar", () => {
     expect(sidebarSlot?.textContent).toContain("Plugin slot outlet");
     const workSectionContainer = sidebarSlot?.parentElement?.parentElement;
     const workText = workSectionContainer?.textContent ?? "";
-    expect(workText).toContain("Work");
-    expect(workText).toContain("Workspaces");
-    expect(workText.indexOf("Workspaces")).toBeLessThan(workText.indexOf("Plugin slot outlet"));
+    expect(workText).toContain("Tarefas");
+    expect(workText).toContain("Áreas de trabalho");
+    expect(workText.indexOf("Áreas de trabalho")).toBeLessThan(workText.indexOf("Plugin slot outlet"));
 
     const primaryNavText = container.querySelector("nav > div:first-child")?.textContent ?? "";
-    expect(primaryNavText).toContain("Inbox");
+    expect(primaryNavText).toContain("Entrada");
     expect(primaryNavText).not.toContain("Plugin slot outlet");
 
     flushSync(() => {
@@ -294,7 +294,7 @@ describe("Sidebar", () => {
     mockInstanceSettingsApi.getExperimental.mockImplementation(() => new Promise(() => {}));
     const root = await renderSidebar();
 
-    expect(container.textContent).not.toContain("Workspaces");
+    expect(container.textContent).not.toContain("Áreas de trabalho");
 
     flushSync(() => {
       root.unmount();
@@ -321,7 +321,7 @@ describe("Sidebar", () => {
 
     const primaryNavLinks = [...container.querySelectorAll("nav > div:first-child a")];
     const decisionsLink = primaryNavLinks.find(
-      (anchor) => anchor.textContent?.trim() === "Decisions",
+      (anchor) => anchor.textContent?.trim() === "Decisões",
     );
     const statusLink = primaryNavLinks.find((anchor) => anchor.getAttribute("href") === "/status");
 
@@ -341,20 +341,20 @@ describe("Sidebar", () => {
     const root = await renderSidebar();
 
     const artifactsLink = [...container.querySelectorAll("a")].find(
-      (anchor) => anchor.textContent === "Artifacts",
+      (anchor) => anchor.textContent === "Artefatos",
     );
     expect(artifactsLink?.getAttribute("href")).toBe("/artifacts");
 
     const navText = container.querySelector("nav")?.textContent ?? "";
-    expect(navText).toContain("Artifacts");
-    expect(navText).toContain("Skills");
-    expect(navText.indexOf("Artifacts")).toBeLessThan(navText.indexOf("Skills"));
+    expect(navText).toContain("Artefatos");
+    expect(navText).toContain("Habilidades");
+    expect(navText.indexOf("Artefatos")).toBeLessThan(navText.indexOf("Habilidades"));
 
     const sections = [...container.querySelectorAll("nav > div")];
-    const workSection = sections.find((section) => section.textContent?.startsWith("Work"));
-    const companySection = sections.find((section) => section.textContent?.startsWith("Company"));
-    expect(workSection?.textContent).toContain("Skills");
-    expect(companySection?.textContent).not.toContain("Skills");
+    const workSection = sections.find((section) => section.textContent?.startsWith("Trabalho"));
+    const companySection = sections.find((section) => section.textContent?.startsWith("Empresa"));
+    expect(workSection?.textContent).toContain("Habilidades");
+    expect(companySection?.textContent).not.toContain("Habilidades");
 
     flushSync(() => {
       root.unmount();
@@ -368,7 +368,7 @@ describe("Sidebar", () => {
     });
     const root = await renderSidebar();
 
-    expect([...container.querySelectorAll("nav a")].map((a) => a.textContent?.trim())).not.toContain("Goals");
+    expect([...container.querySelectorAll("nav a")].map((a) => a.textContent?.trim())).not.toContain("Metas");
 
     flushSync(() => {
       root.unmount();
@@ -379,7 +379,7 @@ describe("Sidebar", () => {
     mockInstanceSettingsApi.getExperimental.mockImplementation(() => new Promise(() => {}));
     const root = await renderSidebar();
 
-    expect([...container.querySelectorAll("nav a")].map((a) => a.textContent?.trim())).not.toContain("Goals");
+    expect([...container.querySelectorAll("nav a")].map((a) => a.textContent?.trim())).not.toContain("Metas");
     expect(container.querySelector('[data-testid="sidebar-goals-placeholder"]')).not.toBeNull();
 
     flushSync(() => {
@@ -394,11 +394,11 @@ describe("Sidebar", () => {
     });
     const root = await renderSidebar();
 
-    const link = [...container.querySelectorAll("a")].find((anchor) => anchor.textContent === "Goals");
+    const link = [...container.querySelectorAll("a")].find((anchor) => anchor.textContent === "Metas");
     expect(link?.getAttribute("href")).toBe("/goals");
 
     const navText = container.querySelector("nav")?.textContent ?? "";
-    expect(navText.indexOf("Goals")).toBeLessThan(navText.indexOf("Artifacts"));
+    expect(navText.indexOf("Metas")).toBeLessThan(navText.indexOf("Artefatos"));
 
     flushSync(() => {
       root.unmount();
@@ -410,12 +410,12 @@ describe("Sidebar", () => {
     const root = await renderSidebar();
 
     const sections = [...container.querySelectorAll("nav > div")];
-    const workSection = sections.find((section) => section.textContent?.startsWith("Work"));
-    const companySection = sections.find((section) => section.textContent?.startsWith("Company"));
-    expect(workSection?.textContent).not.toContain("Timeline");
-    expect(companySection?.textContent).toContain("Timeline");
+    const workSection = sections.find((section) => section.textContent?.startsWith("Trabalho"));
+    const companySection = sections.find((section) => section.textContent?.startsWith("Empresa"));
+    expect(workSection?.textContent).not.toContain("Linha do tempo");
+    expect(companySection?.textContent).toContain("Linha do tempo");
 
-    const timelineLink = [...container.querySelectorAll("a")].find((anchor) => anchor.textContent === "Timeline");
+    const timelineLink = [...container.querySelectorAll("a")].find((anchor) => anchor.textContent === "Linha do tempo");
     expect(timelineLink?.getAttribute("href")).toBe("/timeline");
 
     flushSync(() => {
@@ -431,7 +431,7 @@ describe("Sidebar", () => {
     const root = await renderSidebar();
 
     const link = [...container.querySelectorAll("nav a")].find(
-      (anchor) => anchor.textContent?.trim() === "Conference Room",
+      (anchor) => anchor.textContent?.trim() === "Sala de Reunião",
     );
     expect(link?.getAttribute("href")).toBe("/board-chat");
 
@@ -447,7 +447,7 @@ describe("Sidebar", () => {
     });
     const root = await renderSidebar();
 
-    expect(container.textContent).not.toContain("Conference Room");
+    expect(container.textContent).not.toContain("Sala de Reunião");
 
     flushSync(() => {
       root.unmount();
@@ -458,7 +458,7 @@ describe("Sidebar", () => {
     mockInstanceSettingsApi.getExperimental.mockImplementation(() => new Promise(() => {}));
     const root = await renderSidebar();
 
-    expect(container.textContent).not.toContain("Conference Room");
+    expect(container.textContent).not.toContain("Sala de Reunião");
 
     flushSync(() => {
       root.unmount();
@@ -530,7 +530,7 @@ describe("Sidebar", () => {
     mockInstanceSettingsApi.getExperimental.mockResolvedValue({ enableIsolatedWorkspaces: true });
     const root = await renderSidebar();
 
-    const link = [...container.querySelectorAll("a")].find((anchor) => anchor.textContent === "Workspaces");
+    const link = [...container.querySelectorAll("a")].find((anchor) => anchor.textContent === "Áreas de trabalho");
     expect(link?.getAttribute("href")).toBe("/workspaces");
 
     flushSync(() => {

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -196,11 +196,11 @@ export function Sidebar() {
               width; a nav row also keeps search reachable from the
               collapsed rail, where the old header icon was dropped entirely.
               Cmd/Ctrl+K remains the keyboard path (command palette). */}
-          <SidebarNavItem to="/search" label="Search" icon={Search} />
-          <SidebarNavItem to="/dashboard" label="Dashboard" icon={LayoutDashboard} liveCount={liveRunCount} />
+          <SidebarNavItem to="/search" label="Buscar" icon={Search} />
+          <SidebarNavItem to="/dashboard" label="Painel" icon={LayoutDashboard} liveCount={liveRunCount} />
           <SidebarNavItem
             to="/inbox"
-            label="Inbox"
+            label="Entrada"
             icon={Inbox}
             badge={inboxBadge.inbox}
             badgeLabel="unread"
@@ -210,7 +210,7 @@ export function Sidebar() {
           {showDecisions ? (
             <SidebarNavItem
               to="/decisions"
-              label="Decisions"
+              label="Decisões"
               icon={ListChecks}
               badge={attentionCount}
               badgeLabel="decisions"
@@ -220,21 +220,21 @@ export function Sidebar() {
             <SidebarNavItem to="/status" label="Status" icon={LayoutGrid} textBadge="beta" />
           ) : null}
           {conferenceRoomChatEnabled ? (
-            <SidebarNavItem to="/board-chat" label="Conference Room" icon={MessagesSquare} />
+            <SidebarNavItem to="/board-chat" label="Sala de Reunião" icon={MessagesSquare} />
           ) : null}
         </div>
 
-        <SidebarSection label="Work" collapsible={{ open: workOpen, onOpenChange: setWorkOpen }}>
-          <SidebarNavItem to="/issues" label="Tasks" icon={CircleDot} />
+        <SidebarSection label="Trabalho" collapsible={{ open: workOpen, onOpenChange: setWorkOpen }}>
+          <SidebarNavItem to="/issues" label="Tarefas" icon={CircleDot} />
           {showCases ? (
-            <SidebarNavItem to="/cases" label="Cases" icon={Layers} textBadge="beta" />
+            <SidebarNavItem to="/cases" label="Casos" icon={Layers} textBadge="beta" />
           ) : null}
-          <SidebarNavItem to="/routines" label="Routines" icon={Repeat} />
+          <SidebarNavItem to="/routines" label="Rotinas" icon={Repeat} />
           {showPipelines ? (
             <SidebarNavItem to="/pipelines" label="Pipelines" icon={GitBranch} />
           ) : null}
           {showGoalsLink ? (
-            <SidebarNavItem to="/goals" label="Goals" icon={Target} />
+            <SidebarNavItem to="/goals" label="Metas" icon={Target} />
           ) : goalsLinkPending ? (
             <div
               data-testid="sidebar-goals-placeholder"
@@ -242,14 +242,14 @@ export function Sidebar() {
               aria-hidden="true"
             />
           ) : null}
-          <SidebarNavItem to="/artifacts" label="Artifacts" icon={Package} />
-          <SidebarNavItem to="/skills" label="Skills" icon={Boxes} />
+          <SidebarNavItem to="/artifacts" label="Artefatos" icon={Package} />
+          <SidebarNavItem to="/skills" label="Habilidades" icon={Boxes} />
           {showWorkspacesLink ? (
-            <SidebarNavItem to="/workspaces" label="Workspaces" icon={GitBranch} />
+            <SidebarNavItem to="/workspaces" label="Áreas de trabalho" icon={GitBranch} />
           ) : null}
           {streamlined ? (
             <>
-              <SidebarNavItem to="/projects" label="Projects" icon={FolderOpen} />
+              <SidebarNavItem to="/projects" label="Projetos" icon={FolderOpen} />
               <SidebarStarredProjects />
             </>
           ) : null}
@@ -273,14 +273,14 @@ export function Sidebar() {
 
         <SidebarAgents streamlined={streamlined} />
 
-        <SidebarSection label="Company" collapsible={{ open: companyOpen, onOpenChange: setCompanyOpen }}>
-          <SidebarNavItem to="/org" label="Org" icon={Network} />
+        <SidebarSection label="Empresa" collapsible={{ open: companyOpen, onOpenChange: setCompanyOpen }}>
+          <SidebarNavItem to="/org" label="Organograma" icon={Network} />
           {showApps ? <SidebarNavItem to="/apps" label="Apps" icon={AppWindow} /> : null}
-          <SidebarNavItem to="/timeline" label="Timeline" icon={GanttChartSquare} />
-          <SidebarNavItem to="/costs" label="Costs" icon={DollarSign} />
+          <SidebarNavItem to="/timeline" label="Linha do tempo" icon={GanttChartSquare} />
+          <SidebarNavItem to="/costs" label="Custos" icon={DollarSign} />
           {/* One entry — /audit merged into the rich Activity feed (PAP-16302). */}
-          <SidebarNavItem to="/activity" label="Activity" icon={History} />
-          <SidebarNavItem to="/company/settings" label="Settings" icon={Settings} />
+          <SidebarNavItem to="/activity" label="Atividade" icon={History} />
+          <SidebarNavItem to="/company/settings" label="Configurações" icon={Settings} />
         </SidebarSection>
 
         <PluginSlotOutlet

--- a/ui/src/components/SidebarAgents.test.tsx
+++ b/ui/src/components/SidebarAgents.test.tsx
@@ -172,7 +172,7 @@ async function flushReact() {
   });
 }
 
-async function openAgentMenu(label = "Open actions for Alpha") {
+async function openAgentMenu(label = "Ações de Alpha") {
   const trigger = document.body.querySelector(`button[aria-label="${label}"]`);
   expect(trigger).not.toBeNull();
 
@@ -184,7 +184,7 @@ async function openAgentMenu(label = "Open actions for Alpha") {
 }
 
 async function openAgentsSectionMenu() {
-  const trigger = document.body.querySelector('button[aria-label="Agents section actions"]');
+  const trigger = document.body.querySelector('button[aria-label="Ações da seção Agentes"]');
   expect(trigger).not.toBeNull();
 
   await act(async () => {
@@ -215,7 +215,7 @@ function agentLinkLabels(container: HTMLElement) {
 function seeAllAgentsLink(container: HTMLElement) {
   return (
     Array.from(container.querySelectorAll('a[href="/agents/all"]')).find((anchor) =>
-      anchor.textContent?.includes("See all agents"),
+      anchor.textContent?.includes("Ver todos os agentes"),
     ) ?? null
   );
 }
@@ -400,10 +400,10 @@ describe("SidebarAgents", () => {
     expect(nameSpan?.className).toContain("overflow-hidden");
     const agentLink = container.querySelector('a[href^="/agents/"]:not([href="/agents/all"])');
     expect(agentLink?.parentElement?.getAttribute("data-slot")).toBe("tooltip-trigger");
-    expect(container.querySelector('button[aria-label="Open actions for Alpha"]')).toBeNull();
+    expect(container.querySelector('button[aria-label="Ações de Alpha"]')).toBeNull();
 
     // The section header collapses to a divider (no caret / section menu).
-    expect(container.querySelector('button[aria-label="Agents section actions"]')).toBeNull();
+    expect(container.querySelector('button[aria-label="Ações da seção Agentes"]')).toBeNull();
   });
 
   it("pins starred agents at the top without subheadings and dedupes them from the recent list", async () => {
@@ -434,9 +434,9 @@ describe("SidebarAgents", () => {
     // Starred order lands the starred agent first.
     expect(labels[0]).toBe("Bravo");
 
-    // The starred row offers an explicit "Remove from starred" menu action.
-    await openAgentMenu("Open actions for Bravo");
-    expect(document.body.textContent).toContain("Remove from starred");
+    // The starred row offers an explicit "Remover dos favoritos" menu action.
+    await openAgentMenu("Ações de Bravo");
+    expect(document.body.textContent).toContain("Remover dos favoritos");
   });
 
   it("offers star agent from an unstarred sidebar agent menu", async () => {
@@ -444,7 +444,7 @@ describe("SidebarAgents", () => {
     await openAgentMenu();
 
     const starItem = Array.from(document.body.querySelectorAll('[data-slot="dropdown-menu-item"]'))
-      .find((element) => element.textContent?.includes("Star agent"));
+      .find((element) => element.textContent?.includes("Favoritar agente"));
     expect(starItem).toBeTruthy();
 
     await act(async () => {
@@ -508,11 +508,11 @@ describe("SidebarAgents", () => {
   it("uses the heading for section menu and the plus button for agent creation", async () => {
     await renderSidebarAgents();
 
-    const sectionMenuTrigger = container.querySelector('button[aria-label="Agents section actions"]');
-    expect(sectionMenuTrigger?.textContent).toContain("Agents");
+    const sectionMenuTrigger = container.querySelector('button[aria-label="Ações da seção Agentes"]');
+    expect(sectionMenuTrigger?.textContent).toContain("Agentes");
     expect(sectionMenuTrigger?.querySelector("svg")).toBeNull();
 
-    const newAgentButton = container.querySelector('button[aria-label="New agent"]');
+    const newAgentButton = container.querySelector('button[aria-label="Novo agente"]');
     expect(newAgentButton).toBeTruthy();
     await act(async () => {
       newAgentButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
@@ -522,10 +522,10 @@ describe("SidebarAgents", () => {
     await openAgentsSectionMenu();
 
     const newAgentItem = Array.from(document.body.querySelectorAll('[data-slot="dropdown-menu-item"]'))
-      .find((element) => element.textContent?.includes("New agent"));
+      .find((element) => element.textContent?.includes("Novo agente"));
     expect(newAgentItem).toBeFalsy();
     const browseLink = Array.from(document.body.querySelectorAll("a"))
-      .find((element) => element.textContent?.includes("Browse agents"));
+      .find((element) => element.textContent?.includes("Ver agentes"));
     expect(browseLink?.getAttribute("href")).toBe("/agents/all");
   });
 
@@ -538,7 +538,7 @@ describe("SidebarAgents", () => {
 
     await renderSidebarAgents();
     await openAgentsSectionMenu();
-    await chooseSortMode("Alphabetical");
+    await chooseSortMode("Alfabético");
 
     expect(agentLinkLabels(container)).toEqual(["Alpha", "Bravo", "Charlie"]);
     expect(localStorage.getItem("paperclip.agentSortMode:company-1:user-1")).toBe("alphabetical");
@@ -574,7 +574,7 @@ describe("SidebarAgents", () => {
 
     await renderSidebarAgents();
     await openAgentsSectionMenu();
-    await chooseSortMode("Recent");
+    await chooseSortMode("Recente");
 
     expect(agentLinkLabels(container)).toEqual(["Bravo", "Charlie", "Alpha"]);
   });
@@ -611,12 +611,12 @@ describe("SidebarAgents", () => {
     await openAgentMenu();
 
     const editLink = Array.from(document.body.querySelectorAll("a"))
-      .find((element) => element.textContent?.includes("Edit agent"));
+      .find((element) => element.textContent?.includes("Editar agente"));
     expect(editLink?.getAttribute("href")).toBe("/agents/alpha/configuration");
-    expect(document.body.textContent).toContain("Pause agent");
+    expect(document.body.textContent).toContain("Pausar agente");
 
     const pauseItem = Array.from(document.body.querySelectorAll('[data-slot="dropdown-menu-item"]'))
-      .find((element) => element.textContent?.includes("Pause agent"));
+      .find((element) => element.textContent?.includes("Pausar agente"));
     expect(pauseItem).toBeTruthy();
 
     await act(async () => {
@@ -633,7 +633,7 @@ describe("SidebarAgents", () => {
     await openAgentMenu();
 
     const leaveItem = Array.from(document.body.querySelectorAll('[data-slot="dropdown-menu-item"]'))
-      .find((element) => element.textContent?.includes("Leave agent"));
+      .find((element) => element.textContent?.includes("Sair do agente"));
     expect(leaveItem).toBeTruthy();
 
     await act(async () => {
@@ -658,7 +658,7 @@ describe("SidebarAgents", () => {
     await openAgentMenu();
 
     const resumeItem = Array.from(document.body.querySelectorAll('[data-slot="dropdown-menu-item"]'))
-      .find((element) => element.textContent?.includes("Resume agent"));
+      .find((element) => element.textContent?.includes("Retomar agente"));
     expect(resumeItem).toBeTruthy();
 
     await act(async () => {
@@ -681,19 +681,19 @@ describe("SidebarAgents", () => {
     await openAgentMenu();
 
     const pauseItem = Array.from(document.body.querySelectorAll('[data-slot="dropdown-menu-item"]'))
-      .find((element) => element.textContent?.includes("Pause agent"));
+      .find((element) => element.textContent?.includes("Pausar agente"));
     expect(pauseItem).toBeTruthy();
 
     await act(async () => {
       pauseItem?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
     await flushReact();
-    await openAgentMenu("Open actions for Beta");
+    await openAgentMenu("Ações de Beta");
 
     const betaPauseItem = Array.from(
       document.body.querySelectorAll('[data-slot="dropdown-menu-item"]'),
     )
-      .find((element) => element.textContent?.includes("Pause agent"));
+      .find((element) => element.textContent?.includes("Pausar agente"));
     expect(betaPauseItem).toBeTruthy();
     expect(document.body.textContent).not.toContain("Updating...");
   });
@@ -862,7 +862,7 @@ describe("SidebarAgents", () => {
     expect(labels[0]).toBe("Alpha");
     expect(labels[1]).toContain("Bravo");
     expect(labels[2]).toBe("Charlie");
-    // No recent-5 truncation, so no "See all agents" link in classic mode.
+    // No recent-5 truncation, so no "Ver todos os agentes" link in classic mode.
     expect(seeAllAgentsLink(container)).toBeNull();
   });
 
@@ -917,7 +917,7 @@ describe("SidebarAgents", () => {
     const budgetPausedItem = Array.from(
       document.body.querySelectorAll('[data-slot="dropdown-menu-item"]'),
     )
-      .find((element) => element.textContent?.includes("Budget paused"));
+      .find((element) => element.textContent?.includes("Pausado por orçamento"));
     expect(budgetPausedItem).toBeTruthy();
 
     await act(async () => {

--- a/ui/src/components/SidebarAgents.tsx
+++ b/ui/src/components/SidebarAgents.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { Link, useLocation } from "@/lib/router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -12,7 +12,9 @@ import {
   Star,
   Users,
   AlertTriangle,
+  ChevronRight,
 } from "lucide-react";
+import { buildAgentTree, type AgentTreeNode } from "./agentTree";
 import { useCompany } from "../context/CompanyContext";
 import { useDialogActions } from "../context/DialogContext";
 import { useSidebar } from "../context/SidebarContext";
@@ -67,9 +69,9 @@ const RECENT_AGENT_LIMIT = 3;
 const LIVE_AGENT_LINGER_MS = 120_000;
 
 const AGENT_SORT_CHOICES: SidebarSectionRadioChoice[] = [
-  { value: "top", label: "Top" },
-  { value: "alphabetical", label: "Alphabetical" },
-  { value: "recent", label: "Recent" },
+  { value: "top", label: "Prioritário" },
+  { value: "alphabetical", label: "Alfabético" },
+  { value: "recent", label: "Recente" },
 ];
 
 function agentTimestamp(agent: Agent, field: "lastHeartbeatAt" | "updatedAt" | "createdAt"): number {
@@ -121,6 +123,10 @@ function SidebarAgentItem({
   starred = false,
   onToggleStar,
   starPending = false,
+  depth = 0,
+  hasReports = false,
+  expanded = true,
+  onToggleExpand,
 }: {
   activeAgentId: string | null;
   activeTab: string | null;
@@ -137,6 +143,14 @@ function SidebarAgentItem({
   starred?: boolean;
   onToggleStar?: (agent: Agent, starred: boolean) => void;
   starPending?: boolean;
+  /** Org-tree depth (0 = CEO/root). Drives left indentation of the row. */
+  depth?: number;
+  /** Whether this agent has direct reports (shows the expand/collapse chevron). */
+  hasReports?: boolean;
+  /** Whether this node's reports are currently shown. */
+  expanded?: boolean;
+  /** Toggle this node's reports. Absent = not collapsible. */
+  onToggleExpand?: (agent: Agent) => void;
 }) {
   const routeRef = agentRouteRef(agent);
   const href = activeTab ? `${agentUrl(agent)}/${activeTab}` : agentUrl(agent);
@@ -145,19 +159,19 @@ function SidebarAgentItem({
   const isPaused = agent.status === "paused";
   const isBudgetPaused = isPaused && agent.pauseReason === "budget";
   const hasInvalidOrgChain = agent.orgChainHealth?.status === "invalid_org_chain";
-  const pauseResumeLabel = isPaused ? "Resume agent" : "Pause agent";
+  const pauseResumeLabel = isPaused ? "Retomar agente" : "Pausar agente";
   const pauseResumeDisabled = disabled || agent.status === "pending_approval" || isBudgetPaused || (isPaused && hasInvalidOrgChain);
   const pauseResumeDisabledLabel = disabled
-    ? "Updating..."
+    ? "Atualizando..."
     : isBudgetPaused
-      ? "Budget paused"
+      ? "Pausado por orçamento"
       : isPaused && hasInvalidOrgChain
-        ? "Invalid org chain"
+        ? "Cadeia hierárquica inválida"
       : pauseResumeLabel;
   const showBuiltInLifecycle = builtInStatus === "needs_setup" || builtInStatus === "pending_approval";
   const trailingLabel = [
     showBuiltInLifecycle ? `Built-in agent ${builtInStatus.replace(/_/g, " ")}` : null,
-    hasInvalidOrgChain ? "Invalid reporting chain" : null,
+    hasInvalidOrgChain ? "Cadeia hierárquica inválida" : null,
   ].filter(Boolean).join(", ") || undefined;
 
   // C11 (DECISION-SHEET.md): the row itself is a SidebarNavItem, so agent rows
@@ -181,14 +195,14 @@ function SidebarAgentItem({
           <span className="ml-1 flex shrink-0 items-center gap-1">
             {showBuiltInLifecycle ? <BuiltInLifecycleChip status={builtInStatus} compact /> : null}
             {hasInvalidOrgChain ? (
-              <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-amber-500" aria-label="Invalid reporting chain" />
+              <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-amber-500" aria-label="Cadeia hierárquica inválida" />
             ) : null}
           </span>
         ) : undefined
       }
       trailingLabel={trailingLabel}
       liveAccessory={
-        agent.pauseReason === "budget" ? <BudgetSidebarMarker title="Agent paused by budget" /> : undefined
+        agent.pauseReason === "budget" ? <BudgetSidebarMarker title="Agente pausado por orçamento" /> : undefined
       }
     />
   );
@@ -199,7 +213,24 @@ function SidebarAgentItem({
   if (rail) return navItem;
 
   return (
-    <div className="group/agent relative flex items-center">
+    <div
+      className="group/agent relative flex items-center"
+      style={depth > 0 ? { paddingLeft: depth * 14 } : undefined}
+    >
+      {hasReports ? (
+        <button
+          type="button"
+          onClick={() => onToggleExpand?.(agent)}
+          aria-label={expanded ? `Recolher liderados de ${agent.name}` : `Expandir liderados de ${agent.name}`}
+          aria-expanded={expanded}
+          className="mr-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
+        >
+          <ChevronRight className={cn("h-3.5 w-3.5 transition-transform", expanded && "rotate-90")} />
+        </button>
+      ) : (
+        // Spacer keeps leaf-row icons aligned with rows that have a chevron.
+        <span aria-hidden className="mr-0.5 h-5 w-5 shrink-0" />
+      )}
       {navItem}
 
       {starred && !isMobile && onToggleStar ? (
@@ -228,7 +259,7 @@ function SidebarAgentItem({
                 ? "opacity-100"
                 : "pointer-events-none opacity-0 group-hover/agent:pointer-events-auto group-hover/agent:opacity-100 group-focus-within/agent:pointer-events-auto group-focus-within/agent:opacity-100",
             )}
-            aria-label={`Open actions for ${agent.name}`}
+            aria-label={`Ações de ${agent.name}`}
           >
             <MoreHorizontal className="h-3.5 w-3.5" />
           </Button>
@@ -248,7 +279,7 @@ function SidebarAgentItem({
                 ) : (
                   <Star className={cn("size-4", starred && "fill-amber-500 text-amber-500")} />
                 )}
-                <span>{starred ? "Remove from starred" : "Star agent"}</span>
+                <span>{starred ? "Remover dos favoritos" : "Favoritar agente"}</span>
               </DropdownMenuItem>
               <DropdownMenuSeparator />
             </>
@@ -261,7 +292,7 @@ function SidebarAgentItem({
               }}
             >
               <Pencil className="size-4" />
-              <span>Edit agent</span>
+              <span>Editar agente</span>
             </Link>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
@@ -285,7 +316,7 @@ function SidebarAgentItem({
             disabled={leaving}
           >
             {leaving ? <Loader2 className="size-4 motion-safe:animate-spin" /> : <LogOut className="size-4" />}
-            <span>{leaving ? "Leaving..." : "Leave agent"}</span>
+            <span>{leaving ? "Saindo..." : "Sair do agente"}</span>
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
@@ -295,6 +326,17 @@ function SidebarAgentItem({
 
 export function SidebarAgents({ streamlined = false }: { streamlined?: boolean } = {}) {
   const [open, setOpen] = useState(true);
+  // Org-tree: which CEO/manager nodes are collapsed (session-scoped). Default is
+  // expanded, so the hierarchy is visible without a click.
+  const [collapsedNodeIds, setCollapsedNodeIds] = useState<Set<string>>(() => new Set());
+  const toggleNodeCollapsed = useCallback((agent: Agent) => {
+    setCollapsedNodeIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(agent.id)) next.delete(agent.id);
+      else next.add(agent.id);
+      return next;
+    });
+  }, []);
   const [pendingAgentIds, setPendingAgentIds] = useState<Set<string>>(() => new Set());
   const [liveLingerVersion, setLiveLingerVersion] = useState(0);
   const lastSeenLiveAtRef = useRef<Map<string, number>>(new Map());
@@ -608,7 +650,11 @@ export function SidebarAgents({ streamlined = false }: { streamlined?: boolean }
     [displayedAgents, starredAgentIdSet],
   );
 
-  const renderAgentRow = (agent: Agent, isStarredRow: boolean) => (
+  const renderAgentRow = (
+    agent: Agent,
+    isStarredRow: boolean,
+    tree?: { depth: number; hasReports: boolean; expanded: boolean },
+  ) => (
     <SidebarAgentItem
       key={agent.id}
       activeAgentId={activeAgentId}
@@ -626,32 +672,57 @@ export function SidebarAgents({ streamlined = false }: { streamlined?: boolean }
       starred={isStarredRow || isStarred(membershipsQuery.data, "agent", agent.id)}
       onToggleStar={toggleStarAgent}
       starPending={agentStarPending(agent)}
+      depth={tree?.depth ?? 0}
+      hasReports={tree?.hasReports ?? false}
+      expanded={tree?.expanded ?? true}
+      onToggleExpand={tree ? toggleNodeCollapsed : undefined}
     />
   );
 
+  // Org tree (CEOs → reports) built from the flat non-starred list. Falls back to
+  // a flat list in the collapsed rail and in streamlined mode, where a nested
+  // tree has no room / doesn't fit the "recent few" affordance.
+  const agentTree = useMemo(
+    () => buildAgentTree(dedupedDisplayedAgents),
+    [dedupedDisplayedAgents],
+  );
+  const useTreeLayout = !rail && !streamlined;
+  const renderAgentTree = (nodes: AgentTreeNode[]): ReactNode[] =>
+    nodes.flatMap((node) => {
+      const hasReports = node.reports.length > 0;
+      const expanded = !collapsedNodeIds.has(node.agent.id);
+      const rows: ReactNode[] = [
+        renderAgentRow(node.agent, false, { depth: node.depth, hasReports, expanded }),
+      ];
+      if (hasReports && expanded) rows.push(...renderAgentTree(node.reports));
+      return rows;
+    });
+
   return (
     <SidebarSection
-      label="Agents"
+      label="Agentes"
       collapsible={{ open, onOpenChange: setOpen }}
       headerAction={{
-        ariaLabel: "New agent",
+        ariaLabel: "Novo agente",
         icon: Plus,
         onClick: openNewAgent,
       }}
       menu={{
-        ariaLabel: "Agents section actions",
+        ariaLabel: "Ações da seção Agentes",
         actions: [
-          { type: "item", label: "Browse agents", icon: Users, href: "/agents/all" },
+          { type: "item", label: "Ver agentes", icon: Users, href: "/agents/all" },
           { type: "separator" },
         ],
-        radioLabel: "Agent sort",
+        radioLabel: "Ordenar agentes",
         radioChoices: AGENT_SORT_CHOICES,
         radioValue: sortMode,
         onRadioValueChange: persistSortMode,
       }}
     >
       {starredAgents.map((agent: Agent) => renderAgentRow(agent, true))}
-      {dedupedDisplayedAgents.map((agent: Agent) => renderAgentRow(agent, false))}
+      {useTreeLayout
+        ? renderAgentTree(agentTree)
+        : dedupedDisplayedAgents.map((agent: Agent) => renderAgentRow(agent, false))}
       {showSeeAllLink && (() => {
         // Deliberately NOT a SidebarNavItem: this is a quiet muted affordance
         // (plain Link) that must not adopt nav-row active-route highlighting.
@@ -659,20 +730,20 @@ export function SidebarAgents({ streamlined = false }: { streamlined?: boolean }
           <Link
             to="/agents/all"
             state={SIDEBAR_SCROLL_RESET_STATE}
-            aria-label={rail ? "See all agents" : undefined}
+            aria-label={rail ? "Ver todos os agentes" : undefined}
             onClick={() => {
               if (isMobile) setSidebarOpen(false);
             }}
             className="flex items-center gap-2.5 mx-2 rounded-lg px-2 py-1.5 pointer-coarse:py-1 text-(length:--text-compact) font-medium text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
           >
             <Users className="shrink-0 h-4 w-4" />
-            <span className={rail ? SIDEBAR_RAIL_HIDDEN_LABEL : undefined}>See all agents</span>
+            <span className={rail ? SIDEBAR_RAIL_HIDDEN_LABEL : undefined}>Ver todos os agentes</span>
           </Link>
         );
         return rail ? (
           <Tooltip>
             <TooltipTrigger asChild>{seeAllLink}</TooltipTrigger>
-            <TooltipContent side="right">See all agents</TooltipContent>
+            <TooltipContent side="right">Ver todos os agentes</TooltipContent>
           </Tooltip>
         ) : (
           seeAllLink

--- a/ui/src/components/agentTree.test.ts
+++ b/ui/src/components/agentTree.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import type { Agent } from "@paperclipai/shared";
+
+import { buildAgentTree, flattenAgentTree } from "./agentTree";
+
+function agent(id: string, reportsTo: string | null, name = id): Agent {
+  const now = new Date("2026-08-19T00:00:00.000Z");
+  return {
+    id,
+    companyId: "c1",
+    name,
+    urlKey: id,
+    role: "engineer",
+    title: null,
+    icon: null,
+    status: "active",
+    reportsTo,
+    capabilities: null,
+    adapterType: "codex_local",
+    adapterConfig: {},
+    runtimeConfig: {},
+    budgetMonthlyCents: 0,
+    spentMonthlyCents: 0,
+    lastHeartbeatAt: null,
+    metadata: null,
+    createdAt: now,
+    updatedAt: now,
+    pauseReason: null,
+    pausedAt: null,
+    permissions: { canCreateAgents: false },
+  } as Agent;
+}
+
+const byName = (a: Agent, b: Agent) => a.name.localeCompare(b.name);
+
+describe("buildAgentTree", () => {
+  it("nests reports under their manager and marks CEOs (no manager) as roots", () => {
+    const ceo = agent("ceo", null);
+    const lead = agent("lead", "ceo");
+    const ic = agent("ic", "lead");
+
+    const tree = buildAgentTree([ic, lead, ceo]);
+
+    expect(tree).toHaveLength(1);
+    expect(tree[0].agent.id).toBe("ceo");
+    expect(tree[0].depth).toBe(0);
+    expect(tree[0].reports[0].agent.id).toBe("lead");
+    expect(tree[0].reports[0].depth).toBe(1);
+    expect(tree[0].reports[0].reports[0].agent.id).toBe("ic");
+    expect(tree[0].reports[0].reports[0].depth).toBe(2);
+  });
+
+  it("treats a dangling manager pointer as a root so the agent stays visible", () => {
+    const orphan = agent("orphan", "ghost-manager-not-in-list");
+    const tree = buildAgentTree([orphan]);
+    expect(tree).toHaveLength(1);
+    expect(tree[0].agent.id).toBe("orphan");
+    expect(tree[0].depth).toBe(0);
+  });
+
+  it("keeps every agent visible even under a pure reportsTo cycle", () => {
+    const a = agent("a", "b");
+    const b = agent("b", "a");
+    const flat = flattenAgentTree(buildAgentTree([a, b]));
+    expect(flat.map((n) => n.agent.id).sort()).toEqual(["a", "b"]);
+  });
+
+  it("orders siblings with the provided comparator (sort mode preserved)", () => {
+    const ceo = agent("ceo", null, "Zeus");
+    const alice = agent("alice", "ceo", "Alice");
+    const bob = agent("bob", "ceo", "Bob");
+
+    const flat = flattenAgentTree(buildAgentTree([bob, alice, ceo], byName));
+    expect(flat.map((n) => n.agent.name)).toEqual(["Zeus", "Alice", "Bob"]);
+  });
+
+  it("supports multiple CEOs (forest)", () => {
+    const tree = buildAgentTree(
+      [agent("c2", null, "C2"), agent("c1", null, "C1"), agent("r1", "c1", "R1")],
+      byName,
+    );
+    expect(tree.map((n) => n.agent.name)).toEqual(["C1", "C2"]);
+    expect(tree[0].reports[0].agent.name).toBe("R1");
+  });
+});

--- a/ui/src/components/agentTree.ts
+++ b/ui/src/components/agentTree.ts
@@ -1,0 +1,84 @@
+import type { Agent } from "@paperclipai/shared";
+
+/**
+ * A node in the agent org tree: an agent plus its direct reports, already
+ * ordered. Depth is precomputed so the sidebar can indent without re-walking.
+ */
+export interface AgentTreeNode {
+  agent: Agent;
+  depth: number;
+  reports: AgentTreeNode[];
+}
+
+/**
+ * Build the CEO/org tree from a flat agent list using `reportsTo`.
+ *
+ * Roots are the "CEOs": agents with no `reportsTo`, or whose manager is not in
+ * the provided list (dangling pointer — treated as a root so the agent never
+ * disappears). Cycles are broken defensively: any agent reached again while
+ * walking is dropped from the second position, and agents left unvisited after
+ * the walk (pure cycles with no root) are surfaced as roots so nothing is
+ * silently hidden — an invisible agent is worse than a mis-parented one.
+ *
+ * `orderRoots`/`orderReports` decide sibling order at each level; callers pass
+ * the same comparator they use for the flat list so sort mode is preserved.
+ */
+export function buildAgentTree(
+  agents: Agent[],
+  compare?: (a: Agent, b: Agent) => number,
+): AgentTreeNode[] {
+  const byId = new Map<string, Agent>();
+  for (const agent of agents) byId.set(agent.id, agent);
+
+  const childrenByParent = new Map<string | null, Agent[]>();
+  const rootKey = null;
+  for (const agent of agents) {
+    const managerInList = agent.reportsTo != null && byId.has(agent.reportsTo);
+    const key = managerInList ? (agent.reportsTo as string) : rootKey;
+    const bucket = childrenByParent.get(key);
+    if (bucket) bucket.push(agent);
+    else childrenByParent.set(key, [agent]);
+  }
+
+  const visited = new Set<string>();
+
+  const buildNodes = (parentKey: string | null, depth: number): AgentTreeNode[] => {
+    const siblings = childrenByParent.get(parentKey) ?? [];
+    const ordered = compare ? [...siblings].sort(compare) : siblings;
+    const nodes: AgentTreeNode[] = [];
+    for (const agent of ordered) {
+      if (visited.has(agent.id)) continue; // cycle guard
+      visited.add(agent.id);
+      nodes.push({ agent, depth, reports: buildNodes(agent.id, depth + 1) });
+    }
+    return nodes;
+  };
+
+  const roots = buildNodes(rootKey, 0);
+
+  // Any agent not reached (pure cycle with no root anchor) becomes a root so it
+  // stays visible instead of vanishing from the sidebar.
+  const orphans = agents.filter((agent) => !visited.has(agent.id));
+  const orderedOrphans = compare ? [...orphans].sort(compare) : orphans;
+  for (const agent of orderedOrphans) {
+    if (visited.has(agent.id)) continue;
+    visited.add(agent.id);
+    roots.push({ agent, depth: 0, reports: buildNodes(agent.id, 1) });
+  }
+
+  return roots;
+}
+
+/** Flatten a tree to a preorder list of {agent, depth} — handy for rendering
+ * and for asserting order in tests. */
+export function flattenAgentTree(nodes: AgentTreeNode[]): Array<{ agent: Agent; depth: number }> {
+  const out: Array<{ agent: Agent; depth: number }> = [];
+  const walk = (list: AgentTreeNode[]) => {
+    for (const node of list) {
+      out.push({ agent: node.agent, depth: node.depth });
+      walk(node.reports);
+    }
+  };
+  walk(nodes);
+  return out;
+}


### PR DESCRIPTION
## Summary

Two changes to `packages/adapters/opencode-local/src/server/execute.ts` targeting `?? -1` exit code evasion:

### 1. Preflight memory check (before spawn)
- `os.freemem()` called before spawning opencode
- Default threshold: 1024 MiB, configurable via `OPENCODE_MIN_FREE_MEM_MB`
- Fail-fast: returns a preflight-aborted result instead of spawning — avoids OOM-evict cycles that manifest as `exit code -1 / signal` with no usable sessionId

### 2. Structured signal-evict log
- When `synthesizedExitCode === -1` **and** `proc.signal` is set, emit structured log:
  ```
  [paperclip][WORA-1315] opencode_local signal-evict detected: signal=<sig> exitCode=<code> free_mem=<n>MiB total_mem=<n>MiB adapter_rss=<n>B
  ```
- Distinguishes evict (OOM/SIGKILL) from crash in observability

### Context
- Follow-up to WORA-1315 / WORA-1317
- Hotfix already deployed via dist patch in `companies/devex/patches/wora1315-exit-minus-one/`
- Build verified: `tsc --project packages/adapters/opencode-local/tsconfig.json` passes clean
