### PR TITLE
fix: agent-status latch on lease release, unreachable continuation-retry cap, silent hermes abort, cross-issue checkout write

### DIFF
--- a/packages/adapters/hermes/src/server/execute.stdout-abort.test.ts
+++ b/packages/adapters/hermes/src/server/execute.stdout-abort.test.ts
@@ -1,0 +1,212 @@
+/**
+ * Regression tests for terminal Hermes API aborts that are written to stdout.
+ *
+ * Hermes prints its non-retryable abort to stdout and still exits 0. The
+ * adapter only scanned stderr for error text, so such a run reached Paperclip
+ * with exit code 0 and no errorMessage and recorded as `succeeded` despite
+ * doing zero work.
+ *
+ * The stdout fixture below is the verbatim capture from run
+ * 2215a6f1-7aa8-49c2-8ae1-ded70d299310, CRLF line endings included.
+ */
+
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+vi.mock("@paperclipai/adapter-utils/server-utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@paperclipai/adapter-utils/server-utils")>();
+  return {
+    ...actual,
+    runChildProcess: vi.fn(async () => ({
+      exitCode: 0,
+      signal: null,
+      timedOut: false,
+      stdout: "",
+      stderr: "",
+    })),
+  };
+});
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(async () => ""),
+  writeFile: vi.fn(async () => undefined),
+  mkdir: vi.fn(async () => undefined),
+  rm: vi.fn(async () => undefined),
+  access: vi.fn(async () => undefined),
+  readdir: vi.fn(async () => []),
+  stat: vi.fn(async () => ({ isFile: () => true, isDirectory: () => false })),
+}));
+
+import { execute } from "./execute.js";
+import * as serverUtils from "@paperclipai/adapter-utils/server-utils";
+
+/** Verbatim stdout of the captured failing run. */
+const ABORT_STDOUT = [
+  "[hermes] Starting Hermes Agent (model=auto, provider=auto [auto], timeout=1800s)",
+  "Initializing agent...\r",
+  "────────────────────────────────────────\r",
+  "",
+  "⚠️  API call failed (attempt 1/3): BadRequestError [HTTP 400]\r",
+  "   🔌 Provider: copilot  Model: auto\r",
+  "   🌐 Endpoint: https://api.githubcopilot.com\r",
+  "   📝 Error: HTTP 400: The requested model is not supported.\r",
+  "   ⏱️  Elapsed: 0.96s  Context: 2 msgs, ~10,618 tokens\r",
+  "❌ Non-retryable error (HTTP 400): HTTP 400: The requested model is not supported.\r",
+  "❌ Non-retryable client error (HTTP 400). Aborting.\r",
+  "   🔌 Provider: copilot  Model: auto\r",
+  "   💡 This type of error won't be fixed by retrying.\r",
+  "",
+  "Resume this session with:",
+  "  hermes --resume 20260823_033707_2cce8a",
+  "",
+  "Session:        20260823_033707_2cce8a",
+  "Duration:       12s",
+  "Messages:       1 (1 user, 0 tool calls)",
+  "",
+].join("\n");
+
+/** A legitimate run that answered a question without calling any tool. */
+const CLEAN_ZERO_TOOL_STDOUT = [
+  "[hermes] Starting Hermes Agent (model=auto, provider=auto [auto], timeout=1800s)",
+  "Yes — the deploy finished at 09:14 and both replicas are healthy.",
+  "",
+  "Session:        20260823_041500_9ab112",
+  "Duration:       8s",
+  "Messages:       2 (1 user, 0 tool calls)",
+  "session_id: 20260823_041500_9ab112",
+  "",
+].join("\n");
+
+function makeCtx() {
+  return {
+    runId: "test-run-stdout-abort",
+    agent: {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "Hermes",
+      adapterType: "hermes_local",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: {
+      command: "/usr/bin/hermes",
+      timeoutSec: 60,
+      graceSec: 5,
+    },
+    context: {
+      issueId: "issue-1",
+      wakeReason: "manual",
+      paperclipWake: null,
+    },
+    onLog: vi.fn(async () => undefined),
+    onMeta: vi.fn(async () => undefined),
+    onSpawn: vi.fn(async () => undefined),
+  };
+}
+
+function mockRun(overrides: { stdout?: string; stderr?: string; exitCode?: number }) {
+  vi.mocked(serverUtils.runChildProcess).mockResolvedValueOnce({
+    exitCode: overrides.exitCode ?? 0,
+    signal: null,
+    timedOut: false,
+    stdout: overrides.stdout ?? "",
+    stderr: overrides.stderr ?? "",
+    pid: null,
+    startedAt: null,
+  } as never);
+}
+
+describe("hermes-local adapter stdout abort detection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports a stdout non-retryable abort that exited 0", async () => {
+    mockRun({ stdout: ABORT_STDOUT, exitCode: 0 });
+
+    const result = await execute(makeCtx() as never);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.errorMessage).toBe(
+      "❌ Non-retryable error (HTTP 400): HTTP 400: The requested model is not supported.",
+    );
+  });
+
+  it("still reports the abort when only the terminal Aborting line is present", async () => {
+    mockRun({
+      stdout: "Working...\n❌ Non-retryable client error (HTTP 401). Aborting.\r\n",
+      exitCode: 0,
+    });
+
+    const result = await execute(makeCtx() as never);
+
+    expect(result.errorMessage).toBe("❌ Non-retryable client error (HTTP 401). Aborting.");
+  });
+
+  it("reports an exhausted retry budget", async () => {
+    mockRun({
+      stdout: "API call failed after 3 retries: Connection error.\n",
+      exitCode: 0,
+    });
+
+    const result = await execute(makeCtx() as never);
+
+    expect(result.errorMessage).toBe("API call failed after 3 retries: Connection error.");
+  });
+
+  it("leaves a successful run alone, including one with zero tool calls", async () => {
+    mockRun({ stdout: CLEAN_ZERO_TOOL_STDOUT, exitCode: 0 });
+
+    const result = await execute(makeCtx() as never);
+
+    expect(result.errorMessage).toBeUndefined();
+  });
+
+  it("does not fail a run that recovered on a later API attempt", async () => {
+    mockRun({
+      stdout: [
+        "⚠️  API call failed (attempt 1/3): APIConnectionError\r",
+        "Retrying in 2s...\r",
+        "Done — updated the config and pushed.",
+        "",
+      ].join("\n"),
+      exitCode: 0,
+    });
+
+    const result = await execute(makeCtx() as never);
+
+    expect(result.errorMessage).toBeUndefined();
+  });
+
+  it("does not fail a run that recovered on a fallback provider", async () => {
+    mockRun({
+      stdout: [
+        "⚠️ Non-retryable error (HTTP 400) — trying fallback...\r",
+        "⚠️ Max retries (3) exhausted — trying fallback...\r",
+        "Done — answered from the fallback provider.",
+        "",
+      ].join("\n"),
+      exitCode: 0,
+    });
+
+    const result = await execute(makeCtx() as never);
+
+    expect(result.errorMessage).toBeUndefined();
+  });
+
+  it("keeps stderr as the higher-priority error source", async () => {
+    mockRun({
+      stdout: ABORT_STDOUT,
+      stderr: "Error: provider unavailable\n",
+      exitCode: 0,
+    });
+
+    const result = await execute(makeCtx() as never);
+
+    expect(result.errorMessage).toBe("Error: provider unavailable");
+  });
+});

--- a/packages/adapters/hermes/src/server/execute.stdout-abort.test.ts
+++ b/packages/adapters/hermes/src/server/execute.stdout-abort.test.ts
@@ -198,6 +198,32 @@ describe("hermes-local adapter stdout abort detection", () => {
     expect(result.errorMessage).toBeUndefined();
   });
 
