### PR TITLE
feat(server): add secure GitLab credentials for managed workspaces (rebase of #12838)

### DIFF
--- a/doc/DOCKER.md
+++ b/doc/DOCKER.md
@@ -227,20 +227,20 @@ The `docker/quadlet/` directory contains unit files to run Paperclip + PostgreSQ
    EOL
    ```
 
-4. Create the data directory and start:
+4. Create the data and certs directories, then start. The certs directory backs the unit's
+   `/certs` bind mount and must exist even if you don't use self-hosted GitLab:
 
    ```sh
-   mkdir -p ~/.local/share/paperclip
+   mkdir -p ~/.local/share/paperclip ~/.config/containers/systemd/paperclip-certs
    systemctl --user daemon-reload
    systemctl --user start paperclip-pod
    ```
 
-   For self-hosted GitLab on a private/internal CA, also create the certs directory, drop the
-   PEM bundle in it, and set `PAPERCLIP_GITLAB_HOSTS`/`PAPERCLIP_GITLAB_CA_CERT_PATH` in
+   For self-hosted GitLab on a private/internal CA, drop the PEM bundle into that certs
+   directory and set `PAPERCLIP_GITLAB_HOSTS`/`PAPERCLIP_GITLAB_CA_CERT_PATH` in
    `paperclip.env` (see `docker/certs/README.md`):
 
    ```sh
-   mkdir -p ~/.config/containers/systemd/paperclip-certs
    cp /path/to/lab-ca.pem ~/.config/containers/systemd/paperclip-certs/
    ```
 

--- a/doc/DOCKER.md
+++ b/doc/DOCKER.md
@@ -235,6 +235,15 @@ The `docker/quadlet/` directory contains unit files to run Paperclip + PostgreSQ
    systemctl --user start paperclip-pod
    ```
 
+   For self-hosted GitLab on a private/internal CA, also create the certs directory, drop the
+   PEM bundle in it, and set `PAPERCLIP_GITLAB_HOSTS`/`PAPERCLIP_GITLAB_CA_CERT_PATH` in
+   `paperclip.env` (see `docker/certs/README.md`):
+
+   ```sh
+   mkdir -p ~/.config/containers/systemd/paperclip-certs
+   cp /path/to/lab-ca.pem ~/.config/containers/systemd/paperclip-certs/
+   ```
+
 ### Quadlet management
 
 ```sh

--- a/docker/certs/.gitignore
+++ b/docker/certs/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/docker/certs/README.md
+++ b/docker/certs/README.md
@@ -2,13 +2,15 @@
 
 Drop a PEM CA bundle here for a self-hosted GitLab instance on a private or
 internal CA — this directory is mounted read-only into the server container
-at `/paperclip/ca`.
+at `/certs` (deliberately not under `/paperclip`: the entrypoint recursively
+chowns that whole tree before dropping privileges, and that fails outright on
+a read-only mount).
 
 Then point `PAPERCLIP_GITLAB_CA_CERT_PATH` at the in-container path, e.g. for
 a file named `lab-ca.pem`:
 
 ```
-PAPERCLIP_GITLAB_CA_CERT_PATH=/paperclip/ca/lab-ca.pem
+PAPERCLIP_GITLAB_CA_CERT_PATH=/certs/lab-ca.pem
 ```
 
 Only applies to a host configured in `PAPERCLIP_GITLAB_HOSTS` — never to

--- a/docker/certs/README.md
+++ b/docker/certs/README.md
@@ -6,6 +6,11 @@ at `/certs` (deliberately not under `/paperclip`: the entrypoint recursively
 chowns that whole tree before dropping privileges, and that fails outright on
 a read-only mount).
 
+This applies to both `docker/docker-compose.yml` and
+`docker/docker-compose.quickstart.yml`. For the Podman Quadlet deployment, the
+equivalent directory is `~/.config/containers/systemd/paperclip-certs` (see
+`doc/DOCKER.md`).
+
 Then point `PAPERCLIP_GITLAB_CA_CERT_PATH` at the in-container path, e.g. for
 a file named `lab-ca.pem`:
 

--- a/docker/certs/README.md
+++ b/docker/certs/README.md
@@ -1,0 +1,18 @@
+# docker/certs
+
+Drop a PEM CA bundle here for a self-hosted GitLab instance on a private or
+internal CA — this directory is mounted read-only into the server container
+at `/paperclip/ca`.
+
+Then point `PAPERCLIP_GITLAB_CA_CERT_PATH` at the in-container path, e.g. for
+a file named `lab-ca.pem`:
+
+```
+PAPERCLIP_GITLAB_CA_CERT_PATH=/paperclip/ca/lab-ca.pem
+```
+
+Only applies to a host configured in `PAPERCLIP_GITLAB_HOSTS` — never to
+gitlab.com itself.
+
+Certificate files placed here are git-ignored (see `.gitignore` in this
+directory); only this README is tracked.

--- a/docker/docker-compose.quickstart.yml
+++ b/docker/docker-compose.quickstart.yml
@@ -39,6 +39,18 @@ services:
 
       # ── Required secret for session signing (generate with: openssl rand -hex 32) ──
       BETTER_AUTH_SECRET: "${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set}"
+
+      # ── Optional self-hosted GitLab support (see docker/certs/README.md) ──
+      PAPERCLIP_GITLAB_HOSTS: "${PAPERCLIP_GITLAB_HOSTS:-}"
+      # Points at a PEM CA bundle for a self-hosted GitLab instance on a private/internal CA.
+      # Drop the bundle file into ./certs (mounted read-only below) and set this to its
+      # in-container path, e.g. PAPERCLIP_GITLAB_CA_CERT_PATH=/certs/lab-ca.pem.
+      PAPERCLIP_GITLAB_CA_CERT_PATH: "${PAPERCLIP_GITLAB_CA_CERT_PATH:-}"
     volumes:
       # Persistent data directory (database, agent workspaces, uploads)
       - "${PAPERCLIP_DATA_DIR:-../data/docker-paperclip}:/paperclip"
+      # Deliberately NOT under /paperclip: scripts/docker-entrypoint.sh recursively
+      # chowns the whole $PAPERCLIP_HOME tree to the node user before dropping
+      # privileges, and that chown fails outright on a read-only mount, so a cert
+      # mounted at e.g. /paperclip/ca would crash the container on every boot.
+      - ./certs:/certs:ro

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -41,11 +41,15 @@ services:
       PAPERCLIP_GITLAB_HOSTS: "${PAPERCLIP_GITLAB_HOSTS}"
       # Points at a PEM CA bundle for a self-hosted GitLab instance on a private/internal CA.
       # Drop the bundle file into ./certs (mounted read-only below) and set this to its
-      # in-container path, e.g. PAPERCLIP_GITLAB_CA_CERT_PATH=/paperclip/ca/lab-ca.pem.
+      # in-container path, e.g. PAPERCLIP_GITLAB_CA_CERT_PATH=/certs/lab-ca.pem.
       PAPERCLIP_GITLAB_CA_CERT_PATH: "${PAPERCLIP_GITLAB_CA_CERT_PATH}"
     volumes:
       - paperclip-data:/paperclip
-      - ./certs:/paperclip/ca:ro
+      # Deliberately NOT under /paperclip: scripts/docker-entrypoint.sh recursively
+      # chowns the whole $PAPERCLIP_HOME tree to the node user before dropping
+      # privileges, and that chown fails outright on a read-only mount, so a cert
+      # mounted at e.g. /paperclip/ca would crash the container on every boot.
+      - ./certs:/certs:ro
     depends_on:
       db:
         condition: service_healthy

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       PAPERCLIP_DEPLOYMENT_EXPOSURE: "private"
       PAPERCLIP_PUBLIC_URL: "${PAPERCLIP_PUBLIC_URL:-http://localhost:3100}"
       BETTER_AUTH_SECRET: "${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set}"
+      PAPERCLIP_GITLAB_HOSTS: "${PAPERCLIP_GITLAB_HOSTS}"
     volumes:
       - paperclip-data:/paperclip
     depends_on:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -39,8 +39,13 @@ services:
       PAPERCLIP_PUBLIC_URL: "${PAPERCLIP_PUBLIC_URL:-http://localhost:3100}"
       BETTER_AUTH_SECRET: "${BETTER_AUTH_SECRET:?BETTER_AUTH_SECRET must be set}"
       PAPERCLIP_GITLAB_HOSTS: "${PAPERCLIP_GITLAB_HOSTS}"
+      # Points at a PEM CA bundle for a self-hosted GitLab instance on a private/internal CA.
+      # Drop the bundle file into ./certs (mounted read-only below) and set this to its
+      # in-container path, e.g. PAPERCLIP_GITLAB_CA_CERT_PATH=/paperclip/ca/lab-ca.pem.
+      PAPERCLIP_GITLAB_CA_CERT_PATH: "${PAPERCLIP_GITLAB_CA_CERT_PATH}"
     volumes:
       - paperclip-data:/paperclip
+      - ./certs:/paperclip/ca:ro
     depends_on:
       db:
         condition: service_healthy

--- a/docker/quadlet/paperclip.container
+++ b/docker/quadlet/paperclip.container
@@ -8,10 +8,12 @@ Image=paperclip-local
 ContainerName=paperclip
 Pod=paperclip.pod
 Volume=%h/.local/share/paperclip:/paperclip:Z
-# Optional: for a self-hosted GitLab instance on a private/internal CA, drop the PEM bundle
-# into this directory and set PAPERCLIP_GITLAB_CA_CERT_PATH=/certs/<file> (and PAPERCLIP_GITLAB_HOSTS)
-# in paperclip.env below -- see docker/certs/README.md. Deliberately not under /paperclip: the
-# entrypoint recursively chowns that whole tree, which fails outright on a read-only mount.
+# Backs the /certs mount below; the setup docs create this directory unconditionally (empty is
+# fine) since Quadlet does not create bind-mount sources for you. For a self-hosted GitLab
+# instance on a private/internal CA, drop the PEM bundle in and set
+# PAPERCLIP_GITLAB_CA_CERT_PATH=/certs/<file> (and PAPERCLIP_GITLAB_HOSTS) in paperclip.env below
+# -- see docker/certs/README.md. Deliberately not under /paperclip: the entrypoint recursively
+# chowns that whole tree, which fails outright on a read-only mount.
 Volume=%h/.config/containers/systemd/paperclip-certs:/certs:ro,Z
 Environment=HOST=0.0.0.0
 Environment=PAPERCLIP_HOME=/paperclip

--- a/docker/quadlet/paperclip.container
+++ b/docker/quadlet/paperclip.container
@@ -8,6 +8,11 @@ Image=paperclip-local
 ContainerName=paperclip
 Pod=paperclip.pod
 Volume=%h/.local/share/paperclip:/paperclip:Z
+# Optional: for a self-hosted GitLab instance on a private/internal CA, drop the PEM bundle
+# into this directory and set PAPERCLIP_GITLAB_CA_CERT_PATH=/certs/<file> (and PAPERCLIP_GITLAB_HOSTS)
+# in paperclip.env below -- see docker/certs/README.md. Deliberately not under /paperclip: the
+# entrypoint recursively chowns that whole tree, which fails outright on a read-only mount.
+Volume=%h/.config/containers/systemd/paperclip-certs:/certs:ro,Z
 Environment=HOST=0.0.0.0
 Environment=PAPERCLIP_HOME=/paperclip
 Environment=PAPERCLIP_DEPLOYMENT_MODE=authenticated

--- a/server/src/__tests__/git-credentials.test.ts
+++ b/server/src/__tests__/git-credentials.test.ts
@@ -1,8 +1,10 @@
-import { spawn } from "node:child_process";
+import { execFile, execFileSync, spawn } from "node:child_process";
 import fs from "node:fs/promises";
+import https from "node:https";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { Db } from "@paperclipai/db";
 import {
   DEFAULT_GITHUB_TOKEN_SECRET_NAMES,
@@ -388,6 +390,57 @@ describe("createGitRemoteAuthProvider", () => {
         await expect(provider(portedUrl)).resolves.toBeNull();
       });
     });
+
+    describe("custom CA (PAPERCLIP_GITLAB_CA_CERT_PATH)", () => {
+      it("sets GIT_SSL_CAINFO for a self-hosted match when a CA cert path is configured", async () => {
+        const secrets = buildSecretsFake({ GITLAB_TOKEN: "glpat-token" });
+        const provider = createGitRemoteAuthProvider(fakeDb, "company-1", undefined, {
+          secrets,
+          env: {
+            PAPERCLIP_GITLAB_HOSTS: "gitlab.mycompany.com",
+            PAPERCLIP_GITLAB_CA_CERT_PATH: "/paperclip/ca/lab-ca.pem",
+          },
+        });
+        const invocation = await provider(selfHostedUrl);
+        expect(invocation?.env.GIT_SSL_CAINFO).toBe("/paperclip/ca/lab-ca.pem");
+      });
+
+      it("does not set GIT_SSL_CAINFO when no CA cert path is configured", async () => {
+        const secrets = buildSecretsFake({ GITLAB_TOKEN: "glpat-token" });
+        const provider = createGitRemoteAuthProvider(fakeDb, "company-1", undefined, {
+          secrets,
+          env: { PAPERCLIP_GITLAB_HOSTS: "gitlab.mycompany.com" },
+        });
+        const invocation = await provider(selfHostedUrl);
+        expect(invocation?.env.GIT_SSL_CAINFO).toBeUndefined();
+      });
+
+      it("never sets GIT_SSL_CAINFO for gitlab.com itself, even with a CA cert path configured", async () => {
+        // GIT_SSL_CAINFO replaces (not augments) git's default trust store for the process it
+        // is set on. Applying a self-hosted CA bundle to a gitlab.com clone would break that
+        // clone's TLS verification unless the bundle happened to also carry the public roots.
+        const secrets = buildSecretsFake({ GITLAB_TOKEN: "glpat-token" });
+        const provider = createGitRemoteAuthProvider(fakeDb, "company-1", undefined, {
+          secrets,
+          env: {
+            PAPERCLIP_GITLAB_HOSTS: "gitlab.mycompany.com",
+            PAPERCLIP_GITLAB_CA_CERT_PATH: "/paperclip/ca/lab-ca.pem",
+          },
+        });
+        const invocation = await provider("https://gitlab.com/example/repo.git");
+        expect(invocation?.env.GIT_SSL_CAINFO).toBeUndefined();
+      });
+
+      it("trims whitespace and treats a blank configured path as unset", async () => {
+        const secrets = buildSecretsFake({ GITLAB_TOKEN: "glpat-token" });
+        const provider = createGitRemoteAuthProvider(fakeDb, "company-1", undefined, {
+          secrets,
+          env: { PAPERCLIP_GITLAB_HOSTS: "gitlab.mycompany.com", PAPERCLIP_GITLAB_CA_CERT_PATH: "   " },
+        });
+        const invocation = await provider(selfHostedUrl);
+        expect(invocation?.env.GIT_SSL_CAINFO).toBeUndefined();
+      });
+    });
   });
 });
 
@@ -464,6 +517,30 @@ describe("buildGitAuthInvocation", () => {
     expect(joined).toContain("oauth2");
     expect(joined).not.toContain("credential.https://gitlab.com.helper=");
     expect(joined).not.toContain("credential.https://www.gitlab.com.helper=");
+  });
+
+  it("sets GIT_SSL_CAINFO when a caCertPath is passed", () => {
+    const invocation = buildGitAuthInvocation(
+      {
+        token: "super-secret-token",
+        source: "company_secret",
+        secretName: "GITLAB_TOKEN",
+        providerId: "gitlab",
+      },
+      ["gitlab.mycompany.com"],
+      "/paperclip/ca/lab-ca.pem",
+    );
+    expect(invocation.env.GIT_SSL_CAINFO).toBe("/paperclip/ca/lab-ca.pem");
+  });
+
+  it("omits GIT_SSL_CAINFO when no caCertPath is passed", () => {
+    const invocation = buildGitAuthInvocation({
+      token: "super-secret-token",
+      source: "company_secret",
+      secretName: "GITHUB_TOKEN",
+      providerId: "github",
+    });
+    expect(invocation.env.GIT_SSL_CAINFO).toBeUndefined();
   });
 });
 
@@ -573,6 +650,79 @@ describe("credential helper execution (real git, no network)", () => {
     } finally {
       await fs.rm(cwd, { recursive: true, force: true });
     }
+  });
+});
+
+// This module never sends real bytes over the wire on its own (`buildGitAuthInvocation` only
+// prepares config); GIT_SSL_CAINFO is trusted to work exactly as git's own docs say. Prove that
+// trust against a real self-signed TLS server instead of assuming it: without GIT_SSL_CAINFO
+// git must reject the self-signed cert, and with it pointed at the exact cert, git must get
+// past the TLS handshake (and only then fail for an unrelated reason -- there is no real git
+// server behind the test endpoint).
+//
+// The availability check must be synchronous and run at collection time (not inside beforeAll):
+// `describe.skipIf`/`it.skipIf` evaluate their condition immediately when called, before any
+// hook runs, so a boolean only known once an async beforeAll completes would never take effect.
+const opensslAvailable = (() => {
+  try {
+    execFileSync("openssl", ["version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+describe.skipIf(!opensslAvailable)("GIT_SSL_CAINFO against a real self-signed TLS server", () => {
+  const execFileAsync = promisify(execFile);
+  let workDir: string;
+  let certPath: string;
+  let server: https.Server;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    workDir = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-git-ca-test-"));
+    certPath = path.join(workDir, "cert.pem");
+    const keyPath = path.join(workDir, "key.pem");
+    await execFileAsync("openssl", [
+      "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+      "-keyout", keyPath, "-out", certPath, "-days", "1",
+      "-subj", "/CN=127.0.0.1", "-addext", "subjectAltName=IP:127.0.0.1",
+    ]);
+    const [key, cert] = await Promise.all([fs.readFile(keyPath), fs.readFile(certPath)]);
+    server = https.createServer({ key, cert }, (_req, res) => {
+      res.writeHead(404);
+      res.end("not a real git server");
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    baseUrl = `https://127.0.0.1:${port}/example/repo.git`;
+  });
+
+  afterAll(async () => {
+    if (server) await new Promise<void>((resolve) => server.close(() => resolve()));
+    if (workDir) await fs.rm(workDir, { recursive: true, force: true });
+  });
+
+  it("rejects the self-signed cert with no GIT_SSL_CAINFO", async () => {
+    await expect(
+      execFileAsync("git", ["ls-remote", baseUrl], { env: { ...process.env } }),
+    ).rejects.toThrow(/certificate|SSL|TLS/i);
+  });
+
+  it("gets past the TLS handshake once GIT_SSL_CAINFO points at the exact cert", async () => {
+    const error = await execFileAsync("git", ["ls-remote", baseUrl], {
+      env: { ...process.env, GIT_SSL_CAINFO: certPath },
+    }).then(
+      () => null,
+      (err: unknown) => err as { stderr?: string; message: string },
+    );
+    // Still fails -- there is no real git smart-HTTP backend behind the test endpoint -- but
+    // the failure must not be a certificate/TLS error, proving trust was actually established.
+    expect(error).not.toBeNull();
+    const failureText = `${error?.stderr ?? ""} ${error?.message ?? ""}`;
+    expect(failureText).not.toMatch(/certificate|SSL certificate problem|unable to get local issuer/i);
+    expect(failureText).toMatch(/not found|repository/i);
   });
 });
 

