### PR TITLE
feat(adapter): added first-class antigravity_local adapter

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -41,6 +41,7 @@
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-cloud": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
+    "@paperclipai/adapter-antigravity-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-grok-local": "workspace:*",
     "@paperclipai/adapter-kimi-local": "workspace:*",

--- a/cli/src/adapters/registry.ts
+++ b/cli/src/adapters/registry.ts
@@ -3,6 +3,7 @@ import { printClaudeStreamEvent } from "@paperclipai/adapter-claude-local/cli";
 import { printCodexStreamEvent } from "@paperclipai/adapter-codex-local/cli";
 import { printCursorStreamEvent } from "@paperclipai/adapter-cursor-local/cli";
 import { printCursorCloudEvent } from "@paperclipai/adapter-cursor-cloud/cli";
+import { printAntigravityStreamEvent } from "@paperclipai/adapter-antigravity-local/cli";
 import { printGeminiStreamEvent } from "@paperclipai/adapter-gemini-local/cli";
 import { printGrokStreamEvent } from "@paperclipai/adapter-grok-local/cli";
 import { printKimiStreamEvent } from "@paperclipai/adapter-kimi-local/cli";
@@ -44,6 +45,11 @@ const cursorCloudCLIAdapter: CLIAdapterModule = {
   formatStdoutEvent: printCursorCloudEvent,
 };
 
+const antigravityLocalCLIAdapter: CLIAdapterModule = {
+  type: "antigravity_local",
+  formatStdoutEvent: printAntigravityStreamEvent,
+};
+
 const geminiLocalCLIAdapter: CLIAdapterModule = {
   type: "gemini_local",
   formatStdoutEvent: printGeminiStreamEvent,
@@ -82,6 +88,7 @@ const adaptersByType = new Map<string, CLIAdapterModule>(
     piLocalCLIAdapter,
     cursorLocalCLIAdapter,
     cursorCloudCLIAdapter,
+    antigravityLocalCLIAdapter,
     geminiLocalCLIAdapter,
     grokLocalCLIAdapter,
     kimiLocalCLIAdapter,

--- a/docs/adapters/antigravity-local.md
+++ b/docs/adapters/antigravity-local.md
@@ -19,7 +19,7 @@ The `antigravity_local` adapter runs the Antigravity CLI (`agy`) locally. It pro
 | `model` | string | No | Model for the CLI session. Defaults to `gemini-3.8-flash-high`. |
 | `effort` | string | No | Reasoning effort level (`low`, `medium`, `high`) passed via `--effort`. |
 | `agent` | string | No | Optional subagent or personality name passed via `--agent`. |
-| `dangerouslySkipPermissions` | boolean | No | Auto-approve all tool permission requests with `--dangerously-skip-permissions` for unattended autonomous execution. Defaults to `true`. |
+| `dangerouslySkipPermissions` | boolean | No | Auto-approve tool permission requests with `--dangerously-skip-permissions` for unattended autonomous execution. Defaults to `false`. |
 | `sandbox` | boolean | No | Pass `--sandbox` to run in a restricted terminal sandbox. Defaults to `false`. |
 | `printTimeout` | string | No | Timeout duration for headless print mode passed via `--print-timeout` (e.g. `30m`). |
 | `instructionsFilePath` | string | No | Absolute path to markdown instructions file (e.g. `AGENTS.md`) prepended to the prompt at runtime. |
@@ -33,13 +33,13 @@ The `antigravity_local` adapter runs the Antigravity CLI (`agy`) locally. It pro
 The adapter invokes `agy` in headless streaming mode:
 
 ```sh
-agy --print "<prompt>" --output-format stream-json --dangerously-skip-permissions
+agy --print "<prompt>" --output-format stream-json
 ```
 
 Key differences from other adapters:
 - **No Gemini flags**: Antigravity is an independent native agent CLI. The adapter does not inject `--approval-mode yolo`, `--sandbox=none`, or Gemini-specific options.
 - **Headless streaming**: Outputs real-time NDJSON events (`init`, `step_update`, `result`, `error`) parsed directly into Paperclip's transcript format.
-- **Permission bypass**: Uses `--dangerously-skip-permissions` to allow unattended execution in automated control planes.
+- **Permission bypass**: Pass `--dangerously-skip-permissions` when auto-approving tool actions is desired for autonomous runs.
 
 ## Session Persistence
 
@@ -59,5 +59,5 @@ Use the "Test Environment" button in the UI to validate the adapter setup. It ch
 2. Target working directory is valid
 3. A live test prompt execution succeeds:
    ```sh
-   agy --print "Respond with hello." --output-format stream-json --dangerously-skip-permissions
+   agy --print "Respond with OK." --output-format stream-json
    ```

--- a/docs/adapters/antigravity-local.md
+++ b/docs/adapters/antigravity-local.md
@@ -1,0 +1,63 @@
+---
+title: Antigravity CLI
+summary: Antigravity CLI (`agy`) local adapter setup and configuration
+---
+
+The `antigravity_local` adapter runs the Antigravity CLI (`agy`) locally. It provides first-class support for native Antigravity execution semantics, structured NDJSON streaming, session persistence with `--conversation`, and permission auto-approval for unattended operation.
+
+## Prerequisites
+
+- Antigravity CLI installed (`agy` command available in PATH)
+- Antigravity authentication configured (`agy login` or `agy auth login`)
+
+## Configuration Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `command` | string | No | Path or name of the Antigravity CLI binary. Defaults to `agy`. |
+| `cwd` | string | Yes | Working directory for the agent process (absolute path). |
+| `model` | string | No | Model for the CLI session. Defaults to `gemini-3.8-flash-high`. |
+| `effort` | string | No | Reasoning effort level (`low`, `medium`, `high`) passed via `--effort`. |
+| `agent` | string | No | Optional subagent or personality name passed via `--agent`. |
+| `dangerouslySkipPermissions` | boolean | No | Auto-approve all tool permission requests with `--dangerously-skip-permissions` for unattended autonomous execution. Defaults to `true`. |
+| `sandbox` | boolean | No | Pass `--sandbox` to run in a restricted terminal sandbox. Defaults to `false`. |
+| `printTimeout` | string | No | Timeout duration for headless print mode passed via `--print-timeout` (e.g. `30m`). |
+| `instructionsFilePath` | string | No | Absolute path to markdown instructions file (e.g. `AGENTS.md`) prepended to the prompt at runtime. |
+| `extraArgs` | array/string | No | Extra CLI flags or arguments appended to the `agy` invocation. |
+| `env` | object | No | Environment variables (supports secret references). |
+| `timeoutSec` | number | No | Process timeout in seconds (0 = no timeout). |
+| `graceSec` | number | No | Grace period in seconds before force-killing the process. |
+
+## Execution Semantics
+
+The adapter invokes `agy` in headless streaming mode:
+
+```sh
+agy --print "<prompt>" --output-format stream-json --dangerously-skip-permissions
+```
+
+Key differences from other adapters:
+- **No Gemini flags**: Antigravity is an independent native agent CLI. The adapter does not inject `--approval-mode yolo`, `--sandbox=none`, or Gemini-specific options.
+- **Headless streaming**: Outputs real-time NDJSON events (`init`, `step_update`, `result`, `error`) parsed directly into Paperclip's transcript format.
+- **Permission bypass**: Uses `--dangerously-skip-permissions` to allow unattended execution in automated control planes.
+
+## Session Persistence
+
+The adapter tracks the Antigravity session ID (`conversation_id` emitted by `agy`). On subsequent runs in the same workspace, Paperclip supplies:
+
+```sh
+--conversation <conversation-id>
+```
+
+If a previous conversation cannot be resumed (e.g. deleted or invalid session), the adapter detects the warning, marks the session as unrecoverable, and automatically falls back to starting a fresh conversation.
+
+## Environment Diagnostics
+
+Use the "Test Environment" button in the UI to validate the adapter setup. It checks:
+
+1. `agy` command is installed and executable
+2. Target working directory is valid
+3. A live test prompt execution succeeds:
+   ```sh
+   agy --print "Respond with hello." --output-format stream-json --dangerously-skip-permissions
+   ```

--- a/docs/adapters/overview.md
+++ b/docs/adapters/overview.md
@@ -20,6 +20,7 @@ When a heartbeat fires, Paperclip:
 |---------|----------|-------------|
 | [Claude Code](/adapters/claude-local) | `claude_local` | Runs Claude Code CLI locally, with a native ACP engine when available |
 | [Codex](/adapters/codex-local) | `codex_local` | Runs OpenAI Codex CLI locally, with a native ACP engine when available |
+| [Antigravity CLI](/adapters/antigravity-local) | `antigravity_local` | Runs Antigravity CLI (`agy`) locally with native stream-json output |
 | [Gemini CLI](/adapters/gemini-local) | `gemini_local` | Runs Gemini CLI locally (experimental — adapter package exists, not yet in stable type enum) |
 | [Kimi Code CLI](/adapters/kimi-local) | `kimi_local` | Runs Kimi Code CLI locally through ACP, with headless `-p` mode as a fallback |
 | OpenCode | `opencode_local` | Runs OpenCode CLI locally (multi-provider `provider/model`) |

--- a/packages/adapter-utils/src/session-compaction.ts
+++ b/packages/adapter-utils/src/session-compaction.ts
@@ -74,6 +74,11 @@ export const ADAPTER_SESSION_MANAGEMENT: Record<string, AdapterSessionManagement
     nativeContextManagement: "unknown",
     defaultSessionCompaction: DEFAULT_SESSION_COMPACTION_POLICY,
   },
+  antigravity_local: {
+    supportsSessionResume: true,
+    nativeContextManagement: "unknown",
+    defaultSessionCompaction: DEFAULT_SESSION_COMPACTION_POLICY,
+  },
   kimi_local: {
     supportsSessionResume: true,
     nativeContextManagement: "unknown",

--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -681,6 +681,10 @@ export interface CreateConfigValues {
   geminiAcpNonInteractivePermissions?: "deny" | "fail";
   geminiAcpStateDir?: string;
   geminiAcpWarmHandleIdleMs?: number;
+  antigravityAgent?: string;
+  antigravityEffort?: string;
+  antigravityPrintTimeout?: string;
+  antigravitySandbox?: boolean;
   search: boolean;
   fastMode: boolean;
   dangerouslyBypassSandbox: boolean;

--- a/packages/adapters/antigravity-local/package.json
+++ b/packages/adapters/antigravity-local/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@paperclipai/adapter-antigravity-local",
+  "version": "0.3.1",
+  "license": "MIT",
+  "homepage": "https://github.com/paperclipai/paperclip",
+  "bugs": {
+    "url": "https://github.com/paperclipai/paperclip/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/paperclipai/paperclip",
+    "directory": "packages/adapters/antigravity-local"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./server": "./src/server/index.ts",
+    "./ui": "./src/ui/index.ts",
+    "./cli": "./src/cli/index.ts"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server/index.d.ts",
+        "import": "./dist/server/index.js"
+      },
+      "./ui": {
+        "types": "./dist/ui/index.d.ts",
+        "import": "./dist/ui/index.js"
+      },
+      "./cli": {
+        "types": "./dist/cli/index.d.ts",
+        "import": "./dist/cli/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@paperclipai/adapter-utils": "workspace:*",
+    "picocolors": "^1.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "typescript": "^7.0.2"
+  },
+  "engines": {
+    "node": ">=24.11.0"
+  }
+}

--- a/packages/adapters/antigravity-local/src/cli/format-event.ts
+++ b/packages/adapters/antigravity-local/src/cli/format-event.ts
@@ -1,0 +1,123 @@
+// CLI terminal event formatter for Antigravity stream-json output
+
+import pc from "picocolors";
+
+// Asserts value is a record object
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+// Safely coerces value to string with fallback
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+// Safely coerces value to finite number with fallback
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+// Extracts error message string from unknown payload
+function errorText(value: unknown): string {
+  if (typeof value === "string") return value.trim();
+  const rec = asRecord(value);
+  if (!rec) return "";
+  const msg =
+    (typeof rec.message === "string" && rec.message) ||
+    (typeof rec.error === "string" && rec.error) ||
+    (typeof rec.code === "string" && rec.code) ||
+    "";
+  if (msg) return msg.trim();
+  try {
+    return JSON.stringify(rec);
+  } catch {
+    return "";
+  }
+}
+
+// Formats and prints an Antigravity stream-json line to stdout with terminal colors
+export function printAntigravityStreamEvent(raw: string, _debug: boolean): void {
+  const line = raw.trim();
+  if (!line) return;
+
+  let parsed: Record<string, unknown> | null = null;
+  try {
+    parsed = JSON.parse(line) as Record<string, unknown>;
+  } catch {
+    console.log(line);
+    return;
+  }
+
+  const eventName = asString(parsed.event, asString(parsed.type)).trim().toLowerCase();
+
+  // Handle initialization event
+  if (eventName === "init") {
+    const sessionId = asString(parsed.conversation_id, asString(parsed.sessionId));
+    const model = asString(parsed.model);
+    const details = [sessionId ? `session: ${sessionId}` : "", model ? `model: ${model}` : ""]
+      .filter(Boolean)
+      .join(", ");
+    console.log(pc.blue(`Antigravity init${details ? ` (${details})` : ""}`));
+    return;
+  }
+
+  // Handle step updates
+  if (eventName === "step_update") {
+    const step = asRecord(parsed.step_update) ?? asRecord(parsed.step) ?? parsed;
+    const stepType = asString(step.step_type ?? step.type).trim().toLowerCase();
+
+    if (stepType === "agent_response" || stepType === "planner_response") {
+      const text = asString(step.text_delta ?? step.content ?? step.text);
+      if (text) console.log(pc.green(text));
+      return;
+    }
+
+    if (stepType === "thinking") {
+      const text = asString(step.thinking ?? step.text ?? step.content);
+      if (text) console.log(pc.gray(`thinking: ${text}`));
+      return;
+    }
+
+    if (stepType === "tool_call") {
+      const name = asString(step.tool_name ?? step.name, "tool");
+      console.log(pc.yellow(`tool_call: ${name}`));
+      return;
+    }
+
+    if (stepType === "tool_result") {
+      const isError = step.is_error === true || asString(step.status).toLowerCase() === "error";
+      console.log((isError ? pc.red : pc.cyan)(`tool_result${isError ? " (error)" : ""}`));
+      return;
+    }
+
+    return;
+  }
+
+  // Handle final result event
+  if (eventName === "result") {
+    const res = asRecord(parsed.result) ?? parsed;
+    const usage = asRecord(res.usage) ?? {};
+    const input = asNumber(usage.input_tokens, asNumber(usage.inputTokens));
+    const output = asNumber(usage.output_tokens, asNumber(usage.outputTokens));
+    const cached = asNumber(usage.cache_read_tokens, asNumber(usage.cachedTokens));
+    const status = asString(res.status).toLowerCase();
+    const isError = status === "error" || status === "failure" || res.is_error === true;
+
+    console.log(pc.blue(`\ntokens: in=${input} out=${output} cached=${cached}`));
+    if (isError) {
+      const text = errorText(res.error ?? res.message);
+      if (text) console.log(pc.red(`error: ${text}`));
+    }
+    return;
+  }
+
+  // Handle error event
+  if (eventName === "error") {
+    const text = errorText(parsed.error ?? parsed.message ?? parsed.detail);
+    if (text) console.log(pc.red(`error: ${text}`));
+    return;
+  }
+
+  console.log(line);
+}

--- a/packages/adapters/antigravity-local/src/cli/index.ts
+++ b/packages/adapters/antigravity-local/src/cli/index.ts
@@ -1,0 +1,3 @@
+// CLI exports for @paperclipai/adapter-antigravity-local
+
+export { printAntigravityStreamEvent } from "./format-event.js";

--- a/packages/adapters/antigravity-local/src/index.ts
+++ b/packages/adapters/antigravity-local/src/index.ts
@@ -1,0 +1,67 @@
+// Antigravity CLI adapter module definition and metadata for Paperclip
+
+export const type = "antigravity_local";
+export const label = "Antigravity CLI";
+
+// Default model ID used when creating a new Antigravity agent
+export const DEFAULT_ANTIGRAVITY_LOCAL_MODEL = "gemini-3.8-flash-high";
+
+// Supported reasoning effort options for Antigravity sessions
+export const ANTIGRAVITY_EFFORT_OPTIONS = [
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+] as const;
+
+// Available models supported by the Antigravity CLI
+export const models = [
+  { id: "gemini-3.8-flash-high", label: "Gemini 3.8 Flash (High)" },
+  { id: "gemini-3.8-flash-medium", label: "Gemini 3.8 Flash (Medium)" },
+  { id: "gemini-3.8-flash-low", label: "Gemini 3.8 Flash (Low)" },
+  { id: "gemini-3.7-flash-high", label: "Gemini 3.7 Flash (High)" },
+  { id: "gemini-3.7-flash-medium", label: "Gemini 3.7 Flash (Medium)" },
+  { id: "gemini-3.7-flash-low", label: "Gemini 3.7 Flash (Low)" },
+  { id: "gemini-3.6-flash-high", label: "Gemini 3.6 Flash (High)" },
+  { id: "gemini-3.6-flash-medium", label: "Gemini 3.6 Flash (Medium)" },
+  { id: "gemini-3.6-flash-low", label: "Gemini 3.6 Flash (Low)" },
+  { id: "gemini-3.1-pro-high", label: "Gemini 3.1 Pro (High)" },
+  { id: "gemini-3.1-pro-low", label: "Gemini 3.1 Pro (Low)" },
+  { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6 (Thinking)" },
+  { id: "claude-opus-4-6-thinking", label: "Claude Opus 4.6 (Thinking)" },
+  { id: "gpt-oss-120b-medium", label: "GPT-OSS 120B (Medium)" },
+];
+
+// User-facing documentation for antigravity_local configuration in Paperclip
+export const agentConfigurationDoc = `# antigravity_local agent configuration
+
+Adapter: antigravity_local
+
+Use when:
+- You want Paperclip to execute agent tasks using the native Antigravity CLI (\`agy\`)
+- You want conversation sessions resumed across heartbeats via Antigravity's native \`--conversation <id>\`
+- You want unattended agent execution using Antigravity's native \`--dangerously-skip-permissions\`
+- You want streaming structured JSON output via \`--output-format stream-json\`
+
+Don't use when:
+- You are targeting Google's Gemini CLI with ACP or Gemini-specific CLI flags (use \`gemini_local\`)
+- You need webhook-style external invocation (use \`http\` or \`openclaw_gateway\`)
+- \`agy\` is not installed on the machine running Paperclip
+
+Core fields:
+- command (string, optional): CLI binary to run; defaults to "agy"
+- cwd (string, optional): working directory fallback for the agent process
+- model (string, optional): Antigravity model ID (e.g. "gemini-3.8-flash-high")
+- agent (string, optional): Agent name for the CLI session
+- effort (string, optional): Reasoning effort for the session ("low", "medium", "high")
+- sandbox (boolean, optional): run in sandbox with terminal restrictions (default: false)
+- dangerouslySkipPermissions (boolean, optional): auto-approve tool permissions (default: true)
+- printTimeout (string, optional): timeout duration for print mode wait (e.g. "5m0s")
+- extraArgs (string[], optional): additional user-supplied CLI arguments
+- env (object, optional): environment variables to inject into the process
+- instructionsFilePath (string, optional): path to instructions markdown file prepended to prompt
+- promptTemplate (string, optional): prompt template for runs
+
+Operational fields:
+- timeoutSec (number, optional): run timeout in seconds
+- graceSec (number, optional): SIGTERM grace period in seconds
+`;

--- a/packages/adapters/antigravity-local/src/server/config-schema.ts
+++ b/packages/adapters/antigravity-local/src/server/config-schema.ts
@@ -1,0 +1,66 @@
+// Configuration schema for Antigravity local adapter fields in Paperclip
+
+import type { AdapterConfigSchema } from "@paperclipai/adapter-utils";
+import { DEFAULT_ANTIGRAVITY_LOCAL_MODEL, models } from "../index.js";
+
+// Returns the configuration field schema for the Antigravity local adapter
+export function getConfigSchema(): AdapterConfigSchema {
+  return {
+    fields: [
+      {
+        key: "command",
+        label: "Command",
+        type: "text",
+        default: "agy",
+        hint: "Path or name of the Antigravity CLI binary. Defaults to 'agy'.",
+      },
+      {
+        key: "model",
+        label: "Model",
+        type: "select",
+        default: DEFAULT_ANTIGRAVITY_LOCAL_MODEL,
+        options: models.map((m) => ({ value: m.id, label: m.label })),
+        hint: "Model for the CLI session.",
+      },
+      {
+        key: "agent",
+        label: "Agent",
+        type: "text",
+        hint: "Optional agent name for the CLI session.",
+      },
+      {
+        key: "effort",
+        label: "Reasoning effort",
+        type: "select",
+        default: "",
+        options: [
+          { value: "", label: "Default" },
+          { value: "low", label: "Low" },
+          { value: "medium", label: "Medium" },
+          { value: "high", label: "High" },
+        ],
+        hint: "Reasoning effort for the current CLI session (low|medium|high).",
+      },
+      {
+        key: "sandbox",
+        label: "Sandbox",
+        type: "toggle",
+        default: false,
+        hint: "Run in a sandbox with terminal restrictions enabled.",
+      },
+      {
+        key: "dangerouslySkipPermissions",
+        label: "Dangerously skip permissions",
+        type: "toggle",
+        default: true,
+        hint: "Auto-approve all tool permission requests without prompting for unattended operation.",
+      },
+      {
+        key: "printTimeout",
+        label: "Print timeout",
+        type: "text",
+        hint: "Timeout duration for print mode wait (e.g. 5m0s).",
+      },
+    ],
+  };
+}

--- a/packages/adapters/antigravity-local/src/server/config-schema.ts
+++ b/packages/adapters/antigravity-local/src/server/config-schema.ts
@@ -52,8 +52,8 @@ export function getConfigSchema(): AdapterConfigSchema {
         key: "dangerouslySkipPermissions",
         label: "Dangerously skip permissions",
         type: "toggle",
-        default: true,
-        hint: "Auto-approve all tool permission requests without prompting for unattended operation.",
+        default: false,
+        hint: "Auto-approve tool permission requests without prompting. Recommended only for trusted, sandboxed environments.",
       },
       {
         key: "printTimeout",

--- a/packages/adapters/antigravity-local/src/server/execute.test.ts
+++ b/packages/adapters/antigravity-local/src/server/execute.test.ts
@@ -1,0 +1,204 @@
+// Unit tests for Antigravity local execution service verifying flags, permissions, prompt security, and session management
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
+
+type ProcessCall = {
+  command: string;
+  args: string[];
+  opts: Record<string, unknown>;
+};
+
+const recordedCalls: ProcessCall[] = [];
+let mockProcessResult = {
+  exitCode: 0 as number | null,
+  stdout: JSON.stringify({
+    event: "result",
+    result: {
+      status: "SUCCESS",
+      conversation_id: "conv-mock-1",
+      response: "task complete",
+      usage: { input_tokens: 50, output_tokens: 15 },
+    },
+  }),
+  stderr: "",
+  timedOut: false,
+};
+
+vi.mock("@paperclipai/adapter-utils/execution-target", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    ensureAdapterExecutionTargetCommandResolvable: vi.fn().mockResolvedValue(undefined),
+    ensureAdapterExecutionTargetRuntimeCommandInstalled: vi.fn().mockResolvedValue(undefined),
+    resolveAdapterExecutionTargetCommandForLogs: vi.fn().mockImplementation((cmd: string) => Promise.resolve(cmd)),
+    runAdapterExecutionTargetProcess: vi.fn().mockImplementation(
+      async (_runId: string, _target: unknown, command: string, args: string[], opts: Record<string, unknown>) => {
+        recordedCalls.push({ command, args, opts });
+        return mockProcessResult;
+      },
+    ),
+  };
+});
+
+import { execute } from "./execute.js";
+
+function makeContext(overrides: {
+  config?: Record<string, unknown>;
+  runtime?: Record<string, unknown>;
+  context?: Record<string, unknown>;
+  authToken?: string | null;
+}): AdapterExecutionContext {
+  return {
+    runId: "run-test-1",
+    agent: {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "Test Agent",
+      adapterType: "antigravity_local",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+      ...overrides.runtime,
+    },
+    config: {
+      command: "agy",
+      cwd: "/test/workspace",
+      model: "gemini-3.8-flash-high",
+      promptTemplate: "Perform work.",
+      ...overrides.config,
+    },
+    context: overrides.context ?? {},
+    authToken: overrides.authToken ?? "test-auth-token",
+    onLog: async () => {},
+  } as unknown as AdapterExecutionContext;
+}
+
+describe("antigravity execute unit tests", () => {
+  beforeEach(() => {
+    recordedCalls.length = 0;
+    mockProcessResult = {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        event: "result",
+        result: {
+          status: "SUCCESS",
+          conversation_id: "conv-mock-1",
+          response: "task complete",
+          usage: { input_tokens: 50, output_tokens: 15 },
+        },
+      }),
+      stderr: "",
+      timedOut: false,
+    };
+  });
+
+  it("defaults dangerouslySkipPermissions to false and does NOT pass --dangerously-skip-permissions", async () => {
+    const ctx = makeContext({ config: {} });
+    const result = await execute(ctx);
+
+    expect(result.exitCode).toBe(0);
+    expect(recordedCalls).toHaveLength(1);
+    const args = recordedCalls[0].args;
+    expect(args).not.toContain("--dangerously-skip-permissions");
+  });
+
+  it("passes --dangerously-skip-permissions only when dangerouslySkipPermissions is explicitly true", async () => {
+    const ctx = makeContext({
+      config: { dangerouslySkipPermissions: true },
+    });
+    const result = await execute(ctx);
+
+    expect(result.exitCode).toBe(0);
+    expect(recordedCalls).toHaveLength(1);
+    const args = recordedCalls[0].args;
+    expect(args).toContain("--dangerously-skip-permissions");
+  });
+
+  it("ensures prompt does NOT leak PAPERCLIP_API_KEY, auth bearer tokens, or curl instructions", async () => {
+    const ctx = makeContext({
+      authToken: "super-secret-jwt-bearer-token",
+    });
+    await execute(ctx);
+
+    expect(recordedCalls).toHaveLength(1);
+    const args = recordedCalls[0].args;
+    const printIndex = args.indexOf("--print");
+    expect(printIndex).toBeGreaterThanOrEqual(0);
+    const prompt = args[printIndex + 1];
+
+    expect(prompt).not.toContain("super-secret-jwt-bearer-token");
+    expect(prompt).not.toContain("PAPERCLIP_API_KEY");
+    expect(prompt).not.toContain("Authorization: Bearer");
+    expect(prompt).not.toContain("curl");
+  });
+
+  it("handles string extraArgs separated by comma or whitespace", async () => {
+    const ctx = makeContext({
+      config: { extraArgs: "--verbose, --debug, --flag=1" },
+    });
+    await execute(ctx);
+
+    expect(recordedCalls).toHaveLength(1);
+    const args = recordedCalls[0].args;
+    expect(args).toContain("--verbose");
+    expect(args).toContain("--debug");
+    expect(args).toContain("--flag=1");
+  });
+
+  it("handles structured ERROR or FAILURE as failure even when exitCode is 0", async () => {
+    mockProcessResult = {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        event: "result",
+        result: {
+          status: "FAILURE",
+          error: "API rate limit reached",
+          response: "",
+        },
+      }),
+      stderr: "",
+      timedOut: false,
+    };
+
+    const ctx = makeContext({});
+    const result = await execute(ctx);
+
+    expect(result.errorMessage).toBe("API rate limit reached");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("clears/does not rebind old session ID when cwd changed and child returns no new session ID", async () => {
+    mockProcessResult = {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        event: "result",
+        result: {
+          status: "SUCCESS",
+          response: "done without emitting id",
+        },
+      }),
+      stderr: "",
+      timedOut: false,
+    };
+
+    const ctx = makeContext({
+      config: { cwd: "/test/new-workspace" },
+      runtime: {
+        sessionId: "old-session-from-other-workspace",
+        sessionParams: {
+          sessionId: "old-session-from-other-workspace",
+          cwd: "/test/old-workspace",
+        },
+      },
+    });
+
+    const result = await execute(ctx);
+    // Because cwd did not match, session could not be resumed, and because child emitted no ID,
+    // resolvedSessionId must be null, not falling back to old-session-from-other-workspace
+    expect(result.sessionId).toBeNull();
+  });
+});

