### PR TITLE
fix(claude-local): keep mcpServerIdentity and remoteExecution in the session codec

### DIFF
--- a/packages/adapters/claude-local/src/server/index.ts
+++ b/packages/adapters/claude-local/src/server/index.ts
@@ -69,6 +69,32 @@ function readNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
+// Session params carry a nested remoteExecution identity for remote targets;
+// execute.ts compares it on the next heartbeat, so it must survive the codec.
+// Only the keys that identity comparison actually uses are kept: a same-named
+// object elsewhere in the runtime carries privateKey/knownHosts, and those must
+// never reach session_params_json.
+const REMOTE_EXECUTION_IDENTITY_KEYS = [
+  "transport",
+  "host",
+  "port",
+  "username",
+  "remoteCwd",
+  "providerKey",
+  "environmentId",
+  "leaseId",
+] as const;
+
+function readRemoteExecutionIdentity(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  const identity: Record<string, unknown> = {};
+  for (const key of REMOTE_EXECUTION_IDENTITY_KEYS) {
+    if (record[key] !== undefined && record[key] !== null) identity[key] = record[key];
+  }
+  return Object.keys(identity).length > 0 ? identity : null;
+}
+
 export const sessionCodec: AdapterSessionCodec = {
   deserialize(raw: unknown) {
     if (typeof raw !== "object" || raw === null || Array.isArray(raw)) return null;
@@ -85,6 +111,12 @@ export const sessionCodec: AdapterSessionCodec = {
     const workspaceId = readNonEmptyString(record.workspaceId) ?? readNonEmptyString(record.workspace_id);
     const repoUrl = readNonEmptyString(record.repoUrl) ?? readNonEmptyString(record.repo_url);
     const repoRef = readNonEmptyString(record.repoRef) ?? readNonEmptyString(record.repo_ref);
+    // Preserve the runtime MCP identity written by execute.ts so a later
+    // heartbeat can prove the saved session used the same MCP server set.
+    const mcpServerIdentity =
+      readNonEmptyString(record.mcpServerIdentity) ?? readNonEmptyString(record.mcp_server_identity);
+    const remoteExecution =
+      readRemoteExecutionIdentity(record.remoteExecution) ?? readRemoteExecutionIdentity(record.remote_execution);
     return {
       sessionId,
       ...(cwd ? { cwd } : {}),
@@ -92,6 +124,8 @@ export const sessionCodec: AdapterSessionCodec = {
       ...(workspaceId ? { workspaceId } : {}),
       ...(repoUrl ? { repoUrl } : {}),
       ...(repoRef ? { repoRef } : {}),
+      ...(mcpServerIdentity ? { mcpServerIdentity } : {}),
+      ...(remoteExecution ? { remoteExecution } : {}),
     };
   },
   serialize(params: Record<string, unknown> | null) {
@@ -108,6 +142,10 @@ export const sessionCodec: AdapterSessionCodec = {
     const workspaceId = readNonEmptyString(params.workspaceId) ?? readNonEmptyString(params.workspace_id);
     const repoUrl = readNonEmptyString(params.repoUrl) ?? readNonEmptyString(params.repo_url);
     const repoRef = readNonEmptyString(params.repoRef) ?? readNonEmptyString(params.repo_ref);
+    const mcpServerIdentity =
+      readNonEmptyString(params.mcpServerIdentity) ?? readNonEmptyString(params.mcp_server_identity);
+    const remoteExecution =
+      readRemoteExecutionIdentity(params.remoteExecution) ?? readRemoteExecutionIdentity(params.remote_execution);
     return {
       sessionId,
       ...(cwd ? { cwd } : {}),
@@ -115,6 +153,8 @@ export const sessionCodec: AdapterSessionCodec = {
       ...(workspaceId ? { workspaceId } : {}),
       ...(repoUrl ? { repoUrl } : {}),
       ...(repoRef ? { repoRef } : {}),
+      ...(mcpServerIdentity ? { mcpServerIdentity } : {}),
+      ...(remoteExecution ? { remoteExecution } : {}),
     };
   },
   getDisplayId(params: Record<string, unknown> | null) {

--- a/server/src/__tests__/adapter-session-codecs.test.ts
+++ b/server/src/__tests__/adapter-session-codecs.test.ts
@@ -37,6 +37,60 @@ describe("adapter session codecs", () => {
     expect(claudeSessionCodec.getDisplayId?.(serialized ?? null)).toBe("claude-session-1");
   });
 
+  it("round-trips the runtime MCP identity so claude sessions can resume", () => {
+    const identity =
+      '[{"name":"Paperclip connections","url":"http://127.0.0.1:3100/mcp/runtime-tools","connectionId":"paperclip-runtime-tools"}]';
+    const parsed = claudeSessionCodec.deserialize({
+      sessionId: "claude-session-2",
+      cwd: "/repo",
+      promptBundleKey: "bundle-2",
+      mcpServerIdentity: identity,
+    });
+    expect(parsed?.mcpServerIdentity).toBe(identity);
+    const serialized = claudeSessionCodec.serialize(parsed);
+    expect(serialized?.mcpServerIdentity).toBe(identity);
+
+    const withoutIdentity = claudeSessionCodec.deserialize({
+      sessionId: "claude-session-3",
+      cwd: "/repo",
+    });
+    expect(withoutIdentity).not.toHaveProperty("mcpServerIdentity");
+    expect(withoutIdentity).not.toHaveProperty("remoteExecution");
+  });
+
+  it("round-trips the remote execution identity so remote sessions can resume", () => {
+    const remoteExecution = {
+      transport: "ssh",
+      host: "127.0.0.1",
+      port: 2222,
+      username: "fixture",
+      remoteCwd: "/remote/workspace",
+    };
+    const parsed = claudeSessionCodec.deserialize({
+      sessionId: "claude-session-4",
+      cwd: "/remote/workspace",
+      remoteExecution,
+    });
+    expect(parsed?.remoteExecution).toEqual(remoteExecution);
+    const serialized = claudeSessionCodec.serialize(parsed);
+    expect(serialized?.remoteExecution).toEqual(remoteExecution);
+
+    const emptyRemote = claudeSessionCodec.deserialize({
+      sessionId: "claude-session-5",
+      cwd: "/repo",
+      remoteExecution: {},
+    });
+    expect(emptyRemote).not.toHaveProperty("remoteExecution");
+
+    const withCredentials = claudeSessionCodec.deserialize({
+      sessionId: "claude-session-6",
+      cwd: "/remote/workspace",
+      remoteExecution: { ...remoteExecution, privateKey: "PRIVATE KEY", knownHosts: "host key" },
+    });
+    expect(withCredentials?.remoteExecution).toEqual(remoteExecution);
+    expect(JSON.stringify(withCredentials)).not.toContain("PRIVATE KEY");
+  });
+
   it("preserves claude ACP session params for ACP lane resumes", () => {
     const parsed = claudeSessionCodec.deserialize({
       sessionKey: "paperclip:company:agent:task:fingerprint",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The `claude_local` adapter starts one Claude CLI process per heartbeat, and it saves session params so the next heartbeat can pass `--resume`
> - `sessionCodec` rebuilds those params from a fixed whitelist, and the whitelist omits two fields that `execute.ts` writes and later reads
> - The saved MCP identity is therefore always empty, so `hasMatchingMcpServers` is always false when any MCP server is registered
> - `native_mcp` always registers at least one server, so `canResumeSession` never becomes true and `--resume` is never passed
> - Every heartbeat then rebuilds the whole prompt, which costs about 32k cache-creation tokens per run
> - This pull request keeps the two fields through the codec round trip
> - The benefit is that agents with MCP servers can resume sessions again, and remote targets can also match their saved execution identity

## Linked Issues or Issue Description

No public issue exists. The problem is described below with the bug report fields.

**What happened?**
Agents on the `claude_local` adapter never resume a saved Claude session. Each heartbeat starts a new session id. The run log always contains `was saved with a different runtime MCP server set and will not be resumed`.

**Expected behavior**
A later heartbeat of the same task resumes the saved session when the prompt bundle, the MCP server set, and the working directory all match.

**Steps to reproduce**
1. Create an agent with `adapterType: claude_local` and `engine: cli`.
2. Keep the default runtime MCP server (`native_mcp` registers the Paperclip runtime tools server).
3. Assign one issue to the agent and let it run two or more heartbeats.
4. Read the run logs. The `session_id` of the `system/init` event differs on every run, and `--resume` never appears in the command line.

**Paperclip version or commit**
`master` at `165ca56`.

**Deployment mode**
Local instance.

**Installation method**
Repository checkout with `pnpm`.

**Agent adapter(s) involved**
`claude_local` (Claude Code CLI lane).

Refs #1907 — that pull request fixes a related but different split, where a resumed session keeps the wrong workspace. It does not touch the codec.

## What Changed

- `sessionCodec.deserialize` and `sessionCodec.serialize` now keep `mcpServerIdentity` (also accepted as `mcp_server_identity`).
- Both functions now keep `remoteExecution` (also accepted as `remote_execution`).
- `remoteExecution` is rebuilt from an explicit key list: `transport`, `host`, `port`, `username`, `remoteCwd`, `providerKey`, `environmentId`, `leaseId`. A same-named object elsewhere in the runtime carries `privateKey` and `knownHosts`. Those keys must never reach `session_params_json`.
- An empty object is not stored, so an absent field stays absent.
- Tests cover the round trip of both fields, the absent case, the empty object case, and the removal of credentials.

## Verification

Run these commands from the repository root:

```
pnpm --filter @paperclipai/server exec vitest run src/__tests__/adapter-session-codecs.test.ts
pnpm --filter @paperclipai/adapter-claude-local exec vitest run
pnpm --filter @paperclipai/adapter-claude-local exec tsc --noEmit -p .
```

Results on this branch: 15 tests pass, 246 tests pass with 1 skipped, and the type check reports no error.

To confirm the behavior on a live instance, run one agent twice on the same issue. Before the fix, the `system/init` `session_id` changes on every run. After the fix, the second run passes `--resume` and keeps the same id.

Measured on a five-company instance with 23 agents: 0 resumes in 212 runs before the fix.

## Risks

Low risk.

- The change only adds fields to the codec. It removes nothing.
- Agents that never had a saved identity keep their current behavior, because an empty value still fails the match.
- Saved sessions that were written before this change do not contain the two fields. Those sessions still start fresh once. The fields appear after the next write.
- The key list for `remoteExecution` matches the keys that `adapterExecutionTargetSessionMatches` reads. A new key in that comparison must also be added to the list.

## Model Used

Claude Opus 5 (`claude-opus-5`), 1M context window, extended thinking, with tool use and code execution in Claude Code. The author reviewed and tested every change locally.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