--- a/server/src/__tests__/git-credentials.test.ts
+++ b/server/src/__tests__/git-credentials.test.ts
@@ -6,11 +6,13 @@ import { describe, expect, it, vi } from "vitest";
 import type { Db } from "@paperclipai/db";
 import {
   DEFAULT_GITHUB_TOKEN_SECRET_NAMES,
+  DEFAULT_GITLAB_TOKEN_SECRET_NAMES,
   GIT_CREDENTIAL_TOKEN_ENV_KEY,
   buildGitAuthInvocation,
   createGitRemoteAuthProvider,
   describeGitAuthFailure,
   isGitHubHttpsRemoteUrl,
+  isGitLabHttpsRemoteUrl,
   scrubGitCredentialText,
 } from "../services/git-credentials.ts";
 
@@ -44,6 +46,23 @@ describe("isGitHubHttpsRemoteUrl", () => {
     expect(isGitHubHttpsRemoteUrl("https://gitlab.com/example/repo.git")).toBe(false);
     expect(isGitHubHttpsRemoteUrl("https://alice:token@github.com/example/repo.git")).toBe(false);
     expect(isGitHubHttpsRemoteUrl("/local/path/repo.git")).toBe(false);
+  });
+});
+
+describe("isGitLabHttpsRemoteUrl", () => {
+  it("accepts https gitlab.com and www.gitlab.com URLs", () => {
+    expect(isGitLabHttpsRemoteUrl("https://gitlab.com/example/repo.git")).toBe(true);
+    expect(isGitLabHttpsRemoteUrl("https://www.gitlab.com/example/repo.git")).toBe(true);
+  });
+
+  it("rejects ssh, http, self-managed hosts, other providers, userinfo URLs, and non-URLs", () => {
+    expect(isGitLabHttpsRemoteUrl("git@gitlab.com:example/repo.git")).toBe(false);
+    expect(isGitLabHttpsRemoteUrl("ssh://git@gitlab.com/example/repo.git")).toBe(false);
+    expect(isGitLabHttpsRemoteUrl("http://gitlab.com/example/repo.git")).toBe(false);
+    expect(isGitLabHttpsRemoteUrl("https://gitlab.internal.example/org/repo.git")).toBe(false);
+    expect(isGitLabHttpsRemoteUrl("https://github.com/example/repo.git")).toBe(false);
+    expect(isGitLabHttpsRemoteUrl("https://oauth2:token@gitlab.com/example/repo.git")).toBe(false);
+    expect(isGitLabHttpsRemoteUrl("/local/path/repo.git")).toBe(false);
   });
 });
 
@@ -94,13 +113,14 @@ describe("createGitRemoteAuthProvider", () => {
     expect(invocation?.env.GIT_CONFIG_KEY_3).toBe("url.https://github.com/.insteadOf");
   });
 