--- a/packages/adapters/antigravity-local/src/server/execute.ts
+++ b/packages/adapters/antigravity-local/src/server/execute.ts
@@ -1,0 +1,588 @@
+// Server execution service for the Antigravity local adapter
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { AdapterExecutionContext, AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import {
+  adapterExecutionTargetIsRemote,
+  adapterExecutionTargetRemoteCwd,
+  overrideAdapterExecutionTargetRemoteCwd,
+  adapterExecutionTargetSessionIdentity,
+  adapterExecutionTargetSessionMatches,
+  adapterExecutionTargetUsesPaperclipBridge,
+  describeAdapterExecutionTarget,
+  ensureAdapterExecutionTargetCommandResolvable,
+  ensureAdapterExecutionTargetRuntimeCommandInstalled,
+  prepareAdapterExecutionTargetRuntime,
+  adapterExecutionTargetDuplexObservabilityRecorder,
+  adapterExecutionTargetEnablesSandboxDuplexBridge,
+  readAdapterExecutionTarget,
+  resolveAdapterExecutionTargetTimeoutSec,
+  resolveAdapterExecutionTargetCommandForLogs,
+  runAdapterExecutionTargetProcess,
+  startAdapterExecutionTargetPaperclipBridge,
+} from "@paperclipai/adapter-utils/execution-target";
+import {
+  asBoolean,
+  asNumber,
+  asString,
+  asStringArray,
+  buildPaperclipEnv,
+  buildRuntimeToolsEnv,
+  buildInvocationEnvForLogs,
+  ensureAbsoluteDirectory,
+  joinPromptSections,
+  ensurePathInEnv,
+  refreshPaperclipWorkspaceEnvForExecution,
+  readPaperclipIssueWorkModeFromContext,
+  parseObject,
+  renderTemplate,
+  renderPaperclipWakePrompt,
+  isPaperclipRecoveryWakePayload,
+  stringifyPaperclipWakePayload,
+  DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
+} from "@paperclipai/adapter-utils/server-utils";
+import { DEFAULT_ANTIGRAVITY_LOCAL_MODEL } from "../index.js";
+import {
+  describeAntigravityFailure,
+  detectAntigravityAuthRequired,
+  isAntigravitySessionUnrecoverableError,
+  parseAntigravityJsonl,
+} from "./parse.js";
+import { firstNonEmptyLine } from "./utils.js";
+
+// Checks if an environment dictionary contains a non-empty value for a key
+function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
+  const raw = env[key];
+  return typeof raw === "string" && raw.trim().length > 0;
+}
+
+// Builds the child process environment for Antigravity headless execution
+function buildAntigravityHeadlessEnv(env: Record<string, string>): Record<string, string> {
+  const next = { ...env };
+  const term = env.TERM?.trim().toLowerCase();
+  if (!term || term === "dumb" || term === "vt100") {
+    next.TERM = "xterm-256color";
+  }
+  if (!next.COLORTERM?.trim()) {
+    next.COLORTERM = "truecolor";
+  }
+  next.NO_BROWSER = "1";
+  return next;
+}
+
+// Builds the merged runtime environment with full system PATH resolution
+function buildAntigravityRuntimeEnv(env: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(ensurePathInEnv({ ...process.env, ...buildAntigravityHeadlessEnv(env) })).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+}
+
+// Renders diagnostic note describing PAPERCLIP_* variables present in the run
+function renderPaperclipEnvNote(env: Record<string, string>): string {
+  const paperclipKeys = Object.keys(env)
+    .filter((key) => key.startsWith("PAPERCLIP_"))
+    .sort();
+  if (paperclipKeys.length === 0) return "";
+  return [
+    "Paperclip runtime note:",
+    `The following PAPERCLIP_* environment variables are available in this run: ${paperclipKeys.join(", ")}`,
+    "Do not assume these variables are missing without checking your shell environment.",
+    "",
+    "",
+  ].join("\n");
+}
+
+// Renders usage instructions for making Paperclip API calls from the agent
+function renderApiAccessNote(env: Record<string, string>): string {
+  if (!hasNonEmptyEnvValue(env, "PAPERCLIP_API_URL") || !hasNonEmptyEnvValue(env, "PAPERCLIP_API_KEY")) return "";
+  return [
+    "Paperclip API access note:",
+    "Use run_shell_command with curl to make Paperclip API requests.",
+    "GET example:",
+    `  run_shell_command({ command: "curl -s -H \\"Authorization: Bearer $PAPERCLIP_API_KEY\\" \\"$PAPERCLIP_API_URL/api/agents/me\\"" })`,
+    "POST/PATCH example:",
+    `  run_shell_command({ command: "curl -s -X POST -H \\"Authorization: Bearer $PAPERCLIP_API_KEY\\" -H 'Content-Type: application/json' -H \\"X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID\\" -d '{...}' \\"$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID/checkout\\"" })`,
+    "When PAPERCLIP_TASK_ID is not set, substitute a real issue id from the current context; never send a placeholder like {id} in the URL.",
+    "",
+    "",
+  ].join("\n");
+}
+
+// Executes an Antigravity agent heartbeat turn with native CLI flags
+export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
+  const { runId, agent, runtime, config, context, onLog, onMeta, onSpawn, authToken } = ctx;
+  const executionTarget = readAdapterExecutionTarget({
+    executionTarget: ctx.executionTarget,
+    legacyRemoteExecution: ctx.executionTransport?.remoteExecution,
+  });
+  const executionTargetIsRemote = adapterExecutionTargetIsRemote(executionTarget);
+
+  const promptTemplate = asString(
+    config.promptTemplate,
+    DEFAULT_PAPERCLIP_AGENT_PROMPT_TEMPLATE,
+  );
+  const command = asString(config.command, "agy");
+  const model = asString(config.model, DEFAULT_ANTIGRAVITY_LOCAL_MODEL).trim();
+  const agentName = asString(config.agent, "").trim();
+  const effort = asString(config.effort, "").trim().toLowerCase();
+  const sandbox = asBoolean(config.sandbox, false);
+  const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
+  const printTimeout = asString(config.printTimeout, "").trim();
+
+  const workspaceContext = parseObject(context.paperclipWorkspace);
+  const workspaceCwd = asString(workspaceContext.cwd, "");
+  const workspaceSource = asString(workspaceContext.source, "");
+  const workspaceId = asString(workspaceContext.workspaceId, "");
+  const workspaceRepoUrl = asString(workspaceContext.repoUrl, "");
+  const workspaceRepoRef = asString(workspaceContext.repoRef, "");
+  const agentHome = asString(workspaceContext.agentHome, "");
+  const workspaceHints = Array.isArray(context.paperclipWorkspaces)
+    ? context.paperclipWorkspaces.filter(
+      (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+    )
+    : [];
+  const configuredCwd = asString(config.cwd, "");
+  const useConfiguredInsteadOfAgentHome = workspaceSource === "agent_home" && configuredCwd.length > 0;
+  const effectiveWorkspaceCwd = useConfiguredInsteadOfAgentHome ? "" : workspaceCwd;
+  const cwd = effectiveWorkspaceCwd || configuredCwd || process.cwd();
+  let effectiveExecutionCwd = adapterExecutionTargetRemoteCwd(executionTarget, cwd);
+  await ensureAbsoluteDirectory(cwd, { createIfMissing: true });
+
+  const envConfig = parseObject(config.env);
+  const env: Record<string, string> = {
+    ...buildPaperclipEnv(agent),
+    ...buildRuntimeToolsEnv(ctx.runtimeTools),
+  };
+  env.PAPERCLIP_RUN_ID = runId;
+
+  const wakeTaskId =
+    (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||
+    (typeof context.issueId === "string" && context.issueId.trim().length > 0 && context.issueId.trim()) ||
+    null;
+  const wakeReason =
+    typeof context.wakeReason === "string" && context.wakeReason.trim().length > 0
+      ? context.wakeReason.trim()
+      : null;
+  const wakeCommentId =
+    (typeof context.wakeCommentId === "string" && context.wakeCommentId.trim().length > 0 && context.wakeCommentId.trim()) ||
+    (typeof context.commentId === "string" && context.commentId.trim().length > 0 && context.commentId.trim()) ||
+    null;
+  const approvalId =
+    typeof context.approvalId === "string" && context.approvalId.trim().length > 0
+      ? context.approvalId.trim()
+      : null;
+  const approvalStatus =
+    typeof context.approvalStatus === "string" && context.approvalStatus.trim().length > 0
+      ? context.approvalStatus.trim()
+      : null;
+  const linkedIssueIds = Array.isArray(context.issueIds)
+    ? context.issueIds.filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+    : [];
+  const wakePayloadJson = stringifyPaperclipWakePayload(context.paperclipWake);
+  const issueWorkMode = readPaperclipIssueWorkModeFromContext(context);
+
+  if (wakeTaskId) env.PAPERCLIP_TASK_ID = wakeTaskId;
+  if (issueWorkMode) env.PAPERCLIP_ISSUE_WORK_MODE = issueWorkMode;
+  if (wakeReason) env.PAPERCLIP_WAKE_REASON = wakeReason;
+  if (wakeCommentId) env.PAPERCLIP_WAKE_COMMENT_ID = wakeCommentId;
+  if (approvalId) env.PAPERCLIP_APPROVAL_ID = approvalId;
+  if (approvalStatus) env.PAPERCLIP_APPROVAL_STATUS = approvalStatus;
+  if (linkedIssueIds.length > 0) env.PAPERCLIP_LINKED_ISSUE_IDS = linkedIssueIds.join(",");
+  if (wakePayloadJson) env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
+
+  refreshPaperclipWorkspaceEnvForExecution({
+    env,
+    envConfig,
+    workspaceCwd: effectiveWorkspaceCwd,
+    workspaceSource,
+    workspaceId,
+    workspaceRepoUrl,
+    workspaceRepoRef,
+    workspaceHints,
+    agentHome,
+    executionTargetIsRemote,
+    executionCwd: effectiveExecutionCwd,
+  });
+
+  if (authToken) {
+    env.PAPERCLIP_API_KEY = authToken;
+  }
+
+  const runtimeEnv = buildAntigravityRuntimeEnv(env);
+  const timeoutSec = resolveAdapterExecutionTargetTimeoutSec(
+    executionTarget,
+    asNumber(config.timeoutSec, 0),
+  );
+  const graceSec = asNumber(config.graceSec, 20);
+
+  await ensureAdapterExecutionTargetRuntimeCommandInstalled({
+    runId,
+    target: executionTarget,
+    installCommand: ctx.runtimeCommandSpec?.installCommand,
+    detectCommand: ctx.runtimeCommandSpec?.detectCommand,
+    cwd,
+    env: runtimeEnv,
+    timeoutSec,
+    graceSec,
+    onLog,
+  });
+  await ensureAdapterExecutionTargetCommandResolvable(command, executionTarget, cwd, runtimeEnv, {
+    timeoutSec,
+  });
+  const resolvedCommand = await resolveAdapterExecutionTargetCommandForLogs(command, executionTarget, cwd, runtimeEnv);
+
+  const extraArgs = (() => {
+    const fromExtraArgs = asStringArray(config.extraArgs);
+    if (fromExtraArgs.length > 0) return fromExtraArgs;
+    return asStringArray(config.args);
+  })();
+
+  let restoreRemoteWorkspace: (() => Promise<void>) | null = null;
+  let remoteRuntimeRootDir: string | null = null;
+  let paperclipBridge: Awaited<ReturnType<typeof startAdapterExecutionTargetPaperclipBridge>> = null;
+
+  if (executionTargetIsRemote) {
+    try {
+      await onLog(
+        "stdout",
+        `[paperclip] Syncing workspace to ${describeAdapterExecutionTarget(executionTarget)}.\n`,
+      );
+      const preparedExecutionTargetRuntime = await prepareAdapterExecutionTargetRuntime({
+        runId,
+        target: executionTarget,
+        adapterKey: "antigravity",
+        timeoutSec,
+        workspaceLocalDir: cwd,
+        detectCommand: command,
+        onProgress: (line) => onLog("stdout", line),
+        onRuntimeProgress: ctx.onRuntimeProgress,
+      });
+      restoreRemoteWorkspace = () =>
+        preparedExecutionTargetRuntime.restoreWorkspace((line) => onLog("stdout", line));
+      effectiveExecutionCwd = preparedExecutionTargetRuntime.workspaceRemoteDir ?? effectiveExecutionCwd;
+      refreshPaperclipWorkspaceEnvForExecution({
+        env,
+        envConfig,
+        workspaceCwd: effectiveWorkspaceCwd,
+        workspaceSource,
+        workspaceId,
+        workspaceRepoUrl,
+        workspaceRepoRef,
+        workspaceHints,
+        agentHome,
+        executionTargetIsRemote,
+        executionCwd: effectiveExecutionCwd,
+      });
+      remoteRuntimeRootDir = preparedExecutionTargetRuntime.runtimeRootDir;
+    } catch (error) {
+      await Promise.allSettled([restoreRemoteWorkspace?.()]);
+      throw error;
+    }
+  }
+
+  const runtimeExecutionTarget = overrideAdapterExecutionTargetRemoteCwd(executionTarget, effectiveExecutionCwd);
+  if (executionTargetIsRemote && adapterExecutionTargetUsesPaperclipBridge(executionTarget)) {
+    paperclipBridge = await startAdapterExecutionTargetPaperclipBridge({
+      runId,
+      target: runtimeExecutionTarget,
+      enableSandboxDuplexBridge: adapterExecutionTargetEnablesSandboxDuplexBridge(runtimeExecutionTarget),
+      duplexObservabilityRecorder: adapterExecutionTargetDuplexObservabilityRecorder(runtimeExecutionTarget),
+      runtimeRootDir: remoteRuntimeRootDir,
+      adapterKey: "antigravity",
+      timeoutSec,
+      hostApiToken: env.PAPERCLIP_API_KEY,
+      onLog,
+    });
+    if (paperclipBridge) {
+      Object.assign(env, paperclipBridge.env);
+    }
+  }
+
+  const runtimeSessionParams = parseObject(runtime.sessionParams);
+  const runtimeSessionId = asString(runtimeSessionParams.sessionId, runtime.sessionId ?? "");
+  const runtimeSessionCwd = asString(runtimeSessionParams.cwd, "");
+  const runtimeRemoteExecution = parseObject(runtimeSessionParams.remoteExecution);
+  const canResumeSession =
+    runtimeSessionId.length > 0 &&
+    (runtimeSessionCwd.length === 0 || path.resolve(runtimeSessionCwd) === path.resolve(effectiveExecutionCwd)) &&
+    adapterExecutionTargetSessionMatches(runtimeRemoteExecution, runtimeExecutionTarget);
+  const sessionId = canResumeSession ? runtimeSessionId : null;
+
+  if (executionTargetIsRemote && runtimeSessionId && !canResumeSession) {
+    await onLog(
+      "stdout",
+      `[paperclip] Antigravity session "${runtimeSessionId}" does not match the current remote execution identity and will not be resumed in "${effectiveExecutionCwd}". Starting a fresh remote session.\n`,
+    );
+  } else if (runtimeSessionId && !canResumeSession) {
+    await onLog(
+      "stdout",
+      `[paperclip] Antigravity session "${runtimeSessionId}" was saved for cwd "${runtimeSessionCwd}" and will not be resumed in "${effectiveExecutionCwd}".\n`,
+    );
+  }
+
+  const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
+  const instructionsDir = instructionsFilePath ? `${path.dirname(instructionsFilePath)}/` : "";
+  let instructionsPrefix = "";
+  if (instructionsFilePath) {
+    try {
+      const instructionsContents = await fs.readFile(instructionsFilePath, "utf8");
+      instructionsPrefix =
+        `${instructionsContents}\n\n` +
+        `The above agent instructions were loaded from ${instructionsFilePath}. ` +
+        `Resolve any relative file references from ${instructionsDir}.\n\n`;
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      await onLog(
+        "stdout",
+        `[paperclip] Warning: could not read agent instructions file "${instructionsFilePath}": ${reason}\n`,
+      );
+    }
+  }
+
+  const commandNotes: string[] = [
+    "Prompt is passed to Antigravity CLI via --print for non-interactive execution.",
+    "Output format is requested as stream-json via --output-format stream-json.",
+  ];
+  if (dangerouslySkipPermissions) {
+    commandNotes.push("Added --dangerously-skip-permissions for unattended execution.");
+  }
+  if (instructionsFilePath && instructionsPrefix.length > 0) {
+    commandNotes.push(
+      `Loaded agent instructions from ${instructionsFilePath}`,
+      `Prepended instructions + path directive to prompt (relative references from ${instructionsDir}).`,
+    );
+  }
+
+  const bootstrapPromptTemplate = asString(config.bootstrapPromptTemplate, "");
+  const templateData = {
+    agentId: agent.id,
+    companyId: agent.companyId,
+    runId,
+    company: { id: agent.companyId },
+    agent,
+    run: { id: runId, source: "on_demand" },
+    context,
+  };
+  const renderedBootstrapPrompt =
+    !sessionId && bootstrapPromptTemplate.trim().length > 0
+      ? renderTemplate(bootstrapPromptTemplate, templateData).trim()
+      : "";
+  const wakePrompt = renderPaperclipWakePrompt(context.paperclipWake, { resumedSession: Boolean(sessionId) });
+  const shouldUseResumeDeltaPrompt = Boolean(sessionId) && wakePrompt.length > 0;
+  const renderedPrompt = shouldUseResumeDeltaPrompt || isPaperclipRecoveryWakePayload(context.paperclipWake)
+    ? ""
+    : renderTemplate(promptTemplate, templateData);
+  const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
+  const paperclipEnvNote = renderPaperclipEnvNote(env);
+  const apiAccessNote = renderApiAccessNote(env);
+  const prompt = joinPromptSections([
+    instructionsPrefix,
+    renderedBootstrapPrompt,
+    wakePrompt,
+    sessionHandoffNote,
+    paperclipEnvNote,
+    apiAccessNote,
+    renderedPrompt,
+  ]);
+  const promptMetrics = {
+    promptChars: prompt.length,
+    instructionsChars: instructionsPrefix.length,
+    bootstrapPromptChars: renderedBootstrapPrompt.length,
+    wakePromptChars: wakePrompt.length,
+    sessionHandoffChars: sessionHandoffNote.length,
+    runtimeNoteChars: paperclipEnvNote.length + apiAccessNote.length,
+    heartbeatPromptChars: renderedPrompt.length,
+  };
+
+  // Constructs native Antigravity CLI arguments without any Gemini-specific flags
+  const buildArgs = (resumeSessionId: string | null) => {
+    const args = ["--print", prompt, "--output-format", "stream-json"];
+    if (dangerouslySkipPermissions) {
+      args.push("--dangerously-skip-permissions");
+    }
+    if (resumeSessionId) {
+      args.push("--conversation", resumeSessionId);
+    }
+    if (model) {
+      args.push("--model", model);
+    }
+    if (agentName) {
+      args.push("--agent", agentName);
+    }
+    if (effort === "low" || effort === "medium" || effort === "high") {
+      args.push("--effort", effort);
+    }
+    if (sandbox) {
+      args.push("--sandbox");
+    }
+    if (printTimeout) {
+      args.push("--print-timeout", printTimeout);
+    }
+    if (extraArgs.length > 0) {
+      args.push(...extraArgs);
+    }
+    return args;
+  };
+
+  // Executes a single process attempt with the given session ID
+  const runAttempt = async (resumeSessionId: string | null) => {
+    const args = buildArgs(resumeSessionId);
+    const invocationEnv = buildAntigravityHeadlessEnv(env);
+    const invocationRuntimeEnv = buildAntigravityRuntimeEnv(env);
+    const loggedEnv = buildInvocationEnvForLogs(invocationEnv, {
+      runtimeEnv: invocationRuntimeEnv,
+      includeRuntimeKeys: ["HOME"],
+      resolvedCommand,
+    });
+    if (onMeta) {
+      await onMeta({
+        adapterType: "antigravity_local",
+        command: resolvedCommand,
+        cwd: effectiveExecutionCwd,
+        commandNotes,
+        commandArgs: args.map((value, index) => (
+          index === 1 ? `<prompt ${prompt.length} chars>` : value
+        )),
+        env: loggedEnv,
+        prompt,
+        promptMetrics,
+        context,
+      });
+    }
+
+    const proc = await runAdapterExecutionTargetProcess(runId, runtimeExecutionTarget, command, args, {
+      cwd,
+      env: invocationEnv,
+      timeoutSec,
+      graceSec,
+      onSpawn,
+      onRuntimeProgress: ctx.onRuntimeProgress,
+      onLog,
+      runLogTail: paperclipBridge?.runLogTail,
+      settleRunDisposition: paperclipBridge?.settleRunDisposition,
+    });
+    return {
+      proc,
+      parsed: parseAntigravityJsonl(proc.stdout),
+    };
+  };
+
+  // Maps process execution and parsed stream output to AdapterExecutionResult
+  const toResult = (
+    attempt: {
+      proc: {
+        exitCode: number | null;
+        signal: string | null;
+        timedOut: boolean;
+        stdout: string;
+        stderr: string;
+        errorCode?: string | null;
+      };
+      parsed: ReturnType<typeof parseAntigravityJsonl>;
+    },
+    clearSessionOnMissingSession = false,
+    isRetry = false,
+  ): AdapterExecutionResult => {
+    const authMeta = detectAntigravityAuthRequired({
+      parsed: attempt.parsed.resultEvent,
+      stdout: attempt.proc.stdout,
+      stderr: attempt.proc.stderr,
+    });
+
+    if (attempt.proc.timedOut) {
+      return {
+        exitCode: attempt.proc.exitCode,
+        signal: attempt.proc.signal,
+        timedOut: true,
+        errorMessage: `Timed out after ${timeoutSec}s`,
+        errorCode: authMeta.requiresAuth ? "antigravity_auth_required" : null,
+        clearSession: clearSessionOnMissingSession,
+      };
+    }
+
+    const parsedError = typeof attempt.parsed.errorMessage === "string" ? attempt.parsed.errorMessage.trim() : "";
+    const stderrLine = firstNonEmptyLine(attempt.proc.stderr);
+    const structuredFailure = attempt.parsed.resultEvent
+      ? describeAntigravityFailure(attempt.parsed.resultEvent)
+      : null;
+    const fallbackErrorMessage =
+      parsedError ||
+      structuredFailure ||
+      stderrLine ||
+      `Antigravity exited with code ${attempt.proc.exitCode ?? -1}`;
+    const failed = (attempt.proc.exitCode ?? 0) !== 0;
+
+    const canFallbackToRuntimeSession = !isRetry;
+    const resolvedSessionId = attempt.parsed.sessionId
+      ?? (canFallbackToRuntimeSession ? (runtimeSessionId ?? runtime.sessionId ?? null) : null);
+    const resolvedSessionParams = resolvedSessionId
+      ? ({
+        sessionId: resolvedSessionId,
+        cwd: effectiveExecutionCwd,
+        ...(workspaceId ? { workspaceId } : {}),
+        ...(workspaceRepoUrl ? { repoUrl: workspaceRepoUrl } : {}),
+        ...(workspaceRepoRef ? { repoRef: workspaceRepoRef } : {}),
+        ...(executionTargetIsRemote
+          ? {
+              remoteExecution: adapterExecutionTargetSessionIdentity(runtimeExecutionTarget),
+            }
+          : {}),
+      } as Record<string, unknown>)
+      : null;
+    const resultJson: Record<string, unknown> = {
+      ...(attempt.parsed.resultEvent ?? {
+        stdout: attempt.proc.stdout,
+        stderr: attempt.proc.stderr,
+      }),
+    };
+
+    return {
+      exitCode: attempt.proc.exitCode,
+      signal: attempt.proc.signal,
+      timedOut: false,
+      errorMessage: failed ? fallbackErrorMessage : null,
+      errorCode: attempt.proc.errorCode
+        ? attempt.proc.errorCode
+        : failed && authMeta.requiresAuth
+        ? "antigravity_auth_required"
+        : null,
+      usage: attempt.parsed.usage,
+      sessionId: resolvedSessionId,
+      sessionParams: resolvedSessionParams,
+      sessionDisplayId: resolvedSessionId,
+      provider: "antigravity",
+      model,
+      costUsd: attempt.parsed.costUsd,
+      resultJson,
+      summary: attempt.parsed.summary,
+      clearSession: Boolean(clearSessionOnMissingSession && !resolvedSessionId),
+    };
+  };
+
+  try {
+    const initial = await runAttempt(sessionId);
+    if (
+      sessionId &&
+      !initial.proc.timedOut &&
+      (initial.proc.exitCode ?? 0) !== 0 &&
+      isAntigravitySessionUnrecoverableError(initial.proc.stdout, initial.proc.stderr)
+    ) {
+      await onLog(
+        "stdout",
+        `[paperclip] Antigravity resume session "${sessionId}" is unavailable; retrying with a fresh session.\n`,
+      );
+      const retry = await runAttempt(null);
+      return toResult(retry, true, true);
+    }
+
+    return toResult(initial);
+  } finally {
+    await Promise.all([
+      paperclipBridge?.stop(),
+      restoreRemoteWorkspace?.(),
+    ]);
+  }
+}

--- a/packages/adapters/antigravity-local/src/server/execute.ts
+++ b/packages/adapters/antigravity-local/src/server/execute.ts
@@ -51,12 +51,6 @@ import {
 } from "./parse.js";
 import { firstNonEmptyLine } from "./utils.js";
 
-// Checks if an environment dictionary contains a non-empty value for a key
-function hasNonEmptyEnvValue(env: Record<string, string>, key: string): boolean {
-  const raw = env[key];
-  return typeof raw === "string" && raw.trim().length > 0;
-}
-
 // Builds the child process environment for Antigravity headless execution
 function buildAntigravityHeadlessEnv(env: Record<string, string>): Record<string, string> {
   const next = { ...env };
@@ -80,32 +74,16 @@ function buildAntigravityRuntimeEnv(env: Record<string, string>): Record<string,
   );
 }
 
