### PR TITLE
fix(ci): isolate private eval checkout app

### DIFF
--- a/.github/scripts/get-bot-token.mjs
+++ b/.github/scripts/get-bot-token.mjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 /**
  * get-bot-token.mjs
- * Generates a short-lived GitHub installation token for the commitperclip app.
- * Reads COMMITPERCLIP_KEY env var (PEM content of private key).
+ * Generates a short-lived GitHub installation token.
+ *
+ * Generic callers set GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY. Existing
+ * commitperclip callers may continue to set COMMITPERCLIP_KEY.
  * Prints the token to stdout.
  *
  * Also exports: generateJWT(privateKey), ghFetch(path, token, options)
@@ -11,13 +13,13 @@
 import { createSign } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 
-const APP_ID = '3718661';
+const COMMITPERCLIP_APP_ID = '3718661';
 const OWNER_PATTERN = /^[a-zA-Z0-9_.-]+$/;
 const REPO_PATTERN = /^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/;
 
-export function generateJWT(privateKey) {
+export function generateJWT(privateKey, appId = COMMITPERCLIP_APP_ID) {
   const now = Math.floor(Date.now() / 1000);
-  const payload = { iat: now - 10, exp: now + 60, iss: APP_ID };
+  const payload = { iat: now - 10, exp: now + 60, iss: appId };
   const header = Buffer.from(JSON.stringify({ alg: 'RS256', typ: 'JWT' })).toString('base64url');
   const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
   const data = `${header}.${body}`;
@@ -59,7 +61,7 @@ export async function ghFetch(path, token, options = {}) {
   }
 }
 
-export async function resolveInstallationId(fetchInstallation, token, repo, owner) {
+export async function resolveInstallationId(fetchInstallation, token, repo, owner, appName = 'GitHub App') {
   if (repo) {
     if (!REPO_PATTERN.test(repo)) {
       throw new Error('ERROR: GH_REPO/GITHUB_REPOSITORY must be in owner/repo format.');
@@ -71,9 +73,7 @@ export async function resolveInstallationId(fetchInstallation, token, repo, owne
 
   const installations = await fetchInstallation('/app/installations', token);
   if (!installations.length) {
-    throw new Error(
-      'ERROR: No installations found for commitperclip. Install URL: https://github.com/apps/commitperclip/installations/new'
-    );
+    throw new Error(`ERROR: No installations found for ${appName}.`);
   }
 
   if (owner) {
@@ -95,23 +95,45 @@ export async function resolveInstallationId(fetchInstallation, token, repo, owne
   }
 
   throw new Error(
-    'ERROR: Multiple commitperclip installations found. Set GH_REPO or GITHUB_REPOSITORY so the correct installation can be selected.'
+    `ERROR: Multiple ${appName} installations found. Set GH_REPO or GITHUB_REPOSITORY so the correct installation can be selected.`
   );
 }
 
+export function resolveAppCredentials(environment) {
+  const explicitAppId = environment.GITHUB_APP_ID;
+  const explicitPrivateKey = environment.GITHUB_APP_PRIVATE_KEY;
+  if (Boolean(explicitAppId) !== Boolean(explicitPrivateKey)) {
+    throw new Error('ERROR: GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY must be set together.');
+  }
+  if (explicitAppId && explicitPrivateKey) {
+    return {
+      appId: explicitAppId,
+      privateKey: explicitPrivateKey,
+      appName: environment.GITHUB_APP_NAME ?? 'GitHub App',
+    };
+  }
+  if (!environment.COMMITPERCLIP_KEY) {
+    throw new Error('ERROR: GITHUB_APP_PRIVATE_KEY or COMMITPERCLIP_KEY env var not set.');
+  }
+  return {
+    appId: COMMITPERCLIP_APP_ID,
+    privateKey: environment.COMMITPERCLIP_KEY,
+    appName: 'commitperclip',
+  };
+}
+
 async function main() {
-  const privateKey = process.env.COMMITPERCLIP_KEY;
-  if (!privateKey) {
-    console.error('ERROR: COMMITPERCLIP_KEY env var not set.');
-    console.error('Add to ~/.bash_profile: export COMMITPERCLIP_KEY="$(cat ~/.config/commitperclip/private-key.pem)"');
+  const { appId, privateKey, appName } = resolveAppCredentials(process.env);
+  if (!/^\d+$/.test(appId)) {
+    console.error('ERROR: GITHUB_APP_ID must be a numeric GitHub App ID.');
     process.exit(1);
   }
 
-  const jwt = generateJWT(privateKey);
+  const jwt = generateJWT(privateKey, appId);
   const repo = process.env.GH_REPO ?? process.env.GITHUB_REPOSITORY;
   const owner = process.env.GITHUB_REPOSITORY_OWNER ?? repo?.split('/')[0];
 
-  const installationId = await resolveInstallationId(ghFetch, jwt, repo, owner);
+  const installationId = await resolveInstallationId(ghFetch, jwt, repo, owner, appName);
 
   const { token } = await ghFetch(
     `/app/installations/${installationId}/access_tokens`,

--- a/.github/scripts/tests/get-bot-token.test.mjs
+++ b/.github/scripts/tests/get-bot-token.test.mjs
@@ -1,6 +1,42 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { resolveInstallationId } from '../get-bot-token.mjs';
+import { generateKeyPairSync } from 'node:crypto';
+import {
+  generateJWT,
+  resolveAppCredentials,
+  resolveInstallationId,
+} from '../get-bot-token.mjs';
+
+test('generateJWT: uses an explicitly selected GitHub App ID as the issuer', () => {
+  const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const token = generateJWT(privateKey, '987654');
+  const payload = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString('utf8'));
+
+  assert.equal(payload.iss, '987654');
+});
+
+test('resolveAppCredentials: selects an explicit app without mixing legacy credentials', () => {
+  assert.deepEqual(resolveAppCredentials({
+    GITHUB_APP_ID: '987654',
+    GITHUB_APP_PRIVATE_KEY: 'dedicated-key',
+    GITHUB_APP_NAME: 'paperclip-evals',
+    COMMITPERCLIP_KEY: 'legacy-key',
+  }), {
+    appId: '987654',
+    privateKey: 'dedicated-key',
+    appName: 'paperclip-evals',
+  });
+});
+
+test('resolveAppCredentials: rejects a partially configured explicit app', () => {
+  assert.throws(
+    () => resolveAppCredentials({
+      GITHUB_APP_ID: '987654',
+      COMMITPERCLIP_KEY: 'legacy-key',
+    }),
+    /GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY must be set together/
+  );
+});
 
 test('resolveInstallationId: uses the repo installation endpoint when repo context is available', async () => {
   const seenPaths = [];
@@ -28,6 +64,6 @@ test('resolveInstallationId: rejects ambiguous installations without repo or own
       { id: 1, account: { login: 'org-one' } },
       { id: 2, account: { login: 'org-two' } },
     ]), 'jwt'),
-    /Multiple commitperclip installations found/
+    /Multiple GitHub App installations found/
   );
 });

--- a/.github/workflows/runner-protocol-live-evals.yml
+++ b/.github/workflows/runner-protocol-live-evals.yml
@@ -104,7 +104,9 @@ jobs:
       - name: Generate private eval-repository token
         id: evals_token
         env:
-          COMMITPERCLIP_KEY: ${{ secrets.COMMITPERCLIP_KEY }}
+          GITHUB_APP_ID: ${{ vars.PAPERCLIP_EVALS_APP_ID }}
+          GITHUB_APP_PRIVATE_KEY: ${{ secrets.PAPERCLIP_EVALS_APP_PRIVATE_KEY }}
+          GITHUB_APP_NAME: paperclip-evals
           GH_REPO: paperclipai/paperclip-evals
         run: |
           set -euo pipefail
@@ -176,7 +178,9 @@ jobs:
       - name: Generate private eval-repository token
         id: evals_token
         env:
-          COMMITPERCLIP_KEY: ${{ secrets.COMMITPERCLIP_KEY }}
+          GITHUB_APP_ID: ${{ vars.PAPERCLIP_EVALS_APP_ID }}
+          GITHUB_APP_PRIVATE_KEY: ${{ secrets.PAPERCLIP_EVALS_APP_PRIVATE_KEY }}
+          GITHUB_APP_NAME: paperclip-evals
           GH_REPO: paperclipai/paperclip-evals
         run: |
           set -euo pipefail
@@ -331,7 +335,9 @@ jobs:
       - name: Generate private eval-repository token
         id: evals_token
         env:
-          COMMITPERCLIP_KEY: ${{ secrets.COMMITPERCLIP_KEY }}
+          GITHUB_APP_ID: ${{ vars.PAPERCLIP_EVALS_APP_ID }}
+          GITHUB_APP_PRIVATE_KEY: ${{ secrets.PAPERCLIP_EVALS_APP_PRIVATE_KEY }}
+          GITHUB_APP_NAME: paperclip-evals
           GH_REPO: paperclipai/paperclip-evals
         run: |
           set -euo pipefail
@@ -501,7 +507,9 @@ jobs:
       - name: Generate private eval-repository token
         id: evals_token
         env:
-          COMMITPERCLIP_KEY: ${{ secrets.COMMITPERCLIP_KEY }}
+          GITHUB_APP_ID: ${{ vars.PAPERCLIP_EVALS_APP_ID }}
+          GITHUB_APP_PRIVATE_KEY: ${{ secrets.PAPERCLIP_EVALS_APP_PRIVATE_KEY }}
+          GITHUB_APP_NAME: paperclip-evals
           GH_REPO: paperclipai/paperclip-evals
         run: |
           set -euo pipefail

--- a/packages/paperclip-runner/docs/runner-protocol-live-evals.md
+++ b/packages/paperclip-runner/docs/runner-protocol-live-evals.md
@@ -37,9 +37,13 @@ from the default branch and provide:
   attempt explicitly reports a retryable infrastructure failure.
 
 The authorization job resolves the Paperclip branch to a commit and verifies
-the supplied eval commit before any checkout. A short-lived bot token generated
-from `COMMITPERCLIP_KEY` authorizes each checkout of the private eval repository;
-the token is masked and is never forwarded to a provider process. The workflow
+the supplied eval commit before any checkout. A short-lived installation token
+from the dedicated `paperclip-evals` GitHub App authorizes each checkout of the
+private eval repository; the token is masked and is never forwarded to a
+provider process. The app is installed only on `paperclipai/paperclip-evals`,
+with repository metadata and read-only contents access. The workflow reads its
+numeric App ID from the `PAPERCLIP_EVALS_APP_ID` repository variable and its
+private key from the `PAPERCLIP_EVALS_APP_PRIVATE_KEY` repository secret. It
 uses the same numeric actor
 allowlist, protected `runner-e2e-paid` environment, RunsOn fleet selector, and
 `RUNNER_E2E_MAX_PARALLEL` ceiling as the full-stack E2E workflow. Two balanced
@@ -101,6 +105,11 @@ role admits only the `paperclipai/paperclip` repository's protected
 `runner-e2e-paid` environment as its web-identity subject.
 Scheduled runs additionally require `RUNNER_PROTOCOL_EVAL_NIGHTLY_ENABLED=true`
 and the pinned `RUNNER_PROTOCOL_EVALS_SHA` repository variable.
+
+The dedicated App has no webhook, organization permissions, or repository
+write permissions. Rotate its private key by adding the replacement key to the
+repository secret, proving a workflow authorization/checkout, and only then
+deleting the previous key in the App settings.
 
 ## Reports and history
 

--- a/packages/paperclip-runner/scripts/runner-protocol-eval-workflow-security.test.mjs
+++ b/packages/paperclip-runner/scripts/runner-protocol-eval-workflow-security.test.mjs
@@ -61,7 +61,15 @@ test("resolves both repositories immutably and bounds total matrix concurrency",
     authorize,
     /repos\/paperclipai\/paperclip-evals\/commits\/\$EVALS_SHA/u,
   );
-  assert.match(authorize, /COMMITPERCLIP_KEY/u);
+  assert.match(
+    authorize,
+    /GITHUB_APP_ID: \$\{\{ vars\.PAPERCLIP_EVALS_APP_ID \}\}/u,
+  );
+  assert.match(
+    authorize,
+    /GITHUB_APP_PRIVATE_KEY: \$\{\{ secrets\.PAPERCLIP_EVALS_APP_PRIVATE_KEY \}\}/u,
+  );
+  assert.doesNotMatch(workflow, /COMMITPERCLIP_KEY/u);
   assert.match(authorize, /GH_REPO: paperclipai\/paperclip-evals/u);
   assert.match(
     authorize,
@@ -91,6 +99,16 @@ test("resolves both repositories immutably and bounds total matrix concurrency",
   ];
   assert.equal(privateTokenSteps.length, 4);
   for (const tokenStep of privateTokenSteps) {
+    assert.match(
+      tokenStep.groups.body,
+      /^ {10}GITHUB_APP_ID: \$\{\{ vars\.PAPERCLIP_EVALS_APP_ID \}\}$/mu,
+      "every private-eval token must use the dedicated eval app ID",
+    );
+    assert.match(
+      tokenStep.groups.body,
+      /^ {10}GITHUB_APP_PRIVATE_KEY: \$\{\{ secrets\.PAPERCLIP_EVALS_APP_PRIVATE_KEY \}\}$/mu,
+      "every private-eval token must use the dedicated eval app key",
+    );
     assert.match(
       tokenStep.groups.body,
       /^ {10}GH_REPO: paperclipai\/paperclip-evals$/mu,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The Runner has a direct live protocol eval suite.
> - Its workflow must read a private eval repository.
> - The current workflow uses the shared commitperclip App.
> - This pull request gives the eval workflow its own App identity.
> - The dedicated App needs only read access to the eval repository.

## Linked Issues or Issue Description

**What existing behavior does this improve?**

Private repository checkout in the direct live Runner eval workflow.

**Current behavior**

The eval workflow uses COMMITPERCLIP_KEY and the shared commitperclip App ID.

**Proposed behavior**

Use PAPERCLIP_EVALS_APP_ID and PAPERCLIP_EVALS_APP_PRIVATE_KEY. Install that App only on paperclipai/paperclip-evals with read-only contents access.

**Reason and benefit**

Separate credential ownership and key rotation from unrelated automation.

**Breaking changes**

The eval workflow requires the new App variable and secret before merge. Other token-helper callers retain their current behavior.

Related public work: #12932. No duplicate dedicated-App change was found.

## What Changed

- Add explicit App credentials to the existing token helper.
- Keep the legacy commitperclip credentials for unrelated callers.
- Reject incomplete explicit credentials instead of mixing identities.
- Change all four private-eval token steps to the dedicated App.
- Document permissions, setup, and key rotation.
- Add identity and workflow regression tests.

## Verification

- Passed 10 focused tests: `node --test .github/scripts/tests/get-bot-token.test.mjs packages/paperclip-runner/scripts/runner-protocol-eval-workflow-security.test.mjs`.
- Passed `actionlint .github/workflows/runner-protocol-live-evals.yml`.
- Passed `git diff --check`.
- Live checkout proof is pending App registration. Keep this PR unmerged until credentials and access are verified.
- Repo-wide typecheck, build, and tests were not repeated locally for this workflow/helper-only change. CI will provide those checks.

## Risks

- Missing App configuration blocks eval checkout. Configure and test the App before merge.
- Install the App only on the eval repository. Grant contents read and metadata read. Do not grant write access or enable webhooks.
- This change does not alter the browser full-stack E2E workflow or model execution code.

## Model Used

- OpenAI GPT-6 (`gpt-6-astra`) through Codex, with reasoning, tool use, and code execution. The session does not expose an exact context-window limit.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