-  it("returns null for non-GitHub URLs without touching the secret store", async () => {
+  it("returns null for out-of-scope URLs without touching the secret store", async () => {
     const secrets = buildSecretsFake({ GITHUB_TOKEN: "token" });
     const provider = createGitRemoteAuthProvider(fakeDb, "company-1", undefined, {
       secrets,
       env: {},
     });
-    await expect(provider("https://gitlab.com/example/repo.git")).resolves.toBeNull();
+    await expect(provider("https://bitbucket.org/example/repo.git")).resolves.toBeNull();
+    await expect(provider("https://gitlab.internal.example/example/repo.git")).resolves.toBeNull();
     expect(secrets.getByName).not.toHaveBeenCalled();
   });
 
@@ -150,6 +170,7 @@ describe("createGitRemoteAuthProvider", () => {
     expect(invocation?.secretName).toBe("GH_TOKEN");
   });
 
+
   it("ignores a managed connection installed only for another agent", async () => {
     const query = (rows: unknown[]) => ({
       from: () => ({ where: async () => rows }),
@@ -183,6 +204,61 @@ describe("createGitRemoteAuthProvider", () => {
     expect(invocation?.env[GIT_CREDENTIAL_TOKEN_ENV_KEY]).toBe("agent-b-legacy-token");
     expect(db.select).toHaveBeenCalledTimes(2);
   });
+
+  describe("GitLab", () => {
+    const gitlabUrl = "https://gitlab.com/example/repo.git";
+
+    it("resolves a GITLAB_TOKEN company secret", async () => {
+      const secrets = buildSecretsFake({ GITLAB_TOKEN: "glpat-token" });
+      const provider = createGitRemoteAuthProvider(fakeDb, "company-1", undefined, {
+        secrets,
+        env: {},
+      });
+      const invocation = await provider(gitlabUrl);
+      expect(invocation?.env[GIT_CREDENTIAL_TOKEN_ENV_KEY]).toBe("glpat-token");
+      expect(invocation?.source).toBe("company_secret");
+      expect(invocation?.secretName).toBe("GITLAB_TOKEN");
+      expect(invocation?.providerId).toBe("gitlab");
+    });
+
+    it("falls back to the server env GITLAB_TOKEN", async () => {
+      const provider = createGitRemoteAuthProvider(fakeDb, "company-1", undefined, {
+        secrets: buildSecretsFake({}),
+        env: { GITLAB_TOKEN: "env-gitlab" },
+      });
+      const invocation = await provider(gitlabUrl);
+      expect(invocation?.env[GIT_CREDENTIAL_TOKEN_ENV_KEY]).toBe("env-gitlab");
+      expect(invocation?.source).toBe("server_env");
+      expect(invocation?.secretName).toBeNull();
+      expect(invocation?.providerId).toBe("gitlab");
+    });
+
+    it("never probes GitHub secret names for a GitLab remote, and vice versa", async () => {
+      const secrets = buildSecretsFake({ GITLAB_TOKEN: "glpat-token" });
+      const provider = createGitRemoteAuthProvider(fakeDb, "company-1", undefined, {
+        secrets,
+        env: {},
+      });
+      await provider(gitlabUrl);
+      expect(secrets.getByName.mock.calls.map((call) => call[1])).toEqual([
+        "GITLAB_TOKEN",
+      ]);
+    });
+
+    it("resolves GitHub and GitLab credentials independently within one run", async () => {
+      const secrets = buildSecretsFake({ GITHUB_TOKEN: "gh-token", GITLAB_TOKEN: "gl-token" });
+      const provider = createGitRemoteAuthProvider(fakeDb, "company-1", undefined, {
+        secrets,
+        env: {},
+      });
+      const githubInvocation = await provider(githubUrl);
+      const gitlabInvocation = await provider(gitlabUrl);
+      expect(githubInvocation?.env[GIT_CREDENTIAL_TOKEN_ENV_KEY]).toBe("gh-token");
+      expect(gitlabInvocation?.env[GIT_CREDENTIAL_TOKEN_ENV_KEY]).toBe("gl-token");
+      // One lookup chain per host, not one shared/cross-contaminated lookup.
+      expect(secrets.getByName.mock.calls.map((call) => call[1])).toEqual(["GITHUB_TOKEN", "GITLAB_TOKEN"]);
+    });
+  });
 });
 
 describe("buildGitAuthInvocation", () => {
@@ -191,6 +267,7 @@ describe("buildGitAuthInvocation", () => {
       token: "super-secret-token",
       source: "company_secret",
       secretName: "GITHUB_TOKEN",
+      providerId: "github",
     });
     expect(invocation.configArgs.join(" ")).not.toContain("super-secret-token");
     expect(invocation.configArgs[0]).toBe("-c");
@@ -203,6 +280,7 @@ describe("buildGitAuthInvocation", () => {
     expect(invocation.env.GITHUB_TOKEN).toBe("super-secret-token");
     expect(invocation.env.GIT_TERMINAL_PROMPT).toBe("0");
     expect(invocation.env).not.toHaveProperty("HOME");
+    expect(invocation.providerId).toBe("github");
   });
 
   it("sets GitHub's stable noreply commit identity without exposing the token in config", () => {
@@ -210,6 +288,7 @@ describe("buildGitAuthInvocation", () => {
       token: "super-secret-token",
       source: "managed_connection",
       secretName: null,
+      providerId: "github",
       githubIdentity: { userId: "12345", login: "octocat" },
     });
     expect(invocation.env.GIT_CONFIG_KEY_7).toBe("user.name");
@@ -222,16 +301,34 @@ describe("buildGitAuthInvocation", () => {
     expect(invocation.env.GIT_COMMITTER_EMAIL).toBe("12345+octocat@users.noreply.github.com");
     expect(Object.values(invocation.env).filter((value) => value.includes("super-secret-token"))).toHaveLength(3);
   });
+
+  it("keeps the token out of argv and installs the helper URL-scoped to gitlab.com", () => {
+    const invocation = buildGitAuthInvocation({
+      token: "super-secret-token",
+      source: "company_secret",
+      secretName: "GITLAB_TOKEN",
+      providerId: "gitlab",
+    });
+    expect(invocation.configArgs.join(" ")).not.toContain("super-secret-token");
+    expect(invocation.configArgs[0]).toBe("-c");
+    expect(invocation.configArgs[1]).toBe("credential.helper=");
+    expect(invocation.configArgs[3]).toContain("credential.https://gitlab.com.helper=");
+    expect(invocation.configArgs[3]).toContain("oauth2");
+    expect(invocation.configArgs[5]).toContain("credential.https://www.gitlab.com.helper=");
+    expect(invocation.env[GIT_CREDENTIAL_TOKEN_ENV_KEY]).toBe("super-secret-token");
+    expect(invocation.providerId).toBe("gitlab");
+  });
 });
 
 describe("credential helper execution (real git, no network)", () => {
-  async function runCredentialFill(description: string) {
+  async function runCredentialFill(description: string, providerId: "github" | "gitlab" = "github") {
     const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-git-cred-fill-"));
     try {
       const invocation = buildGitAuthInvocation({
         token: "abc123",
         source: "company_secret",
-        secretName: "GITHUB_TOKEN",
+        secretName: providerId === "github" ? "GITHUB_TOKEN" : "GITLAB_TOKEN",
+        providerId,
       });
       return await new Promise<{ code: number | null; stdout: string; stderr: string }>(
         (resolve, reject) => {
@@ -277,6 +374,25 @@ describe("credential helper execution (real git, no network)", () => {
     expect(result.code).not.toBe(0);
     expect(result.stdout).not.toContain("abc123");
   });
+
+  it("answers a gitlab.com https request with the env-carried token, using the oauth2 username", async () => {
+    const result = await runCredentialFill("protocol=https\nhost=gitlab.com\n\n", "gitlab");
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("username=oauth2");
+    expect(result.stdout).toContain("password=abc123");
+  });
+
+  it("a gitlab-scoped invocation never answers for github.com", async () => {
+    const result = await runCredentialFill("protocol=https\nhost=github.com\n\n", "gitlab");
+    expect(result.code).not.toBe(0);
+    expect(result.stdout).not.toContain("abc123");
+  });
+
+  it("a github-scoped invocation never answers for gitlab.com", async () => {
+    const result = await runCredentialFill("protocol=https\nhost=gitlab.com\n\n", "github");
+    expect(result.code).not.toBe(0);
+    expect(result.stdout).not.toContain("abc123");
+  });
 });
 
 describe("scrubGitCredentialText", () => {
@@ -310,25 +426,63 @@ describe("scrubGitCredentialText", () => {
 });
 
 describe("describeGitAuthFailure", () => {
-  it("names the company secret when a stored credential was used", () => {
+  it("names the company secret when a stored GitHub credential was used", () => {
     expect(describeGitAuthFailure({
       error: "fatal: Authentication failed",
-      used: { source: "company_secret", secretName: "GH_TOKEN" },
+      used: { source: "company_secret", secretName: "GH_TOKEN", providerId: "github" },
     })).toContain("the GH_TOKEN company-secret GitHub credential");
   });
 
-  it("names the server environment when an env credential was used", () => {
+  it("names the server environment when an env GitHub credential was used", () => {
     expect(describeGitAuthFailure({
       error: "fatal: Authentication failed",
-      used: { source: "server_env", secretName: null },
+      used: { source: "server_env", secretName: null, providerId: "github" },
     })).toContain("server-environment GitHub credential");
   });
 
-  it("points at Settings → Secrets for auth-looking failures without a credential", () => {
+  it("names the company secret when a stored GitLab credential was used", () => {
+    expect(describeGitAuthFailure({
+      error: "fatal: Authentication failed",
+      used: { source: "company_secret", secretName: "GITLAB_TOKEN", providerId: "gitlab" },
+    })).toContain("the GITLAB_TOKEN company-secret GitLab credential");
+  });
+
+  it("names the server environment when an env GitLab credential was used", () => {
+    expect(describeGitAuthFailure({
+      error: "fatal: Authentication failed",
+      used: { source: "server_env", secretName: null, providerId: "gitlab" },
+    })).toContain("server-environment GitLab credential");
+  });
+
+  it("points at Settings → Secrets for a GitHub remote with no credential", () => {
     expect(describeGitAuthFailure({
       error: "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
       used: null,
-    })).toContain("add a GITHUB_TOKEN or GH_TOKEN company secret");
+      remoteUrl: "https://github.com/example/repo.git",
+    })).toContain("No GitHub credential is configured — add a GITHUB_TOKEN or GH_TOKEN company secret");
+  });
+
+  it("points at Settings → Secrets for a GitLab remote with no credential", () => {
+    expect(describeGitAuthFailure({
+      error: "fatal: could not read Username for 'https://gitlab.com': terminal prompts disabled",
+      used: null,
+      remoteUrl: "https://gitlab.com/example/repo.git",
+    })).toContain("No GitLab credential is configured — add a GITLAB_TOKEN company secret");
+  });
+
+  it("falls back to generic guidance when the remote's provider is unknown", () => {
+    expect(describeGitAuthFailure({
+      error: "fatal: could not read Username for 'https://bitbucket.org': terminal prompts disabled",
+      used: null,
+      remoteUrl: "https://bitbucket.org/example/repo.git",
+    })).toContain("No git credential is configured — add a GITHUB_TOKEN/GH_TOKEN or GITLAB_TOKEN company secret");
+  });
+
+  it("falls back to generic guidance when no remoteUrl is available either", () => {
+    expect(describeGitAuthFailure({
+      error: "fatal: could not read Username for 'https://example.invalid': terminal prompts disabled",
+      used: null,
+    })).toContain("No git credential is configured — add a GITHUB_TOKEN/GH_TOKEN or GITLAB_TOKEN company secret");
   });
 
   it("stays silent for non-auth failures without a credential", () => {
@@ -343,7 +497,7 @@ describe("describeGitAuthFailure", () => {
     // collision) must not be blamed for it.
     expect(describeGitAuthFailure({
       error: "fatal: destination path '/x/y' already exists and is not an empty directory.",
-      used: { source: "company_secret", secretName: "GH_TOKEN" },
+      used: { source: "company_secret", secretName: "GH_TOKEN", providerId: "github" },
     })).toBeNull();
   });
 });
@@ -354,6 +508,15 @@ describe("DEFAULT_GITHUB_TOKEN_SECRET_NAMES", () => {
       "GITHUB_TOKEN",
       "GH_TOKEN",
       "PAPERCLIP_GITHUB_TOKEN",
+    ]);
+  });
+});
+
+describe("DEFAULT_GITLAB_TOKEN_SECRET_NAMES", () => {
+  it("keeps the shared name order stable", () => {
+    expect([...DEFAULT_GITLAB_TOKEN_SECRET_NAMES]).toEqual([
+      "GITLAB_TOKEN",
+      "PAPERCLIP_GITLAB_TOKEN",
     ]);
   });
 });

--- a/server/src/__tests__/git-credentials.test.ts
+++ b/server/src/__tests__/git-credentials.test.ts
@@ -340,6 +340,54 @@ describe("createGitRemoteAuthProvider", () => {
       expect(invocation?.source).toBe("server_env");
       expect(invocation?.env[GIT_CREDENTIAL_TOKEN_ENV_KEY]).toBe("env-gitlab");
     });
+
+    describe("custom ports", () => {
+      const portedUrl = "https://gitlab.mycompany.com:1234/example/repo.git";
+
+      it("matches a configured host:port exactly, scoping the helper to host:port", async () => {
+        const secrets = buildSecretsFake({ GITLAB_TOKEN: "glpat-token" });
+        const provider = createGitRemoteAuthProvider(fakeDb, "company-1", undefined, {
+          secrets,
+          env: { PAPERCLIP_GITLAB_HOSTS: "gitlab.mycompany.com:1234" },
+        });
+        const invocation = await provider(portedUrl);
+        expect(invocation?.env[GIT_CREDENTIAL_TOKEN_ENV_KEY]).toBe("glpat-token");
+        // The config key must carry the port too -- git only consults credential.<url>.helper
+        // for the exact port it specifies (an omitted port matches only the default port).
+        expect(invocation?.configArgs.join(" ")).toContain(
+          "credential.https://gitlab.mycompany.com:1234.helper=",
+        );
+      });
+
+      it("accepts a configured full URL with a port", async () => {
+        const secrets = buildSecretsFake({ GITLAB_TOKEN: "glpat-token" });
+        const provider = createGitRemoteAuthProvider(fakeDb, "company-1", undefined, {
+          secrets,
+          env: { PAPERCLIP_GITLAB_HOSTS: "https://gitlab.mycompany.com:1234/" },
+        });
+        await expect(provider(portedUrl)).resolves.not.toBeNull();
+      });
+
+      it("does not match when the configured host omits the port the remote actually uses", async () => {
+        const secrets = buildSecretsFake({ GITLAB_TOKEN: "glpat-token" });
+        const provider = createGitRemoteAuthProvider(fakeDb, "company-1", undefined, {
+          // Configured without a port; the remote is on a non-default one. Least-privilege
+          // means this must stay out of scope rather than guessing the operator meant any port.
+          secrets,
+          env: { PAPERCLIP_GITLAB_HOSTS: "gitlab.mycompany.com" },
+        });
+        await expect(provider(portedUrl)).resolves.toBeNull();
+      });
+
+      it("does not match a different port than the one configured", async () => {
+        const secrets = buildSecretsFake({ GITLAB_TOKEN: "glpat-token" });
+        const provider = createGitRemoteAuthProvider(fakeDb, "company-1", undefined, {
+          secrets,
+          env: { PAPERCLIP_GITLAB_HOSTS: "gitlab.mycompany.com:5678" },
+        });
+        await expect(provider(portedUrl)).resolves.toBeNull();
+      });
+    });
   });
 });
 
@@ -491,6 +539,40 @@ describe("credential helper execution (real git, no network)", () => {
     const result = await runCredentialFill("protocol=https\nhost=gitlab.com\n\n", "github");
     expect(result.code).not.toBe(0);
     expect(result.stdout).not.toContain("abc123");
+  });
+
+  it("answers a self-hosted request on a custom port, with the port in git's host= line", async () => {
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-git-cred-fill-port-"));
+    try {
+      const invocation = buildGitAuthInvocation(
+        {
+          token: "abc123",
+          source: "company_secret",
+          secretName: "GITLAB_TOKEN",
+          providerId: "gitlab",
+        },
+        ["gitlab.mycompany.com:1234"],
+      );
+      const result = await new Promise<{ code: number | null; stdout: string }>((resolve, reject) => {
+        const child = spawn("git", [...invocation.configArgs, "credential", "fill"], {
+          cwd,
+          env: { ...process.env, ...invocation.env },
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+        let stdout = "";
+        child.stdout.on("data", (chunk) => { stdout += String(chunk); });
+        child.on("error", reject);
+        child.on("close", (code) => resolve({ code, stdout }));
+        // Git's credential protocol carries the port as part of `host=` for a non-default port.
+        child.stdin.write("protocol=https\nhost=gitlab.mycompany.com:1234\n\n");
+        child.stdin.end();
+      });
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain("username=oauth2");
+      expect(result.stdout).toContain("password=abc123");
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
   });
 });
 

--- a/server/src/__tests__/git-credentials.test.ts
+++ b/server/src/__tests__/git-credentials.test.ts
@@ -440,6 +440,40 @@ describe("createGitRemoteAuthProvider", () => {
         const invocation = await provider(selfHostedUrl);
         expect(invocation?.env.GIT_SSL_CAINFO).toBeUndefined();
       });
+
+      it("never leaks the CA path into a GitHub invocation from the same provider, in either call order", async () => {
+        // Each invocation is a freshly-built env object for one specific execFile("git", ...)
+        // call, not process-wide state -- a mixed GitHub + self-hosted-GitLab company must see
+        // no cross-contamination regardless of which project is cloned first, or whether the
+        // per-provider credential memoization (keyed by providerId) is warm for one host and
+        // cold for the other.
+        const secrets = buildSecretsFake({ GITHUB_TOKEN: "gh-token", GITLAB_TOKEN: "glpat-token" });
+
+        const forward = createGitRemoteAuthProvider(fakeDb, "company-1", undefined, {
+          secrets,
+          env: {
+            PAPERCLIP_GITLAB_HOSTS: "gitlab.mycompany.com",
+            PAPERCLIP_GITLAB_CA_CERT_PATH: "/paperclip/ca/lab-ca.pem",
+          },
+        });
+        const gitlabFirst = await forward(selfHostedUrl);
+        const githubSecond = await forward(githubUrl);
+        expect(gitlabFirst?.env.GIT_SSL_CAINFO).toBe("/paperclip/ca/lab-ca.pem");
+        expect(githubSecond?.env.GIT_SSL_CAINFO).toBeUndefined();
+        expect(githubSecond?.env[GIT_CREDENTIAL_TOKEN_ENV_KEY]).toBe("gh-token");
+
+        const reversed = createGitRemoteAuthProvider(fakeDb, "company-1", undefined, {
+          secrets,
+          env: {
+            PAPERCLIP_GITLAB_HOSTS: "gitlab.mycompany.com",
+            PAPERCLIP_GITLAB_CA_CERT_PATH: "/paperclip/ca/lab-ca.pem",
+          },
+        });
+        const githubFirst = await reversed(githubUrl);
+        const gitlabSecond = await reversed(selfHostedUrl);
+        expect(githubFirst?.env.GIT_SSL_CAINFO).toBeUndefined();
+        expect(gitlabSecond?.env.GIT_SSL_CAINFO).toBe("/paperclip/ca/lab-ca.pem");
+      });
     });
   });
 });

--- a/server/src/__tests__/git-credentials.test.ts
+++ b/server/src/__tests__/git-credentials.test.ts
@@ -259,6 +259,88 @@ describe("createGitRemoteAuthProvider", () => {
       expect(secrets.getByName.mock.calls.map((call) => call[1])).toEqual(["GITHUB_TOKEN", "GITLAB_TOKEN"]);
     });
   });
+
+  describe("self-hosted GitLab (PAPERCLIP_GITLAB_HOSTS)", () => {
+    const selfHostedUrl = "https://gitlab.mycompany.com/example/repo.git";
+
+    it("is out of scope with no PAPERCLIP_GITLAB_HOSTS configured", async () => {
+      const secrets = buildSecretsFake({ GITLAB_TOKEN: "glpat-token" });
+      const provider = createGitRemoteAuthProvider(fakeDb, "company-1", undefined, {
+        secrets,
+        env: {},
+      });
+      await expect(provider(selfHostedUrl)).resolves.toBeNull();
+      expect(secrets.getByName).not.toHaveBeenCalled();
+    });
+
+    it("authenticates a configured self-hosted host with the same GITLAB_TOKEN secret", async () => {
+      const secrets = buildSecretsFake({ GITLAB_TOKEN: "glpat-token" });
+      const provider = createGitRemoteAuthProvider(fakeDb, "company-1", undefined, {
+        secrets,
+        env: { PAPERCLIP_GITLAB_HOSTS: "gitlab.mycompany.com" },
+      });
+      const invocation = await provider(selfHostedUrl);
+      expect(invocation?.env[GIT_CREDENTIAL_TOKEN_ENV_KEY]).toBe("glpat-token");
+      expect(invocation?.providerId).toBe("gitlab");
+      // Scoped to exactly the self-hosted host, never gitlab.com.
+      expect(invocation?.configArgs.join(" ")).toContain("credential.https://gitlab.mycompany.com.helper=");
+      expect(invocation?.configArgs.join(" ")).not.toContain("credential.https://gitlab.com.helper=");
+    });
+
+    it("accepts a full URL entry and normalizes it to a bare hostname", async () => {
+      const secrets = buildSecretsFake({ GITLAB_TOKEN: "glpat-token" });
+      const provider = createGitRemoteAuthProvider(fakeDb, "company-1", undefined, {
+        secrets,
+        env: { PAPERCLIP_GITLAB_HOSTS: "https://gitlab.mycompany.com/" },
+      });
+      await expect(provider(selfHostedUrl)).resolves.not.toBeNull();
+    });
+
+    it("supports multiple comma-separated self-hosted hosts", async () => {
+      const secrets = buildSecretsFake({ GITLAB_TOKEN: "glpat-token" });
+      const provider = createGitRemoteAuthProvider(fakeDb, "company-1", undefined, {
+        secrets,
+        env: { PAPERCLIP_GITLAB_HOSTS: "gitlab.a.example, gitlab.mycompany.com ,gitlab.b.example" },
+      });
+      const invocation = await provider(selfHostedUrl);
+      expect(invocation?.env[GIT_CREDENTIAL_TOKEN_ENV_KEY]).toBe("glpat-token");
+      // Scoped only to the one host actually being cloned, not the other configured hosts.
+      expect(invocation?.configArgs.join(" ")).not.toContain("gitlab.a.example");
+      expect(invocation?.configArgs.join(" ")).not.toContain("gitlab.b.example");
+    });
+
+    it("stays out of scope for a host not in the configured list", async () => {
+      const secrets = buildSecretsFake({ GITLAB_TOKEN: "glpat-token" });
+      const provider = createGitRemoteAuthProvider(fakeDb, "company-1", undefined, {
+        secrets,
+        env: { PAPERCLIP_GITLAB_HOSTS: "gitlab.other-company.example" },
+      });
+      await expect(provider(selfHostedUrl)).resolves.toBeNull();
+    });
+
+    it("still authenticates gitlab.com itself when self-hosted hosts are also configured", async () => {
+      const secrets = buildSecretsFake({ GITLAB_TOKEN: "glpat-token" });
+      const provider = createGitRemoteAuthProvider(fakeDb, "company-1", undefined, {
+        secrets,
+        env: { PAPERCLIP_GITLAB_HOSTS: "gitlab.mycompany.com" },
+      });
+      const invocation = await provider("https://gitlab.com/example/repo.git");
+      expect(invocation?.env[GIT_CREDENTIAL_TOKEN_ENV_KEY]).toBe("glpat-token");
+      expect(invocation?.configArgs.join(" ")).toContain("credential.https://gitlab.com.helper=");
+      // The default SaaS match keeps scoping to both SaaS hosts, unaffected by self-hosted config.
+      expect(invocation?.configArgs.join(" ")).toContain("credential.https://www.gitlab.com.helper=");
+    });
+
+    it("falls back to the server env GITLAB_TOKEN for a self-hosted host too", async () => {
+      const provider = createGitRemoteAuthProvider(fakeDb, "company-1", undefined, {
+        secrets: buildSecretsFake({}),
+        env: { PAPERCLIP_GITLAB_HOSTS: "gitlab.mycompany.com", GITLAB_TOKEN: "env-gitlab" },
+      });
+      const invocation = await provider(selfHostedUrl);
+      expect(invocation?.source).toBe("server_env");
+      expect(invocation?.env[GIT_CREDENTIAL_TOKEN_ENV_KEY]).toBe("env-gitlab");
+    });
+  });
 });
 
 describe("buildGitAuthInvocation", () => {
@@ -317,6 +399,23 @@ describe("buildGitAuthInvocation", () => {
     expect(invocation.configArgs[5]).toContain("credential.https://www.gitlab.com.helper=");
     expect(invocation.env[GIT_CREDENTIAL_TOKEN_ENV_KEY]).toBe("super-secret-token");
     expect(invocation.providerId).toBe("gitlab");
+  });
+
+  it("scopes the helper to exactly the given hosts when scopedHosts is passed", () => {
+    const invocation = buildGitAuthInvocation(
+      {
+        token: "super-secret-token",
+        source: "company_secret",
+        secretName: "GITLAB_TOKEN",
+        providerId: "gitlab",
+      },
+      ["gitlab.mycompany.com"],
+    );
+    const joined = invocation.configArgs.join(" ");
+    expect(joined).toContain("credential.https://gitlab.mycompany.com.helper=");
+    expect(joined).toContain("oauth2");
+    expect(joined).not.toContain("credential.https://gitlab.com.helper=");
+    expect(joined).not.toContain("credential.https://www.gitlab.com.helper=");
   });
 });
 
@@ -475,6 +574,24 @@ describe("describeGitAuthFailure", () => {
       error: "fatal: could not read Username for 'https://bitbucket.org': terminal prompts disabled",
       used: null,
       remoteUrl: "https://bitbucket.org/example/repo.git",
+    })).toContain("No git credential is configured — add a GITHUB_TOKEN/GH_TOKEN or GITLAB_TOKEN company secret");
+  });
+
+  it("recognizes a configured self-hosted GitLab remote with no credential", () => {
+    expect(describeGitAuthFailure({
+      error: "fatal: could not read Username for 'https://gitlab.mycompany.com': terminal prompts disabled",
+      used: null,
+      remoteUrl: "https://gitlab.mycompany.com/example/repo.git",
+      env: { PAPERCLIP_GITLAB_HOSTS: "gitlab.mycompany.com" },
+    })).toContain("No GitLab credential is configured — add a GITLAB_TOKEN company secret");
+  });
+
+  it("falls back to generic guidance for an unconfigured self-hosted-looking host", () => {
+    expect(describeGitAuthFailure({
+      error: "fatal: could not read Username for 'https://gitlab.mycompany.com': terminal prompts disabled",
+      used: null,
+      remoteUrl: "https://gitlab.mycompany.com/example/repo.git",
+      env: {},
     })).toContain("No git credential is configured — add a GITHUB_TOKEN/GH_TOKEN or GITLAB_TOKEN company secret");
   });
 