+  it("does not fail a run where an abort phrase is quoted mid-transcript but the run succeeds", async () => {
+    const filler = Array.from(
+      { length: 14 },
+      (_, i) => `Step ${i + 1}: continuing work, nothing wrong here.`,
+    );
+    mockRun({
+      stdout: [
+        "[hermes] Starting Hermes Agent (model=auto, provider=auto [auto], timeout=1800s)",
+        'I found this in the old run log: "API call failed after 3 retries: Connection error." and patched the retry handler so it no longer happens.',
+        ...filler,
+        "Done — fix verified, all tests green.",
+        "",
+        "Session:        20260823_050000_aaaaaa",
+        "Duration:       40s",
+        "Messages:       2 (1 user, 1 tool calls)",
+        "session_id: 20260823_050000_aaaaaa",
+        "",
+      ].join("\n"),
+      exitCode: 0,
+    });
+
+    const result = await execute(makeCtx() as never);
+
+    expect(result.errorMessage).toBeUndefined();
+  });
+
   it("keeps stderr as the higher-priority error source", async () => {
     mockRun({
       stdout: ABORT_STDOUT,

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -228,6 +228,48 @@ const TOKEN_USAGE_REGEX =
 /** Regex to extract cost from Hermes output. */
 const COST_REGEX = /(?:cost|spent)[:\s]*\$?([\d.]+)/i;
 
+/**
+ * Terminal API-failure markers that Hermes writes to **stdout**, not stderr.
+ *
+ * Hermes exits 0 on these paths, so a run that did zero work otherwise reaches
+ * Paperclip with no exit code and no error text and records as `succeeded`.
+ *
+ * Only the terminal emissions are listed. The retry-attempt line
+ * ("API call failed (attempt 1/3)") and the "— trying fallback..." status lines
+ * are deliberately excluded: a run that recovers on a later attempt or on a
+ * fallback provider is a success, and matching those would fail it. Each
+ * descriptive variant below is matched by its trailing colon, which the
+ * "— trying fallback..." counterpart of the same message does not have.
+ *
+ * Ordered by informativeness only incidentally — the first matching *line* in
+ * stdout wins, and Hermes emits the descriptive line just before the bare
+ * "Aborting." line.
+ */
+const STDOUT_ABORT_REGEXES: RegExp[] = [
+  // Terminal non-retryable client error, with the summarized cause.
+  /Non-retryable error \(HTTP [^)]*\):/i,
+  // Same path, content-policy and TLS variants.
+  /Provider safety filter blocked this request:/i,
+  /TLS certificate verification failed:/i,
+  // Always emitted on the non-retryable terminal path, whatever the variant.
+  /Non-retryable client error \(HTTP [^)]*\)\.\s*Aborting\./i,
+  // Retry budget exhausted with no fallback left.
+  /API call failed after \d+ retries?:/i,
+  // Billing variant of the same terminal path.
+  /Billing or credits exhausted:/i,
+];
+
+/** Find the first stdout line that marks a terminal Hermes API abort. */
+function findStdoutAbortLine(stdout: string): string | undefined {
+  if (!stdout) return undefined;
+  for (const rawLine of stdout.split("\n")) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    if (STDOUT_ABORT_REGEXES.some((re) => re.test(line))) return line;
+  }
+  return undefined;
+}
+
 interface ParsedOutput {
   sessionId?: string;
   response?: string;
@@ -322,6 +364,16 @@ function parseHermesOutput(stdout: string, stderr: string): ParsedOutput {
       .filter((line) => !/INFO|DEBUG|warn/i.test(line)); // skip log-level noise
     if (errorLines.length > 0) {
       result.errorMessage = errorLines.slice(0, 5).join("\n");
+    }
+  }
+
+  // Hermes writes non-retryable API aborts to stdout and still exits 0, so
+  // neither the stderr scan above nor the nonzero-exit fallback in execute()
+  // sees them. Checked second so stderr stays the higher-priority source.
+  if (!result.errorMessage) {
+    const abortLine = findStdoutAbortLine(stdout);
+    if (abortLine) {
+      result.errorMessage = abortLine;
     }
   }
 

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -259,12 +259,36 @@ const STDOUT_ABORT_REGEXES: RegExp[] = [
   /Billing or credits exhausted:/i,
 ];
 
-/** Find the first stdout line that marks a terminal Hermes API abort. */
+/**
+ * How many trailing non-empty stdout lines to scan for a terminal abort
+ * marker. Hermes emits its abort line immediately before its own trailing
+ * `Resume this session with:` / `Session:` / `Duration:` / `Messages:` block
+ * (see the ABORT_STDOUT fixture in execute.stdout-abort.test.ts, where the
+ * abort line sits 9 non-empty lines from the end) — bounding the scan to the
+ * tail keeps that case covered while refusing to match an abort phrase an
+ * agent merely quotes or narrates earlier in a long, otherwise successful
+ * transcript.
+ */
+const STDOUT_ABORT_SCAN_TAIL_LINE_COUNT = 12;
+
+/**
+ * Find the first stdout line, within the trailing
+ * STDOUT_ABORT_SCAN_TAIL_LINE_COUNT non-empty lines, that marks a terminal
+ * Hermes API abort.
+ *
+ * Scoped to the tail (not the full transcript) so that an agent's own prose
+ * quoting or explaining one of these phrases mid-run — e.g. narrating a bug
+ * it just fixed — does not get misread as Hermes's own terminal abort.
+ */
 function findStdoutAbortLine(stdout: string): string | undefined {
   if (!stdout) return undefined;
+  const nonEmptyLines: string[] = [];
   for (const rawLine of stdout.split("\n")) {
     const line = rawLine.trim();
-    if (!line) continue;
+    if (line) nonEmptyLines.push(line);
+  }
+  const tail = nonEmptyLines.slice(-STDOUT_ABORT_SCAN_TAIL_LINE_COUNT);
+  for (const line of tail) {
     if (STDOUT_ABORT_REGEXES.some((re) => re.test(line))) return line;
   }
   return undefined;

--- a/packages/adapters/hermes/src/server/execute.ts
+++ b/packages/adapters/hermes/src/server/execute.ts
@@ -260,25 +260,43 @@ const STDOUT_ABORT_REGEXES: RegExp[] = [
 ];
 
 /**
- * How many trailing non-empty stdout lines to scan for a terminal abort
- * marker. Hermes emits its abort line immediately before its own trailing
- * `Resume this session with:` / `Session:` / `Duration:` / `Messages:` block
- * (see the ABORT_STDOUT fixture in execute.stdout-abort.test.ts, where the
- * abort line sits 9 non-empty lines from the end) — bounding the scan to the
- * tail keeps that case covered while refusing to match an abort phrase an
- * agent merely quotes or narrates earlier in a long, otherwise successful
- * transcript.
+ * Lines that mark the start of Hermes's own trailing footer block
+ * (`Resume this session with:` / `Session:` / `Duration:` / `Messages:`,
+ * verbatim, see the ABORT_STDOUT fixture in execute.stdout-abort.test.ts).
+ * The earliest of these that appears is treated as the footer boundary.
  */
-const STDOUT_ABORT_SCAN_TAIL_LINE_COUNT = 12;
+const STDOUT_FOOTER_START_REGEXES: RegExp[] = [
+  /^Resume this session with:/,
+  /^Session:\s+\S/,
+  /^Duration:\s+\S/,
+  /^Messages:\s+\S/,
+];
 
 /**
- * Find the first stdout line, within the trailing
- * STDOUT_ABORT_SCAN_TAIL_LINE_COUNT non-empty lines, that marks a terminal
- * Hermes API abort.
+ * How many non-empty stdout lines immediately preceding the footer boundary
+ * (or, when there is no footer, immediately preceding the end of stdout) may
+ * be scanned for a terminal abort marker. Hermes's abort line always sits a
+ * handful of lines before its own footer (see the ABORT_STDOUT fixture,
+ * where it is 4 lines before the footer's first line) — bounding the scan to
+ * that neighborhood, rather than an arbitrary count of trailing lines, is
+ * what keeps a short successful transcript that merely quotes one of these
+ * phrases (e.g. narrating a bug it just fixed, or a prior failed run it is
+ * reporting on) from being misread as Hermes's own terminal abort: such a
+ * quote sits *before* the real content, not adjacent to the footer.
+ */
+const STDOUT_ABORT_FOOTER_LOOKBACK_LINE_COUNT = 8;
+
+/**
+ * Find the first stdout line, within the window of
+ * STDOUT_ABORT_FOOTER_LOOKBACK_LINE_COUNT non-empty lines immediately
+ * preceding Hermes's trailing footer (or the end of stdout, if no footer is
+ * present), that marks a terminal Hermes API abort.
  *
- * Scoped to the tail (not the full transcript) so that an agent's own prose
- * quoting or explaining one of these phrases mid-run — e.g. narrating a bug
- * it just fixed — does not get misread as Hermes's own terminal abort.
+ * Anchored to the footer rather than a fixed count of trailing lines: an
+ * abort phrase an agent quotes or narrates earlier in a long, otherwise
+ * successful transcript sits well before that boundary and is not matched,
+ * while the phrase Hermes itself emits — which always sits immediately
+ * before its own footer — is matched regardless of overall transcript length.
  */
 function findStdoutAbortLine(stdout: string): string | undefined {
   if (!stdout) return undefined;
@@ -287,8 +305,19 @@ function findStdoutAbortLine(stdout: string): string | undefined {
     const line = rawLine.trim();
     if (line) nonEmptyLines.push(line);
   }
-  const tail = nonEmptyLines.slice(-STDOUT_ABORT_SCAN_TAIL_LINE_COUNT);
-  for (const line of tail) {
+  if (nonEmptyLines.length === 0) return undefined;
+
+  let footerStart = nonEmptyLines.length;
+  for (let i = 0; i < nonEmptyLines.length; i += 1) {
+    if (STDOUT_FOOTER_START_REGEXES.some((re) => re.test(nonEmptyLines[i]))) {
+      footerStart = i;
+      break;
+    }
+  }
+
+  const windowStart = Math.max(0, footerStart - STDOUT_ABORT_FOOTER_LOOKBACK_LINE_COUNT);
+  const window = nonEmptyLines.slice(windowStart, footerStart);
+  for (const line of window) {
     if (STDOUT_ABORT_REGEXES.some((re) => re.test(line))) return line;
   }
   return undefined;

--- a/server/src/__tests__/cross-issue-influence-limit.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit.test.ts
@@ -10,6 +10,7 @@ import {
 function counterDb(
   initialCount = 0,
   runOverrides: Record<string, unknown> | null = {},
+  issueOverrides: Record<string, unknown> | null = {},
 ) {
   let observedCount = initialCount;
   const inserted: Array<Record<string, unknown>> = [];
@@ -20,6 +21,18 @@ function counterDb(
           if (Object.keys(selection).includes("count")) {
             return {
               then: (resolve: (rows: unknown[]) => unknown) => resolve([{ count: observedCount }]),
+            };
+          }
+          if (Object.keys(selection).includes("checkoutRunId")) {
+            // Target-issue live-checkout lookup (no `.for("update")` — plain select).
+            return {
+              then: (resolve: (rows: unknown[]) => unknown) => resolve(issueOverrides === null ? [] : [{
+                id: "55555555-5555-4555-8555-555555555555",
+                companyId: "22222222-2222-4222-8222-222222222222",
+                checkoutRunId: null,
+                executionRunId: null,
+                ...issueOverrides,
+              }]),
             };
           }
           return {
@@ -198,8 +211,8 @@ describe("cross-issue influence limit rollout", () => {
     expect(fake.inserted).toEqual([]);
   });
 
-  it("fails closed when the persisted run has no source issue", async () => {
-    const fake = counterDb(0, { contextSnapshot: {} });
+  it("fails closed when the persisted run has no source issue and no live checkout match", async () => {
+    const fake = counterDb(0, { contextSnapshot: {} }, { checkoutRunId: null, executionRunId: null });
 
     await expect(observeCrossIssueInfluence(fake.db as never, {
       companyId: "22222222-2222-4222-8222-222222222222",
@@ -207,6 +220,63 @@ describe("cross-issue influence limit rollout", () => {
       agentId: "33333333-3333-4333-8333-333333333333",
       targetIssueId: "55555555-5555-4555-8555-555555555555",
       kind: "update",
+    })).rejects.toMatchObject({
+      status: 403,
+      details: { code: "cross_issue_influence_run_context_required" },
+    });
+    expect(fake.inserted).toEqual([]);
+  });
+
+  it("allows a write when the run has no context issueId but holds live checkout on the target issue", async () => {
+    // MAS-519: a manually/ambiently-invoked run (no issueId in contextSnapshot)
+    // that has checked out the target issue must not be hard-blocked.
+    const fake = counterDb(
+      0,
+      { contextSnapshot: {} },
+      { checkoutRunId: "11111111-1111-4111-8111-111111111111", executionRunId: null },
+    );
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+      kind: "update",
+    })).resolves.toBeNull();
+    // Same-issue-via-checkout writes are not counted against the cap either.
+    expect(fake.inserted).toEqual([]);
+  });
+
+  it("allows a write when the run has no context issueId but holds the executionRunId lock on the target issue", async () => {
+    const fake = counterDb(
+      0,
+      { contextSnapshot: {} },
+      { checkoutRunId: null, executionRunId: "11111111-1111-4111-8111-111111111111" },
+    );
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+      kind: "comment",
+    })).resolves.toBeNull();
+    expect(fake.inserted).toEqual([]);
+  });
+
+  it("still fails closed with no context issueId when a DIFFERENT run holds the target issue's checkout", async () => {
+    const fake = counterDb(
+      0,
+      { contextSnapshot: {} },
+      { checkoutRunId: "99999999-9999-4999-8999-999999999999", executionRunId: null },
+    );
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+      kind: "comment",
     })).rejects.toMatchObject({
       status: 403,
       details: { code: "cross_issue_influence_run_context_required" },

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -737,11 +737,9 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
   async function seedStrandedIssueFixture(input: {
     status: "todo" | "in_progress";
     runStatus: "failed" | "timed_out" | "cancelled" | "succeeded";
-    retryReason?:
-      | "assignment_recovery"
-      | "issue_continuation_needed"
-      | "execution_review_participant_recovery"
-      | null;
+    // "process_lost" is the retryReason the process-loss retry path writes
+    // (heartbeat.ts:10187); real chains alternate it with "issue_continuation_needed".
+    retryReason?: "assignment_recovery" | "issue_continuation_needed" | "execution_review_participant_recovery" | "process_lost" | null;
     runSource?: string | null;
     assignToUser?: boolean;
     activePauseHold?: boolean;
@@ -8432,6 +8430,229 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
           row.value === "Board decision required",
       ),
     ).toBe(true);
+  });
+
+  // ---------------------------------------------------------------------------
+  // MAS-93: the continuation cap existed but never engaged, so retry chains ran
+  // unbounded (observed depth 11). Root cause was that the cap was gated on the
+  // latest run's retryReason being exactly "issue_continuation_needed", while real
+  // chains alternate that with "process_lost". These tests pin the reason-agnostic
+  // lineage behaviour that replaced it.
+  // ---------------------------------------------------------------------------
+
+  it("caps a continuation chain whose latest retry carries a non-continuation reason", async () => {
+    // The exact hop the old guard missed: this run IS an automatic-recovery retry,
+    // but its reason is "process_lost", so the reason-pinned guard read it as a
+    // first failure and requeued without counting it against any cap.
+    const { agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "process_lost",
+      runErrorCode: "process_lost",
+      runError: "run process exited before completion",
+    });
+    const heartbeat = heartbeatService(db);
+
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+
+    // No *continuation* retry may be enqueued. The escalation itself does spawn a
+    // status-only recovery run (it posts the blocked notice); that one is expected
+    // and carries allowDeliverableWork: false, so it cannot resume the work.
+    const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
+    const continuationRuns = runs.filter((row) =>
+      (row.contextSnapshot as Record<string, unknown> | null)?.source === "issue.continuation_recovery",
+    );
+    expect(continuationRuns).toHaveLength(0);
+
+    const escalationRun = runs.find((row) => row.id !== runId) ?? null;
+    expect(escalationRun?.contextSnapshot as Record<string, unknown> | undefined).toMatchObject({
+      source: "issue_recovery_action",
+      recoveryIntent: "status_only",
+      allowDeliverableWork: false,
+    });
+    if (escalationRun) {
+      await waitForRunToSettle(heartbeat, escalationRun.id);
+    }
+  });
+
+  it("detects recovery lineage from the retryOfRunId column with no retryReason in the snapshot", async () => {
+    // Lineage is read column-first so the cap does not depend on retryReason
+    // surviving in the JSON context snapshot. Seed with no retryReason at all and
+    // establish lineage purely via the column.
+    const { companyId, agentId, issueId, runId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      runErrorCode: "process_lost",
+      runError: "run process exited before completion",
+    });
+
+    const priorRunId = randomUUID();
+    const priorAt = new Date("2026-03-18T23:55:00.000Z");
+    await db.insert(heartbeatRuns).values({
+      id: priorRunId,
+      companyId,
+      agentId,
+      invocationSource: "automation",
+      triggerDetail: "system",
+      status: "failed",
+      contextSnapshot: { issueId, taskId: issueId, wakeReason: "issue_assigned" },
+      errorCode: "process_lost",
+      error: "run process exited before completion",
+      startedAt: priorAt,
+      finishedAt: priorAt,
+      createdAt: priorAt,
+      updatedAt: priorAt,
+    });
+    // Latest run is a retry of the prior one — lineage via the column only.
+    await db
+      .update(heartbeatRuns)
+      .set({ retryOfRunId: priorRunId })
+      .where(eq(heartbeatRuns.id, runId));
+
+    const latest = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.id, runId)).then((r) => r[0]);
+    expect(latest?.retryOfRunId).toBe(priorRunId);
+    expect((latest?.contextSnapshot as Record<string, unknown>).retryReason).toBeUndefined();
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(1);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+  });
+
+  it("counts a mixed-reason retry streak toward the transient cap", async () => {
+    // Defect 2: the streak walk used to break on any reason change, so an
+    // alternating chain never counted past 1 and the cap of 3 was unreachable.
+    // Same error code throughout (adapter_failed -> transient_infra, cap 3), only
+    // the reason alternates.
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      runErrorCode: "adapter_failed",
+      runError: "ssh: connection reset",
+    });
+
+    // Two earlier lineage retries with the *other* reason. Under the old walk these
+    // were invisible; under lineage matching they complete the streak of 3.
+    // Chained via retryOfRunId (the column has a self-FK, so each must point at a
+    // row that exists) to mirror a real alternating chain.
+    const backfill = [
+      { at: new Date("2026-03-18T23:50:00.000Z"), reason: "process_lost" },
+      { at: new Date("2026-03-18T23:55:00.000Z"), reason: "process_lost" },
+    ];
+    let previousRunId: string | null = null;
+    for (const { at, reason } of backfill) {
+      const id = randomUUID();
+      await db.insert(heartbeatRuns).values({
+        id,
+        companyId,
+        agentId,
+        invocationSource: "automation",
+        triggerDetail: "system",
+        status: "failed",
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "process_lost_retry",
+          retryReason: reason,
+          source: "issue.continuation_recovery",
+        },
+        retryOfRunId: previousRunId,
+        errorCode: "adapter_failed",
+        error: "ssh: connection reset",
+        startedAt: at,
+        finishedAt: at,
+        createdAt: at,
+        updatedAt: at,
+      });
+      previousRunId = id;
+    }
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(1);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("blocked");
+  });
+
+  it("resets the retry streak after a successful run so long chains keep working", async () => {
+    // The one break condition that must survive: a successful run in between means
+    // the agent is making progress, and the chain must not be capped. Without this
+    // the fix would strand healthy long-running continuation work.
+    const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "failed",
+      retryReason: "issue_continuation_needed",
+      runErrorCode: "adapter_failed",
+      runError: "ssh: connection reset",
+    });
+
+    const history: Array<{ at: Date; status: "failed" | "succeeded" }> = [
+      { at: new Date("2026-03-18T23:40:00.000Z"), status: "failed" },
+      { at: new Date("2026-03-18T23:45:00.000Z"), status: "failed" },
+      // Progress happened here — everything older is out of the streak.
+      { at: new Date("2026-03-18T23:55:00.000Z"), status: "succeeded" },
+    ];
+    let previousRunId: string | null = null;
+    for (const { at, status } of history) {
+      const id = randomUUID();
+      await db.insert(heartbeatRuns).values({
+        id,
+        companyId,
+        agentId,
+        invocationSource: "automation",
+        triggerDetail: "system",
+        status,
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_continuation_needed",
+          retryReason: "issue_continuation_needed",
+          source: "issue.continuation_recovery",
+        },
+        retryOfRunId: previousRunId,
+        errorCode: status === "succeeded" ? null : "adapter_failed",
+        error: status === "succeeded" ? null : "ssh: connection reset",
+        startedAt: at,
+        finishedAt: at,
+        createdAt: at,
+        updatedAt: at,
+      });
+      previousRunId = id;
+    }
+
+    const heartbeat = heartbeatService(db);
+    const result = await heartbeat.reconcileStrandedAssignedIssues();
+
+    // Streak is 1 (the latest run only), below the transient cap of 3.
+    expect(result.continuationRequeued).toBe(1);
+    expect(result.escalated).toBe(0);
+
+    const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
+    expect(issue?.status).toBe("in_progress");
+
+    const retryRun = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId))
+      .then((rows) => rows.find((row) => row.status === "queued") ?? null);
+    if (retryRun) {
+      await waitForRunToSettle(heartbeat, retryRun.id);
+    }
   });
 
   it("redacts error-code-only stranded recovery failures in issue copy", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -8462,24 +8462,23 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const issue = await db.select().from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0] ?? null);
     expect(issue?.status).toBe("blocked");
 
