### PR TITLE
fix(issues): cancel live execution run on force-release

### DIFF
--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -8,6 +8,7 @@ import {
   agents,
   companies,
   createDb,
+  heartbeatRunEvents,
   heartbeatRuns,
   issueComments,
   issueRelations,
@@ -45,6 +46,7 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
     await db.delete(issueRelations);
     await db.delete(activityLog);
     await db.delete(issues);
+    await db.delete(heartbeatRunEvents);
     await db.delete(heartbeatRuns);
     await db.delete(agents);
     await db.delete(companies);
@@ -410,7 +412,7 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
     expect(checkoutActivity).toHaveLength(0);
   });
 
-  it("restricts admin force-release to board users with company access and writes an audit event", async () => {
+  it("restricts admin force-release to board users, cancels a live execution run, and writes an audit event", async () => {
     const { companyId, agentId, failedRunId, currentRunId } = await seedCompanyAgentAndRuns();
     const issueId = randomUUID();
     await db.insert(issues).values({
@@ -421,7 +423,7 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
       priority: "high",
       assigneeAgentId: agentId,
       checkoutRunId: currentRunId,
-      executionRunId: failedRunId,
+      executionRunId: currentRunId,
       executionAgentNameKey: "codexcoder",
       executionLockedAt: new Date(),
     });
@@ -454,8 +456,15 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
     });
     expect(res.body.previous).toEqual({
       checkoutRunId: currentRunId,
-      executionRunId: failedRunId,
+      executionRunId: currentRunId,
     });
+
+    const executionRun = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, currentRunId))
+      .then((rows) => rows[0]);
+    expect(executionRun).toEqual({ status: "cancelled" });
 
     const audit = await db
       .select({
@@ -475,7 +484,7 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
         issueId,
         actorUserId: "board-user",
         prevCheckoutRunId: currentRunId,
-        prevExecutionRunId: failedRunId,
+        prevExecutionRunId: currentRunId,
         clearAssignee: true,
       },
     });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -11729,6 +11729,10 @@ export function issueRoutes(
       return;
     }
 
+    if (result.previous.executionRunId) {
+      await heartbeat.cancelRun(result.previous.executionRunId, "admin force-release");
+    }
+
     const actor = getActorInfo(req);
     await logActivity(db, {
       companyId: result.issue.companyId,


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates AI-agent work through issue routes and heartbeat-run lifecycle state.
> - Board users use `POST /api/issues/:id/admin/force-release` to clear stale checkout and execution locks.
> - Clearing the issue row alone can leave the prior `heartbeat_runs` record in `running` state.
> - That live orphan blocks later work even though the issue lock was released.
> - This pull request cancels the recorded prior execution run immediately after a successful force-release.
> - The route-level regression proves a live execution heartbeat becomes `cancelled` while the existing audit and authorization behavior remains intact.
> - The benefit is that force-release closes both the issue lock and the heartbeat lifecycle for the released execution.

## Linked Issues or Issue Description

Refs #11819.

A board force-release clears `checkoutRunId` and `executionRunId`, but previously left a live `executionRunId` heartbeat run running. That run could continue to block subsequent work. The expected result is that force-release also cancels that prior execution run.

Duplicate/related prior attempt: #6056. It is still open but based on an old master and changes both checkout and execution runs; this PR intentionally covers only the current requested `executionRunId` behavior.

## What Changed

- Cancel `result.previous.executionRunId` with reason `admin force-release` after `adminForceRelease` succeeds.
- Extend the stale-execution-lock route regression to prove a running execution heartbeat becomes `cancelled`.
- Clean up heartbeat run events created by cancellation in the test fixture teardown.

## Verification

```sh
node_modules/.bin/vitest run server/src/__tests__/issue-stale-execution-lock-routes.test.ts
node_modules/.bin/tsc --noEmit -p server/tsconfig.json
```

Both commands passed locally. The regression first failed on the base route with the execution run still `running`, then passed after the route change.

## Risks

Low risk. This only runs after a board-authorized force-release has successfully cleared the issue's execution lock, and only when the prior execution run ID exists. It does not alter checkout-run handling.

## Model Used

- Provider: OpenAI Codex
- Model ID: `gpt-5.6-terra`
- Context window: runtime-provided; not exposed to this session
- Capabilities: reasoning, tool use, repository edits, test execution

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no documentation change is required for this route-only bug fix)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