--- a/server/src/__tests__/git-credentials.test.ts
+++ b/server/src/__tests__/git-credentials.test.ts
@@ -685,6 +685,42 @@ describe("credential helper execution (real git, no network)", () => {
       await fs.rm(cwd, { recursive: true, force: true });
     }
   });
+
+  it("answers a self-hosted request on a bracketed IPv6 host", async () => {
+    // A bracketed IPv6 host lands unescaped in the credential helper's shell `case` pattern
+    // unless `[`/`]` are escaped there -- the shell would otherwise read them as a glob
+    // character class instead of literal brackets, and the pattern would never match.
+    const cwd = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-git-cred-fill-ipv6-"));
+    try {
+      const invocation = buildGitAuthInvocation(
+        {
+          token: "abc123",
+          source: "company_secret",
+          secretName: "GITLAB_TOKEN",
+          providerId: "gitlab",
+        },
+        ["[2001:db8::1]:8443"],
+      );
+      const result = await new Promise<{ code: number | null; stdout: string }>((resolve, reject) => {
+        const child = spawn("git", [...invocation.configArgs, "credential", "fill"], {
+          cwd,
+          env: { ...process.env, ...invocation.env },
+          stdio: ["pipe", "pipe", "pipe"],
+        });
+        let stdout = "";
+        child.stdout.on("data", (chunk) => { stdout += String(chunk); });
+        child.on("error", reject);
+        child.on("close", (code) => resolve({ code, stdout }));
+        child.stdin.write("protocol=https\nhost=[2001:db8::1]:8443\n\n");
+        child.stdin.end();
+      });
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain("username=oauth2");
+      expect(result.stdout).toContain("password=abc123");
+    } finally {
+      await fs.rm(cwd, { recursive: true, force: true });
+    }
+  });
 });
 
 // This module never sends real bytes over the wire on its own (`buildGitAuthInvocation` only