-// Renders diagnostic note describing PAPERCLIP_* variables present in the run
+// Renders diagnostic note describing non-secret PAPERCLIP_* variables present in the run
 function renderPaperclipEnvNote(env: Record<string, string>): string {
   const paperclipKeys = Object.keys(env)
-    .filter((key) => key.startsWith("PAPERCLIP_"))
+    .filter((key) => key.startsWith("PAPERCLIP_") && key !== "PAPERCLIP_API_KEY")
     .sort();
   if (paperclipKeys.length === 0) return "";
   return [
     "Paperclip runtime note:",
     `The following PAPERCLIP_* environment variables are available in this run: ${paperclipKeys.join(", ")}`,
     "Do not assume these variables are missing without checking your shell environment.",
-    "",
-    "",
-  ].join("\n");
-}
-
-// Renders usage instructions for making Paperclip API calls from the agent
-function renderApiAccessNote(env: Record<string, string>): string {
-  if (!hasNonEmptyEnvValue(env, "PAPERCLIP_API_URL") || !hasNonEmptyEnvValue(env, "PAPERCLIP_API_KEY")) return "";
-  return [
-    "Paperclip API access note:",
-    "Use run_shell_command with curl to make Paperclip API requests.",
-    "GET example:",
-    `  run_shell_command({ command: "curl -s -H \\"Authorization: Bearer $PAPERCLIP_API_KEY\\" \\"$PAPERCLIP_API_URL/api/agents/me\\"" })`,
-    "POST/PATCH example:",
-    `  run_shell_command({ command: "curl -s -X POST -H \\"Authorization: Bearer $PAPERCLIP_API_KEY\\" -H 'Content-Type: application/json' -H \\"X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID\\" -d '{...}' \\"$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID/checkout\\"" })`,
-    "When PAPERCLIP_TASK_ID is not set, substitute a real issue id from the current context; never send a placeholder like {id} in the URL.",
     "",
     "",
   ].join("\n");
@@ -129,7 +107,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const agentName = asString(config.agent, "").trim();
   const effort = asString(config.effort, "").trim().toLowerCase();
   const sandbox = asBoolean(config.sandbox, false);
-  const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, true);
+  const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, false);
   const printTimeout = asString(config.printTimeout, "").trim();
 
   const workspaceContext = parseObject(context.paperclipWorkspace);
@@ -237,6 +215,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const extraArgs = (() => {
     const fromExtraArgs = asStringArray(config.extraArgs);
     if (fromExtraArgs.length > 0) return fromExtraArgs;
+    if (typeof config.extraArgs === "string" && config.extraArgs.trim().length > 0) {
+      const trimmed = config.extraArgs.trim();
+      const delimiter = trimmed.includes(",") ? "," : /\s+/;
+      return trimmed.split(delimiter).map((s) => s.trim()).filter(Boolean);
+    }
     return asStringArray(config.args);
   })();
 
@@ -377,14 +360,12 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     : renderTemplate(promptTemplate, templateData);
   const sessionHandoffNote = asString(context.paperclipSessionHandoffMarkdown, "").trim();
   const paperclipEnvNote = renderPaperclipEnvNote(env);
-  const apiAccessNote = renderApiAccessNote(env);
   const prompt = joinPromptSections([
     instructionsPrefix,
     renderedBootstrapPrompt,
     wakePrompt,
     sessionHandoffNote,
     paperclipEnvNote,
-    apiAccessNote,
     renderedPrompt,
   ]);
   const promptMetrics = {
@@ -393,7 +374,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     bootstrapPromptChars: renderedBootstrapPrompt.length,
     wakePromptChars: wakePrompt.length,
     sessionHandoffChars: sessionHandoffNote.length,
-    runtimeNoteChars: paperclipEnvNote.length + apiAccessNote.length,
+    runtimeNoteChars: paperclipEnvNote.length,
     heartbeatPromptChars: renderedPrompt.length,
   };
 
@@ -508,14 +489,20 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const structuredFailure = attempt.parsed.resultEvent
       ? describeAntigravityFailure(attempt.parsed.resultEvent)
       : null;
+    const processFailed = (attempt.proc.exitCode ?? 0) !== 0;
+    const structuredFailed = Boolean(
+      parsedError ||
+      structuredFailure ||
+      (attempt.parsed.status && ["ERROR", "FAILURE"].includes(attempt.parsed.status.toUpperCase()))
+    );
+    const failed = processFailed || structuredFailed;
     const fallbackErrorMessage =
       parsedError ||
       structuredFailure ||
       stderrLine ||
-      `Antigravity exited with code ${attempt.proc.exitCode ?? -1}`;
-    const failed = (attempt.proc.exitCode ?? 0) !== 0;
+      (attempt.parsed.status ? `Antigravity run reported status: ${attempt.parsed.status}` : `Antigravity exited with code ${attempt.proc.exitCode ?? -1}`);
 
-    const canFallbackToRuntimeSession = !isRetry;
+    const canFallbackToRuntimeSession = canResumeSession && !isRetry;
     const resolvedSessionId = attempt.parsed.sessionId
       ?? (canFallbackToRuntimeSession ? (runtimeSessionId ?? runtime.sessionId ?? null) : null);
     const resolvedSessionParams = resolvedSessionId

--- a/packages/adapters/antigravity-local/src/server/index.ts
+++ b/packages/adapters/antigravity-local/src/server/index.ts
@@ -1,0 +1,79 @@
+// Server exports and session codec for Antigravity local adapter
+
+export { execute } from "./execute.js";
+export { getConfigSchema } from "./config-schema.js";
+export { testEnvironment } from "./test.js";
+export {
+  parseAntigravityJsonl,
+  isAntigravitySessionUnrecoverableError,
+  isAntigravityAuthError,
+  describeAntigravityFailure,
+  detectAntigravityAuthRequired,
+} from "./parse.js";
+import type { AdapterSessionCodec } from "@paperclipai/adapter-utils";
+
+// Helper to normalize and extract non-empty string values
+function readNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+// Session codec for Antigravity conversation session identity
+export const sessionCodec: AdapterSessionCodec = {
+  deserialize(raw: unknown) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
+    const record = raw as Record<string, unknown>;
+    const sessionId =
+      readNonEmptyString(record.sessionId) ??
+      readNonEmptyString(record.session_id) ??
+      readNonEmptyString(record.conversation_id) ??
+      readNonEmptyString(record.conversationId);
+    if (!sessionId) return null;
+    const cwd =
+      readNonEmptyString(record.cwd) ??
+      readNonEmptyString(record.workdir) ??
+      readNonEmptyString(record.folder);
+    const workspaceId = readNonEmptyString(record.workspaceId) ?? readNonEmptyString(record.workspace_id);
+    const repoUrl = readNonEmptyString(record.repoUrl) ?? readNonEmptyString(record.repo_url);
+    const repoRef = readNonEmptyString(record.repoRef) ?? readNonEmptyString(record.repo_ref);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+      ...(workspaceId ? { workspaceId } : {}),
+      ...(repoUrl ? { repoUrl } : {}),
+      ...(repoRef ? { repoRef } : {}),
+    };
+  },
+  serialize(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    const sessionId =
+      readNonEmptyString(params.sessionId) ??
+      readNonEmptyString(params.session_id) ??
+      readNonEmptyString(params.conversation_id) ??
+      readNonEmptyString(params.conversationId);
+    if (!sessionId) return null;
+    const cwd =
+      readNonEmptyString(params.cwd) ??
+      readNonEmptyString(params.workdir) ??
+      readNonEmptyString(params.folder);
+    const workspaceId = readNonEmptyString(params.workspaceId) ?? readNonEmptyString(params.workspace_id);
+    const repoUrl = readNonEmptyString(params.repoUrl) ?? readNonEmptyString(params.repo_url);
+    const repoRef = readNonEmptyString(params.repoRef) ?? readNonEmptyString(params.repo_ref);
+    return {
+      sessionId,
+      ...(cwd ? { cwd } : {}),
+      ...(workspaceId ? { workspaceId } : {}),
+      ...(repoUrl ? { repoUrl } : {}),
+      ...(repoRef ? { repoRef } : {}),
+    };
+  },
+  getDisplayId(params: Record<string, unknown> | null) {
+    if (!params) return null;
+    return (
+      readNonEmptyString(params.sessionId) ??
+      readNonEmptyString(params.session_id) ??
+      readNonEmptyString(params.conversation_id) ??
+      readNonEmptyString(params.conversationId) ??
+      null
+    );
+  },
+};