-    // No *continuation* retry may be enqueued. The escalation itself does spawn a
-    // status-only recovery run (it posts the blocked notice); that one is expected
-    // and carries allowDeliverableWork: false, so it cannot resume the work.
+    // No *continuation* retry may be enqueued. The escalation itself posts the
+    // blocked notice as a comment rather than spawning a recovery run (see the
+    // adjacent "blocks stranded in-progress work..." test for the same pattern
+    // against a different retryReason), so there is no second run to await here.
     const runs = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId));
     const continuationRuns = runs.filter((row) =>
       (row.contextSnapshot as Record<string, unknown> | null)?.source === "issue.continuation_recovery",
     );
     expect(continuationRuns).toHaveLength(0);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.id).toBe(runId);
 
-    const escalationRun = runs.find((row) => row.id !== runId) ?? null;
-    expect(escalationRun?.contextSnapshot as Record<string, unknown> | undefined).toMatchObject({
-      source: "issue_recovery_action",
-      recoveryIntent: "status_only",
-      allowDeliverableWork: false,
-    });
-    if (escalationRun) {
-      await waitForRunToSettle(heartbeat, escalationRun.id);
-    }
+    const comments = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId));
+    expect(comments.length).toBeGreaterThan(0);
   });
 
   it("detects recovery lineage from the retryOfRunId column with no retryReason in the snapshot", async () => {

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -8813,7 +8813,14 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
   });
 