--- a/server/src/__tests__/heartbeat-managed-clone-credentials.test.ts
+++ b/server/src/__tests__/heartbeat-managed-clone-credentials.test.ts
@@ -82,6 +82,8 @@ describe("ensureManagedProjectWorkspace clone credentials", () => {
       env: { [GIT_CREDENTIAL_TOKEN_ENV_KEY]: "token", GIT_TERMINAL_PROMPT: "0" },
       source: "company_secret" as const,
       secretName: "GH_TOKEN",
+      providerId: "github" as const,
+      providerLabel: "GitHub",
     }));
     const error = await ensureManagedProjectWorkspace({
       companyId: "company-authfail",
@@ -184,6 +186,7 @@ describe("ensureManagedProjectWorkspace clone credentials", () => {
       token: "tok",
       source: "company_secret",
       secretName: "GITHUB_TOKEN",
+      providerId: "github",
     });
     const cloneEnv = {
       ...sanitizeRuntimeServiceBaseEnv({ ...process.env, [GIT_CREDENTIAL_TOKEN_ENV_KEY]: "stale" }),

--- a/server/src/__tests__/workspace-runtime.test.ts
+++ b/server/src/__tests__/workspace-runtime.test.ts
@@ -639,10 +639,25 @@ describe("refreshRemoteTrackingBaseRef git auth", () => {
       env: { GIT_TERMINAL_PROMPT: "0" },
       source: "company_secret",
       secretName: "GH_TOKEN",
+      providerLabel: "GitHub",
     }));
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toContain("Could not refresh base ref origin/master");
     expect(warnings[0]).toContain("the GH_TOKEN company-secret GitHub credential");
+  });
+
+  it("attributes a failed authenticated fetch to a GitLab credential when that provider was used", async () => {
+    const { repoRoot } = await createClonedRepoWithRemote();
+    await runGit(repoRoot, ["remote", "set-url", "origin", path.join(os.tmpdir(), "paperclip-missing-remote", "repo.git")]);
+    const warnings = await refreshRemoteTrackingBaseRef(repoRoot, "origin/master", async () => ({
+      configArgs: [],
+      env: { GIT_TERMINAL_PROMPT: "0" },
+      source: "company_secret",
+      secretName: "GITLAB_TOKEN",
+      providerLabel: "GitLab",
+    }));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("the GITLAB_TOKEN company-secret GitLab credential");
   });
 
   it("keeps the unauthenticated failure warning credential-free without a provider", async () => {

--- a/server/src/services/git-credentials.ts
+++ b/server/src/services/git-credentials.ts
@@ -30,10 +30,12 @@ import { toolAccessService } from "./tool-access.js";
  *
  * GitLab additionally supports a self-managed instance at an operator-chosen domain (there is
  * no equivalent for GitHub — GHES stays out of scope, as it always has been here): set
- * `PAPERCLIP_GITLAB_HOSTS` to that instance's hostname (comma-separated for more than one) and
- * the same `GITLAB_TOKEN`/`PAPERCLIP_GITLAB_TOKEN` company secret or `GITLAB_TOKEN` server env
- * used for gitlab.com now also authenticates that host, with the credential helper scoped
- * strictly to it — never to gitlab.com or a different configured self-managed host.
+ * `PAPERCLIP_GITLAB_HOSTS` to that instance's `host[:port]` (comma-separated for more than one;
+ * include the port explicitly if the instance runs on a non-default one, e.g.
+ * `gitlab.mycompany.com:1234` — omitting it only matches the default HTTPS port) and the same
+ * `GITLAB_TOKEN`/`PAPERCLIP_GITLAB_TOKEN` company secret or `GITLAB_TOKEN` server env used for
+ * gitlab.com now also authenticates that host, with the credential helper scoped strictly to
+ * it — never to gitlab.com or a different configured self-managed host.
  */
 
 export type GitProviderId = "github" | "gitlab";
@@ -54,7 +56,8 @@ type GitHostProviderConfig = {
    * Server env var naming this provider's self-managed instance host(s), for operators who
    * run their own server on a custom domain (GitLab's self-hosted offering; there is no
    * equivalent GHES support here, matching this module's prior GHES-out-of-scope stance).
-   * Comma-separated; each entry is a bare hostname or a full URL (only the hostname is used).
+   * Comma-separated; each entry is a bare `host[:port]` or a full URL (only `host[:port]` is
+   * used — an explicit non-default port must be included, since it is not inferred).
    * Undefined for a provider with no self-hosted mode.
    */
   selfHostedEnvName?: string;
@@ -101,16 +104,23 @@ function getGitHostProvider(id: GitProviderId): GitHostProviderConfig {
 }
 
 /**
- * Extract a bare lowercase hostname from an operator-supplied entry in a `selfHostedEnvName`
- * value: either a full URL (`https://gitlab.mycompany.com/`) or a bare hostname
- * (`gitlab.mycompany.com`). Returns null for an empty or unparseable entry.
+ * Extract a lowercase `host[:port]` from an operator-supplied entry in a `selfHostedEnvName`
+ * value: either a full URL (`https://gitlab.mycompany.com:1234/`) or a bare
+ * `host[:port]` (`gitlab.mycompany.com:1234`). Returns null for an empty or unparseable entry.
+ *
+ * Deliberately `URL.host`, not `URL.hostname`: git's credential protocol carries the port as
+ * part of its `host=` field on a non-default port, and `credential.<url>.helper` config keys
+ * are matched port-for-port — a config key that omits the port is consulted only for the
+ * scheme's default port (443 for https), never for an arbitrary one. Dropping the port here
+ * would silently make a self-hosted instance on a custom port unreachable end-to-end: the
+ * helper would never even be consulted, let alone answer.
  */
 function normalizeConfiguredHost(value: string): string | null {
   const trimmed = value.trim();
   if (!trimmed) return null;
   try {
     const url = new URL(trimmed.includes("://") ? trimmed : `https://${trimmed}`);
-    return url.hostname.toLowerCase() || null;
+    return url.host.toLowerCase() || null;
   } catch {
     return null;
   }
@@ -175,10 +185,12 @@ function resolveGitHostMatch(
     return null;
   }
   if (parsed.protocol !== "https:" || parsed.username || parsed.password) return null;
-  const hostname = parsed.hostname.toLowerCase();
+  // `.host`, not `.hostname` — see `normalizeConfiguredHost` for why the port must survive to
+  // this comparison and into `scopedHosts`.
+  const hostWithPort = parsed.host.toLowerCase();
   for (const provider of GIT_HOST_PROVIDERS) {
-    if (resolveConfiguredSelfHostedHosts(provider, env).includes(hostname)) {
-      return { provider, scopedHosts: [hostname] };
+    if (resolveConfiguredSelfHostedHosts(provider, env).includes(hostWithPort)) {
+      return { provider, scopedHosts: [hostWithPort] };
     }
   }
   return null;

--- a/server/src/services/git-credentials.ts
+++ b/server/src/services/git-credentials.ts
@@ -36,6 +36,13 @@ import { toolAccessService } from "./tool-access.js";
  * `GITLAB_TOKEN`/`PAPERCLIP_GITLAB_TOKEN` company secret or `GITLAB_TOKEN` server env used for
  * gitlab.com now also authenticates that host, with the credential helper scoped strictly to
  * it — never to gitlab.com or a different configured self-managed host.
+ *
+ * A self-managed instance on a private/internal CA (common — that is usually the whole reason
+ * it is self-managed) can additionally set `PAPERCLIP_GITLAB_CA_CERT_PATH` to a PEM bundle file
+ * on the server's own filesystem. It is applied only to a self-hosted match, never to
+ * gitlab.com: `GIT_SSL_CAINFO` *replaces* git's default trust store for the git process it is
+ * set on rather than adding to it, so applying it unconditionally would break TLS verification
+ * for the public SaaS domain unless that bundle happened to also carry the public roots.
  */
 
 export type GitProviderId = "github" | "gitlab";
@@ -61,6 +68,13 @@ type GitHostProviderConfig = {
    * Undefined for a provider with no self-hosted mode.
    */
   selfHostedEnvName?: string;
+  /**
+   * Server env var naming a PEM CA bundle file trusted for this provider's self-managed
+   * instance(s) — for a private/internal CA the public trust store does not include. Applied
+   * only when the matched remote is self-hosted (never for the provider's SaaS domain — see
+   * the module doc comment for why). Undefined for a provider with no self-hosted mode.
+   */
+  selfHostedCaCertEnvName?: string;
 };
 
 /** Company-secret names probed for a GitHub token, in priority order. */
@@ -94,6 +108,7 @@ const GIT_HOST_PROVIDERS: readonly GitHostProviderConfig[] = [
     secretNames: DEFAULT_GITLAB_TOKEN_SECRET_NAMES,
     envNames: ["GITLAB_TOKEN"],
     selfHostedEnvName: "PAPERCLIP_GITLAB_HOSTS",
+    selfHostedCaCertEnvName: "PAPERCLIP_GITLAB_CA_CERT_PATH",
   },
 ];
 
@@ -139,6 +154,12 @@ function resolveConfiguredSelfHostedHosts(provider: GitHostProviderConfig, env: 
   return Array.from(hosts);
 }
 
+/** This provider's operator-configured self-managed CA bundle path, if any. */
+function resolveConfiguredCaCertPath(provider: GitHostProviderConfig, env: NodeJS.ProcessEnv): string | undefined {
+  if (!provider.selfHostedCaCertEnvName) return undefined;
+  return env[provider.selfHostedCaCertEnvName]?.trim() || undefined;
+}
+
 /**
  * Resolve the supported provider for one remote URL, or null when the URL is out of scope:
  * non-HTTPS, an unsupported host, or already credentialed (inline userinfo, which this module
@@ -169,14 +190,15 @@ function resolveGitHostProvider(remoteUrl: string): GitHostProviderConfig | null
  * host list for a SaaS match (unchanged from before self-hosted support existed), or exactly
  * the one matched self-hosted host and no other configured self-hosted host, so one
  * self-managed instance's token is never offered to a different self-managed instance or to
- * the SaaS domain.
+ * the SaaS domain. `selfHosted` tells the caller whether it is safe to also apply a configured
+ * CA bundle (see `selfHostedCaCertEnvName`) — never for a SaaS match.
  */
 function resolveGitHostMatch(
   remoteUrl: string,
   env: NodeJS.ProcessEnv,
-): { provider: GitHostProviderConfig; scopedHosts: readonly string[] } | null {
+): { provider: GitHostProviderConfig; scopedHosts: readonly string[]; selfHosted: boolean } | null {
   const staticProvider = resolveGitHostProvider(remoteUrl);
-  if (staticProvider) return { provider: staticProvider, scopedHosts: staticProvider.hosts };
+  if (staticProvider) return { provider: staticProvider, scopedHosts: staticProvider.hosts, selfHosted: false };
 
   let parsed: URL;
   try {
@@ -190,7 +212,7 @@ function resolveGitHostMatch(
   const hostWithPort = parsed.host.toLowerCase();
   for (const provider of GIT_HOST_PROVIDERS) {
     if (resolveConfiguredSelfHostedHosts(provider, env).includes(hostWithPort)) {
-      return { provider, scopedHosts: [hostWithPort] };
+      return { provider, scopedHosts: [hostWithPort], selfHosted: true };
     }
   }
   return null;
@@ -315,6 +337,14 @@ export function buildGitAuthInvocation(
    * never offered to a different host, including the provider's own SaaS domain.
    */
   scopedHosts?: readonly string[],
+  /**
+   * A PEM CA bundle path to trust via `GIT_SSL_CAINFO`, for a self-hosted instance on a
+   * private/internal CA. Callers must pass this only alongside a self-hosted `scopedHosts`
+   * (never for a SaaS match): `GIT_SSL_CAINFO` replaces git's default trust store for the git
+   * process it is set on, so applying it to a gitlab.com clone would break that clone's TLS
+   * verification unless the bundle also carried the public roots.
+   */
+  caCertPath?: string,
 ): GitAuthInvocation {
   const provider = getGitHostProvider(credential.providerId);
   const hosts = scopedHosts ?? provider.hosts;
@@ -352,37 +382,41 @@ export function buildGitAuthInvocation(
       ]
     : [];
 
+  const env: Record<string, string> = {
+    [GIT_CREDENTIAL_TOKEN_ENV_KEY]: credential.token,
+    ...(provider.id === "github"
+      ? {
+          GH_TOKEN: credential.token,
+          GITHUB_TOKEN: credential.token,
+        }
+      : {}),
+    GIT_TERMINAL_PROMPT: "0",
+    ...(identity
+      ? {
+          GIT_AUTHOR_NAME: identity.login,
+          GIT_AUTHOR_EMAIL: noreplyEmail!,
+          GIT_COMMITTER_NAME: identity.login,
+          GIT_COMMITTER_EMAIL: noreplyEmail!,
+        }
+      : {}),
+    ...(configEntries.length > 0
+      ? {
+          GIT_CONFIG_COUNT: String(configEntries.length),
+          ...Object.fromEntries(
+            configEntries.flatMap(([key, value], index) => [
+              [`GIT_CONFIG_KEY_${index}`, key],
+              [`GIT_CONFIG_VALUE_${index}`, value],
+            ]),
+          ),
+        }
+      : {}),
+  };
+  if (caCertPath) {
+    env.GIT_SSL_CAINFO = caCertPath;
+  }
   return {
     configArgs,
-    env: {
-      [GIT_CREDENTIAL_TOKEN_ENV_KEY]: credential.token,
-      ...(provider.id === "github"
-        ? {
-            GH_TOKEN: credential.token,
-            GITHUB_TOKEN: credential.token,
-          }
-        : {}),
-      GIT_TERMINAL_PROMPT: "0",
-      ...(identity
-        ? {
-            GIT_AUTHOR_NAME: identity.login,
-            GIT_AUTHOR_EMAIL: noreplyEmail!,
-            GIT_COMMITTER_NAME: identity.login,
-            GIT_COMMITTER_EMAIL: noreplyEmail!,
-          }
-        : {}),
-      ...(configEntries.length > 0
-        ? {
-            GIT_CONFIG_COUNT: String(configEntries.length),
-            ...Object.fromEntries(
-              configEntries.flatMap(([key, value], index) => [
-                [`GIT_CONFIG_KEY_${index}`, key],
-                [`GIT_CONFIG_VALUE_${index}`, value],
-              ]),
-            ),
-          }
-        : {}),
-    },
+    env,
     source: credential.source,
     secretName: credential.secretName,
     providerId: credential.providerId,
@@ -520,10 +554,10 @@ export function createGitRemoteAuthProvider(
     let match = resolveGitHostMatch(remoteUrl, env);
     if (!match && isSupportedGitHubRemoteUrl(remoteUrl)) {
       const github = getGitHostProvider("github");
-      match = { provider: github, scopedHosts: github.hosts };
+      match = { provider: github, scopedHosts: github.hosts, selfHosted: false };
     }
     if (!match) return null;
-    const { provider, scopedHosts } = match;
+    const { provider, scopedHosts, selfHosted } = match;
     let credentialPromise = credentialPromises.get(provider.id);
     if (!credentialPromise) {
       credentialPromise = resolveCredentialFor(provider);
@@ -531,7 +565,9 @@ export function createGitRemoteAuthProvider(
     }
     const credential = await credentialPromise;
     if (!credential) return null;
-    return buildGitAuthInvocation(credential, scopedHosts);
+    // Only ever applied to a self-hosted match -- see buildGitAuthInvocation's caCertPath doc.
+    const caCertPath = selfHosted ? resolveConfiguredCaCertPath(provider, env) : undefined;
+    return buildGitAuthInvocation(credential, scopedHosts, caCertPath);
   };
 }
 

--- a/server/src/services/git-credentials.ts
+++ b/server/src/services/git-credentials.ts
@@ -14,56 +14,94 @@ import { toolAccessService } from "./tool-access.js";
 
 /**
  * Server-side git credentials for managed project checkouts and execution-workspace base
- * refreshes. Operators store a GitHub token as a company secret under one of the well-known
- * names below (the same convention the GitHub external-object provider reads); this module
- * resolves it and turns it into a git invocation that authenticates clone/fetch against
- * github.com over HTTPS without ever placing the token in argv, URLs, or on disk.
+ * refreshes. Operators store a provider token as a company secret under one of the well-known
+ * names below (the same convention the GitHub external-object provider reads for GitHub);
+ * this module resolves it and turns it into a git invocation that authenticates clone/fetch
+ * against the matching host over HTTPS without ever placing the token in argv, URLs, or on
+ * disk.
  *
  * The provider factory is deliberately the single seam for future credential sources (for
- * example a brokered GitHub connection): swap the factory, keep every call site unchanged.
+ * example a brokered GitHub or GitLab connection): swap the factory, keep every call site
+ * unchanged. Adding a new git host means adding one entry to `GIT_HOST_PROVIDERS` below —
+ * nothing else in this module or its callers is host-specific.
+ *
+ * GitHub additionally supports managed connection identities and SSH remotes rewritten to
+ * HTTPS via process-scoped `insteadOf` config. GitLab support here is company-secret /
+ * server-env tokens for gitlab.com (self-hosted custom domains land in follow-up commits).
  */
+
+export type GitProviderId = "github" | "gitlab";
+
+type GitHostProviderConfig = {
+  id: GitProviderId;
+  /** Human-readable name used in auth-failure guidance, e.g. "GitHub". */
+  label: string;
+  /** Hosts this provider answers for. `www.` variants included where the provider serves them. */
+  hosts: readonly string[];
+  /** The HTTPS Basic username paired with the token — provider-specific by convention. */
+  tokenUsername: string;
+  /** Company-secret names probed for this provider's token, in priority order. */
+  secretNames: readonly string[];
+  /** Server-process env var names probed as a fallback, in priority order. */
+  envNames: readonly string[];
+};
 
 /** Company-secret names probed for a GitHub token, in priority order. */
 export const DEFAULT_GITHUB_TOKEN_SECRET_NAMES = ["GITHUB_TOKEN", "GH_TOKEN", "PAPERCLIP_GITHUB_TOKEN"] as const;
 
-/** Env var the credential helper reads the token from; never appears in argv. */
-export const GIT_CREDENTIAL_TOKEN_ENV_KEY = "PAPERCLIP_GIT_TOKEN";
-
-// `!`-prefixed helpers run via `sh -c` with the credential action appended as "$1". Only the
-// `get` action answers; store/erase drain stdin and exit 0 silently. `x-access-token`
-// authenticates classic PATs, fine-grained PATs, and GitHub App installation tokens alike.
-//
-// The helper re-validates the credential request from its stdin description and answers only
-// for `protocol=https` + `host=github.com`/`www.github.com`. The pre-invocation URL check
-// runs before git applies configuration like repository-local `url.<base>.insteadOf`
-// rewrites, so a rewritten remote could otherwise request the token for an arbitrary host.
-// The helper is additionally installed URL-scoped (`credential.https://github.com.helper`)
-// so git does not consult it for other hosts in the first place — two independent gates.
-const GIT_CREDENTIAL_HELPER =
-  `!f() { ok=; proto=; while IFS= read -r l && [ -n "$l" ]; do case "$l" in host=github.com|host=www.github.com) ok=1;; protocol=https) proto=1;; esac; done; if [ "$1" = get ] && [ -n "$ok" ] && [ -n "$proto" ]; then printf 'username=x-access-token\\npassword=%s\\n' "$PAPERCLIP_GIT_TOKEN"; fi; }; f`;
-
-export type GitCredential = {
-  token: string;
-  source: "managed_connection" | "company_secret" | "server_env";
-  /** The company-secret name the token came from; null for a server-environment token. */
-  secretName: string | null;
-  githubIdentity?: { userId: string; login: string };
-};
-
-/** A prepared, credential-bearing git invocation: config args plus the env that carries the token. */
-export type GitAuthInvocation = {
-  configArgs: string[];
-  env: Record<string, string>;
-  source: GitCredential["source"];
-  secretName: string | null;
-};
+/** Company-secret names probed for a GitLab token, in priority order. */
+export const DEFAULT_GITLAB_TOKEN_SECRET_NAMES = ["GITLAB_TOKEN", "PAPERCLIP_GITLAB_TOKEN"] as const;
 
 /**
- * Resolve auth for one remote URL. Returns null when the URL is out of scope (non-GitHub,
- * ssh, or already credentialed) or when no token is available — callers then run git with
- * ambient behavior, exactly as before this module existed.
+ * Supported git hosts, most specific matching first. GitHub's hosts mirror `isGitHubDotCom`
+ * in `github-fetch.ts`; that helper remains the source of truth for GitHub HTTPS/SSH URL
+ * checks below, while this table drives credential-helper host scoping and GitLab matching.
  */
-export type GitRemoteAuthProvider = (remoteUrl: string) => Promise<GitAuthInvocation | null>;
+const GIT_HOST_PROVIDERS: readonly GitHostProviderConfig[] = [
+  {
+    id: "github",
+    label: "GitHub",
+    hosts: ["github.com", "www.github.com"],
+    tokenUsername: "x-access-token",
+    secretNames: DEFAULT_GITHUB_TOKEN_SECRET_NAMES,
+    envNames: ["GITHUB_TOKEN", "GH_TOKEN"],
+  },
+  {
+    id: "gitlab",
+    label: "GitLab",
+    hosts: ["gitlab.com", "www.gitlab.com"],
+    // GitLab's HTTPS PAT/project-access-token convention: any non-empty username works, but
+    // `oauth2` is GitLab's own documented convention for token-based HTTPS auth.
+    tokenUsername: "oauth2",
+    secretNames: DEFAULT_GITLAB_TOKEN_SECRET_NAMES,
+    envNames: ["GITLAB_TOKEN"],
+  },
+];
+
+function getGitHostProvider(id: GitProviderId): GitHostProviderConfig {
+  const provider = GIT_HOST_PROVIDERS.find((p) => p.id === id);
+  if (!provider) throw new Error(`Unknown git host provider: ${id}`);
+  return provider;
+}
+
+/**
+ * Resolve the supported HTTPS provider for one remote URL, or null when the URL is out of
+ * scope: non-HTTPS, an unsupported/self-hosted host, or already credentialed (inline
+ * userinfo, which this module must never override). GitHub SSH remotes are handled
+ * separately via `isSupportedGitHubRemoteUrl`.
+ */
+function resolveGitHostProvider(remoteUrl: string): GitHostProviderConfig | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(remoteUrl);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "https:") return null;
+  if (parsed.username || parsed.password) return null;
+  const hostname = parsed.hostname.toLowerCase();
+  return GIT_HOST_PROVIDERS.find((provider) => provider.hosts.includes(hostname)) ?? null;
+}
 
 /**
  * True only for `https://github.com/...` (or `www.`) URLs without inline userinfo. GHES and
@@ -82,6 +120,15 @@ export function isGitHubHttpsRemoteUrl(remoteUrl: string): boolean {
   return isGitHubDotCom(parsed.hostname);
 }
 
+/**
+ * True only for `https://gitlab.com/...` (or `www.`) URLs without inline userinfo.
+ * Self-managed GitLab instances are out of scope for now, for the same reason GHES is out of
+ * scope for GitHub: this module never sends a gitlab.com token to an arbitrary host.
+ */
+export function isGitLabHttpsRemoteUrl(remoteUrl: string): boolean {
+  return resolveGitHostProvider(remoteUrl)?.id === "gitlab";
+}
+
 function isSupportedGitHubRemoteUrl(remoteUrl: string): boolean {
   if (isGitHubHttpsRemoteUrl(remoteUrl)) return true;
   if (/^git@(?:www\.)?github\.com:[^\s]+$/i.test(remoteUrl)) return true;
@@ -92,6 +139,61 @@ function isSupportedGitHubRemoteUrl(remoteUrl: string): boolean {
     return false;
   }
 }
+
+/** Env var the credential helper reads the token from; never appears in argv. */
+export const GIT_CREDENTIAL_TOKEN_ENV_KEY = "PAPERCLIP_GIT_TOKEN";
+
+// `!`-prefixed helpers run via `sh -c` with the credential action appended as "$1". Only the
+// `get` action answers; store/erase drain stdin and exit 0 silently. The username is fixed per
+// provider (`x-access-token` authenticates classic PATs, fine-grained PATs, and GitHub App
+// installation tokens alike; `oauth2` is GitLab's HTTPS token-auth convention).
+//
+// The helper re-validates the credential request from its stdin description and answers only
+// for `protocol=https` + one of the provider's own hosts. The pre-invocation URL check runs
+// before git applies configuration like repository-local `url.<base>.insteadOf` rewrites, so a
+// rewritten remote could otherwise request the token for an arbitrary host. The helper is
+// additionally installed URL-scoped per host (`credential.https://<host>.helper`) so git does
+// not consult it for other hosts in the first place — two independent gates.
+function buildCredentialHelperScript(tokenUsername: string, hosts: readonly string[]): string {
+  const hostMatch = hosts.map((host) => `host=${host}`).join("|");
+  return (
+    `!f() { ok=; proto=; while IFS= read -r l && [ -n "$l" ]; do case "$l" in ` +
+    `${hostMatch}) ok=1;; protocol=https) proto=1;; esac; done; ` +
+    `if [ "$1" = get ] && [ -n "$ok" ] && [ -n "$proto" ]; then printf 'username=${tokenUsername}\\npassword=%s\\n' "$PAPERCLIP_GIT_TOKEN"; fi; }; f`
+  );
+}
+
+export type GitCredential = {
+  token: string;
+  source: "managed_connection" | "company_secret" | "server_env";
+  /** The company-secret name the token came from; null for a server-environment token. */
+  secretName: string | null;
+  /** Which host provider this token authenticates against. */
+  providerId: GitProviderId;
+  githubIdentity?: { userId: string; login: string };
+};
+
+/** A prepared, credential-bearing git invocation: config args plus the env that carries the token. */
+export type GitAuthInvocation = {
+  configArgs: string[];
+  env: Record<string, string>;
+  source: GitCredential["source"];
+  secretName: string | null;
+  providerId: GitProviderId;
+  /**
+   * Human-readable provider name for auth-failure warnings, e.g. "GitHub" or "GitLab".
+   * Structurally mirrors `workspace-runtime.ts`'s decoupled `GitRemoteAuthInvocation` type, so
+   * that module can build a provider-neutral warning without importing `GitProviderId`.
+   */
+  providerLabel: string;
+};
+
+/**
+ * Resolve auth for one remote URL. Returns null when the URL is out of scope (unsupported
+ * host, already credentialed) or when no token is available — callers then run git with
+ * ambient behavior, exactly as before this module existed.
+ */
+export type GitRemoteAuthProvider = (remoteUrl: string) => Promise<GitAuthInvocation | null>;
 
 /**
  * Mask credential material embedded in URLs so it never reaches warnings, run errors, or
@@ -108,51 +210,76 @@ export function scrubGitCredentialText(text: string): string {
 }
 
 export function buildGitAuthInvocation(credential: GitCredential): GitAuthInvocation {
+  const provider = getGitHostProvider(credential.providerId);
+  const helperScript = buildCredentialHelperScript(provider.tokenUsername, provider.hosts);
+  // The leading empty helper clears ambient helpers (gh, glab, osxkeychain, credential-store)
+  // so they neither outrank the resolved token nor receive store/erase callbacks for it. Each
+  // subsequent entry installs the token helper URL-scoped to one of this provider's own hosts:
+  // git consults it only for credential requests whose context matches that host over https,
+  // so an `insteadOf`-rewritten remote never reaches it (and the helper itself re-checks the
+  // request host — see above).
+  const configArgs: string[] = ["-c", "credential.helper="];
+  for (const host of provider.hosts) {
+    configArgs.push("-c", `credential.https://${host}.helper=${helperScript}`);
+  }
+
   const identity = credential.githubIdentity;
   const noreplyEmail = identity ? `${identity.userId}+${identity.login}@users.noreply.github.com` : null;
-  const configEntries = [
-    ["credential.helper", ""],
-    ["credential.https://github.com.helper", GIT_CREDENTIAL_HELPER],
-    ["credential.https://www.github.com.helper", GIT_CREDENTIAL_HELPER],
-    ["url.https://github.com/.insteadOf", "git@github.com:"],
-    ["url.https://github.com/.insteadOf", "ssh://git@github.com/"],
-    ["url.https://github.com/.insteadOf", "git@www.github.com:"],
-    ["url.https://github.com/.insteadOf", "ssh://git@www.github.com/"],
-    ...(identity ? [
-      ["user.name", identity.login],
-      ["user.email", noreplyEmail!],
-    ] : []),
-  ];
+
+  // GitHub keeps process-scoped GIT_CONFIG_* entries for SSH→HTTPS rewriting and optional
+  // managed-identity commit authorship. GitLab uses argv `-c` helpers only (no SSH rewrite).
+  const configEntries: Array<[string, string]> = provider.id === "github"
+    ? [
+        ["credential.helper", ""],
+        ...provider.hosts.map((host): [string, string] => [`credential.https://${host}.helper`, helperScript]),
+        ["url.https://github.com/.insteadOf", "git@github.com:"],
+        ["url.https://github.com/.insteadOf", "ssh://git@github.com/"],
+        ["url.https://github.com/.insteadOf", "git@www.github.com:"],
+        ["url.https://github.com/.insteadOf", "ssh://git@www.github.com/"],
+        ...(identity
+          ? [
+              ["user.name", identity.login] as [string, string],
+              ["user.email", noreplyEmail!] as [string, string],
+            ]
+          : []),
+      ]
+    : [];
+
   return {
-    // The leading empty helper clears ambient helpers (gh, osxkeychain, credential-store) so
-    // they neither outrank the resolved token nor receive store/erase callbacks for it. The
-    // token helper is installed URL-scoped: git consults it only for credential requests
-    // whose context matches github.com over https, so an `insteadOf`-rewritten remote never
-    // reaches it (and the helper itself re-checks the request host — see above).
-    configArgs: [
-      "-c", "credential.helper=",
-      "-c", `credential.https://github.com.helper=${GIT_CREDENTIAL_HELPER}`,
-      "-c", `credential.https://www.github.com.helper=${GIT_CREDENTIAL_HELPER}`,
-    ],
+    configArgs,
     env: {
       [GIT_CREDENTIAL_TOKEN_ENV_KEY]: credential.token,
-      GH_TOKEN: credential.token,
-      GITHUB_TOKEN: credential.token,
+      ...(provider.id === "github"
+        ? {
+            GH_TOKEN: credential.token,
+            GITHUB_TOKEN: credential.token,
+          }
+        : {}),
       GIT_TERMINAL_PROMPT: "0",
-      ...(identity ? {
-        GIT_AUTHOR_NAME: identity.login,
-        GIT_AUTHOR_EMAIL: noreplyEmail!,
-        GIT_COMMITTER_NAME: identity.login,
-        GIT_COMMITTER_EMAIL: noreplyEmail!,
-      } : {}),
-      GIT_CONFIG_COUNT: String(configEntries.length),
-      ...Object.fromEntries(configEntries.flatMap(([key, value], index) => [
-        [`GIT_CONFIG_KEY_${index}`, key],
-        [`GIT_CONFIG_VALUE_${index}`, value],
-      ])),
+      ...(identity
+        ? {
+            GIT_AUTHOR_NAME: identity.login,
+            GIT_AUTHOR_EMAIL: noreplyEmail!,
+            GIT_COMMITTER_NAME: identity.login,
+            GIT_COMMITTER_EMAIL: noreplyEmail!,
+          }
+        : {}),
+      ...(configEntries.length > 0
+        ? {
+            GIT_CONFIG_COUNT: String(configEntries.length),
+            ...Object.fromEntries(
+              configEntries.flatMap(([key, value], index) => [
+                [`GIT_CONFIG_KEY_${index}`, key],
+                [`GIT_CONFIG_VALUE_${index}`, value],
+              ]),
+            ),
+          }
+        : {}),
     },
     source: credential.source,
     secretName: credential.secretName,
+    providerId: credential.providerId,
+    providerLabel: provider.label,
   };
 }
 
@@ -164,23 +291,35 @@ const GIT_AUTH_FAILURE_PATTERN =
  * Returns null when the failure does not look auth-related — a credential that was merely
  * present during an unrelated failure (network outage, target-path collision) must not be
  * blamed for it.
+ *
+ * `remoteUrl` lets the no-credential-used branch name the right provider's guidance even
+ * though no credential was resolved; it is ignored once `used.providerId` is known.
  */
 export function describeGitAuthFailure(input: {
   error: string;
-  used: { source: GitCredential["source"]; secretName: string | null } | null;
+  used: { source: GitCredential["source"]; secretName: string | null; providerId?: GitProviderId } | null;
+  remoteUrl?: string | null;
 }): string | null {
   if (!GIT_AUTH_FAILURE_PATTERN.test(input.error)) {
     return null;
   }
+  const provider = input.used?.providerId
+    ? getGitHostProvider(input.used.providerId)
+    : (input.remoteUrl ? resolveGitHostProvider(input.remoteUrl) : null);
   if (input.used) {
+    const providerLabel = provider?.label ?? "git";
     const label = input.used.secretName
-      ? `the ${input.used.secretName} company-secret GitHub credential`
+      ? `the ${input.used.secretName} company-secret ${providerLabel} credential`
       : input.used.source === "managed_connection"
         ? "the resolved GitHub connection"
-      : "the server-environment GitHub credential";
+        : `the server-environment ${providerLabel} credential`;
     return `The operation authenticated with ${label}, which was rejected or lacks access to this repository.`;
   }
-  return "No GitHub credential is configured — add a GITHUB_TOKEN or GH_TOKEN company secret in Settings → Secrets, or configure a local checkout cwd for this project workspace.";
+  if (provider) {
+    const names = provider.secretNames.filter((name) => !name.startsWith("PAPERCLIP_")).join(" or ");
+    return `No ${provider.label} credential is configured — add a ${names} company secret in Settings → Secrets, or configure a local checkout cwd for this project workspace.`;
+  }
+  return "No git credential is configured — add a GITHUB_TOKEN/GH_TOKEN or GITLAB_TOKEN company secret in Settings → Secrets, or configure a local checkout cwd for this project workspace.";
 }
 
 type SecretServiceLike = ReturnType<typeof secretService>;
@@ -195,12 +334,13 @@ type GitCredentialSecretsDeps = {
 };
 
 /**
- * Build the credential provider for one run. Resolution order: the managed GitHub identity
- * resolver, then a company secret by well-known name, then the server process environment
- * (`GITHUB_TOKEN`/`GH_TOKEN`) for self-hosted operators. A configured managed identity fails
- * closed instead of falling through to legacy credentials. The lookup is memoized per
- * provider instance so one run performs at most one secret resolution (and writes at most
- * one audit event) no matter how many git operations it authenticates.
+ * Build the credential provider for one run. Resolution order per host:
+ * - GitHub: managed GitHub identity (fails closed when configured), then company secret by
+ *   well-known name, then server process environment (`GITHUB_TOKEN`/`GH_TOKEN`).
+ * - GitLab: company secret by well-known name, then server process environment (`GITLAB_TOKEN`).
+ * Lookups are memoized per resolved provider — a run that touches both a GitHub and a GitLab
+ * remote performs at most one secret resolution per host (and writes at most one audit event
+ * per host) no matter how many git operations it authenticates.
  */
 export function createGitRemoteAuthProvider(
   db: Db,
@@ -214,25 +354,29 @@ export function createGitRemoteAuthProvider(
   deps?: {
     secrets?: GitCredentialSecretsDeps;
     env?: NodeJS.ProcessEnv;
+    /** Overrides the probed company-secret names for every provider a run resolves. Test-only. */
     secretNames?: readonly string[];
   },
 ): GitRemoteAuthProvider {
   const secrets: GitCredentialSecretsDeps = deps?.secrets ?? secretService(db);
   const env = deps?.env ?? process.env;
-  const secretNames = deps?.secretNames ?? DEFAULT_GITHUB_TOKEN_SECRET_NAMES;
-  let credentialPromise: Promise<GitCredential | null> | null = null;
+  const credentialPromises = new Map<GitProviderId, Promise<GitCredential | null>>();
 
-  const resolveCredential = async (): Promise<GitCredential | null> => {
-    // Unit callers historically pass a null DB through the typed test seam. Production
-    // always supplies a real DB and therefore always checks managed identities before
-    // considering legacy secrets or process environment credentials.
-    const managed = db
-      ? await resolveManagedGitHubCredential(db, secrets, companyId, context ?? {})
-      : { configured: false as const };
-    if (managed.configured) {
-      if (!managed.credential) throw new Error(managed.error ?? "Managed GitHub connection is unavailable");
-      return managed.credential;
+  const resolveCredentialFor = async (provider: GitHostProviderConfig): Promise<GitCredential | null> => {
+    if (provider.id === "github") {
+      // Unit callers historically pass a null DB through the typed test seam. Production
+      // always supplies a real DB and therefore always checks managed identities before
+      // considering legacy secrets or process environment credentials.
+      const managed = db
+        ? await resolveManagedGitHubCredential(db, secrets, companyId, context ?? {})
+        : { configured: false as const };
+      if (managed.configured) {
+        if (!managed.credential) throw new Error(managed.error ?? "Managed GitHub connection is unavailable");
+        return managed.credential;
+      }
     }
+
+    const secretNames = deps?.secretNames ?? provider.secretNames;
     for (const secretName of secretNames) {
       const secret = await Promise.resolve(secrets.getByName(companyId, secretName)).catch(() => null);
       if (!secret) continue;
@@ -251,16 +395,25 @@ export function createGitRemoteAuthProvider(
         })
         .then((value) => value.trim())
         .catch(() => "");
-      if (token) return { token, source: "company_secret", secretName };
+      if (token) return { token, source: "company_secret", secretName, providerId: provider.id };
     }
-    const envToken = env.GITHUB_TOKEN?.trim() || env.GH_TOKEN?.trim() || "";
-    if (envToken) return { token: envToken, source: "server_env", secretName: null };
+    for (const envName of provider.envNames) {
+      const envToken = env[envName]?.trim();
+      if (envToken) return { token: envToken, source: "server_env", secretName: null, providerId: provider.id };
+    }
     return null;
   };
 
   return async (remoteUrl: string) => {
-    if (!isSupportedGitHubRemoteUrl(remoteUrl)) return null;
-    credentialPromise ??= resolveCredential();
+    const provider = isSupportedGitHubRemoteUrl(remoteUrl)
+      ? getGitHostProvider("github")
+      : resolveGitHostProvider(remoteUrl);
+    if (!provider) return null;
+    let credentialPromise = credentialPromises.get(provider.id);
+    if (!credentialPromise) {
+      credentialPromise = resolveCredentialFor(provider);
+      credentialPromises.set(provider.id, credentialPromise);
+    }
     const credential = await credentialPromise;
     if (!credential) return null;
     return buildGitAuthInvocation(credential);
@@ -466,6 +619,7 @@ async function resolveManagedGitHubCredential(
       token,
       source: "managed_connection",
       secretName: null,
+      providerId: "github",
       githubIdentity: { userId: github.userId, login: github.login },
     },
   };

--- a/server/src/services/git-credentials.ts
+++ b/server/src/services/git-credentials.ts
@@ -272,8 +272,16 @@ export const GIT_CREDENTIAL_TOKEN_ENV_KEY = "PAPERCLIP_GIT_TOKEN";
 // rewritten remote could otherwise request the token for an arbitrary host. The helper is
 // additionally installed URL-scoped per host (`credential.https://<host>.helper`) so git does
 // not consult it for other hosts in the first place — two independent gates.
+// A bracketed IPv6 host (from `normalizeConfiguredHost`, e.g. `[2001:db8::1]:8443`) would
+// otherwise land in the `case` pattern below unescaped, where `[`/`]` are glob character-class
+// metacharacters rather than literal brackets — the pattern would then fail to match the
+// literal host git requests, and the helper would never authenticate that self-hosted instance.
+function escapeCasePattern(value: string): string {
+  return value.replace(/[\\*?[\]]/g, "\\$&");
+}
+
 function buildCredentialHelperScript(tokenUsername: string, hosts: readonly string[]): string {
-  const hostMatch = hosts.map((host) => `host=${host}`).join("|");
+  const hostMatch = hosts.map((host) => `host=${escapeCasePattern(host)}`).join("|");
   return (
     `!f() { ok=; proto=; while IFS= read -r l && [ -n "$l" ]; do case "$l" in ` +
     `${hostMatch}) ok=1;; protocol=https) proto=1;; esac; done; ` +

--- a/server/src/services/git-credentials.ts
+++ b/server/src/services/git-credentials.ts
@@ -26,8 +26,14 @@ import { toolAccessService } from "./tool-access.js";
  * nothing else in this module or its callers is host-specific.
  *
  * GitHub additionally supports managed connection identities and SSH remotes rewritten to
- * HTTPS via process-scoped `insteadOf` config. GitLab support here is company-secret /
- * server-env tokens for gitlab.com (self-hosted custom domains land in follow-up commits).
+ * HTTPS via process-scoped `insteadOf` config.
+ *
+ * GitLab additionally supports a self-managed instance at an operator-chosen domain (there is
+ * no equivalent for GitHub — GHES stays out of scope, as it always has been here): set
+ * `PAPERCLIP_GITLAB_HOSTS` to that instance's hostname (comma-separated for more than one) and
+ * the same `GITLAB_TOKEN`/`PAPERCLIP_GITLAB_TOKEN` company secret or `GITLAB_TOKEN` server env
+ * used for gitlab.com now also authenticates that host, with the credential helper scoped
+ * strictly to it — never to gitlab.com or a different configured self-managed host.
  */
 
 export type GitProviderId = "github" | "gitlab";
@@ -36,7 +42,7 @@ type GitHostProviderConfig = {
   id: GitProviderId;
   /** Human-readable name used in auth-failure guidance, e.g. "GitHub". */
   label: string;
-  /** Hosts this provider answers for. `www.` variants included where the provider serves them. */
+  /** Well-known SaaS hosts this provider answers for. `www.` variants included where served. */
   hosts: readonly string[];
   /** The HTTPS Basic username paired with the token — provider-specific by convention. */
   tokenUsername: string;
@@ -44,6 +50,14 @@ type GitHostProviderConfig = {
   secretNames: readonly string[];
   /** Server-process env var names probed as a fallback, in priority order. */
   envNames: readonly string[];
+  /**
+   * Server env var naming this provider's self-managed instance host(s), for operators who
+   * run their own server on a custom domain (GitLab's self-hosted offering; there is no
+   * equivalent GHES support here, matching this module's prior GHES-out-of-scope stance).
+   * Comma-separated; each entry is a bare hostname or a full URL (only the hostname is used).
+   * Undefined for a provider with no self-hosted mode.
+   */
+  selfHostedEnvName?: string;
 };
 
 /** Company-secret names probed for a GitHub token, in priority order. */
@@ -71,10 +85,12 @@ const GIT_HOST_PROVIDERS: readonly GitHostProviderConfig[] = [
     label: "GitLab",
     hosts: ["gitlab.com", "www.gitlab.com"],
     // GitLab's HTTPS PAT/project-access-token convention: any non-empty username works, but
-    // `oauth2` is GitLab's own documented convention for token-based HTTPS auth.
+    // `oauth2` is GitLab's own documented convention for token-based HTTPS auth. It applies
+    // the same way to a self-managed instance as it does to gitlab.com.
     tokenUsername: "oauth2",
     secretNames: DEFAULT_GITLAB_TOKEN_SECRET_NAMES,
     envNames: ["GITLAB_TOKEN"],
+    selfHostedEnvName: "PAPERCLIP_GITLAB_HOSTS",
   },
 ];
 
@@ -85,10 +101,43 @@ function getGitHostProvider(id: GitProviderId): GitHostProviderConfig {
 }
 
 /**
- * Resolve the supported HTTPS provider for one remote URL, or null when the URL is out of
- * scope: non-HTTPS, an unsupported/self-hosted host, or already credentialed (inline
- * userinfo, which this module must never override). GitHub SSH remotes are handled
- * separately via `isSupportedGitHubRemoteUrl`.
+ * Extract a bare lowercase hostname from an operator-supplied entry in a `selfHostedEnvName`
+ * value: either a full URL (`https://gitlab.mycompany.com/`) or a bare hostname
+ * (`gitlab.mycompany.com`). Returns null for an empty or unparseable entry.
+ */
+function normalizeConfiguredHost(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    const url = new URL(trimmed.includes("://") ? trimmed : `https://${trimmed}`);
+    return url.hostname.toLowerCase() || null;
+  } catch {
+    return null;
+  }
+}
+
+/** This provider's operator-configured self-managed instance hosts, deduplicated. */
+function resolveConfiguredSelfHostedHosts(provider: GitHostProviderConfig, env: NodeJS.ProcessEnv): string[] {
+  if (!provider.selfHostedEnvName) return [];
+  const raw = env[provider.selfHostedEnvName];
+  if (!raw) return [];
+  const hosts = new Set<string>();
+  for (const entry of raw.split(",")) {
+    const host = normalizeConfiguredHost(entry);
+    if (host) hosts.add(host);
+  }
+  return Array.from(hosts);
+}
+
+/**
+ * Resolve the supported provider for one remote URL, or null when the URL is out of scope:
+ * non-HTTPS, an unsupported host, or already credentialed (inline userinfo, which this module
+ * must never override). Mirrors `isGitHubHttpsRemoteUrl`'s prior scoping rules, generalized
+ * across every entry in `GIT_HOST_PROVIDERS`. Static SaaS hosts only — no `env`, so it never
+ * depends on ambient process state; self-hosted matching lives in `resolveGitHostMatch` below,
+ * which every real credential-resolution path uses instead.
+ * GitHub SSH remotes are handled separately via `isSupportedGitHubRemoteUrl` in
+ * `createGitRemoteAuthProvider`.
  */
 function resolveGitHostProvider(remoteUrl: string): GitHostProviderConfig | null {
   let parsed: URL;
@@ -104,9 +153,43 @@ function resolveGitHostProvider(remoteUrl: string): GitHostProviderConfig | null
 }
 
 /**
+ * The full match used by real credential resolution: static SaaS hosts first, then each
+ * provider's operator-configured self-hosted hosts (env-driven, see `selfHostedEnvName`).
+ * `scopedHosts` is what the credential helper gets installed for — the provider's whole SaaS
+ * host list for a SaaS match (unchanged from before self-hosted support existed), or exactly
+ * the one matched self-hosted host and no other configured self-hosted host, so one
+ * self-managed instance's token is never offered to a different self-managed instance or to
+ * the SaaS domain.
+ */
+function resolveGitHostMatch(
+  remoteUrl: string,
+  env: NodeJS.ProcessEnv,
+): { provider: GitHostProviderConfig; scopedHosts: readonly string[] } | null {
+  const staticProvider = resolveGitHostProvider(remoteUrl);
+  if (staticProvider) return { provider: staticProvider, scopedHosts: staticProvider.hosts };
+
+  let parsed: URL;
+  try {
+    parsed = new URL(remoteUrl);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "https:" || parsed.username || parsed.password) return null;
+  const hostname = parsed.hostname.toLowerCase();
+  for (const provider of GIT_HOST_PROVIDERS) {
+    if (resolveConfiguredSelfHostedHosts(provider, env).includes(hostname)) {
+      return { provider, scopedHosts: [hostname] };
+    }
+  }
+  return null;
+}
+
+/**
  * True only for `https://github.com/...` (or `www.`) URLs without inline userinfo. GHES and
- * other hosts are out of scope for now — sending a github.com token to an arbitrary host
- * would leak it, and an operator's inline URL credential must never be overridden.
+ * other hosts are out of scope — sending a github.com token to an arbitrary host would leak
+ * it, and an operator's inline URL credential must never be overridden. Static-only: unlike
+ * real credential resolution, this helper never consults `PAPERCLIP_GITLAB_HOSTS`-style
+ * self-hosted config, so it stays a pure function of its argument.
  */
 export function isGitHubHttpsRemoteUrl(remoteUrl: string): boolean {
   let parsed: URL;
@@ -121,9 +204,10 @@ export function isGitHubHttpsRemoteUrl(remoteUrl: string): boolean {
 }
 
 /**
- * True only for `https://gitlab.com/...` (or `www.`) URLs without inline userinfo.
- * Self-managed GitLab instances are out of scope for now, for the same reason GHES is out of
- * scope for GitHub: this module never sends a gitlab.com token to an arbitrary host.
+ * True only for `https://gitlab.com/...` (or `www.`) URLs without inline userinfo. Static-only:
+ * a self-managed GitLab instance configured via `PAPERCLIP_GITLAB_HOSTS` is a supported
+ * credential target (see `createGitRemoteAuthProvider`) but does not make this function true —
+ * this helper is a pure function of its argument, not of ambient server config.
  */
 export function isGitLabHttpsRemoteUrl(remoteUrl: string): boolean {
   return resolveGitHostProvider(remoteUrl)?.id === "gitlab";
@@ -209,17 +293,28 @@ export function scrubGitCredentialText(text: string): string {
     .replace(/([a-z][a-z0-9+.-]*:\/\/[^\s"'?]*)\?[^\s"']*/gi, "$1?***");
 }
 
-export function buildGitAuthInvocation(credential: GitCredential): GitAuthInvocation {
+export function buildGitAuthInvocation(
+  credential: GitCredential,
+  /**
+   * Hosts to install the credential helper for. Defaults to the provider's full SaaS host
+   * list (e.g. github.com + www.github.com). Real credential resolution
+   * (`createGitRemoteAuthProvider`) passes a narrower list — exactly the one matched
+   * self-hosted host — when the remote is a self-managed instance, so that host's token is
+   * never offered to a different host, including the provider's own SaaS domain.
+   */
+  scopedHosts?: readonly string[],
+): GitAuthInvocation {
   const provider = getGitHostProvider(credential.providerId);
-  const helperScript = buildCredentialHelperScript(provider.tokenUsername, provider.hosts);
+  const hosts = scopedHosts ?? provider.hosts;
+  const helperScript = buildCredentialHelperScript(provider.tokenUsername, hosts);
   // The leading empty helper clears ambient helpers (gh, glab, osxkeychain, credential-store)
   // so they neither outrank the resolved token nor receive store/erase callbacks for it. Each
-  // subsequent entry installs the token helper URL-scoped to one of this provider's own hosts:
-  // git consults it only for credential requests whose context matches that host over https,
-  // so an `insteadOf`-rewritten remote never reaches it (and the helper itself re-checks the
-  // request host — see above).
+  // subsequent entry installs the token helper URL-scoped to one of the resolved hosts: git
+  // consults it only for credential requests whose context matches that host over https, so an
+  // `insteadOf`-rewritten remote never reaches it (and the helper itself re-checks the request
+  // host — see above).
   const configArgs: string[] = ["-c", "credential.helper="];
-  for (const host of provider.hosts) {
+  for (const host of hosts) {
     configArgs.push("-c", `credential.https://${host}.helper=${helperScript}`);
   }
 
@@ -231,7 +326,7 @@ export function buildGitAuthInvocation(credential: GitCredential): GitAuthInvoca
   const configEntries: Array<[string, string]> = provider.id === "github"
     ? [
         ["credential.helper", ""],
-        ...provider.hosts.map((host): [string, string] => [`credential.https://${host}.helper`, helperScript]),
+        ...hosts.map((host): [string, string] => [`credential.https://${host}.helper`, helperScript]),
         ["url.https://github.com/.insteadOf", "git@github.com:"],
         ["url.https://github.com/.insteadOf", "ssh://git@github.com/"],
         ["url.https://github.com/.insteadOf", "git@www.github.com:"],
@@ -293,19 +388,22 @@ const GIT_AUTH_FAILURE_PATTERN =
  * blamed for it.
  *
  * `remoteUrl` lets the no-credential-used branch name the right provider's guidance even
- * though no credential was resolved; it is ignored once `used.providerId` is known.
+ * though no credential was resolved; it is ignored once `used.providerId` is known. `env`
+ * (defaulting to `process.env`) lets that branch also recognize an operator-configured
+ * self-hosted GitLab host via `PAPERCLIP_GITLAB_HOSTS`.
  */
 export function describeGitAuthFailure(input: {
   error: string;
   used: { source: GitCredential["source"]; secretName: string | null; providerId?: GitProviderId } | null;
   remoteUrl?: string | null;
+  env?: NodeJS.ProcessEnv;
 }): string | null {
   if (!GIT_AUTH_FAILURE_PATTERN.test(input.error)) {
     return null;
   }
   const provider = input.used?.providerId
     ? getGitHostProvider(input.used.providerId)
-    : (input.remoteUrl ? resolveGitHostProvider(input.remoteUrl) : null);
+    : (input.remoteUrl ? resolveGitHostMatch(input.remoteUrl, input.env ?? process.env)?.provider ?? null : null);
   if (input.used) {
     const providerLabel = provider?.label ?? "git";
     const label = input.used.secretName
@@ -405,10 +503,15 @@ export function createGitRemoteAuthProvider(
   };
 
   return async (remoteUrl: string) => {
-    const provider = isSupportedGitHubRemoteUrl(remoteUrl)
-      ? getGitHostProvider("github")
-      : resolveGitHostProvider(remoteUrl);
-    if (!provider) return null;
+    // HTTPS SaaS + self-hosted GitLab first; GitHub SSH remotes are an extra upstream path
+    // (process-scoped insteadOf rewrite) that resolveGitHostMatch does not cover.
+    let match = resolveGitHostMatch(remoteUrl, env);
+    if (!match && isSupportedGitHubRemoteUrl(remoteUrl)) {
+      const github = getGitHostProvider("github");
+      match = { provider: github, scopedHosts: github.hosts };
+    }
+    if (!match) return null;
+    const { provider, scopedHosts } = match;
     let credentialPromise = credentialPromises.get(provider.id);
     if (!credentialPromise) {
       credentialPromise = resolveCredentialFor(provider);
@@ -416,7 +519,7 @@ export function createGitRemoteAuthProvider(
     }
     const credential = await credentialPromise;
     if (!credential) return null;
-    return buildGitAuthInvocation(credential);
+    return buildGitAuthInvocation(credential, scopedHosts);
   };
 }
 

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -2213,7 +2213,8 @@ async function materializeManagedProjectWorkspace(
     const reason = error instanceof Error ? error.message : String(error);
     const authNote = describeGitAuthFailure({
       error: reason,
-      used: auth ? { source: auth.source, secretName: auth.secretName } : null,
+      used: auth ? { source: auth.source, secretName: auth.secretName, providerId: auth.providerId } : null,
+      remoteUrl: input.repoUrl,
     });
     throw new Error(
       scrubGitCredentialText(

--- a/server/src/services/workspace-runtime.ts
+++ b/server/src/services/workspace-runtime.ts
@@ -142,6 +142,8 @@ export type GitRemoteAuthInvocation = {
   env: Record<string, string>;
   source?: string;
   secretName?: string | null;
+  /** Human-readable host name for auth-failure warnings, e.g. "GitHub" or "GitLab". */
+  providerLabel?: string | null;
 };
 
 export type GitRemoteAuthProvider = (remoteUrl: string) => Promise<GitRemoteAuthInvocation | null>;
@@ -991,8 +993,9 @@ export async function refreshRemoteTrackingBaseRef(
     const message = rawMessage
       .replace(/([a-z][a-z0-9+.-]*:\/\/)[^/@\s]+@/gi, "$1***@")
       .replace(/([a-z][a-z0-9+.-]*:\/\/[^\s"'?]*)\?[^\s"']*/gi, "$1?***");
+    const providerLabel = auth?.providerLabel ?? "git";
     const authNote = auth
-      ? ` The fetch authenticated with ${auth.secretName ? `the ${auth.secretName} company-secret GitHub credential` : "the server-environment GitHub credential"}, which may have been rejected.`
+      ? ` The fetch authenticated with ${auth.secretName ? `the ${auth.secretName} company-secret ${providerLabel} credential` : `the server-environment ${providerLabel} credential`}, which may have been rejected.`
       : "";
     return [`Could not refresh base ref ${baseRef} before preparing the execution workspace: ${message}${authNote}`];
   }


### PR DESCRIPTION
Rebase of #12838 onto current master for board NOM-24.

Original: https://github.com/paperclipai/paperclip/pull/12838

Keeps GitLab company-secret / self-hosted credential feature intent while preserving newer master structure:
- Multi-provider git credentials (github | gitlab)
- PAPERCLIP_GITLAB_HOSTS self-hosted host[:port] scoping
- PAPERCLIP_GITLAB_CA_CERT_PATH private CA (self-hosted only)
- Docker/Compose/Quadlet/quickstart wiring from the original PR
- Preserved from upstream master: managed GitHub connection identity, SSH-to-HTTPS insteadOf rewriting, isGitHubDotCom checks

Conflict files resolved during rebase:
- server/src/services/git-credentials.ts
- server/src/__tests__/git-credentials.test.ts

Refs: #12838 #12837 NOM-24