### PR TITLE
fix(tests): broadcastBeforeAdapterExecute in plugin-env heartbeat mocks

### DIFF
--- a/server/src/__tests__/heartbeat-plugin-environment.test.ts
+++ b/server/src/__tests__/heartbeat-plugin-environment.test.ts
@@ -105,6 +105,7 @@ describeEmbeddedPostgres("heartbeat plugin environments", () => {
         }
         throw new Error(`Unexpected plugin environment method: ${method}`);
       }),
+      broadcastBeforeAdapterExecute: vi.fn(async () => ({})),
     } as unknown as PluginWorkerManager;
 
     await db.insert(companies).values({
@@ -508,6 +509,7 @@ describeEmbeddedPostgres("heartbeat plugin environments", () => {
         }
         throw new Error(`Unexpected plugin environment method: ${method}`);
       }),
+      broadcastBeforeAdapterExecute: vi.fn(async () => ({})),
     } as unknown as PluginWorkerManager;
 
     await instanceSettingsService(db).updateExperimental({


### PR DESCRIPTION
## Summary
Surgical replacement for contaminated upstream PR #12827 (NOM-25).

Original #12827 claimed a 2-line test fix but the head branch carried **671 commits / 723 files** (unrelated docs/features). This PR cherry-picks **only** `d6c434866` onto current `master`.

## Change
- `server/src/__tests__/heartbeat-plugin-environment.test.ts`: add `broadcastBeforeAdapterExecute: vi.fn(async () => ({}))` in two mock setups

## Test plan
- [ ] CI green on this PR
- [ ] Diff is exactly 1 file / +2 lines

Recommend closing #12827 as superseded.