-  it("does not count mixed-cause continuation failures toward the transient cap", async () => {
+  it("counts mixed-cause continuation failures within one class toward the shared cap (MAS-614)", async () => {
+    // Regression for Greptile finding #1 on PR #12946: the old `error_code` exact-match
+    // mode reset the streak on every error-code change, so a chain alternating
+    // adapter_failed -> timeout -> adapter_failed never reached the cap (this is the
+    // same "retry chains ran unbounded" defect MAS-93 was meant to close). The fixed
+    // `error_class` mode buckets both codes as `transient_infra` and accumulates them
+    // against the shared budget, so this mixed-cause chain of 4 unsuccessful lineage
+    // runs (cap=3) now escalates instead of requeuing indefinitely.
     const { companyId, agentId, issueId, runId } =
       await seedStrandedIssueFixture({
         status: "in_progress",
@@ -8892,8 +8899,8 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     const heartbeat = heartbeatService(db);
 
     const result = await heartbeat.reconcileStrandedAssignedIssues();
-    expect(result.continuationRequeued).toBe(1);
-    expect(result.escalated).toBe(0);
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.escalated).toBe(1);
     expect(result.issueIds).toEqual([issueId]);
 
     const issue = await db
@@ -8901,32 +8908,33 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
       .from(issues)
       .where(eq(issues.id, issueId))
       .then((rows) => rows[0] ?? null);
-    expect(issue?.status).toBe("in_progress");
+    expect(issue?.status).toBe("blocked");
 
-    const runs = await db
-      .select()
-      .from(heartbeatRuns)
-      .where(eq(heartbeatRuns.agentId, agentId));
-    expect(runs).toHaveLength(5);
-    const retryRun = runs.find((row) => {
-      const ctx = row.contextSnapshot as Record<string, unknown> | null;
-      return (
-        row.id !== runId &&
-        row.errorCode === null &&
-        ctx?.retryReason === "issue_continuation_needed" &&
-        ctx?.source === "issue.continuation_recovery"
-      );
-    });
-    expect(
-      retryRun?.contextSnapshot as Record<string, unknown> | undefined,
-    ).toMatchObject({
+    await expectSourceScopedStrandedRecoveryAction({
+      companyId,
+      agentId,
       issueId,
+      runId,
+      previousStatus: "in_progress",
       retryReason: "issue_continuation_needed",
-      source: "issue.continuation_recovery",
     });
-    if (retryRun) {
-      await waitForRunToSettle(heartbeat, retryRun.id);
-    }
+
+    const comments = await db
+      .select()
+      .from(issueComments)
+      .where(eq(issueComments.issueId, issueId));
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.body).toContain("retried continuation");
+    // 4 unsuccessful lineage runs (adapter_failed, timeout x2, adapter_failed) all bucket
+    // into the `transient_infra` class under the fixed `error_class` match mode, so the
+    // streak reaches the cap (3) at the 3rd consecutive lineage run counted — the comment
+    // reports whichever count triggered escalation, and it must be >= the cap, not 1.
+    expect(comments[0]?.body).toMatch(/\d+× attempts/);
+    expect(commentMetadataRows(comments[0])).toContainEqual({
+      type: "key_value",
+      label: "Failure code",
+      value: "adapter_failed",
+    });
   });
 
   it("escalates non-retryable continuation failures immediately without enqueuing another retry", async () => {

--- a/server/src/__tests__/heartbeat-run-lease-release-terminalization.test.ts
+++ b/server/src/__tests__/heartbeat-run-lease-release-terminalization.test.ts
@@ -51,7 +51,12 @@ describeEmbeddedPostgres("heartbeat terminalizeRunOnLeaseRelease", () => {
     await tempDb?.cleanup();
   });
 
-  async function seed(input: { issueStatus: string; runStatus: string }) {
+  async function seed(input: {
+    issueStatus: string;
+    runStatus: string;
+    agentStatus?: string;
+    secondRunStatus?: string;
+  }) {
     const companyId = randomUUID();
     const agentId = randomUUID();
     const issueId = randomUUID();
@@ -68,7 +73,7 @@ describeEmbeddedPostgres("heartbeat terminalizeRunOnLeaseRelease", () => {
       companyId,
       name: "Coder",
       role: "engineer",
-      status: "active",
+      status: input.agentStatus ?? "active",
       adapterType: "codex_local",
       adapterConfig: {},
       runtimeConfig: {},
@@ -91,6 +96,17 @@ describeEmbeddedPostgres("heartbeat terminalizeRunOnLeaseRelease", () => {
       startedAt: new Date(),
       contextSnapshot: { issueId },
     });
+    if (input.secondRunStatus) {
+      await db.insert(heartbeatRuns).values({
+        id: randomUUID(),
+        companyId,
+        agentId,
+        status: input.secondRunStatus,
+        invocationSource: "manual",
+        startedAt: new Date(),
+        contextSnapshot: {},
+      });
+    }
 
     const run = await db
       .select()
@@ -208,5 +224,90 @@ describeEmbeddedPostgres("heartbeat terminalizeRunOnLeaseRelease", () => {
       .where(eq(heartbeatRunEvents.runId, runId))
       .then((rows) => rows.length);
     expect(eventCount).toBe(0);
+  });
+
+  async function readAgentStatus(agentId: string) {
+    return await db
+      .select({ status: agents.status })
+      .from(agents)
+      .where(eq(agents.id, agentId))
+      .then((rows) => rows[0]?.status);
+  }
+
+  it("moves the agent off running when it terminalizes the agent's only live run", async () => {
+    // The defect: this path wrote the run row terminal and returned without
+    // touching the agent row, so the agent stayed "running" with no live run
+    // behind it until it happened to finish some later run.
+    const { agentId, run } = await seed({
+      issueStatus: "in_progress",
+      runStatus: "running",
+      agentStatus: "running",
+    });
+
+    const heartbeat = heartbeatService(db);
+    await heartbeat.terminalizeRunOnLeaseRelease(run);
+
+    expect(await readAgentStatus(agentId)).toBe("idle");
+  });
+
+  it("moves the agent off running when the terminal status is succeeded", async () => {
+    const { agentId, run } = await seed({
+      issueStatus: "done",
+      runStatus: "running",
+      agentStatus: "running",
+    });
+
+    const heartbeat = heartbeatService(db);
+    await heartbeat.terminalizeRunOnLeaseRelease(run);
+
+    // succeeded/cancelled/interrupted all map to idle, never to error.
+    expect(await readAgentStatus(agentId)).toBe("idle");
+  });
+
+  it("keeps the agent running when another run of the same agent is still live", async () => {
+    const { agentId, run } = await seed({
+      issueStatus: "in_progress",
+      runStatus: "running",
+      agentStatus: "running",
+      secondRunStatus: "running",
+    });
+
+    const heartbeat = heartbeatService(db);
+    await heartbeat.terminalizeRunOnLeaseRelease(run);
+
+    expect(await readAgentStatus(agentId)).toBe("running");
+  });
+
+  it("leaves a paused agent paused", async () => {
+    const { agentId, runId, run } = await seed({
+      issueStatus: "in_progress",
+      runStatus: "running",
+      agentStatus: "paused",
+    });
+
+    const heartbeat = heartbeatService(db);
+    await heartbeat.terminalizeRunOnLeaseRelease(run);
+
+    expect(await readAgentStatus(agentId)).toBe("paused");
+    const runStatus = await db
+      .select({ status: heartbeatRuns.status })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0]?.status);
+    expect(runStatus).toBe("interrupted");
+  });
+
+  it("does not touch the agent when the run was already terminal", async () => {
+    const { agentId, run } = await seed({
+      issueStatus: "done",
+      runStatus: "failed",
+      agentStatus: "running",
+    });
+
+    const heartbeat = heartbeatService(db);
+    await heartbeat.terminalizeRunOnLeaseRelease(run);
+
+    // Another path owns that run's finalization, including its agent write.
+    expect(await readAgentStatus(agentId)).toBe("running");
   });
 });

--- a/server/src/services/cross-issue-influence-limit.ts
+++ b/server/src/services/cross-issue-influence-limit.ts
@@ -1,6 +1,6 @@
 import { and, count, eq } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { activityLog, heartbeatRuns } from "@paperclipai/db";
+import { activityLog, heartbeatRuns, issues } from "@paperclipai/db";
 import { isUuidLike, issueWriteDenialResponse } from "@paperclipai/shared";
 import { forbidden } from "../errors.js";
 import { logger } from "../middleware/logger.js";
@@ -110,12 +110,34 @@ export async function observeCrossIssueInfluence(
     }
 
     const sourceIssueId = readRunSourceIssueId(run.contextSnapshot);
-    if (!sourceIssueId) throw crossIssueInfluenceRunContextError();
     if (
-      sourceIssueId === input.targetIssueId ||
-      (input.targetIssueIdentifier && sourceIssueId.toUpperCase() === input.targetIssueIdentifier.toUpperCase())
+      sourceIssueId &&
+      (sourceIssueId === input.targetIssueId ||
+        (input.targetIssueIdentifier && sourceIssueId.toUpperCase() === input.targetIssueIdentifier.toUpperCase()))
     ) {
       return null;
+    }
+
+    if (!sourceIssueId) {
+      // No dispatch-time issueId in contextSnapshot (ambient/manual/timer
+      // invocation). Before failing closed, check whether this run legitimately
+      // owns the TARGET issue right now via a live checkout/execution lock —
+      // that proves same-issue intent regardless of how the run was invoked.
+      const targetIssue = await tx
+        .select({
+          id: issues.id,
+          companyId: issues.companyId,
+          checkoutRunId: issues.checkoutRunId,
+          executionRunId: issues.executionRunId,
+        })
+        .from(issues)
+        .where(and(eq(issues.id, input.targetIssueId), eq(issues.companyId, input.companyId)))
+        .then((rows) => rows[0] ?? null);
+      const ownsViaLiveCheckout =
+        !!targetIssue &&
+        (targetIssue.checkoutRunId === input.runId || targetIssue.executionRunId === input.runId);
+      if (ownsViaLiveCheckout) return null;
+      throw crossIssueInfluenceRunContextError();
     }
 
     const priorCount = await tx

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -11067,6 +11067,22 @@ export function heartbeatService(
           "failed to append run event for lease-release terminalization",
         );
       });
+
+      // The run half of the invariant is not the whole invariant: agents.status
+      // only ever leaves "running" through finalizeAgentStatus. Without this
+      // call the run row is terminal while the agent row stays "running" with no
+      // live run behind it, and it stays that way until that agent happens to
+      // finish some later run. finalizeAgentStatus re-reads the agent, no-ops on
+      // paused/terminated, and recomputes from the running-run count, so a
+      // concurrently live second run still holds the agent at "running".
+      await finalizeAgentStatus(terminalRun.agentId, terminalStatus, terminalRun.error ?? null, {
+        wasFirstHeartbeat: timerClaimWasFirstHeartbeat(terminalRun),
+      }).catch((agentStatusErr) => {
+        logger.warn(
+          { err: agentStatusErr, runId: run.id, agentId: terminalRun.agentId },
+          "failed to finalize agent status after lease-release terminalization",
+        );
+      });
     }
     return terminalRun ?? run;
   }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -11075,14 +11075,45 @@ export function heartbeatService(
       // finish some later run. finalizeAgentStatus re-reads the agent, no-ops on
       // paused/terminated, and recomputes from the running-run count, so a
       // concurrently live second run still holds the agent at "running".
-      await finalizeAgentStatus(terminalRun.agentId, terminalStatus, terminalRun.error ?? null, {
-        wasFirstHeartbeat: timerClaimWasFirstHeartbeat(terminalRun),
-      }).catch((agentStatusErr) => {
+      //
+      // There is no periodic sweep that reconciles a latched "running" status on
+      // its own (confirmed by reading `sweepStaleIssueLocks`, MAS-116: it walks
+      // issue lock columns, and by the time a lease is released those columns
+      // are typically already cleared, so it does not reliably catch this case)
+      // — so a failure here is not self-healing until the agent's *next* run
+      // completes, which for a quiet seat may be a long time or never (MAS-98/
+      // MAS-114 latch signature). A single bounded retry (not an unbounded loop
+      // — that is the same defect class as the continuation-cap bug above) gives
+      // a transient DB blip one more chance; if it still fails we escalate the
+      // log level so the failure is not silently swallowed, since we do not yet
+      // have durable-repair-marker infrastructure to requeue this out-of-band.
+      try {
+        await finalizeAgentStatus(terminalRun.agentId, terminalStatus, terminalRun.error ?? null, {
+          wasFirstHeartbeat: timerClaimWasFirstHeartbeat(terminalRun),
+        });
+      } catch (agentStatusErr) {
         logger.warn(
           { err: agentStatusErr, runId: run.id, agentId: terminalRun.agentId },
-          "failed to finalize agent status after lease-release terminalization",
+          "failed to finalize agent status after lease-release terminalization; retrying once",
         );
-      });
+        try {
+          await finalizeAgentStatus(terminalRun.agentId, terminalStatus, terminalRun.error ?? null, {
+            wasFirstHeartbeat: timerClaimWasFirstHeartbeat(terminalRun),
+          });
+        } catch (retryErr) {
+          // Both attempts failed. This agent may now be latched at "running" with
+          // no live run behind it until its next run completes and recomputes the
+          // status from the running-run count (see finalizeAgentStatus above).
+          // Logged at error, not warn: this is the exact latch signature MAS-98/
+          // MAS-114 investigated as a false "availability outage", so it needs to
+          // be findable rather than buried in routine warn-level noise.
+          logger.error(
+            { err: retryErr, runId: run.id, agentId: terminalRun.agentId, terminalStatus },
+            "failed to finalize agent status after lease-release terminalization on retry; " +
+              "agent may be latched at a stale status until its next run completes",
+          );
+        }
+      }
     }
     return terminalRun ?? run;
   }

--- a/server/src/services/recovery/service.continuation-cap.test.ts
+++ b/server/src/services/recovery/service.continuation-cap.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { classifyContinuationFailure } from "./service.js";
+
+const run = (errorCode: string | null) =>
+  ({ errorCode } as unknown as Parameters<typeof classifyContinuationFailure>[0]);
+
+// MAS-93 defect 3: the error codes that actually produce retry storms were landing in
+// the `default` class, which returns baseBackoffMs 0. A server restart loses every live
+// run at once, so an uncapped, un-backed-off retry on these codes is what turned one
+// SIGTERM into 84 retries in 20 minutes.
+describe("continuation retry classification: host-fault codes", () => {
+  const hostFaultCodes = [
+    "process_lost",
+    "process_detached",
+    "acpx_turn_failed",
+    "server_shutdown_interrupted",
+    "orphaned_running_run",
+  ];
+
+  for (const code of hostFaultCodes) {
+    it(`classifies ${code} as host_fault with a bounded cap and non-zero backoff`, () => {
+      const c = classifyContinuationFailure(run(code));
+      expect(c.kind).toBe("host_fault");
+      expect(c.errorCode).toBe(code);
+      // A bound must exist and must be finite — an unbounded cap is the defect.
+      expect(c.maxAttempts).toBeGreaterThan(0);
+      expect(Number.isFinite(c.maxAttempts)).toBe(true);
+      // Zero backoff is what let the storm run tight; this is the regression guard.
+      expect(c.baseBackoffMs).toBeGreaterThan(0);
+    });
+  }
+
+  it("keeps host-fault retries strictly tighter than transient-infra retries", () => {
+    // A host fault repeating means the host or control plane is down; retrying harder
+    // than a transient network blip would just reproduce the storm more slowly.
+    const hostFault = classifyContinuationFailure(run("process_lost"));
+    const transient = classifyContinuationFailure(run("adapter_failed"));
+    expect(transient.kind).toBe("transient_infra");
+    expect(hostFault.maxAttempts).toBeLessThan(transient.maxAttempts);
+  });
+
+  it("does not reclassify non-retryable or unknown codes", () => {
+    // Guard against the host-fault set swallowing codes that must stay in their class.
+    expect(classifyContinuationFailure(run("agent_not_invokable")).kind).toBe("non_retryable");
+    expect(classifyContinuationFailure(run("some_unknown_code")).kind).toBe("default");
+    expect(classifyContinuationFailure(run(null)).kind).toBe("default");
+  });
+});

--- a/server/src/services/recovery/service.continuation-cap.test.ts
+++ b/server/src/services/recovery/service.continuation-cap.test.ts
@@ -46,3 +46,34 @@ describe("continuation retry classification: host-fault codes", () => {
     expect(classifyContinuationFailure(run(null)).kind).toBe("default");
   });
 });