--- a/packages/adapters/antigravity-local/src/server/index.ts
+++ b/packages/adapters/antigravity-local/src/server/index.ts
@@ -17,6 +17,13 @@ function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
+// Helper to safely extract a nested record object
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
 // Session codec for Antigravity conversation session identity
 export const sessionCodec: AdapterSessionCodec = {
   deserialize(raw: unknown) {
@@ -35,12 +42,14 @@ export const sessionCodec: AdapterSessionCodec = {
     const workspaceId = readNonEmptyString(record.workspaceId) ?? readNonEmptyString(record.workspace_id);
     const repoUrl = readNonEmptyString(record.repoUrl) ?? readNonEmptyString(record.repo_url);
     const repoRef = readNonEmptyString(record.repoRef) ?? readNonEmptyString(record.repo_ref);
+    const remoteExecution = readRecord(record.remoteExecution);
     return {
       sessionId,
       ...(cwd ? { cwd } : {}),
       ...(workspaceId ? { workspaceId } : {}),
       ...(repoUrl ? { repoUrl } : {}),
       ...(repoRef ? { repoRef } : {}),
+      ...(remoteExecution ? { remoteExecution } : {}),
     };
   },
   serialize(params: Record<string, unknown> | null) {
@@ -58,12 +67,14 @@ export const sessionCodec: AdapterSessionCodec = {
     const workspaceId = readNonEmptyString(params.workspaceId) ?? readNonEmptyString(params.workspace_id);
     const repoUrl = readNonEmptyString(params.repoUrl) ?? readNonEmptyString(params.repo_url);
     const repoRef = readNonEmptyString(params.repoRef) ?? readNonEmptyString(params.repo_ref);
+    const remoteExecution = readRecord(params.remoteExecution);
     return {
       sessionId,
       ...(cwd ? { cwd } : {}),
       ...(workspaceId ? { workspaceId } : {}),
       ...(repoUrl ? { repoUrl } : {}),
       ...(repoRef ? { repoRef } : {}),
+      ...(remoteExecution ? { remoteExecution } : {}),
     };
   },
   getDisplayId(params: Record<string, unknown> | null) {

--- a/packages/adapters/antigravity-local/src/server/parse.test.ts
+++ b/packages/adapters/antigravity-local/src/server/parse.test.ts
@@ -115,6 +115,22 @@ describe("antigravity_local parser", () => {
     expect(parsed.errorMessage).toBe("model invalid-model is not recognized");
   });
 
+  it("generates fallback error message when status is FAILURE without error field", () => {
+    const stdout = JSON.stringify({
+      event: "result",
+      result: {
+        conversation_id: "conv-fail",
+        status: "FAILURE",
+        response: "",
+      },
+    });
+
+    const parsed = parseAntigravityJsonl(stdout);
+    expect(parsed.sessionId).toBe("conv-fail");
+    expect(parsed.status).toBe("FAILURE");
+    expect(parsed.errorMessage).toBe("Antigravity run reported status: FAILURE");
+  });
+
   it("concatenates streaming deltas if final result response is empty", () => {
     const stdout = [
       JSON.stringify({
@@ -177,5 +193,14 @@ describe("describeAntigravityFailure", () => {
       },
     });
     expect(desc).toBe("Antigravity run failed: status=ERROR: Quota exceeded");
+  });
+
+  it("formats status when error message is empty", () => {
+    const desc = describeAntigravityFailure({
+      result: {
+        status: "FAILURE",
+      },
+    });
+    expect(desc).toBe("Antigravity run failed: status=FAILURE");
   });
 });

--- a/packages/adapters/antigravity-local/src/server/parse.test.ts
+++ b/packages/adapters/antigravity-local/src/server/parse.test.ts
@@ -1,0 +1,181 @@
+// Unit tests for Antigravity stream-json parser
+
+import { describe, expect, it } from "vitest";
+import {
+  parseAntigravityJsonl,
+  isAntigravitySessionUnrecoverableError,
+  detectAntigravityAuthRequired,
+  describeAntigravityFailure,
+} from "./parse.js";
+
+describe("antigravity_local parser", () => {
+  it("extracts sessionId, response, token usage, and status from valid stream-json events", () => {
+    const stdout = [
+      JSON.stringify({
+        event: "init",
+        conversation_id: "conv-12345",
+        init: { cwd: "/workspace", tools: ["view_file", "write_to_file"] },
+      }),
+      JSON.stringify({
+        event: "step_update",
+        step_update: {
+          conversation_id: "conv-12345",
+          step_index: 0,
+          state: "DONE",
+          step_type: "user_input",
+        },
+      }),
+      JSON.stringify({
+        event: "step_update",
+        step_update: {
+          conversation_id: "conv-12345",
+          step_index: 1,
+          state: "DONE",
+          step_type: "agent_response",
+          text_delta: "Hello from Antigravity!",
+          duration_seconds: 1.2,
+          usage: {
+            input_tokens: 100,
+            output_tokens: 20,
+            thinking_tokens: 10,
+            cache_read_tokens: 50,
+            total_tokens: 120,
+          },
+        },
+      }),
+      JSON.stringify({
+        event: "result",
+        result: {
+          conversation_id: "conv-12345",
+          status: "SUCCESS",
+          response: "Hello from Antigravity!",
+          duration_seconds: 2.5,
+          num_turns: 1,
+          usage: {
+            input_tokens: 100,
+            output_tokens: 20,
+            thinking_tokens: 10,
+            cache_read_tokens: 50,
+            total_tokens: 120,
+          },
+        },
+      }),
+    ].join("\n");
+
+    const parsed = parseAntigravityJsonl(stdout);
+    expect(parsed.sessionId).toBe("conv-12345");
+    expect(parsed.summary).toBe("Hello from Antigravity!");
+    expect(parsed.status).toBe("SUCCESS");
+    expect(parsed.errorMessage).toBeNull();
+    expect(parsed.usage.inputTokens).toBe(100);
+    expect(parsed.usage.outputTokens).toBe(20);
+    expect(parsed.usage.cachedInputTokens).toBe(50);
+  });
+
+  it("handles non-JSON warning banners without throwing", () => {
+    const stdout = [
+      "warning: conversation \"old-id\" not found",
+      JSON.stringify({
+        event: "init",
+        conversation_id: "fresh-id-999",
+        init: { cwd: "/workspace" },
+      }),
+      JSON.stringify({
+        event: "result",
+        result: {
+          conversation_id: "fresh-id-999",
+          status: "SUCCESS",
+          response: "recovered",
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+      }),
+    ].join("\n");
+
+    const parsed = parseAntigravityJsonl(stdout);
+    expect(parsed.sessionId).toBe("fresh-id-999");
+    expect(parsed.summary).toBe("recovered");
+    expect(parsed.status).toBe("SUCCESS");
+  });
+
+  it("extracts error message from ERROR result events", () => {
+    const stdout = JSON.stringify({
+      event: "result",
+      result: {
+        conversation_id: "conv-err",
+        status: "ERROR",
+        response: "",
+        error: "model invalid-model is not recognized",
+        usage: { input_tokens: 0, output_tokens: 0 },
+      },
+    });
+
+    const parsed = parseAntigravityJsonl(stdout);
+    expect(parsed.sessionId).toBe("conv-err");
+    expect(parsed.status).toBe("ERROR");
+    expect(parsed.errorMessage).toBe("model invalid-model is not recognized");
+  });
+
+  it("concatenates streaming deltas if final result response is empty", () => {
+    const stdout = [
+      JSON.stringify({
+        event: "step_update",
+        step_update: {
+          step_type: "agent_response",
+          text_delta: "part 1, ",
+        },
+      }),
+      JSON.stringify({
+        event: "step_update",
+        step_update: {
+          step_type: "agent_response",
+          text_delta: "part 2",
+        },
+      }),
+    ].join("\n");
+
+    const parsed = parseAntigravityJsonl(stdout);
+    expect(parsed.summary).toBe("part 1, part 2");
+  });
+
+  it("returns safe defaults for completely empty output", () => {
+    const parsed = parseAntigravityJsonl("");
+    expect(parsed.sessionId).toBeNull();
+    expect(parsed.summary).toBe("");
+    expect(parsed.status).toBeNull();
+    expect(parsed.errorMessage).toBeNull();
+    expect(parsed.usage.inputTokens).toBe(0);
+    expect(parsed.usage.outputTokens).toBe(0);
+  });
+});
+
+describe("isAntigravitySessionUnrecoverableError", () => {
+  it("detects missing conversation warning", () => {
+    expect(isAntigravitySessionUnrecoverableError("warning: conversation \"123\" not found", "")).toBe(true);
+    expect(isAntigravitySessionUnrecoverableError("", "conversation not found")).toBe(true);
+    expect(isAntigravitySessionUnrecoverableError("unknown conversation", "")).toBe(true);
+  });
+
+  it("returns false for normal errors", () => {
+    expect(isAntigravitySessionUnrecoverableError("file not found", "")).toBe(false);
+    expect(isAntigravitySessionUnrecoverableError("", "syntax error")).toBe(false);
+  });
+});
+
+describe("detectAntigravityAuthRequired", () => {
+  it("detects authentication requirements", () => {
+    expect(detectAntigravityAuthRequired({ parsed: null, stdout: "please authenticate to proceed", stderr: "" }).requiresAuth).toBe(true);
+    expect(detectAntigravityAuthRequired({ parsed: null, stdout: "", stderr: "login required" }).requiresAuth).toBe(true);
+  });
+});
+
+describe("describeAntigravityFailure", () => {
+  it("formats structured failure message", () => {
+    const desc = describeAntigravityFailure({
+      result: {
+        status: "ERROR",
+        error: "Quota exceeded",
+      },
+    });
+    expect(desc).toBe("Antigravity run failed: status=ERROR: Quota exceeded");
+  });
+});

--- a/packages/adapters/antigravity-local/src/server/parse.ts
+++ b/packages/adapters/antigravity-local/src/server/parse.ts
@@ -160,7 +160,7 @@ export function parseAntigravityJsonl(stdout: string): ParsedAntigravityRun {
 
       if (isError) {
         const err = asErrorText(resultObj.error ?? resultObj.message ?? response);
-        if (err) errorMessage = err;
+        errorMessage = err || `Antigravity run reported status: ${runStatus || "ERROR"}`;
       }
 
       costUsd = asNumber(resultObj.cost_usd, asNumber(resultObj.total_cost_usd, 0)) || null;

--- a/packages/adapters/antigravity-local/src/server/parse.ts
+++ b/packages/adapters/antigravity-local/src/server/parse.ts
@@ -1,0 +1,232 @@
+// Structured output parser for Antigravity stream-json CLI events
+
+import { asNumber, asString, parseJson, parseObject } from "@paperclipai/adapter-utils/server-utils";
+
+// Parsed result structure returned by parseAntigravityJsonl
+export interface ParsedAntigravityRun {
+  sessionId: string | null;
+  summary: string;
+  usage: {
+    inputTokens: number;
+    cachedInputTokens: number;
+    outputTokens: number;
+    thinkingTokens?: number;
+    totalTokens?: number;
+  };
+  costUsd: number | null;
+  errorMessage: string | null;
+  resultEvent: Record<string, unknown> | null;
+  status: string | null;
+}
+
+// Safely extracts error text from a message or error record
+function asErrorText(value: unknown): string {
+  if (typeof value === "string") return value.trim();
+  const rec = parseObject(value);
+  const message =
+    asString(rec.message, "") ||
+    asString(rec.error, "") ||
+    asString(rec.code, "") ||
+    asString(rec.detail, "");
+  if (message) return message.trim();
+  try {
+    const serialized = JSON.stringify(rec);
+    return serialized === "{}" ? "" : serialized;
+  } catch {
+    return "";
+  }
+}
+
+// Extracts usage token counts from an Antigravity usage record
+function extractUsage(usageRaw: unknown): {
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+  thinkingTokens: number;
+  totalTokens: number;
+} {
+  const usage = parseObject(usageRaw);
+  const inputTokens = asNumber(
+    usage.input_tokens,
+    asNumber(usage.inputTokens, asNumber(usage.promptTokenCount, 0)),
+  );
+  const cachedInputTokens = asNumber(
+    usage.cache_read_tokens,
+    asNumber(usage.cached_input_tokens, asNumber(usage.cachedTokens, 0)),
+  );
+  const outputTokens = asNumber(
+    usage.output_tokens,
+    asNumber(usage.outputTokens, asNumber(usage.candidatesTokenCount, 0)),
+  );
+  const thinkingTokens = asNumber(
+    usage.thinking_tokens,
+    asNumber(usage.thinkingTokens, 0),
+  );
+  const totalTokens = asNumber(
+    usage.total_tokens,
+    asNumber(usage.totalTokens, inputTokens + outputTokens),
+  );
+  return { inputTokens, cachedInputTokens, outputTokens, thinkingTokens, totalTokens };
+}
+
+// Parses newline-delimited stream-json output from Antigravity CLI
+export function parseAntigravityJsonl(stdout: string): ParsedAntigravityRun {
+  let sessionId: string | null = null;
+  const assistantDeltas: string[] = [];
+  let finalResponse: string | null = null;
+  let errorMessage: string | null = null;
+  let resultEvent: Record<string, unknown> | null = null;
+  let runStatus: string | null = null;
+  let costUsd: number | null = null;
+
+  let latestUsage = {
+    inputTokens: 0,
+    cachedInputTokens: 0,
+    outputTokens: 0,
+    thinkingTokens: 0,
+    totalTokens: 0,
+  };
+
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    // Defensively parse line; ignore non-JSON lines such as warning banners or logs
+    const event = parseJson(line);
+    if (!event) continue;
+
+    // Check for conversation identity in root event fields
+    const directSessionId =
+      asString(event.conversation_id, "").trim() ||
+      asString(event.conversationId, "").trim() ||
+      asString(event.session_id, "").trim() ||
+      asString(event.sessionId, "").trim();
+    if (directSessionId) {
+      sessionId = directSessionId;
+    }
+
+    const eventName = asString(event.event, asString(event.type, "")).trim().toLowerCase();
+
+    // Event: init -> captures conversation ID and environment tools
+    if (eventName === "init") {
+      const initObj = parseObject(event.init);
+      const initSessionId =
+        asString(event.conversation_id, "").trim() ||
+        asString(initObj.conversation_id, "").trim();
+      if (initSessionId) sessionId = initSessionId;
+      continue;
+    }
+
+    // Event: step_update -> captures intermediate assistant deltas and usage
+    if (eventName === "step_update") {
+      const stepUpdate = parseObject(event.step_update ?? event);
+      const stepSessionId = asString(stepUpdate.conversation_id, "").trim();
+      if (stepSessionId) sessionId = stepSessionId;
+
+      const stepType = asString(stepUpdate.step_type, "").trim().toLowerCase();
+      const textDelta = asString(stepUpdate.text_delta, "");
+      if (stepType === "agent_response" && textDelta) {
+        assistantDeltas.push(textDelta);
+      }
+
+      if (stepUpdate.usage) {
+        latestUsage = extractUsage(stepUpdate.usage);
+      }
+      continue;
+    }
+
+    // Event: result -> final run disposition, complete response, usage, and status
+    if (eventName === "result") {
+      resultEvent = event;
+      const resultObj = parseObject(event.result ?? event);
+      const resultSessionId = asString(resultObj.conversation_id, "").trim();
+      if (resultSessionId) sessionId = resultSessionId;
+
+      runStatus = asString(resultObj.status, "").trim();
+      const response = asString(resultObj.response, "");
+      if (response) {
+        finalResponse = response;
+      }
+
+      if (resultObj.usage) {
+        latestUsage = extractUsage(resultObj.usage);
+      }
+
+      const isError =
+        runStatus.toUpperCase() === "ERROR" ||
+        runStatus.toUpperCase() === "FAILURE" ||
+        resultObj.is_error === true ||
+        Boolean(resultObj.error);
+
+      if (isError) {
+        const err = asErrorText(resultObj.error ?? resultObj.message ?? response);
+        if (err) errorMessage = err;
+      }
+
+      costUsd = asNumber(resultObj.cost_usd, asNumber(resultObj.total_cost_usd, 0)) || null;
+      continue;
+    }
+
+    // Event: error -> direct error payload
+    if (eventName === "error") {
+      const err = asErrorText(event.error ?? event.message ?? event.detail);
+      if (err) errorMessage = err;
+      continue;
+    }
+  }
+
+  const summary = (finalResponse !== null ? finalResponse : assistantDeltas.join("")).trim();
+
+  return {
+    sessionId,
+    summary,
+    usage: latestUsage,
+    costUsd,
+    errorMessage,
+    resultEvent,
+    status: runStatus,
+  };
+}
+
+// Checks if the output indicates an unrecoverable conversation session that warrants retry with a fresh session
+export function isAntigravitySessionUnrecoverableError(stdout: string, stderr: string): boolean {
+  const combined = `${stdout}\n${stderr}`;
+  return /conversation\s+.*not\s+found|conversation\s+".*"\s+not\s+found|unknown\s+conversation|session\s+.*not\s+found|cannot\s+resume|failed\s+to\s+resume|stale\s+session/i.test(
+    combined,
+  );
+}
+
+// Helper to check if stdout or stderr indicates an authentication error
+export function isAntigravityAuthError(stdout: string, stderr: string): boolean {
+  return detectAntigravityAuthRequired({ parsed: null, stdout, stderr }).requiresAuth;
+}
+
+// Detects whether the run failed due to authentication or login requirements
+export function detectAntigravityAuthRequired(input: {
+  parsed: Record<string, unknown> | null;
+  stdout: string;
+  stderr: string;
+}): { requiresAuth: boolean } {
+  const messages = [
+    input.stdout,
+    input.stderr,
+    input.parsed ? asErrorText(input.parsed.error ?? input.parsed.message) : "",
+  ].join("\n");
+
+  const requiresAuth = /(?:not\s+authenticated|authenticate|login\s+required|unauthorized|invalid\s+credentials|agy\s+auth|agy\s+login|api[_ ]?key\s+missing)/i.test(
+    messages,
+  );
+  return { requiresAuth };
+}
+
+// Formats a concise description of an Antigravity failure from result event
+export function describeAntigravityFailure(resultEvent: Record<string, unknown>): string | null {
+  const resultObj = parseObject(resultEvent.result ?? resultEvent);
+  const status = asString(resultObj.status, "");
+  const error = asErrorText(resultObj.error ?? resultObj.message);
+
+  const parts = ["Antigravity run failed"];
+  if (status) parts.push(`status=${status}`);
+  if (error) parts.push(error);
+  return parts.length > 1 ? parts.join(": ") : null;
+}

--- a/packages/adapters/antigravity-local/src/server/test.ts
+++ b/packages/adapters/antigravity-local/src/server/test.ts
@@ -7,6 +7,7 @@ import type {
   AdapterEnvironmentTestResult,
 } from "@paperclipai/adapter-utils";
 import {
+  asBoolean,
   asString,
   ensurePathInEnv,
   parseObject,
@@ -18,8 +19,9 @@ import {
   describeAdapterExecutionTarget,
   resolveAdapterExecutionTargetCwd,
 } from "@paperclipai/adapter-utils/execution-target";
-import { detectAntigravityAuthRequired } from "./parse.js";
+import { detectAntigravityAuthRequired, parseAntigravityJsonl } from "./parse.js";
 import { firstNonEmptyLine } from "./utils.js";
+import { DEFAULT_ANTIGRAVITY_LOCAL_MODEL } from "../index.js";
 
 // Computes overall pass/warn/fail status from a list of diagnostic checks
 function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
@@ -29,8 +31,8 @@ function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentT
 }
 
 // Cleans and truncates probe output for concise diagnostic display
-function summarizeProbeDetail(stdout: string, stderr: string): string | null {
-  const raw = firstNonEmptyLine(stderr) || firstNonEmptyLine(stdout);
+function summarizeProbeDetail(stdout: string, stderr: string, extra?: string | null): string | null {
+  const raw = extra || firstNonEmptyLine(stderr) || firstNonEmptyLine(stdout);
   if (!raw) return null;
   const clean = raw.replace(/\s+/g, " ").trim();
   const max = 240;
@@ -44,6 +46,8 @@ export async function testEnvironment(
   const checks: AdapterEnvironmentCheck[] = [];
   const config = parseObject(ctx.config);
   const command = asString(config.command, "agy");
+  const model = asString(config.model, DEFAULT_ANTIGRAVITY_LOCAL_MODEL).trim();
+  const dangerouslySkipPermissions = asBoolean(config.dangerouslySkipPermissions, false);
   const target = ctx.executionTarget ?? null;
   const targetIsRemote = target?.kind === "remote";
   const cwd = resolveAdapterExecutionTargetCwd(target, asString(config.cwd, ""), process.cwd());
@@ -115,53 +119,76 @@ export async function testEnvironment(
     });
   }
 
-  // Check 3: Minimal headless probe invocation if command is resolvable
+  // Check 3: Headless probe invocation if command is resolvable
   if (commandResolvable) {
     try {
+      const probeArgs = ["--print", "Respond with OK.", "--output-format", "stream-json"];
+      if (model && model !== DEFAULT_ANTIGRAVITY_LOCAL_MODEL) {
+        probeArgs.push("--model", model);
+      }
+      if (dangerouslySkipPermissions) {
+        probeArgs.push("--dangerously-skip-permissions");
+      }
+
       const probeProc = await runAdapterExecutionTargetProcess(
         runId,
         target,
         command,
-        ["--help"],
+        probeArgs,
         {
           cwd,
           env: runtimeEnv,
-          timeoutSec: 15,
+          timeoutSec: 30,
           graceSec: 5,
           onLog: async () => {},
         },
       );
 
-      if (probeProc.exitCode === 0) {
+      const parsed = parseAntigravityJsonl(probeProc.stdout);
+      const detail = summarizeProbeDetail(probeProc.stdout, probeProc.stderr, parsed.errorMessage);
+      const auth = detectAntigravityAuthRequired({
+        parsed: parsed.resultEvent,
+        stdout: probeProc.stdout,
+        stderr: probeProc.stderr,
+      });
+
+      const structuredFailed = Boolean(
+        parsed.errorMessage ||
+        (parsed.status && ["ERROR", "FAILURE"].includes(parsed.status.toUpperCase()))
+      );
+      const processFailed = (probeProc.exitCode ?? 0) !== 0;
+
+      if (probeProc.timedOut) {
+        checks.push({
+          code: "antigravity_probe_failed",
+          level: "warn",
+          message: "Antigravity readiness probe timed out.",
+          detail: detail ?? undefined,
+          hint: "Verify Antigravity CLI can run interactively from this directory.",
+        });
+      } else if (auth.requiresAuth) {
+        checks.push({
+          code: "antigravity_auth_required",
+          level: "warn",
+          message: "Antigravity CLI requires authentication.",
+          detail: detail ?? undefined,
+          hint: "Run 'agy' in an interactive terminal to log in.",
+        });
+      } else if (!processFailed && !structuredFailed) {
         checks.push({
           code: "antigravity_cli_ready",
           level: "info",
           message: "Antigravity CLI is ready and responding to commands.",
+          detail: parsed.summary ? parsed.summary.slice(0, 200) : undefined,
         });
       } else {
-        const detail = summarizeProbeDetail(probeProc.stdout, probeProc.stderr);
-        const auth = detectAntigravityAuthRequired({
-          parsed: null,
-          stdout: probeProc.stdout,
-          stderr: probeProc.stderr,
+        checks.push({
+          code: "antigravity_probe_failed",
+          level: "warn",
+          message: `Antigravity probe failed (exit code: ${probeProc.exitCode ?? -1}).`,
+          detail: detail ?? undefined,
+          hint: "Check Antigravity CLI installation and credentials.",
         });
-
-        if (auth.requiresAuth) {
-          checks.push({
-            code: "antigravity_auth_required",
-            level: "warn",
-            message: "Antigravity CLI requires authentication.",
-            detail: detail ?? undefined,
-            hint: "Run 'agy' in an interactive terminal to log in.",
-          });
-        } else {
-          checks.push({
-            code: "antigravity_probe_failed",
-            level: "warn",
-            message: `Antigravity probe exited with status ${probeProc.exitCode}.`,
-            detail: detail ?? undefined,
-          });
-        }
       }
     } catch (err) {
       checks.push({

--- a/packages/adapters/antigravity-local/src/server/test.ts
+++ b/packages/adapters/antigravity-local/src/server/test.ts
@@ -1,0 +1,181 @@
+// Environment diagnostic testing for Antigravity local adapter
+
+import path from "node:path";
+import type {
+  AdapterEnvironmentCheck,
+  AdapterEnvironmentTestContext,
+  AdapterEnvironmentTestResult,
+} from "@paperclipai/adapter-utils";
+import {
+  asString,
+  ensurePathInEnv,
+  parseObject,
+} from "@paperclipai/adapter-utils/server-utils";
+import {
+  ensureAdapterExecutionTargetCommandResolvable,
+  ensureAdapterExecutionTargetDirectory,
+  runAdapterExecutionTargetProcess,
+  describeAdapterExecutionTarget,
+  resolveAdapterExecutionTargetCwd,
+} from "@paperclipai/adapter-utils/execution-target";
+import { detectAntigravityAuthRequired } from "./parse.js";
+import { firstNonEmptyLine } from "./utils.js";
+
+// Computes overall pass/warn/fail status from a list of diagnostic checks
+function summarizeStatus(checks: AdapterEnvironmentCheck[]): AdapterEnvironmentTestResult["status"] {
+  if (checks.some((check) => check.level === "error")) return "fail";
+  if (checks.some((check) => check.level === "warn")) return "warn";
+  return "pass";
+}
+
+// Cleans and truncates probe output for concise diagnostic display
+function summarizeProbeDetail(stdout: string, stderr: string): string | null {
+  const raw = firstNonEmptyLine(stderr) || firstNonEmptyLine(stdout);
+  if (!raw) return null;
+  const clean = raw.replace(/\s+/g, " ").trim();
+  const max = 240;
+  return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
+}
+
+// Tests the host or remote execution environment for Antigravity readiness
+export async function testEnvironment(
+  ctx: AdapterEnvironmentTestContext,
+): Promise<AdapterEnvironmentTestResult> {
+  const checks: AdapterEnvironmentCheck[] = [];
+  const config = parseObject(ctx.config);
+  const command = asString(config.command, "agy");
+  const target = ctx.executionTarget ?? null;
+  const targetIsRemote = target?.kind === "remote";
+  const cwd = resolveAdapterExecutionTargetCwd(target, asString(config.cwd, ""), process.cwd());
+  const targetLabel = targetIsRemote
+    ? ctx.environmentName ?? describeAdapterExecutionTarget(target)
+    : null;
+  const runId = `antigravity-envtest-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+  if (targetLabel) {
+    checks.push({
+      code: "antigravity_environment_target",
+      level: "info",
+      message: `Probing inside environment: ${targetLabel}`,
+    });
+  }
+
+  // Check 1: Working directory accessibility
+  try {
+    await ensureAdapterExecutionTargetDirectory(runId, target, cwd, {
+      cwd,
+      env: {},
+      createIfMissing: true,
+    });
+    checks.push({
+      code: "antigravity_cwd_valid",
+      level: "info",
+      message: `Working directory is valid: ${cwd}`,
+    });
+  } catch (err) {
+    checks.push({
+      code: "antigravity_cwd_invalid",
+      level: "error",
+      message: err instanceof Error ? err.message : "Invalid working directory",
+      detail: cwd,
+    });
+  }
+
+  // Check 2: Environment variables and command resolution
+  const envConfig = parseObject(config.env);
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(envConfig)) {
+    if (typeof value === "string") env[key] = value;
+  }
+  const hostEnv = Object.fromEntries(
+    Object.entries(process.env).filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+  );
+  const runtimeEnv: Record<string, string> = Object.fromEntries(
+    Object.entries(ensurePathInEnv({ ...hostEnv, ...env })).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+
+  let commandResolvable = false;
+  try {
+    await ensureAdapterExecutionTargetCommandResolvable(command, target, cwd, runtimeEnv);
+    checks.push({
+      code: "antigravity_command_resolvable",
+      level: "info",
+      message: `Command is executable: ${command}`,
+    });
+    commandResolvable = true;
+  } catch (err) {
+    checks.push({
+      code: "antigravity_command_unresolvable",
+      level: "error",
+      message: err instanceof Error ? err.message : "Command is not executable",
+      detail: command,
+      hint: "Ensure Antigravity CLI ('agy') is installed and on the system PATH, or provide an absolute path in the command field.",
+    });
+  }
+
+  // Check 3: Minimal headless probe invocation if command is resolvable
+  if (commandResolvable) {
+    try {
+      const probeProc = await runAdapterExecutionTargetProcess(
+        runId,
+        target,
+        command,
+        ["--help"],
+        {
+          cwd,
+          env: runtimeEnv,
+          timeoutSec: 15,
+          graceSec: 5,
+          onLog: async () => {},
+        },
+      );
+
+      if (probeProc.exitCode === 0) {
+        checks.push({
+          code: "antigravity_cli_ready",
+          level: "info",
+          message: "Antigravity CLI is ready and responding to commands.",
+        });
+      } else {
+        const detail = summarizeProbeDetail(probeProc.stdout, probeProc.stderr);
+        const auth = detectAntigravityAuthRequired({
+          parsed: null,
+          stdout: probeProc.stdout,
+          stderr: probeProc.stderr,
+        });
+
+        if (auth.requiresAuth) {
+          checks.push({
+            code: "antigravity_auth_required",
+            level: "warn",
+            message: "Antigravity CLI requires authentication.",
+            detail: detail ?? undefined,
+            hint: "Run 'agy' in an interactive terminal to log in.",
+          });
+        } else {
+          checks.push({
+            code: "antigravity_probe_failed",
+            level: "warn",
+            message: `Antigravity probe exited with status ${probeProc.exitCode}.`,
+            detail: detail ?? undefined,
+          });
+        }
+      }
+    } catch (err) {
+      checks.push({
+        code: "antigravity_probe_error",
+        level: "error",
+        message: err instanceof Error ? err.message : "Failed to execute Antigravity probe",
+      });
+    }
+  }
+
+  return {
+    adapterType: "antigravity_local",
+    status: summarizeStatus(checks),
+    testedAt: new Date().toISOString(),
+    checks,
+  };
+}

--- a/packages/adapters/antigravity-local/src/server/utils.ts
+++ b/packages/adapters/antigravity-local/src/server/utils.ts
@@ -1,0 +1,10 @@
+// Utility functions for Antigravity local server adapter
+
+// Returns the first non-empty line from a string, or null if all lines are blank
+export function firstNonEmptyLine(text: string): string | null {
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed.length > 0) return trimmed;
+  }
+  return null;
+}

--- a/packages/adapters/antigravity-local/src/ui/build-config.test.ts
+++ b/packages/adapters/antigravity-local/src/ui/build-config.test.ts
@@ -1,0 +1,46 @@
+// Unit tests for Antigravity local UI build-config
+
+import { describe, expect, it } from "vitest";
+import { buildAntigravityLocalConfig } from "./build-config.js";
+import { DEFAULT_ANTIGRAVITY_LOCAL_MODEL } from "../index.js";
+
+describe("buildAntigravityLocalConfig", () => {
+  it("builds config with defaults", () => {
+    const config = buildAntigravityLocalConfig({
+      adapterType: "antigravity_local",
+    } as any);
+
+    expect(config.model).toBe(DEFAULT_ANTIGRAVITY_LOCAL_MODEL);
+    expect(config.sandbox).toBe(false);
+    expect(config.dangerouslySkipPermissions).toBe(true);
+    expect(config.timeoutSec).toBe(0);
+    expect(config.graceSec).toBe(15);
+  });
+
+  it("populates Antigravity-specific options when provided", () => {
+    const config = buildAntigravityLocalConfig({
+      adapterType: "antigravity_local",
+      command: "custom-agy",
+      model: "claude-sonnet-4-6",
+      antigravityAgent: "researcher",
+      antigravityEffort: "high",
+      antigravitySandbox: true,
+      antigravityDangerouslySkipPermissions: false,
+      antigravityPrintTimeout: "10m0s",
+      extraArgs: "--log-file,custom.log",
+      cwd: "/my/project",
+      instructionsFilePath: "/my/AGENTS.md",
+    } as any);
+
+    expect(config.command).toBe("custom-agy");
+    expect(config.model).toBe("claude-sonnet-4-6");
+    expect(config.agent).toBe("researcher");
+    expect(config.effort).toBe("high");
+    expect(config.sandbox).toBe(true);
+    expect(config.dangerouslySkipPermissions).toBe(false);
+    expect(config.printTimeout).toBe("10m0s");
+    expect(config.extraArgs).toEqual(["--log-file", "custom.log"]);
+    expect(config.cwd).toBe("/my/project");
+    expect(config.instructionsFilePath).toBe("/my/AGENTS.md");
+  });
+});

--- a/packages/adapters/antigravity-local/src/ui/build-config.test.ts
+++ b/packages/adapters/antigravity-local/src/ui/build-config.test.ts
@@ -1,20 +1,35 @@
 // Unit tests for Antigravity local UI build-config
 
 import { describe, expect, it } from "vitest";
-import { buildAntigravityLocalConfig } from "./build-config.js";
+import type { CreateConfigValues } from "@paperclipai/adapter-utils";
 import { DEFAULT_ANTIGRAVITY_LOCAL_MODEL } from "../index.js";
+import { buildAntigravityLocalConfig } from "./build-config.js";
 
 describe("buildAntigravityLocalConfig", () => {
-  it("builds config with defaults", () => {
+  it("builds config with defaults (dangerouslySkipPermissions is false)", () => {
     const config = buildAntigravityLocalConfig({
       adapterType: "antigravity_local",
-    } as any);
+    } as unknown as CreateConfigValues);
 
     expect(config.model).toBe(DEFAULT_ANTIGRAVITY_LOCAL_MODEL);
     expect(config.sandbox).toBe(false);
-    expect(config.dangerouslySkipPermissions).toBe(true);
+    expect(config.dangerouslySkipPermissions).toBe(false);
     expect(config.timeoutSec).toBe(0);
     expect(config.graceSec).toBe(15);
+  });
+
+  it("enables dangerouslySkipPermissions only when explicitly true", () => {
+    const enabledConfig = buildAntigravityLocalConfig({
+      adapterType: "antigravity_local",
+      dangerouslySkipPermissions: true,
+    } as unknown as CreateConfigValues);
+    expect(enabledConfig.dangerouslySkipPermissions).toBe(true);
+
+    const disabledConfig = buildAntigravityLocalConfig({
+      adapterType: "antigravity_local",
+      dangerouslySkipPermissions: false,
+    } as unknown as CreateConfigValues);
+    expect(disabledConfig.dangerouslySkipPermissions).toBe(false);
   });
 
   it("populates Antigravity-specific options when provided", () => {
@@ -25,22 +40,36 @@ describe("buildAntigravityLocalConfig", () => {
       antigravityAgent: "researcher",
       antigravityEffort: "high",
       antigravitySandbox: true,
-      antigravityDangerouslySkipPermissions: false,
+      antigravityDangerouslySkipPermissions: true,
       antigravityPrintTimeout: "10m0s",
       extraArgs: "--log-file,custom.log",
       cwd: "/my/project",
       instructionsFilePath: "/my/AGENTS.md",
-    } as any);
+    } as unknown as CreateConfigValues);
 
     expect(config.command).toBe("custom-agy");
     expect(config.model).toBe("claude-sonnet-4-6");
     expect(config.agent).toBe("researcher");
     expect(config.effort).toBe("high");
     expect(config.sandbox).toBe(true);
-    expect(config.dangerouslySkipPermissions).toBe(false);
+    expect(config.dangerouslySkipPermissions).toBe(true);
     expect(config.printTimeout).toBe("10m0s");
     expect(config.extraArgs).toEqual(["--log-file", "custom.log"]);
     expect(config.cwd).toBe("/my/project");
     expect(config.instructionsFilePath).toBe("/my/AGENTS.md");
+  });
+
+  it("parses extraArgs from array or whitespace-separated string", () => {
+    const fromArray = buildAntigravityLocalConfig({
+      adapterType: "antigravity_local",
+      extraArgs: ["--flag1", "--flag2"],
+    } as unknown as CreateConfigValues);
+    expect(fromArray.extraArgs).toEqual(["--flag1", "--flag2"]);
+
+    const fromSpaceString = buildAntigravityLocalConfig({
+      adapterType: "antigravity_local",
+      extraArgs: "--verbose --debug",
+    } as unknown as CreateConfigValues);
+    expect(fromSpaceString.extraArgs).toEqual(["--verbose", "--debug"]);
   });
 });

--- a/packages/adapters/antigravity-local/src/ui/build-config.ts
+++ b/packages/adapters/antigravity-local/src/ui/build-config.ts
@@ -1,0 +1,43 @@
+// UI configuration builder for Antigravity local adapter
+
+import { buildAdapterEnvConfig, type CreateConfigValues } from "@paperclipai/adapter-utils";
+import { DEFAULT_ANTIGRAVITY_LOCAL_MODEL } from "../index.js";
+
+// Parses comma-separated arguments string into trimmed array
+function parseCommaArgs(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+// Builds the persistent adapterConfig record from create/edit form values
+export function buildAntigravityLocalConfig(v: CreateConfigValues): Record<string, unknown> {
+  const ac: Record<string, unknown> = {};
+
+  if (v.command) ac.command = v.command;
+  if (v.cwd) ac.cwd = v.cwd;
+  if (v.instructionsFilePath) ac.instructionsFilePath = v.instructionsFilePath;
+
+  ac.model = v.model || DEFAULT_ANTIGRAVITY_LOCAL_MODEL;
+  if (v.antigravityAgent) ac.agent = v.antigravityAgent;
+  const effort = v.antigravityEffort || v.thinkingEffort;
+  if (effort) ac.effort = effort;
+  if (v.antigravityPrintTimeout) ac.printTimeout = v.antigravityPrintTimeout;
+
+  ac.sandbox = Boolean(v.antigravitySandbox);
+  const skipPerms = (v as unknown as Record<string, unknown>).antigravityDangerouslySkipPermissions ?? v.dangerouslySkipPermissions;
+  ac.dangerouslySkipPermissions = skipPerms !== false;
+
+  ac.timeoutSec = 0;
+  ac.graceSec = 15;
+
+  const env = buildAdapterEnvConfig(v.envBindings, v.envVars);
+  if (Object.keys(env).length > 0) ac.env = env;
+
+  if (v.extraArgs) {
+    ac.extraArgs = typeof v.extraArgs === "string" ? parseCommaArgs(v.extraArgs) : v.extraArgs;
+  }
+
+  return ac;
+}

--- a/packages/adapters/antigravity-local/src/ui/build-config.ts
+++ b/packages/adapters/antigravity-local/src/ui/build-config.ts
@@ -3,10 +3,12 @@
 import { buildAdapterEnvConfig, type CreateConfigValues } from "@paperclipai/adapter-utils";
 import { DEFAULT_ANTIGRAVITY_LOCAL_MODEL } from "../index.js";
 
-// Parses comma-separated arguments string into trimmed array
-function parseCommaArgs(value: string): string[] {
-  return value
-    .split(",")
+// Parses comma or whitespace-separated arguments string into trimmed array
+function parseArgs(value: string): string[] {
+  const trimmed = value.trim();
+  const delimiter = trimmed.includes(",") ? "," : /\s+/;
+  return trimmed
+    .split(delimiter)
     .map((item) => item.trim())
     .filter(Boolean);
 }
@@ -27,7 +29,7 @@ export function buildAntigravityLocalConfig(v: CreateConfigValues): Record<strin
 
   ac.sandbox = Boolean(v.antigravitySandbox);
   const skipPerms = (v as unknown as Record<string, unknown>).antigravityDangerouslySkipPermissions ?? v.dangerouslySkipPermissions;
-  ac.dangerouslySkipPermissions = skipPerms !== false;
+  ac.dangerouslySkipPermissions = skipPerms === true;
 
   ac.timeoutSec = 0;
   ac.graceSec = 15;
@@ -36,7 +38,7 @@ export function buildAntigravityLocalConfig(v: CreateConfigValues): Record<strin
   if (Object.keys(env).length > 0) ac.env = env;
 
   if (v.extraArgs) {
-    ac.extraArgs = typeof v.extraArgs === "string" ? parseCommaArgs(v.extraArgs) : v.extraArgs;
+    ac.extraArgs = typeof v.extraArgs === "string" ? parseArgs(v.extraArgs) : v.extraArgs;
   }
 
   return ac;

--- a/packages/adapters/antigravity-local/src/ui/index.ts
+++ b/packages/adapters/antigravity-local/src/ui/index.ts
@@ -1,0 +1,4 @@
+// UI exports for @paperclipai/adapter-antigravity-local
+
+export { buildAntigravityLocalConfig } from "./build-config.js";
+export { parseAntigravityStdoutLine } from "./parse-stdout.js";

--- a/packages/adapters/antigravity-local/src/ui/parse-stdout.test.ts
+++ b/packages/adapters/antigravity-local/src/ui/parse-stdout.test.ts
@@ -1,0 +1,73 @@
+// Unit tests for Antigravity UI parse-stdout
+
+import { describe, expect, it } from "vitest";
+import { parseAntigravityStdoutLine } from "./parse-stdout.js";
+
+describe("parseAntigravityStdoutLine", () => {
+  const ts = "2026-09-06T12:00:00.000Z";
+
+  it("parses init event", () => {
+    const line = JSON.stringify({
+      event: "init",
+      conversation_id: "conv-1",
+      model: "gemini-3.8-flash-high",
+    });
+    const entries = parseAntigravityStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toEqual({
+      kind: "init",
+      ts,
+      model: "gemini-3.8-flash-high",
+      sessionId: "conv-1",
+    });
+  });
+
+  it("parses step_update agent_response delta", () => {
+    const line = JSON.stringify({
+      event: "step_update",
+      step_update: {
+        step_type: "agent_response",
+        text_delta: "working on it...",
+      },
+    });
+    const entries = parseAntigravityStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toEqual({
+      kind: "assistant",
+      ts,
+      text: "working on it...",
+    });
+  });
+
+  it("parses result event with usage", () => {
+    const line = JSON.stringify({
+      event: "result",
+      result: {
+        status: "SUCCESS",
+        response: "Finished!",
+        usage: {
+          input_tokens: 150,
+          output_tokens: 45,
+          cache_read_tokens: 20,
+        },
+      },
+    });
+    const entries = parseAntigravityStdoutLine(line, ts);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      kind: "result",
+      ts,
+      text: "Finished!",
+      inputTokens: 150,
+      outputTokens: 45,
+      cachedTokens: 20,
+      isError: false,
+    });
+  });
+
+  it("passes raw non-JSON text through as stdout entry", () => {
+    const raw = "plain debug log";
+    const entries = parseAntigravityStdoutLine(raw, ts);
+    expect(entries).toEqual([{ kind: "stdout", ts, text: raw }]);
+  });
+});

--- a/packages/adapters/antigravity-local/src/ui/parse-stdout.ts
+++ b/packages/adapters/antigravity-local/src/ui/parse-stdout.ts
@@ -1,0 +1,156 @@
+// Browser-side stdout stream parser for Antigravity transcript rendering in Paperclip
+
+import type { TranscriptEntry } from "@paperclipai/adapter-utils";
+
+// Safely attempts JSON parse, returning null on error
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+// Asserts value is a record object
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+// Safely coerces value to string with fallback
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+// Safely coerces value to finite number with fallback
+function asNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+// Serializes unknown value to formatted string
+function stringifyUnknown(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return "";
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+// Extracts error message string from unknown payload
+function errorText(value: unknown): string {
+  if (typeof value === "string") return value.trim();
+  const rec = asRecord(value);
+  if (!rec) return "";
+  const msg =
+    (typeof rec.message === "string" && rec.message) ||
+    (typeof rec.error === "string" && rec.error) ||
+    (typeof rec.code === "string" && rec.code) ||
+    "";
+  if (msg) return msg.trim();
+  try {
+    return JSON.stringify(rec);
+  } catch {
+    return "";
+  }
+}
+
+// Extracts session ID from an Antigravity event payload
+function readSessionId(parsed: Record<string, unknown>): string {
+  return (
+    asString(parsed.conversation_id) ||
+    asString(parsed.conversationId) ||
+    asString(parsed.session_id) ||
+    asString(parsed.sessionId)
+  );
+}
+
+// Parses an Antigravity stdout line into transcript entries for UI display
+export function parseAntigravityStdoutLine(line: string, ts: string): TranscriptEntry[] {
+  const parsed = asRecord(safeJsonParse(line));
+  if (!parsed) {
+    return [{ kind: "stdout", ts, text: line }];
+  }
+
+  const eventName = asString(parsed.event, asString(parsed.type)).trim().toLowerCase();
+
+  // Handle initialization event
+  if (eventName === "init") {
+    const sessionId = readSessionId(parsed);
+    const model = asString(parsed.model, "antigravity");
+    return [{ kind: "init", ts, model, sessionId: sessionId || "" }];
+  }
+
+  // Handle turn step updates
+  if (eventName === "step_update") {
+    const step = asRecord(parsed.step_update) ?? asRecord(parsed.step) ?? parsed;
+    const stepType = asString(step.step_type ?? step.type).trim().toLowerCase();
+
+    if (stepType === "agent_response" || stepType === "planner_response") {
+      const text = asString(step.text_delta ?? step.content ?? step.text);
+      if (text) return [{ kind: "assistant", ts, text }];
+      return [];
+    }
+
+    if (stepType === "thinking") {
+      const text = asString(step.thinking ?? step.text ?? step.content);
+      if (text) return [{ kind: "thinking", ts, text }];
+      return [];
+    }
+
+    if (stepType === "tool_call") {
+      const name = asString(step.tool_name ?? step.name, "tool");
+      return [{
+        kind: "tool_call",
+        ts,
+        name,
+        input: step.input ?? step.arguments ?? step.args ?? {},
+      }];
+    }
+
+    if (stepType === "tool_result") {
+      const isError = step.is_error === true || asString(step.status).toLowerCase() === "error";
+      const content = asString(step.output ?? step.result, stringifyUnknown(step.output ?? step.result));
+      return [{
+        kind: "tool_result",
+        ts,
+        toolUseId: asString(step.call_id ?? step.id, "tool_result"),
+        content,
+        isError,
+      }];
+    }
+
+    return [];
+  }
+
+  // Handle final result event
+  if (eventName === "result") {
+    const res = asRecord(parsed.result) ?? parsed;
+    const status = asString(res.status).toLowerCase();
+    const isError = status === "error" || status === "failure" || res.is_error === true;
+    const err = isError ? [errorText(res.error ?? res.message ?? res.response)].filter(Boolean) : [];
+    const usage = asRecord(res.usage) ?? {};
+
+    return [{
+      kind: "result",
+      ts,
+      text: asString(res.response),
+      inputTokens: asNumber(usage.input_tokens, asNumber(usage.inputTokens)),
+      outputTokens: asNumber(usage.output_tokens, asNumber(usage.outputTokens)),
+      cachedTokens: asNumber(usage.cache_read_tokens, asNumber(usage.cachedTokens)),
+      costUsd: asNumber(res.cost_usd, asNumber(res.total_cost_usd)),
+      subtype: status || "result",
+      isError,
+      errors: err,
+    }];
+  }
+
+  // Handle error event
+  if (eventName === "error") {
+    const text = errorText(parsed.error ?? parsed.message ?? parsed.detail);
+    return [{ kind: "stderr", ts, text: text || "error" }];
+  }
+
+  return [{ kind: "stdout", ts, text: line }];
+}

--- a/packages/adapters/antigravity-local/tsconfig.json
+++ b/packages/adapters/antigravity-local/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/adapters/antigravity-local/vitest.config.ts
+++ b/packages/adapters/antigravity-local/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -32,6 +32,7 @@ export const AGENT_ADAPTER_TYPES = [
   "paperclip_runner",
   "cursor_cloud",
   "gemini_local",
+  "antigravity_local",
   "grok_local",
   "hermes_gateway",
   "hermes_local",

--- a/packages/shared/src/environment-support.ts
+++ b/packages/shared/src/environment-support.ts
@@ -70,6 +70,7 @@ const REMOTE_MANAGED_ADAPTERS = new Set<AgentAdapterType>([
   "paperclip_runner",
   "cursor",
   "gemini_local",
+  "antigravity_local",
   "grok_local",
   "kimi_local",
   "opencode_local",

--- a/scripts/release-package-manifest.json
+++ b/scripts/release-package-manifest.json
@@ -30,6 +30,11 @@
     "publishFromCi": true
   },
   {
+    "dir": "packages/adapters/antigravity-local",
+    "name": "@paperclipai/adapter-antigravity-local",
+    "publishFromCi": true
+  },
+  {
     "dir": "packages/adapters/grok-local",
     "name": "@paperclipai/adapter-grok-local",
     "publishFromCi": true

--- a/server/package.json
+++ b/server/package.json
@@ -50,6 +50,7 @@
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-cloud": "workspace:*",
     "@paperclipai/adapter-cursor-local": "workspace:*",
+    "@paperclipai/adapter-antigravity-local": "workspace:*",
     "@paperclipai/adapter-gemini-local": "workspace:*",
     "@paperclipai/adapter-grok-local": "workspace:*",
     "@paperclipai/adapter-kimi-local": "workspace:*",

--- a/server/src/__tests__/adapter-session-codecs.test.ts
+++ b/server/src/__tests__/adapter-session-codecs.test.ts
@@ -343,6 +343,40 @@ describe("gemini resume recovery detection", () => {
   });
 });
 
+describe("antigravity session codec", () => {
+  it("normalizes antigravity session params with cwd, repo details, and remote execution", () => {
+    const parsed = antigravitySessionCodec.deserialize({
+      conversation_id: "agy-conv-777",
+      folder: "/tmp/workspace",
+      workspace_id: "ws-1",
+      repo_url: "https://github.com/example/repo",
+      repo_ref: "feat/test",
+      remoteExecution: {
+        environmentId: "env-1",
+        leaseId: "lease-1",
+        host: "remote-host",
+      },
+    });
+
+    expect(parsed).toEqual({
+      sessionId: "agy-conv-777",
+      cwd: "/tmp/workspace",
+      workspaceId: "ws-1",
+      repoUrl: "https://github.com/example/repo",
+      repoRef: "feat/test",
+      remoteExecution: {
+        environmentId: "env-1",
+        leaseId: "lease-1",
+        host: "remote-host",
+      },
+    });
+
+    const serialized = antigravitySessionCodec.serialize(parsed);
+    expect(serialized).toEqual(parsed);
+    expect(antigravitySessionCodec.getDisplayId?.(serialized ?? null)).toBe("agy-conv-777");
+  });
+});
+
 describe("antigravity resume recovery detection", () => {
   it("detects unknown conversation errors from antigravity output", () => {
     expect(

--- a/server/src/__tests__/adapter-session-codecs.test.ts
+++ b/server/src/__tests__/adapter-session-codecs.test.ts
@@ -13,6 +13,10 @@ import {
   sessionCodec as opencodeSessionCodec,
   isOpenCodeUnknownSessionError,
 } from "@paperclipai/adapter-opencode-local/server";
+import {
+  sessionCodec as antigravitySessionCodec,
+  isAntigravitySessionUnrecoverableError,
+} from "@paperclipai/adapter-antigravity-local/server";
 import { sessionCodec as acpxSessionCodec } from "@paperclipai/adapter-utils/acpx-engine/session-codec";
 
 describe("adapter session codecs", () => {
@@ -161,6 +165,24 @@ describe("adapter session codecs", () => {
       cwd: "/tmp/gemini",
     });
     expect(geminiSessionCodec.getDisplayId?.(serialized ?? null)).toBe("gemini-session-1");
+  });
+
+  it("normalizes antigravity session params with cwd", () => {
+    const parsed = antigravitySessionCodec.deserialize({
+      conversation_id: "conv-123",
+      cwd: "/tmp/antigravity",
+    });
+    expect(parsed).toEqual({
+      sessionId: "conv-123",
+      cwd: "/tmp/antigravity",
+    });
+
+    const serialized = antigravitySessionCodec.serialize(parsed);
+    expect(serialized).toEqual({
+      sessionId: "conv-123",
+      cwd: "/tmp/antigravity",
+    });
+    expect(antigravitySessionCodec.getDisplayId?.(serialized ?? null)).toBe("conv-123");
   });
 
   it("preserves gemini ACP session params for ACP lane resumes", () => {
@@ -315,6 +337,29 @@ describe("gemini resume recovery detection", () => {
     expect(
       isGeminiSessionUnrecoverableError(
         "{\"type\":\"result\",\"subtype\":\"success\"}",
+        "",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("antigravity resume recovery detection", () => {
+  it("detects unknown conversation errors from antigravity output", () => {
+    expect(
+      isAntigravitySessionUnrecoverableError(
+        'warning: conversation "c1" not found',
+        "",
+      ),
+    ).toBe(true);
+    expect(
+      isAntigravitySessionUnrecoverableError(
+        "",
+        "Error: conversation c1 not found",
+      ),
+    ).toBe(true);
+    expect(
+      isAntigravitySessionUnrecoverableError(
+        '{"event":"result"}',
         "",
       ),
     ).toBe(false);

--- a/server/src/__tests__/antigravity-local-adapter-environment.test.ts
+++ b/server/src/__tests__/antigravity-local-adapter-environment.test.ts
@@ -91,10 +91,54 @@ describe("antigravity_local environment diagnostics", () => {
     expect(result.status).not.toBe("fail");
     expect(result.checks.some((check) => check.code === "antigravity_cli_ready")).toBe(true);
     const args = JSON.parse(await fs.readFile(argsCapturePath, "utf8")) as string[];
-    expect(args).toContain("--help");
+    expect(args).toContain("--print");
+    expect(args).toContain("--output-format");
+    expect(args).toContain("stream-json");
+    expect(args).not.toContain("--help");
     expect(args).not.toContain("--approval-mode");
     expect(args).not.toContain("yolo");
 
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("detects authentication requirements when probe encounters login requirement", async () => {
+    const root = path.join(
+      os.tmpdir(),
+      `paperclip-antigravity-local-auth-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    );
+    const binDir = path.join(root, "bin");
+    const cwd = path.join(root, "workspace");
+    await fs.mkdir(binDir, { recursive: true });
+
+    const isWindows = process.platform === "win32";
+    const commandPath = path.join(binDir, "agy");
+    const jsPath = isWindows ? commandPath + ".js" : commandPath;
+    const script = `#!/usr/bin/env node
+console.error("Error: Not authenticated. Please run 'agy login' to authenticate.");
+process.exit(1);
+`;
+    await fs.writeFile(jsPath, script, "utf8");
+    if (isWindows) {
+      const cmdPath = commandPath + ".cmd";
+      const cmdScript = `@echo off\r\n"${process.execPath}" "${jsPath}" %*\r\n`;
+      await fs.writeFile(cmdPath, cmdScript, "utf8");
+    } else {
+      await fs.chmod(commandPath, 0o755);
+    }
+
+    const result = await testEnvironment({
+      companyId: "company-1",
+      adapterType: "antigravity_local",
+      config: {
+        command: "agy",
+        cwd,
+        env: {
+          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        },
+      },
+    });
+
+    expect(result.checks.some((check) => check.code === "antigravity_auth_required")).toBe(true);
     await fs.rm(root, { recursive: true, force: true });
   });
 });

--- a/server/src/__tests__/antigravity-local-adapter-environment.test.ts
+++ b/server/src/__tests__/antigravity-local-adapter-environment.test.ts
@@ -1,0 +1,100 @@
+// Diagnostics environment tests for Antigravity local adapter
+import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { testEnvironment } from "@paperclipai/adapter-antigravity-local/server";
+
+async function writeFakeAgyCommand(binDir: string, argsCapturePath: string): Promise<string> {
+  const isWindows = process.platform === "win32";
+  const commandPath = path.join(binDir, "agy");
+  const jsPath = isWindows ? commandPath + ".js" : commandPath;
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+const outPath = process.env.PAPERCLIP_TEST_ARGS_PATH;
+if (outPath) {
+  fs.writeFileSync(outPath, JSON.stringify(process.argv.slice(2)), "utf8");
+}
+console.log(JSON.stringify({
+  event: "init",
+  conversation_id: "test-probe-1",
+}));
+console.log(JSON.stringify({
+  event: "result",
+  result: {
+    status: "SUCCESS",
+    response: "hello",
+  },
+}));
+`;
+  await fs.writeFile(jsPath, script, "utf8");
+  if (isWindows) {
+    const cmdPath = commandPath + ".cmd";
+    const cmdScript = `@echo off\r\n"${process.execPath}" "${jsPath}" %*\r\n`;
+    await fs.writeFile(cmdPath, cmdScript, "utf8");
+    return cmdPath;
+  }
+  await fs.chmod(commandPath, 0o755);
+  return commandPath;
+}
+
+describe("antigravity_local environment diagnostics", () => {
+  it("creates a missing working directory when cwd is absolute", async () => {
+    const cwd = path.join(
+      os.tmpdir(),
+      `paperclip-antigravity-local-cwd-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      "workspace",
+    );
+
+    await fs.rm(path.dirname(cwd), { recursive: true, force: true });
+
+    const result = await testEnvironment({
+      companyId: "company-1",
+      adapterType: "antigravity_local",
+      config: {
+        command: process.execPath,
+        cwd,
+      },
+    });
+
+    expect(result.checks.some((check) => check.code === "antigravity_cwd_valid")).toBe(true);
+    expect(result.checks.some((check) => check.level === "error")).toBe(false);
+    const stats = await fs.stat(cwd);
+    expect(stats.isDirectory()).toBe(true);
+    await fs.rm(path.dirname(cwd), { recursive: true, force: true });
+  });
+
+  it("runs the readiness probe and reports ready", async () => {
+    const root = path.join(
+      os.tmpdir(),
+      `paperclip-antigravity-local-probe-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    );
+    const binDir = path.join(root, "bin");
+    const cwd = path.join(root, "workspace");
+    const argsCapturePath = path.join(root, "args.json");
+    await fs.mkdir(binDir, { recursive: true });
+    await writeFakeAgyCommand(binDir, argsCapturePath);
+
+    const result = await testEnvironment({
+      companyId: "company-1",
+      adapterType: "antigravity_local",
+      config: {
+        command: "agy",
+        cwd,
+        env: {
+          PAPERCLIP_TEST_ARGS_PATH: argsCapturePath,
+          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+        },
+      },
+    });
+
+    expect(result.status).not.toBe("fail");
+    expect(result.checks.some((check) => check.code === "antigravity_cli_ready")).toBe(true);
+    const args = JSON.parse(await fs.readFile(argsCapturePath, "utf8")) as string[];
+    expect(args).toContain("--help");
+    expect(args).not.toContain("--approval-mode");
+    expect(args).not.toContain("yolo");
+
+    await fs.rm(root, { recursive: true, force: true });
+  });
+});

--- a/server/src/__tests__/antigravity-local-adapter.test.ts
+++ b/server/src/__tests__/antigravity-local-adapter.test.ts
@@ -1,0 +1,210 @@
+// Tests for Antigravity local adapter parser, error detection, UI parser, and CLI formatter
+import { describe, expect, it, vi } from "vitest";
+import {
+  isAntigravitySessionUnrecoverableError,
+  isAntigravityAuthError,
+  parseAntigravityJsonl,
+} from "@paperclipai/adapter-antigravity-local/server";
+import { parseAntigravityStdoutLine } from "@paperclipai/adapter-antigravity-local/ui";
+import { printAntigravityStreamEvent } from "@paperclipai/adapter-antigravity-local/cli";
+
+describe("antigravity_local parser", () => {
+  it("extracts session, summary, usage, and cost from stream-json output", () => {
+    const stdout = [
+      JSON.stringify({ event: "init", conversation_id: "agy-conv-123" }),
+      JSON.stringify({
+        event: "step_update",
+        step: {
+          index: 0,
+          type: "PLANNER_RESPONSE",
+          content: "Starting task analysis.",
+        },
+      }),
+      JSON.stringify({
+        event: "result",
+        result: {
+          status: "SUCCESS",
+          response: "Task completed successfully.",
+          usage: {
+            input_tokens: 150,
+            output_tokens: 45,
+          },
+          cost_usd: 0.0025,
+        },
+      }),
+    ].join("\n");
+
+    const parsed = parseAntigravityJsonl(stdout);
+    expect(parsed.sessionId).toBe("agy-conv-123");
+    expect(parsed.summary).toBe("Task completed successfully.");
+    expect(parsed.usage).toMatchObject({
+      inputTokens: 150,
+      outputTokens: 45,
+    });
+    expect(parsed.costUsd).toBeCloseTo(0.0025, 6);
+  });
+
+  it("handles error events and extracts error message", () => {
+    const stdout = [
+      JSON.stringify({ event: "init", conversation_id: "agy-conv-err" }),
+      JSON.stringify({
+        event: "error",
+        message: "Model quota exceeded",
+      }),
+    ].join("\n");
+
+    const parsed = parseAntigravityJsonl(stdout);
+    expect(parsed.sessionId).toBe("agy-conv-err");
+    expect(parsed.errorMessage).toBe("Model quota exceeded");
+  });
+
+  it("handles non-JSON lines and warnings gracefully", () => {
+    const stdout = [
+      'warning: conversation "stale-1" not found, starting a new one',
+      JSON.stringify({ event: "init", conversation_id: "fresh-conv-1" }),
+      JSON.stringify({
+        event: "result",
+        result: {
+          status: "SUCCESS",
+          response: "All good.",
+        },
+      }),
+    ].join("\n");
+
+    const parsed = parseAntigravityJsonl(stdout);
+    expect(parsed.sessionId).toBe("fresh-conv-1");
+    expect(parsed.summary).toBe("All good.");
+  });
+});
+
+describe("antigravity_local session recovery detection", () => {
+  it("detects conversation not found in stdout and stderr", () => {
+    expect(isAntigravitySessionUnrecoverableError('warning: conversation "c-123" not found', "")).toBe(true);
+    expect(isAntigravitySessionUnrecoverableError("", "Error: conversation not found")).toBe(true);
+    expect(isAntigravitySessionUnrecoverableError('failed to resume session: stale session id', "")).toBe(true);
+    expect(isAntigravitySessionUnrecoverableError('{"event":"result"}', "")).toBe(false);
+  });
+});
+
+describe("antigravity_local auth error detection", () => {
+  it("detects authentication requirements in stdout and stderr", () => {
+    expect(isAntigravityAuthError("", "Please run 'agy auth login' to authenticate")).toBe(true);
+    expect(isAntigravityAuthError("Error: unauthorized access", "")).toBe(true);
+    expect(isAntigravityAuthError("not authenticated with provider", "")).toBe(true);
+    expect(isAntigravityAuthError("Regular message content", "")).toBe(false);
+  });
+});
+
+describe("antigravity_local ui stdout parser", () => {
+  it("parses init, step_update, result, and error events into TranscriptEntries", () => {
+    const ts = "2026-03-08T00:00:00.000Z";
+
+    const initEntries = parseAntigravityStdoutLine(
+      JSON.stringify({ event: "init", conversation_id: "conv-ui-1" }),
+      ts,
+    );
+    expect(initEntries[0]).toMatchObject({
+      kind: "init",
+      ts,
+      sessionId: "conv-ui-1",
+    });
+
+    const stepEntries = parseAntigravityStdoutLine(
+      JSON.stringify({
+        event: "step_update",
+        step: {
+          index: 0,
+          type: "PLANNER_RESPONSE",
+          content: "Analyzing workspace.",
+        },
+      }),
+      ts,
+    );
+    expect(stepEntries).toEqual([
+      { kind: "assistant", ts, text: "Analyzing workspace." },
+    ]);
+
+    const resultEntries = parseAntigravityStdoutLine(
+      JSON.stringify({
+        event: "result",
+        result: {
+          status: "SUCCESS",
+          response: "Work finished.",
+          usage: {
+            input_tokens: 100,
+            output_tokens: 20,
+          },
+          cost_usd: 0.001,
+        },
+      }),
+      ts,
+    );
+    expect(resultEntries[0]).toMatchObject({
+      kind: "result",
+      ts,
+      text: "Work finished.",
+      inputTokens: 100,
+      outputTokens: 20,
+      costUsd: 0.001,
+      subtype: "success",
+      isError: false,
+      errors: [],
+    });
+  });
+});
+
+function stripAnsi(value: string): string {
+  return value.replace(/\x1b\[[0-9;]*m/g, "");
+}
+
+describe("antigravity_local cli formatter", () => {
+  it("prints init, assistant steps, results, and errors", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    let joined = "";
+
+    try {
+      printAntigravityStreamEvent(
+        JSON.stringify({ event: "init", conversation_id: "conv-cli-1" }),
+        false,
+      );
+      printAntigravityStreamEvent(
+        JSON.stringify({
+          event: "step_update",
+          step: {
+            index: 0,
+            type: "PLANNER_RESPONSE",
+            content: "inspecting files",
+          },
+        }),
+        false,
+      );
+      printAntigravityStreamEvent(
+        JSON.stringify({
+          event: "result",
+          result: {
+            status: "SUCCESS",
+            response: "Done",
+            usage: {
+              input_tokens: 50,
+              output_tokens: 10,
+            },
+            cost_usd: 0.0005,
+          },
+        }),
+        false,
+      );
+      printAntigravityStreamEvent(
+        JSON.stringify({ event: "error", message: "command error" }),
+        false,
+      );
+      joined = spy.mock.calls.map((call) => stripAnsi(call.join(" "))).join("\n");
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(joined).toContain("Antigravity init (session: conv-cli-1)");
+    expect(joined).toContain("inspecting files");
+    expect(joined).toContain("tokens: in=50 out=10");
+    expect(joined).toContain("error: command error");
+  });
+});

--- a/server/src/__tests__/antigravity-local-execute.test.ts
+++ b/server/src/__tests__/antigravity-local-execute.test.ts
@@ -1,0 +1,300 @@
+// Execution tests for Antigravity local adapter verifying CLI arguments and session management
+import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { execute } from "@paperclipai/adapter-antigravity-local/server";
+
+// Writes a fake agy CLI script that records its invocation arguments and emits valid stream-json events
+async function writeFakeAgyCommand(commandPath: string): Promise<string> {
+  const isWindows = process.platform === "win32";
+  const jsPath = isWindows ? commandPath + ".js" : commandPath;
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+const payload = {
+  argv: process.argv.slice(2),
+  paperclipEnvKeys: Object.keys(process.env)
+    .filter((key) => key.startsWith("PAPERCLIP_"))
+    .sort(),
+};
+if (capturePath) {
+  fs.writeFileSync(capturePath, JSON.stringify(payload), "utf8");
+}
+console.log(JSON.stringify({
+  event: "init",
+  conversation_id: "agy-session-100",
+}));
+console.log(JSON.stringify({
+  event: "step_update",
+  step: {
+    index: 0,
+    type: "PLANNER_RESPONSE",
+    content: "hello from agy",
+  },
+}));
+console.log(JSON.stringify({
+  event: "result",
+  result: {
+    status: "SUCCESS",
+    response: "ok",
+    usage: { input_tokens: 10, output_tokens: 5 },
+    cost_usd: 0.0001,
+  },
+}));
+`;
+  await fs.writeFile(jsPath, script, "utf8");
+  if (isWindows) {
+    const cmdPath = commandPath + ".cmd";
+    const cmdScript = `@echo off\r\n"${process.execPath}" "${jsPath}" %*\r\n`;
+    await fs.writeFile(cmdPath, cmdScript, "utf8");
+    return cmdPath;
+  }
+  await fs.chmod(commandPath, 0o755);
+  return commandPath;
+}
+
+// Writes a fake agy CLI script that simulates an unrecoverable conversation warning
+async function writeStaleSessionAgyCommand(commandPath: string): Promise<string> {
+  const isWindows = process.platform === "win32";
+  const jsPath = isWindows ? commandPath + ".js" : commandPath;
+  const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+
+const capturePath = process.env.PAPERCLIP_TEST_CAPTURE_PATH;
+if (capturePath) {
+  const payload = { argv: process.argv.slice(2) };
+  fs.appendFileSync(capturePath, JSON.stringify(payload) + "\\n", "utf8");
+}
+
+const args = process.argv.slice(2);
+const convIndex = args.indexOf("--conversation");
+if (convIndex >= 0 && args[convIndex + 1] === "stale-session-id") {
+  console.log('warning: conversation "stale-session-id" not found, starting a new one');
+  process.stderr.write('Error: conversation "stale-session-id" not found\\n');
+  process.exit(1);
+}
+
+console.log(JSON.stringify({
+  event: "init",
+  conversation_id: "fresh-session-after-retry",
+}));
+console.log(JSON.stringify({
+  event: "result",
+  result: {
+    status: "SUCCESS",
+    response: "recovered",
+  },
+}));
+`;
+  await fs.writeFile(jsPath, script, "utf8");
+  if (isWindows) {
+    const cmdPath = commandPath + ".cmd";
+    const cmdScript = `@echo off\r\n"${process.execPath}" "${jsPath}" %*\r\n`;
+    await fs.writeFile(cmdPath, cmdScript, "utf8");
+    return cmdPath;
+  }
+  await fs.chmod(commandPath, 0o755);
+  return commandPath;
+}
+
+type CapturePayload = {
+  argv: string[];
+  paperclipEnvKeys: string[];
+};
+
+describe("antigravity execute", () => {
+  it.skipIf(process.platform === "win32")("passes Antigravity-native CLI arguments and never injects Gemini-specific flags", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-antigravity-execute-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "agy");
+    const capturePath = path.join(root, "capture.json");
+    await fs.mkdir(workspace, { recursive: true });
+    const binPath = await writeFakeAgyCommand(commandPath);
+
+    try {
+      const result = await execute({
+        runId: "run-agy-1",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Antigravity Agent",
+          adapterType: "antigravity_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: null,
+          sessionParams: null,
+          sessionDisplayId: null,
+          taskKey: null,
+        },
+        config: {
+          command: binPath,
+          cwd: workspace,
+          model: "gemini-3.8-flash-high",
+          effort: "high",
+          agent: "code-reviewer",
+          sandbox: true,
+          printTimeout: "15m",
+          dangerouslySkipPermissions: true,
+          extraArgs: ["--custom-flag", "value"],
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+          },
+          promptTemplate: "Do the heartbeat task.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.sessionId).toBe("agy-session-100");
+      expect(result.usage?.inputTokens).toBe(10);
+      expect(result.costUsd).toBeCloseTo(0.0001, 6);
+
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
+
+      // Positive assertions for Antigravity-native flags
+      expect(capture.argv).toContain("--print");
+      expect(capture.argv).toContain("--output-format");
+      expect(capture.argv).toContain("stream-json");
+      expect(capture.argv).toContain("--dangerously-skip-permissions");
+      expect(capture.argv).toContain("--model");
+      expect(capture.argv).toContain("gemini-3.8-flash-high");
+      expect(capture.argv).toContain("--effort");
+      expect(capture.argv).toContain("high");
+      expect(capture.argv).toContain("--agent");
+      expect(capture.argv).toContain("code-reviewer");
+      expect(capture.argv).toContain("--sandbox");
+      expect(capture.argv).toContain("--print-timeout");
+      expect(capture.argv).toContain("15m");
+      expect(capture.argv).toContain("--custom-flag");
+      expect(capture.argv).toContain("value");
+
+      // Critical negative assertions: Gemini flags MUST NOT be present
+      expect(capture.argv).not.toContain("--approval-mode");
+      expect(capture.argv).not.toContain("yolo");
+      expect(capture.argv).not.toContain("--sandbox=none");
+      expect(capture.argv).not.toContain("--resume");
+
+      // Verify Paperclip environment injection
+      expect(capture.paperclipEnvKeys).toEqual(
+        expect.arrayContaining([
+          "PAPERCLIP_AGENT_ID",
+          "PAPERCLIP_API_KEY",
+          "PAPERCLIP_API_URL",
+          "PAPERCLIP_COMPANY_ID",
+          "PAPERCLIP_RUN_ID",
+        ]),
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(process.platform === "win32")("resumes sessions using --conversation flag", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-antigravity-resume-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "agy");
+    const capturePath = path.join(root, "capture.json");
+    await fs.mkdir(workspace, { recursive: true });
+    const binPath = await writeFakeAgyCommand(commandPath);
+
+    try {
+      const result = await execute({
+        runId: "run-agy-2",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Antigravity Agent",
+          adapterType: "antigravity_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: "existing-conv-456",
+          sessionParams: { sessionId: "existing-conv-456", cwd: workspace },
+          sessionDisplayId: "existing-conv-456",
+          taskKey: null,
+        },
+        config: {
+          command: binPath,
+          cwd: workspace,
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+          },
+          promptTemplate: "Continue work.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+
+      const capture = JSON.parse(await fs.readFile(capturePath, "utf8")) as CapturePayload;
+      expect(capture.argv).toContain("--conversation");
+      expect(capture.argv).toContain("existing-conv-456");
+      expect(capture.argv).not.toContain("--resume");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it.skipIf(process.platform === "win32")("recovers automatically from stale or missing conversations by starting a fresh session", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-antigravity-recovery-"));
+    const workspace = path.join(root, "workspace");
+    const commandPath = path.join(root, "agy");
+    const capturePath = path.join(root, "capture.json");
+    await fs.mkdir(workspace, { recursive: true });
+    const binPath = await writeStaleSessionAgyCommand(commandPath);
+
+    try {
+      const result = await execute({
+        runId: "run-agy-retry",
+        agent: {
+          id: "agent-1",
+          companyId: "company-1",
+          name: "Antigravity Agent",
+          adapterType: "antigravity_local",
+          adapterConfig: {},
+        },
+        runtime: {
+          sessionId: "stale-session-id",
+          sessionParams: { sessionId: "stale-session-id", cwd: workspace },
+          sessionDisplayId: "stale-session-id",
+          taskKey: null,
+        },
+        config: {
+          command: binPath,
+          cwd: workspace,
+          env: {
+            PAPERCLIP_TEST_CAPTURE_PATH: capturePath,
+          },
+          promptTemplate: "Retry task.",
+        },
+        context: {},
+        authToken: "run-jwt-token",
+        onLog: async () => {},
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.sessionId).toBe("fresh-session-after-retry");
+
+      const captureLines = (await fs.readFile(capturePath, "utf8"))
+        .trim()
+        .split("\n")
+        .map((l) => JSON.parse(l));
+
+      expect(captureLines).toHaveLength(2);
+      // First attempt included stale conversation
+      expect(captureLines[0].argv).toContain("--conversation");
+      expect(captureLines[0].argv).toContain("stale-session-id");
+      // Second attempt retried cleanly without conversation
+      expect(captureLines[1].argv).not.toContain("--conversation");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/src/__tests__/antigravity-local-execute.test.ts
+++ b/server/src/__tests__/antigravity-local-execute.test.ts
@@ -177,7 +177,13 @@ describe("antigravity execute", () => {
       expect(capture.argv).not.toContain("--approval-mode");
       expect(capture.argv).not.toContain("yolo");
       expect(capture.argv).not.toContain("--sandbox=none");
-      expect(capture.argv).not.toContain("--resume");
+      // Verify prompt security: model prompt must NOT leak secret keys, tokens, or curl instructions
+      const printIndex = capture.argv.indexOf("--print");
+      const passedPrompt = capture.argv[printIndex + 1];
+      expect(passedPrompt).not.toContain("PAPERCLIP_API_KEY");
+      expect(passedPrompt).not.toContain("run-jwt-token");
+      expect(passedPrompt).not.toContain("Bearer");
+      expect(passedPrompt).not.toContain("curl");
 
       // Verify Paperclip environment injection
       expect(capture.paperclipEnvKeys).toEqual(

--- a/server/src/adapters/builtin-adapter-types.ts
+++ b/server/src/adapters/builtin-adapter-types.ts
@@ -9,6 +9,7 @@ export const BUILTIN_ADAPTER_TYPES = new Set([
   "cursor_cloud",
   "cursor",
   "gemini_local",
+  "antigravity_local",
   "grok_local",
   "hermes_gateway",
   "hermes_local",

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -59,6 +59,16 @@ import {
 } from "@paperclipai/adapter-cursor-cloud/server";
 import { agentConfigurationDoc as cursorCloudAgentConfigurationDoc } from "@paperclipai/adapter-cursor-cloud";
 import {
+  execute as antigravityExecute,
+  testEnvironment as antigravityTestEnvironment,
+  sessionCodec as antigravitySessionCodec,
+  getConfigSchema as getAntigravityConfigSchema,
+} from "@paperclipai/adapter-antigravity-local/server";
+import {
+  agentConfigurationDoc as antigravityAgentConfigurationDoc,
+  models as antigravityModels,
+} from "@paperclipai/adapter-antigravity-local";
+import {
   execute as geminiExecute,
   listGeminiSkills,
   syncGeminiSkills,
@@ -718,6 +728,27 @@ const geminiLocalAdapter: ServerAdapterModule = {
   getConfigSchema: getGeminiConfigSchema,
 };
 
+const antigravityLocalAdapter: ServerAdapterModule = {
+  type: "antigravity_local",
+  runtimeToolDelivery: "environment",
+  execute: antigravityExecute,
+  testEnvironment: antigravityTestEnvironment,
+  sessionCodec: antigravitySessionCodec,
+  sessionManagement: getAdapterSessionManagement("antigravity_local") ?? undefined,
+  models: antigravityModels,
+  supportsLocalAgentJwt: true,
+  supportsInstructionsBundle: true,
+  instructionsPathKey: "instructionsFilePath",
+  requiresMaterializedRuntimeSkills: false,
+  getRuntimeCommandSpec: (config) => ({
+    command: readConfiguredCommand(config, "agy"),
+    detectCommand: readConfiguredCommand(config, "agy"),
+    installCommand: null,
+  }),
+  agentConfigurationDoc: antigravityAgentConfigurationDoc,
+  getConfigSchema: getAntigravityConfigSchema,
+};
+
 const grokLocalAdapter: ServerAdapterModule = {
   type: "grok_local",
   runtimeToolDelivery: "environment",
@@ -851,6 +882,7 @@ function registerBuiltInAdapters() {
     cursorCloudAdapter,
     cursorLocalAdapter,
     geminiLocalAdapter,
+    antigravityLocalAdapter,
     grokLocalAdapter,
     kimiLocalAdapter,
     hermesGatewayAdapter,

--- a/ui/package.json
+++ b/ui/package.json
@@ -36,6 +36,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@lexical/link": "0.48.0",
     "@mdxeditor/editor": "^4.2.3",
+    "@paperclipai/adapter-antigravity-local": "workspace:*",
     "@paperclipai/adapter-claude-local": "workspace:*",
     "@paperclipai/adapter-codex-local": "workspace:*",
     "@paperclipai/adapter-cursor-cloud": "workspace:*",

--- a/ui/src/adapters/adapter-display-registry.ts
+++ b/ui/src/adapters/adapter-display-registry.ts
@@ -86,6 +86,11 @@ const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
     icon: Cpu,
     experimental: true,
   },
+  antigravity_local: {
+    label: "Antigravity CLI",
+    description: "Antigravity CLI harness",
+    icon: Sparkles,
+  },
   gemini_local: {
     label: "Gemini CLI",
     description: "Gemini CLI harness",

--- a/ui/src/adapters/antigravity-local/config-fields.tsx
+++ b/ui/src/adapters/antigravity-local/config-fields.tsx
@@ -1,0 +1,147 @@
+// Configuration fields for the Antigravity local adapter
+import type { AdapterConfigFieldsProps } from "../types";
+import {
+  DraftInput,
+  Field,
+  ToggleField,
+} from "../../components/agent-config-primitives";
+import { ChoosePathButton } from "../../components/PathInstructionsModal";
+
+const inputClass =
+  "w-full rounded-md border border-border px-2.5 py-1.5 bg-transparent outline-none text-sm font-mono placeholder:text-muted-foreground/40";
+const instructionsFileHint =
+  "Absolute path to a markdown file (e.g. AGENTS.md) that defines this agent's behavior. Prepended to the Antigravity prompt at runtime.";
+
+// Renders the Antigravity-specific configuration fields in the agent edit and create forms
+export function AntigravityLocalConfigFields({
+  isCreate,
+  values,
+  set,
+  config,
+  eff,
+  mark,
+  hideInstructionsFile,
+}: AdapterConfigFieldsProps) {
+  return (
+    <>
+      <ToggleField
+        label="Skip permissions"
+        hint="Passes --dangerously-skip-permissions to agy to allow autonomous execution without prompt gates."
+        checked={
+          isCreate
+            ? values!.dangerouslySkipPermissions !== false
+            : eff(
+                "adapterConfig",
+                "dangerouslySkipPermissions",
+                config.dangerouslySkipPermissions !== false,
+              )
+        }
+        onChange={(v) =>
+          isCreate
+            ? set!({ dangerouslySkipPermissions: v })
+            : mark("adapterConfig", "dangerouslySkipPermissions", v)
+        }
+      />
+      <ToggleField
+        label="Sandbox mode"
+        hint="Passes --sandbox to agy to run in a sandbox with terminal restrictions enabled."
+        checked={
+          isCreate
+            ? Boolean(values!.antigravitySandbox)
+            : eff("adapterConfig", "sandbox", Boolean(config.sandbox))
+        }
+        onChange={(v) =>
+          isCreate
+            ? set!({ antigravitySandbox: v })
+            : mark("adapterConfig", "sandbox", v)
+        }
+      />
+      <Field
+        label="Antigravity agent"
+        hint="Optional subagent or personality name passed via --agent (e.g. 'code-reviewer')."
+      >
+        <DraftInput
+          value={
+            isCreate
+              ? values!.antigravityAgent ?? ""
+              : eff("adapterConfig", "agent", String(config.agent ?? ""))
+          }
+          onCommit={(v) =>
+            isCreate
+              ? set!({ antigravityAgent: v })
+              : mark("adapterConfig", "agent", v || undefined)
+          }
+          immediate
+          className={inputClass}
+          placeholder="default"
+        />
+      </Field>
+      <Field
+        label="Print timeout"
+        hint="Timeout duration passed via --print-timeout (e.g. '30m', '1h')."
+      >
+        <DraftInput
+          value={
+            isCreate
+              ? values!.antigravityPrintTimeout ?? ""
+              : eff("adapterConfig", "printTimeout", String(config.printTimeout ?? ""))
+          }
+          onCommit={(v) =>
+            isCreate
+              ? set!({ antigravityPrintTimeout: v })
+              : mark("adapterConfig", "printTimeout", v || undefined)
+          }
+          immediate
+          className={inputClass}
+          placeholder="30m"
+        />
+      </Field>
+      <Field
+        label="Extra CLI arguments"
+        hint="Additional CLI flags or arguments appended to the agy invocation."
+      >
+        <DraftInput
+          value={
+            isCreate
+              ? values!.extraArgs ?? ""
+              : eff("adapterConfig", "extraArgs", Array.isArray(config.extraArgs) ? config.extraArgs.join(", ") : String(config.extraArgs ?? ""))
+          }
+          onCommit={(v) =>
+            isCreate
+              ? set!({ extraArgs: v })
+              : mark("adapterConfig", "extraArgs", v || undefined)
+          }
+          immediate
+          className={inputClass}
+          placeholder="--verbose"
+        />
+      </Field>
+      {!hideInstructionsFile && (
+        <Field label="Agent instructions file" hint={instructionsFileHint}>
+          <div className="flex items-center gap-2">
+            <DraftInput
+              value={
+                isCreate
+                  ? values!.instructionsFilePath ?? ""
+                  : eff(
+                      "adapterConfig",
+                      "instructionsFilePath",
+                      String(config.instructionsFilePath ?? ""),
+                    )
+              }
+              onCommit={(v) =>
+                isCreate
+                  ? set!({ instructionsFilePath: v })
+                  : mark("adapterConfig", "instructionsFilePath", v || undefined)
+              }
+              immediate
+              className={inputClass}
+              placeholder="/absolute/path/to/AGENTS.md"
+            />
+            <ChoosePathButton />
+          </div>
+        </Field>
+      )}
+    </>
+  );
+}

--- a/ui/src/adapters/antigravity-local/config-fields.tsx
+++ b/ui/src/adapters/antigravity-local/config-fields.tsx
@@ -26,14 +26,14 @@ export function AntigravityLocalConfigFields({
     <>
       <ToggleField
         label="Skip permissions"
-        hint="Passes --dangerously-skip-permissions to agy to allow autonomous execution without prompt gates."
+        hint="Passes --dangerously-skip-permissions to agy to auto-approve tool execution. Recommended only for trusted, sandboxed environments."
         checked={
           isCreate
-            ? values!.dangerouslySkipPermissions !== false
+            ? Boolean(values!.dangerouslySkipPermissions)
             : eff(
                 "adapterConfig",
                 "dangerouslySkipPermissions",
-                config.dangerouslySkipPermissions !== false,
+                Boolean(config.dangerouslySkipPermissions),
               )
         }
         onChange={(v) =>
@@ -104,13 +104,27 @@ export function AntigravityLocalConfigFields({
           value={
             isCreate
               ? values!.extraArgs ?? ""
-              : eff("adapterConfig", "extraArgs", Array.isArray(config.extraArgs) ? config.extraArgs.join(", ") : String(config.extraArgs ?? ""))
+              : eff(
+                  "adapterConfig",
+                  "extraArgs",
+                  Array.isArray(config.extraArgs)
+                    ? (config.extraArgs as string[]).join(", ")
+                    : String(config.extraArgs ?? ""),
+                )
           }
-          onCommit={(v) =>
-            isCreate
-              ? set!({ extraArgs: v })
-              : mark("adapterConfig", "extraArgs", v || undefined)
-          }
+          onCommit={(v) => {
+            if (isCreate) {
+              set!({ extraArgs: v });
+            } else {
+              const trimmed = v?.trim();
+              const parsed = trimmed
+                ? (trimmed.includes(",") ? trimmed.split(",") : trimmed.split(/\s+/))
+                    .map((s) => s.trim())
+                    .filter(Boolean)
+                : undefined;
+              mark("adapterConfig", "extraArgs", parsed && parsed.length > 0 ? parsed : undefined);
+            }
+          }}
           immediate
           className={inputClass}
           placeholder="--verbose"

--- a/ui/src/adapters/antigravity-local/index.ts
+++ b/ui/src/adapters/antigravity-local/index.ts
@@ -1,0 +1,13 @@
+// UI adapter module definition for Antigravity local
+import type { UIAdapterModule } from "../types";
+import { parseAntigravityStdoutLine, buildAntigravityLocalConfig } from "@paperclipai/adapter-antigravity-local/ui";
+import { AntigravityLocalConfigFields } from "./config-fields";
+
+// UI adapter descriptor for Antigravity CLI
+export const antigravityLocalUIAdapter: UIAdapterModule = {
+  type: "antigravity_local",
+  label: "Antigravity CLI",
+  parseStdoutLine: parseAntigravityStdoutLine,
+  ConfigFields: AntigravityLocalConfigFields,
+  buildAdapterConfig: buildAntigravityLocalConfig,
+};

--- a/ui/src/adapters/registry.ts
+++ b/ui/src/adapters/registry.ts
@@ -4,6 +4,7 @@ import { codexLocalUIAdapter } from "./codex-local";
 import { paperclipRunnerUIAdapter } from "./paperclip-runner";
 import { cursorCloudUIAdapter } from "./cursor-cloud";
 import { cursorLocalUIAdapter } from "./cursor";
+import { antigravityLocalUIAdapter } from "./antigravity-local";
 import { geminiLocalUIAdapter } from "./gemini-local";
 import { grokLocalUIAdapter } from "./grok-local";
 import { kimiLocalUIAdapter } from "./kimi-local";
@@ -58,6 +59,7 @@ function registerBuiltInUIAdapters() {
     codexLocalUIAdapter,
     paperclipRunnerUIAdapter,
     cursorCloudUIAdapter,
+    antigravityLocalUIAdapter,
     geminiLocalUIAdapter,
     grokLocalUIAdapter,
     kimiLocalUIAdapter,

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -23,6 +23,7 @@ import {
   DEFAULT_CODEX_LOCAL_MODEL,
 } from "@paperclipai/adapter-codex-local";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
+import { DEFAULT_ANTIGRAVITY_LOCAL_MODEL } from "@paperclipai/adapter-antigravity-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import { DEFAULT_KIMI_LOCAL_MODEL } from "@paperclipai/adapter-kimi-local";
 import { DEFAULT_OPENCODE_LOCAL_MODEL } from "@paperclipai/adapter-opencode-local";
@@ -1387,6 +1388,8 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                     if (t === "codex_local") {
                       nextValues.dangerouslyBypassSandbox =
                         DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX;
+                    } else if (t === "antigravity_local") {
+                      nextValues.model = DEFAULT_ANTIGRAVITY_LOCAL_MODEL;
                     } else if (t === "gemini_local") {
                       nextValues.model = DEFAULT_GEMINI_LOCAL_MODEL;
                     } else if (t === "kimi_local") {
@@ -1407,7 +1410,9 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                       adapterType: t,
                       adapterConfig: {
                         model:
-                          t === "gemini_local"
+                          t === "antigravity_local"
+                            ? DEFAULT_ANTIGRAVITY_LOCAL_MODEL
+                            : t === "gemini_local"
                             ? DEFAULT_GEMINI_LOCAL_MODEL
                             : t === "kimi_local"
                               ? DEFAULT_KIMI_LOCAL_MODEL
@@ -1545,6 +1550,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
                       ({
                         claude_local: "claude",
                         codex_local: "codex",
+                        antigravity_local: "agy",
                         gemini_local: "gemini",
                         kimi_local: "kimi",
                         pi_local: "pi",

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -98,6 +98,7 @@ import {
 import { buildNewAgentRuntimeConfig } from "../lib/new-agent-runtime-config";
 import { DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX } from "@paperclipai/adapter-codex-local";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
+import { DEFAULT_ANTIGRAVITY_LOCAL_MODEL } from "@paperclipai/adapter-antigravity-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import { DEFAULT_KIMI_LOCAL_MODEL } from "@paperclipai/adapter-kimi-local";
 import { DEFAULT_OPENCODE_LOCAL_MODEL, isValidOpenCodeModelId } from "@paperclipai/adapter-opencode-local";
@@ -1166,6 +1167,7 @@ function OnboardingWizardInner({
     isLocalAdapterCaps ||
     adapterType === "claude_local" ||
     adapterType === "codex_local" ||
+    adapterType === "antigravity_local" ||
     adapterType === "gemini_local" ||
     adapterType === "kimi_local" ||
     adapterType === "opencode_local" ||
@@ -1487,6 +1489,10 @@ function OnboardingWizardInner({
       setModel(DEFAULT_OPENCODE_LOCAL_MODEL);
       return;
     }
+    if (next === "antigravity_local") {
+      setModel(DEFAULT_ANTIGRAVITY_LOCAL_MODEL);
+      return;
+    }
     if (next === "gemini_local") {
       setModel(DEFAULT_GEMINI_LOCAL_MODEL);
       return;
@@ -1501,6 +1507,7 @@ function OnboardingWizardInner({
   const COMMAND_PLACEHOLDERS: Record<string, string> = {
     claude_local: "claude",
     codex_local: "codex",
+    antigravity_local: "agy",
     gemini_local: "gemini",
     kimi_local: "kimi",
     pi_local: "pi",
@@ -1832,8 +1839,10 @@ function OnboardingWizardInner({
       ...defaultCreateValues,
       adapterType,
       model:
-        adapterType === "gemini_local"
-          ? model || DEFAULT_GEMINI_LOCAL_MODEL
+        adapterType === "antigravity_local"
+          ? model || DEFAULT_ANTIGRAVITY_LOCAL_MODEL
+          : adapterType === "gemini_local"
+            ? model || DEFAULT_GEMINI_LOCAL_MODEL
           : adapterType === "kimi_local"
             ? model || DEFAULT_KIMI_LOCAL_MODEL
           : adapterType === "cursor"
@@ -3307,6 +3316,8 @@ function OnboardingWizardInner({
                               ? `${effectiveAdapterCommand} -p --mode ask --output-format json \"Respond with hello.\"`
                               : adapterType === "codex_local"
                               ? `${effectiveAdapterCommand} exec --json -`
+                              : adapterType === "antigravity_local"
+                                ? `${effectiveAdapterCommand} --print "Respond with hello." --output-format stream-json --dangerously-skip-permissions`
                               : adapterType === "gemini_local"
                                 ? `${effectiveAdapterCommand} --output-format json "Respond with hello."`
                               : adapterType === "kimi_local"
@@ -3321,26 +3332,33 @@ function OnboardingWizardInner({
                           </p>
                           {adapterType === "cursor" ||
                           adapterType === "codex_local" ||
+                          adapterType === "antigravity_local" ||
                           adapterType === "gemini_local" ||
                           adapterType === "kimi_local" ||
                           adapterType === "opencode_local" ? (
                             <p className="text-muted-foreground">
-                              If auth fails, set{" "}
-                              <span className="font-mono">
-                                {adapterType === "cursor"
-                                  ? "CURSOR_API_KEY"
-                                  : adapterType === "gemini_local"
-                                    ? "GEMINI_API_KEY"
-                                    : adapterType === "kimi_local"
-                                      ? "KIMI_MODEL_NAME + KIMI_MODEL_API_KEY"
-                                    : "OPENAI_API_KEY"}
-                              </span>{" "}
-                              in env or run{" "}
+                              If auth fails, {adapterType === "antigravity_local" ? "run" : "set"}{" "}
+                              {adapterType !== "antigravity_local" && (
+                                <>
+                                  <span className="font-mono">
+                                    {adapterType === "cursor"
+                                      ? "CURSOR_API_KEY"
+                                      : adapterType === "gemini_local"
+                                        ? "GEMINI_API_KEY"
+                                        : adapterType === "kimi_local"
+                                          ? "KIMI_MODEL_NAME + KIMI_MODEL_API_KEY"
+                                        : "OPENAI_API_KEY"}
+                                  </span>{" "}
+                                  in env or run{" "}
+                                </>
+                              )}
                               <span className="font-mono">
                                 {adapterType === "cursor"
                                   ? "agent login"
                                   : adapterType === "codex_local"
                                     ? "codex login"
+                                    : adapterType === "antigravity_local"
+                                      ? "agy login"
                                     : adapterType === "gemini_local"
                                       ? "gemini auth"
                                       : adapterType === "kimi_local"

--- a/ui/src/pages/NewAgent.tsx
+++ b/ui/src/pages/NewAgent.tsx
@@ -42,6 +42,7 @@ import { TrustPresetSection } from "../components/TrustPresetSection";
 import { buildPermissionsForTrustPreset, getTrustPreset } from "../lib/trust-policy-ui";
 import { DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX } from "@paperclipai/adapter-codex-local";
 import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
+import { DEFAULT_ANTIGRAVITY_LOCAL_MODEL } from "@paperclipai/adapter-antigravity-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import { DEFAULT_KIMI_LOCAL_MODEL } from "@paperclipai/adapter-kimi-local";
 import { DEFAULT_OPENCODE_LOCAL_MODEL, isValidOpenCodeModelId } from "@paperclipai/adapter-opencode-local";
@@ -54,6 +55,8 @@ function createValuesForAdapterType(
   if (adapterType === "codex_local") {
     nextValues.dangerouslyBypassSandbox =
       DEFAULT_CODEX_LOCAL_BYPASS_APPROVALS_AND_SANDBOX;
+  } else if (adapterType === "antigravity_local") {
+    nextValues.model = DEFAULT_ANTIGRAVITY_LOCAL_MODEL;
   } else if (adapterType === "gemini_local") {
     nextValues.model = DEFAULT_GEMINI_LOCAL_MODEL;
   } else if (adapterType === "kimi_local") {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
       "packages/skills-catalog",
       "packages/db",
       "packages/adapter-utils",
+      "packages/adapters/antigravity-local",
       "packages/adapters/claude-local",
       "packages/adapters/codex-local",
       "packages/adapters/cursor-cloud",


### PR DESCRIPTION
Implement native Antigravity CLI (agy) adapter support with dedicated CLI flag mappings (--print, --output-format stream-json, --dangerously-skip-permissions, --conversation, --model, --effort, --sandbox, --print-timeout, extraArgs), stream-json event parser, session management codecs, and UI configuration fields.

<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source control plane developers use to orchestrate and manage autonomous AI agents
> - Agent adapters bridge Paperclip's orchestration runtime to local or remote CLI tools
> - Developers using Antigravity CLI (`agy`) previously had no native adapter and attempting to run it through `gemini_local` failed due to injected Gemini-specific flags like `--approval-mode yolo`, `--sandbox=none`, and `--resume`
> - Antigravity is a standalone agent runtime requiring its own native CLI arguments (`--print`, `--output-format stream-json`, `--conversation`, `--effort`, `--agent`, `--sandbox`, etc.)
> - Code review feedback identified critical security improvements (defaulting permissions bypass to `false`, removing secret token names and privileged curl instructions from prompt templates), session lifecycle correctness (preserving `remoteExecution` identity across deserialization and preventing stale session IDs from rebinding across different workspaces), structured error handling (ensuring exitCode 0 with status ERROR/FAILURE reports as failure), UI flexibility (parsing `extraArgs` as arrays), and diagnostic probe verification (executing real headless turns)
> - This pull request implements the first-class `antigravity_local` adapter and resolves all code-review comments with comprehensive unit and integration tests

## Linked Issues or Issue Description

### Problem
Previously, attempting to run Antigravity CLI (`agy`) using the `gemini_local` adapter injected Google Gemini-specific CLI arguments (`--approval-mode yolo`, `--sandbox=none`, `--resume`, etc.) that are invalid for `agy` and resulted in process invocation failures. Furthermore, prompt injection previously leaked privileged API examples and bearer token references into model prompts.

### Solution
Implement a first-class native `antigravity_local` adapter across server, UI, CLI, and shared packages supporting `agy` CLI semantics:
- Non-interactive execution: `--print <prompt>`
- Streaming output format: `--output-format stream-json`
- Permission bypass: `--dangerously-skip-permissions` (strictly opt-in, defaulting to `false`)
- Session continuation: `--conversation <id>` with automatic recovery fallback on stale/missing sessions
- Reasoning effort: `--effort <low|medium|high>`
- Custom agent persona: `--agent <name>`
- Sandbox mode: `--sandbox`
- Print timeout: `--print-timeout <duration>`
- Custom extra CLI flags: `extraArgs` (array or comma/space-separated string)
- Secure prompts: Zero model-prompt token leakage; no curl commands or Authorization headers injected into prompts
- Correct session identity: Session serialization/deserialization preserves `remoteExecution` leases and prevents rebinding stale sessions across different working directories
- Comprehensive diagnostics: Environment probe executes headless `["--print", "Respond with OK.", "--output-format", "stream-json"]` to test end-to-end readiness and auth status

## What Changed

- **`@paperclipai/adapter-antigravity-local` Package**:
  - `src/server/execute.ts`:
    - Changed `dangerouslySkipPermissions` default from `true` to `false`.
    - Removed `renderApiAccessNote` completely; removed curl command examples and bearer token references from prompt.
    - Excluded `PAPERCLIP_API_KEY` from `renderPaperclipEnvNote`.
    - Added structured error handling: `status === "ERROR"` or `"FAILURE"` flags execution as failed and extracts error messages even if exit code is 0.
    - Guarded session fallback with `canFallbackToRuntimeSession = canResumeSession && !isRetry`, ensuring rejected old sessions are never rebound to a new workspace.
    - Enhanced `extraArgs` parsing to support arrays, comma-separated strings, and whitespace-delimited strings.
  - `src/server/index.ts`:
    - Updated `sessionCodec.deserialize` and `serialize` to preserve `remoteExecution` identity across heartbeats.
  - `src/server/parse.ts`:
    - Added fallback error message generation when `result.status` is ERROR or FAILURE without an explicit error string.
    - Enhanced `describeAntigravityFailure` formatting.
  - `src/server/test.ts`:
    - Upgraded `testEnvironment` probe from basic `--help` to live headless prompt execution: `["--print", "Respond with OK.", "--output-format", "stream-json"]`.
    - Added detection of authentication requirements (`antigravity_auth_required`).
  - `src/server/config-schema.ts`:
    - Changed `dangerouslySkipPermissions` default to `false` and updated warning hint.
  - `src/ui/build-config.ts`:
    - Changed `dangerouslySkipPermissions` default to `false`.
    - Enhanced `extraArgs` parsing to convert comma/space strings to trimmed arrays.
  - `src/server/execute.test.ts` (NEW):
    - Added 6 unit tests with mocked process runner testing default permission false, explicit permission true, prompt token sanitization, structured error handling, session rejection isolation, and extra argument parsing.
  - `src/server/parse.test.ts`:
    - Added regression tests for structured ERROR/FAILURE and fallback messages.
  - `src/ui/build-config.test.ts`:
    - Added tests for permission defaults, explicit toggles, extra argument parsing, and eliminated all `any` types.

- **Server & Integration**:
  - `server/src/__tests__/adapter-session-codecs.test.ts`: Added test verifying `antigravitySessionCodec` preserves `remoteExecution` and all metadata across round-trip serialization.
  - `server/src/__tests__/antigravity-local-adapter-environment.test.ts`: Updated probe arguments assertion to `--print`/`stream-json` and added authentication requirement detection test.
  - `server/src/__tests__/antigravity-local-execute.test.ts`: Added security assertions verifying prompt contains no API keys, bearer tokens, or curl instructions.

- **UI**:
  - `ui/src/adapters/antigravity-local/config-fields.tsx`:
    - Changed default skip permissions toggle to `false`.
    - Updated extra CLI arguments onCommit to parse comma/space strings into string arrays in edit mode.
  - Verified `pnpm check:token-gates` — zero violations in `ui/src/adapters/antigravity-local/*`.

- **Documentation**:
  - `docs/adapters/antigravity-local.md`: Updated `dangerouslySkipPermissions` default to `false`, updated execution semantics, and updated diagnostics probe instructions.

## Verification

### Automated Tests
```sh
# 1. Adapter package unit tests (25/25 passed across 4 test suites)
pnpm vitest run packages/adapters/antigravity-local/

# 2. Server integration tests (26 passed, 3 skipped on win32)
pnpm --filter @paperclipai/server exec vitest run src/__tests__/antigravity-local-adapter.test.ts src/__tests__/antigravity-local-adapter-environment.test.ts src/__tests__/adapter-session-codecs.test.ts src/__tests__/antigravity-local-execute.test.ts

# 3. Codec session round-trip tests (16/16 passed)
pnpm --filter @paperclipai/server exec vitest run src/__tests__/adapter-session-codecs.test.ts

# 4. TypeScript compilation (0 errors across all affected packages)
pnpm --filter @paperclipai/adapter-antigravity-local build
pnpm --filter @paperclipai/shared typecheck
pnpm --filter @paperclipai/ui typecheck
pnpm --filter @paperclipai/server exec tsc --noEmit

# 5. Design system token check (0 violations in new UI code)
pnpm check:token-gates
```

### Manual Verification
- Live execution against installed `agy` CLI (v1.1.25):
  `agy --print "Respond with OK." --output-format stream-json`
  verified real output:
  - `init` emitted with conversation ID
  - `step_update` streamed deltas
  - `result` emitted `status: "SUCCESS"` with token counts and cost
- Dev server running cleanly on `http://localhost:3100` (API status OK) and `http://localhost:5173` (Vite UI).

## Risks

- **Low risk**: The changes are isolated to the `@paperclipai/adapter-antigravity-local` package, its UI components, and adapter test suites. Existing adapters (`gemini_local`, `claude_local`, `codex_local`) are untouched.

## Model Used

- **Provider**: Google DeepMind
- **Model ID**: Antigravity Agent (Gemini 3.8 Flash High)
- **Context Window**: 1M context window
- **Capabilities**: Multi-turn tool execution, code analysis, TypeScript verification, subprocess testing, terminal execution

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (`feat/antigravity-local-adapter`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge


-

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

<!--
  Required. Specify which AI model was used to produce or assist with
  this change. Be as descriptive as possible — include:
    • Provider and model name (e.g., Claude, GPT, Gemini, Codex)
    • Exact model ID or version (e.g., claude-opus-4-6, gpt-4-turbo-2024-04-09)
    • Context window size if relevant (e.g., 1M context)
    • Reasoning/thinking mode if applicable (e.g., extended thinking, chain-of-thought)
    • Any other relevant capability details (e.g., tool use, code execution)
  If no AI model was used, write "None — human-authored".
-->