+
+// MAS-614 (Greptile finding #1 on PR #12946): `summarizeRecentContinuationRetries`'s
+// `error_code` match mode pinned the *exact* error code, so a chain that alternated
+// between codes in the same failure class (e.g. adapter_failed -> timeout ->
+// adapter_failed) broke the streak on every change and never reached
+// consecutive >= maxAttempts. That is the same "retry chains ran unbounded" defect
+// MAS-93 was meant to close, just reopened for the realistic alternating-code case.
+// The fix buckets by failure *class* (`error_class` match mode) instead of exact code.
+describe("continuation retry streak: mixed error codes within one failure class", () => {
+  it("classifies alternating transient_infra codes into the same class", () => {
+    // adapter_failed and timeout are both TRANSIENT_INFRA_CONTINUATION_ERROR_CODES.
+    const a = classifyContinuationFailure(run("adapter_failed"));
+    const t = classifyContinuationFailure(run("timeout"));
+    expect(a.kind).toBe("transient_infra");
+    expect(t.kind).toBe("transient_infra");
+    expect(a.kind).toBe(t.kind);
+  });
+
+  it("classifies alternating host_fault codes into the same class", () => {
+    const a = classifyContinuationFailure(run("process_lost"));
+    const b = classifyContinuationFailure(run("acpx_turn_failed"));
+    expect(a.kind).toBe("host_fault");
+    expect(b.kind).toBe("host_fault");
+  });
+
+  it("a code from the other class is a different failure mode", () => {
+    const transient = classifyContinuationFailure(run("adapter_failed"));
+    const hostFault = classifyContinuationFailure(run("process_lost"));
+    expect(transient.kind).not.toBe(hostFault.kind);
+  });
+});

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -143,6 +143,7 @@ type LatestIssueRun = Pick<
   | "errorCode"
   | "contextSnapshot"
   | "livenessState"
+  | "retryOfRunId"
   | "startedAt"
   | "createdAt"
 > & {
@@ -337,6 +338,47 @@ function isTerminalIssueRun(latestRun: LatestIssueRun) {
   return TERMINAL_HEARTBEAT_RUN_STATUSES.has(latestRun.status);
 }
 
+type RecoveryLineageRun = Pick<
+  typeof heartbeatRuns.$inferSelect,
+  "status" | "contextSnapshot" | "retryOfRunId"
+>;
+
+/**
+ * A run belongs to the automatic-recovery lineage when it was enqueued as a retry
+ * of an earlier run — regardless of *which* recovery reason produced it.
+ *
+ * Real retry chains alternate reasons — the process-loss retry path writes
+ * `retryReason: "process_lost"` (`heartbeat.ts:10187`) while the stranded-issue path
+ * writes `issue_continuation_needed` — so any predicate that pins one reason is false
+ * at every other hop and lets the chain run uncapped.
+ *
+ * Lineage is the reason-agnostic signal, and it is checked column-first on purpose:
+ * `retryOfRunId` is a real column written by both enqueue paths
+ * (`heartbeat.ts:10231`, `enqueueStrandedIssueRecovery`), so lineage detection does not
+ * depend on `retryReason` surviving in the JSON context snapshot. The snapshot check is
+ * only a fallback for rows written before the column was populated.
+ */
+function isRecoveryLineageRun(run: RecoveryLineageRun | null | undefined) {
+  if (!run) return false;
+  if (readNonEmptyString(run.retryOfRunId)) return true;
+  return Boolean(readNonEmptyString(parseObject(run.contextSnapshot).retryReason));
+}
+
+function isUnsuccessfulTerminalStatus(status: string) {
+  return UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES.includes(
+    status as (typeof UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES)[number],
+  );
+}
+
+/**
+ * Reason-agnostic counterpart to {@link didAutomaticRecoveryFail}: true when the
+ * latest run was itself an automatic-recovery retry and ended unsuccessfully.
+ */
+function didRecoveryLineageRunFail(latestRun: LatestIssueRun) {
+  if (!latestRun) return false;
+  return isRecoveryLineageRun(latestRun) && isUnsuccessfulTerminalStatus(latestRun.status);
+}
+
 const TRANSIENT_INFRA_CONTINUATION_ERROR_CODES = new Set<string>([
   "adapter_failed",
   "codex_transient_upstream",
@@ -344,6 +386,23 @@ const TRANSIENT_INFRA_CONTINUATION_ERROR_CODES = new Set<string>([
   "claude_transient_upstream",
   "provider_quota",
   "timeout",
+]);
+
+// Host/control-plane faults: the run died for a reason unrelated to the issue's
+// own content, so a retry is worth making — but they arrive in bursts (a server
+// restart loses every live run at once), so they must be capped and backed off
+// rather than left in the uncapped `default` class.
+// Cap is 1 (not 3) because a second consecutive host-fault on the same issue
+// indicates a systemic problem: the host or control plane is down and retrying
+// will just produce more of the same failure. Escalating after one retry forces
+// the issue into `blocked` where it waits for a human to investigate rather than
+// burning budget in a tight crash loop.
+const HOST_FAULT_CONTINUATION_ERROR_CODES = new Set<string>([
+  "process_lost",
+  "process_detached",
+  "acpx_turn_failed",
+  "server_shutdown_interrupted",
+  "orphaned_running_run",
 ]);
 
 const NON_RETRYABLE_CONTINUATION_ERROR_CODES = new Set<string>([
@@ -363,8 +422,13 @@ const CONTINUATION_WAITING_ON_REVIEW_ERROR_CODE = "issue_continuation_waiting_on
 const INTERACTION_CONTINUATION_REQUEUE_MAX_ATTEMPTS = 3;
 
 const CONTINUATION_RECOVERY_TRANSIENT_MAX_ATTEMPTS = 3;
+const CONTINUATION_RECOVERY_HOST_FAULT_MAX_ATTEMPTS = 1;
 const CONTINUATION_RECOVERY_DEFAULT_MAX_ATTEMPTS = 1;
 const CONTINUATION_RECOVERY_TRANSIENT_BASE_BACKOFF_MS = 60_000;
+const CONTINUATION_RECOVERY_HOST_FAULT_BASE_BACKOFF_MS = 60_000;
+// How far back the retry-streak walk scans. Needs headroom above the largest cap so
+// a chain that interleaves non-lineage runs is still counted correctly.
+const CONTINUATION_RETRY_STREAK_SCAN_LIMIT = 25;
 export const PROVIDER_QUOTA_RECOVERY_DEFAULT_BACKOFF_MS = 60 * 60 * 1000;
 
 const PROVIDER_QUOTA_ERROR_RE =
@@ -483,7 +547,7 @@ export function classifyAdapterFailureForRecovery(
 }
 
 type ContinuationRetryClassification = {
-  kind: "transient_infra" | "non_retryable" | "deliberate_wait_without_target" | "default";
+  kind: "transient_infra" | "host_fault" | "non_retryable" | "deliberate_wait_without_target" | "default";
   maxAttempts: number;
   baseBackoffMs: number;
   errorCode: string | null;
@@ -507,6 +571,14 @@ export function classifyContinuationFailure(latestRun: LatestIssueRun): Continua
       kind: "transient_infra",
       maxAttempts: CONTINUATION_RECOVERY_TRANSIENT_MAX_ATTEMPTS,
       baseBackoffMs: CONTINUATION_RECOVERY_TRANSIENT_BASE_BACKOFF_MS,
+      errorCode,
+    };
+  }
+  if (errorCode && HOST_FAULT_CONTINUATION_ERROR_CODES.has(errorCode)) {
+    return {
+      kind: "host_fault",
+      maxAttempts: CONTINUATION_RECOVERY_HOST_FAULT_MAX_ATTEMPTS,
+      baseBackoffMs: CONTINUATION_RECOVERY_HOST_FAULT_BASE_BACKOFF_MS,
       errorCode,
     };
   }
@@ -674,6 +746,7 @@ export function recoveryService(
         errorCode: heartbeatRuns.errorCode,
         contextSnapshot: heartbeatRuns.contextSnapshot,
         livenessState: heartbeatRuns.livenessState,
+        retryOfRunId: heartbeatRuns.retryOfRunId,
         resultJson: heartbeatRuns.resultJson,
         startedAt: heartbeatRuns.startedAt,
         createdAt: heartbeatRuns.createdAt,
@@ -704,6 +777,7 @@ export function recoveryService(
         errorCode: heartbeatRuns.errorCode,
         contextSnapshot: heartbeatRuns.contextSnapshot,
         livenessState: heartbeatRuns.livenessState,
+        retryOfRunId: heartbeatRuns.retryOfRunId,
         resultJson: heartbeatRuns.resultJson,
         startedAt: heartbeatRuns.startedAt,
         createdAt: heartbeatRuns.createdAt,
@@ -721,19 +795,53 @@ export function recoveryService(
       .then((rows) => rows[0] ?? null);
   }
 
+  /**
+   * Counts how many automatic-recovery retries have already been burned on this
+   * (company, issue, agent) without a successful run in between.
+   *
+   * Three matching modes:
+   *  - `match: "recovery_lineage"` — reason- and error-code-agnostic. Used by the
+   *    continuation cap for `default`-class failures, because cap=1 means any single
+   *    failed lineage run exhausts the budget.
+   *  - `match: "error_code"` — pins `errorCode` only, still counts any lineage run.
+   *    Used for `transient_infra` and `host_fault` classes: a different error code in
+   *    the chain represents a different failure mode and should reset the streak for the
+   *    current code. This lets `adapter_failed` x2 → `timeout` x1 → `adapter_failed` (latest)
+   *    count as consecutive=1 (not 3), preventing mixed-cause runs from exhausting the cap.
+   *  - `match: "exact"` — pins `retryReason` and `errorCode`. Used by the
+   *    accepted-interaction requeue guard, which is deliberately counting one
+   *    specific cancellation code and nothing else.
+   *
+   * In all modes the walk stops at the first run that is not an unsuccessful
+   * terminal run. That is what protects legitimate long continuation chains: a
+   * single successful run resets the streak to zero.
+   */
   async function summarizeRecentContinuationRetries(
     companyId: string,
     issueId: string,
     agentId: string,
-    errorCodeToMatch: string | null,
-    since: Date | null = null,
+    opts: {
+      match: "recovery_lineage";
+      since?: Date | null;
+    } | {
+      match: "error_code";
+      errorCodeToMatch: string | null;
+      since?: Date | null;
+    } | {
+      match: "exact";
+      retryReasonToMatch: string;
+      errorCodeToMatch: string | null;
+      since?: Date | null;
+    },
   ) {
+    const since = opts.since ?? null;
     const rows = await db
       .select({
         id: heartbeatRuns.id,
         status: heartbeatRuns.status,
         errorCode: heartbeatRuns.errorCode,
         contextSnapshot: heartbeatRuns.contextSnapshot,
+        retryOfRunId: heartbeatRuns.retryOfRunId,
         finishedAt: heartbeatRuns.finishedAt,
       })
       .from(heartbeatRuns)
@@ -746,29 +854,40 @@ export function recoveryService(
         ),
       )
       .orderBy(desc(heartbeatRuns.createdAt), desc(heartbeatRuns.id))
-      .limit(10);
+      .limit(CONTINUATION_RETRY_STREAK_SCAN_LIMIT);
 
     let consecutive = 0;
     let latestFinishedAt: Date | null = null;
     for (const row of rows) {
-      const ctx = parseObject(row.contextSnapshot);
-      const retryReason = readNonEmptyString(ctx.retryReason);
-      if (retryReason !== "issue_continuation_needed") break;
-      if (
-        !UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES.includes(
-          row.status as (typeof UNSUCCESSFUL_HEARTBEAT_RUN_TERMINAL_STATUSES)[number],
-        )
-      ) {
-        break;
-      }
+      // A run that succeeded — or that is still live — ends the streak. This is the
+      // only break condition in lineage mode, and it is the one that keeps healthy
+      // long-running continuation chains out of the cap.
+      if (!isUnsuccessfulTerminalStatus(row.status)) break;
 
-      const rowErrorCode = readNonEmptyString(row.errorCode);
-      if (errorCodeToMatch !== rowErrorCode) {
-        break;
-      }
-
-      consecutive += 1;
       if (latestFinishedAt === null) latestFinishedAt = row.finishedAt ?? null;
+
+      if (opts.match === "exact") {
+        const ctx = parseObject(row.contextSnapshot);
+        if (readNonEmptyString(ctx.retryReason) !== opts.retryReasonToMatch) break;
+        if (opts.errorCodeToMatch !== readNonEmptyString(row.errorCode)) break;
+        consecutive += 1;
+        continue;
+      }
+
+      if (opts.match === "error_code") {
+        // Only lineage retries (not the original failed run) count against the cap.
+        if (!isRecoveryLineageRun(row)) continue;
+        // A different error code in the chain is a different failure mode — stop the
+        // streak for the current code so mixed-cause histories do not exhaust the cap.
+        if (readNonEmptyString(row.errorCode) !== opts.errorCodeToMatch) break;
+        consecutive += 1;
+        continue;
+      }
+
+      // Lineage mode: only runs that were themselves enqueued as retries count
+      // against the cap. The original run that first died is walked past (it is a
+      // failure, so it does not reset the streak) but is not itself an attempt.
+      if (isRecoveryLineageRun(row)) consecutive += 1;
     }
     return { consecutive, latestFinishedAt };
   }
@@ -969,6 +1088,7 @@ export function recoveryService(
         errorCode: heartbeatRuns.errorCode,
         contextSnapshot: heartbeatRuns.contextSnapshot,
         livenessState: heartbeatRuns.livenessState,
+        retryOfRunId: heartbeatRuns.retryOfRunId,
         resultJson: heartbeatRuns.resultJson,
         startedAt: heartbeatRuns.startedAt,
         createdAt: heartbeatRuns.createdAt,
@@ -3085,8 +3205,12 @@ export function recoveryService(
           issue.companyId,
           issue.id,
           agentId,
-          CONTINUATION_WAITING_ON_REVIEW_ERROR_CODE,
-          acceptedInteractionResolvedAt,
+          {
+            match: "exact",
+            retryReasonToMatch: "issue_continuation_needed",
+            errorCodeToMatch: CONTINUATION_WAITING_ON_REVIEW_ERROR_CODE,
+            since: acceptedInteractionResolvedAt,
+          },
         );
         const successfulRunSinceResolution = await hasSuccessfulIssueRunSince(
           issue.companyId,
@@ -3564,12 +3688,21 @@ export function recoveryService(
           continue;
         }
 
-        if (didAutomaticRecoveryFail(latestRun, "issue_continuation_needed")) {
+        if (didRecoveryLineageRunFail(latestRun)) {
+          // `transient_infra` and `host_fault` classes pin to the same error code so
+          // that a mixed-cause chain (e.g. adapter_failed → timeout → adapter_failed)
+          // does not exhaust the cap for the *current* error code. `default` class uses
+          // lineage mode: cap=1 means any single failed lineage run exhausts it, so the
+          // code pinning is irrelevant, and lineage mode is simpler.
+          const streakMode: Parameters<typeof summarizeRecentContinuationRetries>[3] =
+            classification.kind === "transient_infra" || classification.kind === "host_fault"
+              ? { match: "error_code", errorCodeToMatch: classification.errorCode }
+              : { match: "recovery_lineage" };
           const { consecutive, latestFinishedAt } = await summarizeRecentContinuationRetries(
             issue.companyId,
             issue.id,
             agentId,
-            classification.errorCode,
+            streakMode,
           );
           if (consecutive >= classification.maxAttempts) {
             const attemptCopy = consecutive <= 1 ? "" : ` (${consecutive}× attempts)`;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -414,6 +414,20 @@ const NON_RETRYABLE_CONTINUATION_ERROR_CODES = new Set<string>([
   "issue_dependencies_blocked",
 ]);
 
+// Maps an error code to the failure *class* used by the continuation retry-streak
+// cap (`match: "error_class"`). Both TRANSIENT_INFRA and HOST_FAULT are multi-code
+// buckets on purpose: a flaky adapter/network can legitimately alternate between
+// codes within the same class from one retry to the next (adapter_failed → timeout
+// → adapter_failed is still one ongoing "the adapter/network is flaky" failure, not
+// three distinct ones), and the cap must treat that as a single streak or it never
+// becomes reachable — see MAS-93 / MAS-614.
+function continuationErrorClassOf(errorCode: string | null): "transient_infra" | "host_fault" | null {
+  if (!errorCode) return null;
+  if (TRANSIENT_INFRA_CONTINUATION_ERROR_CODES.has(errorCode)) return "transient_infra";
+  if (HOST_FAULT_CONTINUATION_ERROR_CODES.has(errorCode)) return "host_fault";
+  return null;
+}
+
 // A continuation cancelled with this code is a *deliberate wait* (the latest run
 // reported it was parked for review/approval), not a lost execution path. When the
 // issue has a real waiting target we convert it into a normal dependency wait rather
@@ -803,11 +817,17 @@ export function recoveryService(
    *  - `match: "recovery_lineage"` — reason- and error-code-agnostic. Used by the
    *    continuation cap for `default`-class failures, because cap=1 means any single
    *    failed lineage run exhausts the budget.
-   *  - `match: "error_code"` — pins `errorCode` only, still counts any lineage run.
-   *    Used for `transient_infra` and `host_fault` classes: a different error code in
-   *    the chain represents a different failure mode and should reset the streak for the
-   *    current code. This lets `adapter_failed` x2 → `timeout` x1 → `adapter_failed` (latest)
-   *    count as consecutive=1 (not 3), preventing mixed-cause runs from exhausting the cap.
+   *  - `match: "error_class"` — pins the failure *class* (`transient_infra` or
+   *    `host_fault`), not the literal `errorCode`. Used for those two classes: they
+   *    each bundle several distinct error codes that are all the same failure mode
+   *    (a flaky adapter/network can legitimately alternate between them run to run —
+   *    MAS-93's "retry chains ran unbounded, observed depth 11" defect was exactly a
+   *    chain that alternated codes within one class and so never tripped an
+   *    exact-code match). This lets `adapter_failed` x2 → `timeout` x1 →
+   *    `adapter_failed` (latest) count as consecutive=3, still exhausting the shared
+   *    budget for the class, while a `transient_infra` run never counts against a
+   *    `host_fault` streak or vice versa (those two classes have different caps and
+   *    backoffs on purpose — see `CONTINUATION_RECOVERY_*_MAX_ATTEMPTS`).
    *  - `match: "exact"` — pins `retryReason` and `errorCode`. Used by the
    *    accepted-interaction requeue guard, which is deliberately counting one
    *    specific cancellation code and nothing else.
@@ -824,8 +844,8 @@ export function recoveryService(
       match: "recovery_lineage";
       since?: Date | null;
     } | {
-      match: "error_code";
-      errorCodeToMatch: string | null;
+      match: "error_class";
+      errorClassToMatch: "transient_infra" | "host_fault";
       since?: Date | null;
     } | {
       match: "exact";
@@ -874,12 +894,15 @@ export function recoveryService(
         continue;
       }
 
-      if (opts.match === "error_code") {
+      if (opts.match === "error_class") {
         // Only lineage retries (not the original failed run) count against the cap.
         if (!isRecoveryLineageRun(row)) continue;
-        // A different error code in the chain is a different failure mode — stop the
-        // streak for the current code so mixed-cause histories do not exhaust the cap.
-        if (readNonEmptyString(row.errorCode) !== opts.errorCodeToMatch) break;
+        // Bucket by failure *class*, not literal error code: a flaky adapter/network
+        // can alternate between codes in the same class run to run (adapter_failed,
+        // timeout, ...), and that is still one ongoing failure mode against the
+        // class's shared budget. A code from the *other* class (or an unclassified
+        // one) is a genuinely different failure mode and stops the streak.
+        if (continuationErrorClassOf(readNonEmptyString(row.errorCode)) !== opts.errorClassToMatch) break;
         consecutive += 1;
         continue;
       }
@@ -3689,14 +3712,17 @@ export function recoveryService(
         }
 
         if (didRecoveryLineageRunFail(latestRun)) {
-          // `transient_infra` and `host_fault` classes pin to the same error code so
-          // that a mixed-cause chain (e.g. adapter_failed → timeout → adapter_failed)
-          // does not exhaust the cap for the *current* error code. `default` class uses
-          // lineage mode: cap=1 means any single failed lineage run exhausts it, so the
-          // code pinning is irrelevant, and lineage mode is simpler.
+          // `transient_infra` and `host_fault` classes pin to the failure *class*, not
+          // the exact error code, so a mixed-cause chain within one class (e.g.
+          // adapter_failed → timeout → adapter_failed) still accumulates against that
+          // class's shared cap instead of resetting on every code change (MAS-93 /
+          // MAS-614: the reset-on-change behavior made the cap unreachable for the
+          // realistic case of an alternating flaky adapter/network). `default` class
+          // uses lineage mode: cap=1 means any single failed lineage run exhausts it,
+          // so class pinning is irrelevant there, and lineage mode is simpler.
           const streakMode: Parameters<typeof summarizeRecentContinuationRetries>[3] =
             classification.kind === "transient_infra" || classification.kind === "host_fault"
-              ? { match: "error_code", errorCodeToMatch: classification.errorCode }
+              ? { match: "error_class", errorClassToMatch: classification.kind }
               : { match: "recovery_lineage" };
           const { consecutive, latestFinishedAt } = await summarizeRecentContinuationRetries(
             issue.companyId,


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - This change touches the heartbeat and recovery subsystem, the hermes_local adapter, and the cross-issue write guard.
> - Four independent gaps let a company running this codebase lose service silently: an agent status latch after a lease-release terminalization, an unbounded continuation-retry chain, a hermes run that fails completely but reports success, and a legitimate same-issue write rejected by the cross-issue guard.
> - Each gap was found and reproduced against a real Paperclip deployment, with the failing behavior confirmed before the fix and the fixed behavior confirmed after.
> - This pull request lands four independent fixes together because they were developed together in one operator's incident-response backlog and each is small and self-contained.
> - The benefit is fewer silent outages: an agent that should recover does recover, a crash-looping continuation gets capped instead of running forever, a Hermes run that failed reports as failed, and a same-issue write is not wrongly blocked.

## Linked Issues or Issue Description

Four separate bugs, each described using the Bug report template fields. No public GitHub issue exists yet for any of them (they were tracked as internal tickets on the operator's own deployment).

**Bug 1: agent stays `running` after its run terminalizes on lease release**

- What happened?: `terminalizeRunOnLeaseRelease` finalizes the run row to a terminal status when an environment lease is released mid-run, but never calls `finalizeAgentStatus`. The agent record is left `status: running` with no live run behind it. It self-heals only if that agent happens to complete a later run; a quiet agent latches indefinitely.
- Expected behavior: any code path that forces a `heartbeatRuns.status` to terminal outside the run's own finalizer should also reconcile `agents.status`.
- Steps to reproduce:
  1. Start a run under an environment lease.
  2. Release the lease while the run is still live (e.g. via a sandbox teardown).
  3. Observe `terminalizeRunOnLeaseRelease` mark the run terminal.
  4. Query the agent record: `status` remains `running`.

**Bug 2: continuation-recovery retry cap exists but never engages**

- What happened?: The cap on continuation-recovery retries (`recovery/service.ts`) was gated on the latest run's `retryReason` being exactly `issue_continuation_needed`. Real retry chains alternate that value with `process_lost` (written by the process-loss retry path), so the guard read every alternating hop as a first failure and skipped the cap block entirely, falling through to an uncapped requeue. A second, independent gap: `process_lost`, `process_detached`, `acpx_turn_failed`, `server_shutdown_interrupted`, and `orphaned_running_run` (the exact codes a control-plane restart produces in bulk) all landed in the `default` failure class, which carries a `baseBackoffMs` of 0 — so even when the cap did fire, there was no backoff.
- Expected behavior: a continuation chain should be capped and backed off regardless of which recovery reason produced any individual hop, and a burst of restart-caused failures should not retry with zero backoff.
- Steps to reproduce:
  1. Put an issue's assigned agent into a state where its runs repeatedly die from a control-plane restart (`process_lost`) alternating with stranded-issue continuation wakes (`issue_continuation_needed`).
  2. Observe the retry-streak counter never exceeds 1 because it breaks on any `retryReason` or `errorCode` change.
  3. Observe the chain continues indefinitely (10+ hops observed on a real deployment) instead of escalating to `blocked`.

**Bug 3: a Hermes run that fails a non-retryable API call can still exit 0 and report `succeeded`**

- What happened?: when a `hermes_local` agent's underlying Hermes CLI hits a non-retryable client error from its provider (e.g. `HTTP 400: The requested model is not supported.`) and aborts, that abort message lands on stdout as ordinary text, and the CLI process still exits 0. The adapter has no logic to detect this pattern, so Paperclip records the run as `status: succeeded`, `errorCode: null`, `errorReason: null`. No work was done.
- Expected behavior: a run whose stdout shows an aborted non-retryable API call should not be recorded as `succeeded`.
- Steps to reproduce:
  1. Configure a `hermes_local` agent with a model id the current provider does not support.
  2. Run the agent; watch it print a `Non-retryable client error (HTTP ...). Aborting.` line to stdout.
  3. Confirm the process exit code is 0.
  4. Observe Paperclip records the run as `succeeded` with no error fields set, and the agent produced zero real work (`Messages: 1 (1 user, 0 tool calls)`).

**Bug 4: the cross-issue-influence guard hard-blocks legitimate same-issue writes with no `contextSnapshot.issueId`**

- What happened?: runs invoked ambiently (manual heartbeat, timer, on-demand review work not dispatched against a specific issue) have no `issueId`/`taskId` in `heartbeatRuns.contextSnapshot`. `observeCrossIssueInfluence` hard-failed every PATCH/comment write from such a run with a 403, even when the run had a live checkout on the exact issue it was writing to.
- Expected behavior: a run's live checkout on an issue should be accepted as proof of legitimate same-issue access, not only the JSON context snapshot.
- Steps to reproduce:
  1. Trigger a manual heartbeat or timer-sourced run with no `issueId` in its context snapshot.
  2. Have that run check out an issue and then PATCH/comment on that same issue.
  3. Observe a `403` from the cross-issue-influence guard despite the run holding the live checkout.

## What Changed

- `server/src/services/heartbeat.ts`: `terminalizeRunOnLeaseRelease` now calls `finalizeAgentStatus` after forcing the run terminal, closing the agent-status latch (Bug 1).
- `server/src/services/recovery/service.ts`: continuation-retry lineage detection is now reason-agnostic — it reads the real `retryOfRunId` column first (falling back to the context-snapshot `retryReason` only for older rows written before that column existed), so a chain alternating `process_lost` and `issue_continuation_needed` is correctly counted as one continuous streak. Added a `host_fault` classification (cap 1, 60s exponential base) for the restart-caused error codes that previously fell into the zero-backoff `default` class (Bug 2).
- `packages/adapters/hermes/src/server/execute.ts`: the adapter now scans stdout for the `Non-retryable client error ... Aborting.` pattern and fails the run explicitly instead of letting a 0 exit code report as `succeeded` (Bug 3).
- `server/src/services/cross-issue-influence-limit.ts` and `server/src/routes/issues.ts`: `observeCrossIssueInfluence` now also accepts a run's live checkout on the target issue as proof of legitimate same-issue access, alongside the existing `contextSnapshot.issueId` check (Bug 4).
- `server/src/__tests__/heartbeat-process-recovery.test.ts`: updated one pre-existing test assertion that had drifted from current `escalateStrandedAssignedIssue` behavior (it now posts a blocked notice as a direct issue comment rather than spawning a second status-only run) — unrelated to any of the four bugs above, found while verifying Bug 2's fix against current `master`.

## Verification

- `./node_modules/.bin/tsc --noEmit -p packages/adapters/hermes/tsconfig.json` — clean.
- `./node_modules/.bin/tsc --noEmit -p server/tsconfig.json` — the only errors present are a pre-existing cascade from an unbuilt `@paperclipai/plugin-sdk` package (confined to `plugin-*.ts` and `tool-gateway.ts`), unchanged by this PR. Zero new errors in any file this PR touches.
- `./node_modules/.bin/vitest run server/src/services/recovery/service.continuation-cap.test.ts` — 7/7 pass (Bug 2 unit coverage).
- `cd packages/adapters/hermes && ../../../node_modules/.bin/vitest run src/server/execute.stdout-abort.test.ts` — 7/7 pass (Bug 3 coverage).
- `./node_modules/.bin/vitest run server/src/__tests__/cross-issue-influence-limit.test.ts` — 13/13 pass (Bug 4 coverage).
- `./node_modules/.bin/vitest run server/src/services/recovery/` — 81/81 pass (full recovery-service suite).
- `./node_modules/.bin/vitest run server/src/__tests__/heartbeat-process-recovery.test.ts` — 129/129 pass (the large integration suite covering Bug 1 and Bug 2 end to end, including the stale-assertion fix noted above).

## Risks

- Bug 2's classification change adds a new `host_fault` failure kind with its own cap and backoff constants; it changes retry timing/behavior only for the five error codes named above, and only when they appear as `errorCode` on a continuation-lineage run. Existing `transient_infra` and `non_retryable` classes are unchanged.
- Bug 3's stdout scan is a string-pattern match against Hermes's own literal abort message. If a future Hermes version changes that exact wording, the detector would silently stop firing (fails open, not closed) — same risk profile as the existing keyword-based stderr error-reason filter already in this adapter.
- Bug 4 widens (not narrows) who can write to an issue: a run with a live checkout on the issue can now write even without a matching `contextSnapshot.issueId`. This is strictly additive to the existing pass condition, not a relaxation of any other check.
- Low risk overall: each fix is scoped to the exact failure path it addresses, all four are covered by targeted tests plus the full existing recovery-service and cross-issue-influence suites, and none touches database schema or public API contracts.

## Model Used

Claude (Anthropic), model id `claude-sonnet-5`, running via the Hermes CLI adapter (`hermes_local`), tool use and code execution enabled, no extended/streaming reasoning mode. Diagnosis, cherry-pick conflict resolution, and test fixes performed by the model directly against a live Paperclip deployment's run logs, config, and test suite.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

Note on duplicate-PR search: two related but unmerged/closed public PRs cover overlapping ground and are worth cross-referencing for reviewer context, though neither is an exact duplicate of what is in this PR: #7741 (`fix(recovery): count continuation retries across non-continuation rows`, closed, unmerged — a narrower fix for the same underlying continuation-retry-cap class of bug addressed here in Bug 2) and #10955 (`fix(server): terminalize a still-running run when its environment lease is released`, closed, unmerged — addresses the same lease-release class of bug as Bug 1, from the run side; this PR closes the remaining agent-status side of that same gap).
