### PR TITLE
feat: add pre-start admission veto

### DIFF
--- a/doc/execution-semantics.md
+++ b/doc/execution-semantics.md
@@ -154,6 +154,30 @@ A configuration-incomplete result is a gate outcome, not a runtime failure. It i
 
 An unresolved workspace base ref is another configuration-incomplete condition. A `git_worktree` workspace bases a fresh worktree on a configured base ref. Paperclip first fetches a remote-only ref before dispatch: it maps an unqualified name (for example `fix/foo`) or a remote-tracking name (for example `origin/fix/foo`) to `origin/<branch>`, runs the authenticated fetch, and re-checks the commit. A ref that resolves lets work continue on the resolved commit. A ref that is still unresolvable after the fetch produces a configuration-incomplete blocker that names the requested ref, rather than a dispatched-then-failed run. Because the adapter never started, Paperclip queues no missing-comment retry. The recovery action dedupes by the canonical remote ref (`origin/<branch>`), not the operator spelling. Two equivalent spellings of one remote branch, for example `fix/foo` and `origin/fix/foo`, share one recovery identity, so a repeated failure reuses the active action and does not reset the attempt count or post a second notice. A different remote branch is a distinct blocker. Paperclip resolves the prior recovery action, creates a new action for the new ref, and notifies the operator with the new ref instead of overwriting the active action of the prior ref.
 
+### Pre-start capacity admission
+
+Hosts may install a process-wide hook with `registerPreStartAdmissionHook`, or
+inject `HeartbeatServiceOptions.preStartAdmission` for an isolated host/test, as
+the supported last gate before adapter, native-runner, or provider execution.
+The hook receives
+the company, agent, issue, run, wake request, provider, model, and a previously
+observed capacity snapshot. Its snapshot reader must use existing telemetry; it
+must not make a model/provider call while deciding whether another call may start.
+
+The default mode is `observe`. In that mode the hook's decision is audited but a
+veto cannot stop execution. Enforcement must be activated explicitly after the
+operator's rollout gates pass. Once enforcement is active, missing, mismatched,
+future-dated, stale, or windowless telemetry vetoes the run. The host selects the
+newest current model-specific window after a quota reset and ignores expired
+windows. Hook evaluation must atomically reserve capacity or veto and must be
+idempotent by `runId`.
+
+Wake callers that supply an idempotency key receive the first matching run for
+that company and agent. The issue or agent row lock serializes concurrent
+duplicates, so a repeated wake cannot create a second run or re-evaluate a veto.
+An enforced veto terminalizes the claimed run with
+`pre_start_admission_<reason>` before any execution boundary is crossed.
+
 ## 6. Parent/Sub-Issue vs Blockers
 
 Paperclip uses two different relationships for different jobs.

--- a/server/src/__tests__/pre-start-admission.test.ts
+++ b/server/src/__tests__/pre-start-admission.test.ts
@@ -1,0 +1,273 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { Db } from "@paperclipai/db";
+import {
+  activityLog,
+  agents,
+  agentRuntimeState,
+  agentWakeupRequests,
+  companies,
+  createDb,
+  heartbeatRunEvents,
+  heartbeatRuns,
+} from "@paperclipai/db";
+import {
+  evaluatePreStartAdmission,
+  selectActiveCapacityWindow,
+  type CapacitySnapshot,
+} from "../services/pre-start-admission.ts";
+import { heartbeatService } from "../services/heartbeat.ts";
+import {
+  registerServerAdapter,
+  unregisterServerAdapter,
+} from "../adapters/index.ts";
+import {
+  getEmbeddedPostgresTestSupport,
+  type EmbeddedPostgresTestDatabase,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import { drainHeartbeatRunsToQuiescence } from "./helpers/drain-heartbeat-runs.js";
+
+const TEST_ADAPTER = "pre_start_admission_test";
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported
+  ? describe
+  : describe.skip;
+
+function snapshot(input: {
+  observedAt: Date;
+  windows: CapacitySnapshot["windows"];
+}): CapacitySnapshot {
+  return {
+    provider: "openai",
+    observedAt: input.observedAt,
+    windows: input.windows,
+  };
+}
+
+describe("pre-start admission decisions", () => {
+  it("fails closed on stale telemetry in enforce mode", async () => {
+    const now = new Date("2026-09-06T12:00:00.000Z");
+    const evaluate = vi.fn();
+    const outcome = await evaluatePreStartAdmission({
+      now,
+      subject: {
+        companyId: "company-1",
+        agentId: "agent-1",
+        issue: null,
+        issueId: null,
+        runId: "run-1",
+        wakeupRequestId: "wake-1",
+        provider: "openai",
+        model: "gpt-5.4",
+      },
+      hook: {
+        mode: "enforce",
+        maxSnapshotAgeMs: 30_000,
+        readCapacitySnapshot: async () =>
+          snapshot({
+            observedAt: new Date("2026-09-06T11:59:00.000Z"),
+            windows: [],
+          }),
+        evaluate,
+      },
+    });
+
+    expect(outcome).toMatchObject({
+      allow: false,
+      enforced: true,
+      reasonCode: "telemetry_stale",
+    });
+    expect(evaluate).not.toHaveBeenCalled();
+  });
+
+  it("uses the fresh quota window after reset instead of the exhausted prior window", () => {
+    const now = new Date("2026-09-06T12:00:01.000Z");
+    const active = selectActiveCapacityWindow({
+      now,
+      model: "gpt-5.4",
+      snapshot: snapshot({
+        observedAt: now,
+        windows: [
+          {
+            key: "five-hour:old",
+            startsAt: new Date("2026-09-06T07:00:00.000Z"),
+            resetsAt: new Date("2026-09-06T12:00:00.000Z"),
+            remaining: 0,
+            model: "gpt-5.4",
+          },
+          {
+            key: "five-hour:fresh",
+            startsAt: new Date("2026-09-06T12:00:00.000Z"),
+            resetsAt: new Date("2026-09-06T17:00:00.000Z"),
+            remaining: 100,
+            model: "gpt-5.4",
+          },
+        ],
+      }),
+    });
+
+    expect(active?.key).toBe("five-hour:fresh");
+    expect(active?.remaining).toBe(100);
+  });
+
+  it("keeps vetoes observe-only unless enforcement is explicitly activated", async () => {
+    const now = new Date("2026-09-06T12:00:00.000Z");
+    const outcome = await evaluatePreStartAdmission({
+      now,
+      subject: {
+        companyId: "company-1",
+        agentId: "agent-1",
+        issue: null,
+        issueId: null,
+        runId: "run-1",
+        wakeupRequestId: "wake-1",
+        provider: "openai",
+        model: "gpt-5.4",
+      },
+      hook: {
+        maxSnapshotAgeMs: 30_000,
+        readCapacitySnapshot: async () =>
+          snapshot({
+            observedAt: now,
+            windows: [
+              {
+                key: "five-hour",
+                startsAt: new Date("2026-09-06T10:00:00.000Z"),
+                resetsAt: new Date("2026-09-06T15:00:00.000Z"),
+                remaining: 0,
+              },
+            ],
+          }),
+        evaluate: async () => ({ allow: false, reason: "No capacity" }),
+      },
+    });
+
+    expect(outcome).toMatchObject({
+      allow: true,
+      enforced: false,
+      mode: "observe",
+      reasonCode: "hook_veto",
+    });
+  });
+});
+
+describeEmbeddedPostgres("heartbeat pre-start admission boundary", () => {
+  let db!: Db;
+  let tempDb: EmbeddedPostgresTestDatabase | null = null;
+  const adapterExecute = vi.fn(async () => ({
+    exitCode: 0,
+    signal: null,
+    timedOut: false,
+  }));
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase(
+      "paperclip-pre-start-admission-",
+    );
+    db = createDb(tempDb.connectionString);
+    registerServerAdapter({
+      type: TEST_ADAPTER,
+      execute: adapterExecute,
+      testEnvironment: async () => ({
+        adapterType: TEST_ADAPTER,
+        status: "pass",
+        checks: [],
+        testedAt: new Date().toISOString(),
+      }),
+    });
+  }, 20_000);
+
+  afterEach(async () => {
+    await heartbeatService(db).drainActiveRunExecutions();
+    await db.delete(heartbeatRunEvents);
+    await db.delete(activityLog);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agentRuntimeState);
+    await db.delete(agents);
+    await db.delete(companies);
+    adapterExecute.mockClear();
+  });
+
+  afterAll(async () => {
+    unregisterServerAdapter(TEST_ADAPTER);
+    await tempDb?.cleanup();
+  });
+
+  async function seedAgent() {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Admission test",
+      issuePrefix: `A${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      defaultResponsibleUserId: "responsible-user",
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Admission Agent",
+      role: "engineer",
+      status: "active",
+      adapterType: TEST_ADAPTER,
+      adapterConfig: { provider: "openai", model: "gpt-5.4" },
+      runtimeConfig: {
+        heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 },
+      },
+      permissions: {},
+    });
+    return { agentId };
+  }
+
+  it("vetoes before adapter execution and deduplicates the wake", async () => {
+    const { agentId } = await seedAgent();
+    const evaluate = vi.fn(async () => ({
+      allow: false,
+      reason: "Synthetic capacity exhausted",
+    }));
+    const heartbeat = heartbeatService(db, {
+      preStartAdmission: {
+        mode: "enforce",
+        maxSnapshotAgeMs: 30_000,
+        readCapacitySnapshot: async () => {
+          const now = new Date();
+          return snapshot({
+            observedAt: now,
+            windows: [
+              {
+                key: "five-hour",
+                startsAt: new Date(now.getTime() - 60_000),
+                resetsAt: new Date(now.getTime() + 60_000),
+                remaining: 0,
+              },
+            ],
+          });
+        },
+        evaluate,
+      },
+    });
+    const wakeOptions = {
+      source: "automation" as const,
+      reason: "issue_assigned",
+      idempotencyKey: "synthetic-duplicate-wake",
+      requestedByActorType: "system" as const,
+    };
+
+    const first = await heartbeat.wakeup(agentId, wakeOptions);
+    expect(first).not.toBeNull();
+    await drainHeartbeatRunsToQuiescence(db, heartbeat);
+    const duplicate = await heartbeat.wakeup(agentId, wakeOptions);
+    await drainHeartbeatRunsToQuiescence(db, heartbeat);
+
+    expect(duplicate?.id).toBe(first?.id);
+    expect(evaluate).toHaveBeenCalledTimes(1);
+    expect(adapterExecute).not.toHaveBeenCalled();
+    expect(await heartbeat.getRun(first!.id)).toMatchObject({
+      status: "cancelled",
+      errorCode: "pre_start_admission_hook_veto",
+      error: "Synthetic capacity exhausted",
+    });
+    expect(await db.select().from(heartbeatRuns)).toHaveLength(1);
+  });
+});

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -456,6 +456,11 @@ import {
   type EffectiveRunConfigSecretManifestEntry,
 } from "./effective-run-config-fingerprints.js";
 import type { PluginWorkerManager } from "./plugin-worker-manager.js";
+import {
+  evaluatePreStartAdmission,
+  getPreStartAdmissionHook,
+  type PreStartAdmissionHook,
+} from "./pre-start-admission.js";
 import { serverVersion } from "../version.js";
 
 const MAX_LIVE_LOG_CHUNK_BYTES = 8 * 1024;
@@ -8163,6 +8168,11 @@ export interface HeartbeatServiceOptions {
   environmentRuntime?: HeartbeatEnvironmentRuntime;
   runtimeEnv?: Record<string, string | undefined>;
   /**
+   * Supported host admission boundary. Absent or observe mode cannot veto;
+   * enforce mode fails closed before adapter, native-runner, or provider work.
+   */
+  preStartAdmission?: PreStartAdmissionHook;
+  /**
    * Provider-boundary seam for persisted native-run recovery tests. Keeping
    * the seam here exercises the production reaper, claim, execution, package
    * session loop, persistence port, and finalizer without spawning a provider.
@@ -8309,6 +8319,8 @@ export function heartbeatService(
   const getCurrentUserRedactionOptions = async () => ({
     enabled: (await instanceSettings.getGeneral()).censorUsernameInLogs,
   });
+  const preStartAdmission =
+    options.preStartAdmission ?? getPreStartAdmissionHook();
   const runtimeEnv = options.runtimeEnv ?? process.env;
   const inWorktreeRuntime = isTruthyRuntimeEnvValue(
     runtimeEnv.PAPERCLIP_IN_WORKTREE,
@@ -17951,6 +17963,90 @@ export function heartbeatService(
       }
       run = claimed;
     }
+    if (preStartAdmission) {
+      const admissionAgent = await getAgent(run.agentId);
+      const admissionContext = parseObject(run.contextSnapshot);
+      const admissionIssueId = readNonEmptyString(admissionContext.issueId);
+      const admissionIssue = admissionIssueId
+        ? await db
+            .select({
+              id: issues.id,
+              identifier: issues.identifier,
+              title: issues.title,
+            })
+            .from(issues)
+            .where(
+              and(
+                eq(issues.id, admissionIssueId),
+                eq(issues.companyId, run.companyId),
+              ),
+            )
+            .limit(1)
+            .then((rows) => rows[0] ?? null)
+        : null;
+      const adapterConfig = parseObject(admissionAgent?.adapterConfig);
+      const admission = await evaluatePreStartAdmission({
+        hook: preStartAdmission,
+        subject: {
+          companyId: run.companyId,
+          agentId: run.agentId,
+          issue: admissionIssue,
+          issueId: admissionIssueId,
+          runId: run.id,
+          wakeupRequestId: run.wakeupRequestId,
+          provider:
+            readNonEmptyString(adapterConfig.provider) ??
+            admissionAgent?.adapterType ??
+            "unknown",
+          model: readNonEmptyString(adapterConfig.model),
+        },
+      });
+      await logActivity(db, {
+        companyId: run.companyId,
+        actorType: "system",
+        actorId: "pre-start-admission",
+        agentId: run.agentId,
+        runId: run.id,
+        action: admission.allow
+          ? "heartbeat.pre_start_admission_observed"
+          : "heartbeat.pre_start_admission_vetoed",
+        entityType: "heartbeat_run",
+        entityId: run.id,
+        issueId: admissionIssueId,
+        details: {
+          mode: admission.mode,
+          enforced: admission.enforced,
+          reasonCode: admission.reasonCode,
+          reason: admission.reason,
+          provider: admission.capacitySnapshot?.provider ?? null,
+          observedAt:
+            admission.capacitySnapshot?.observedAt.toISOString() ?? null,
+          activeWindowKey: admission.activeWindow?.key ?? null,
+          activeWindowStartsAt:
+            admission.activeWindow?.startsAt.toISOString() ?? null,
+          activeWindowResetsAt:
+            admission.activeWindow?.resetsAt.toISOString() ?? null,
+          activeWindowRemaining: admission.activeWindow?.remaining ?? null,
+        },
+      });
+      if (!admission.allow) {
+        await cancelRunInternal(run.id, admission.reason, {
+          errorCode: `pre_start_admission_${admission.reasonCode}`,
+          eventMessage: "run vetoed before adapter invocation",
+          eventPayload: {
+            reasonCode: admission.reasonCode,
+            provider:
+              admission.capacitySnapshot?.provider ??
+              readNonEmptyString(adapterConfig.provider) ??
+              admissionAgent?.adapterType ??
+              "unknown",
+            activeWindowKey: admission.activeWindow?.key ?? null,
+            retryAt: admission.activeWindow?.resetsAt.toISOString() ?? null,
+          },
+        });
+        return;
+      }
+    }
 
     if (
       runOptions.nativeLeaseOwner &&
@@ -24269,6 +24365,34 @@ export function heartbeatService(
         await tx.execute(
           sql`select id from issues where id = ${issueId} and company_id = ${agent.companyId} for update`,
         );
+        if (opts.idempotencyKey) {
+          const existingWake = await tx
+            .select({ runId: agentWakeupRequests.runId })
+            .from(agentWakeupRequests)
+            .where(
+              and(
+                eq(agentWakeupRequests.companyId, agent.companyId),
+                eq(agentWakeupRequests.agentId, agentId),
+                eq(agentWakeupRequests.idempotencyKey, opts.idempotencyKey),
+              ),
+            )
+            .orderBy(asc(agentWakeupRequests.createdAt))
+            .limit(1)
+            .then((rows) => rows[0] ?? null);
+          if (existingWake) {
+            const existingRun = existingWake.runId
+              ? await tx
+                  .select()
+                  .from(heartbeatRuns)
+                  .where(eq(heartbeatRuns.id, existingWake.runId))
+                  .limit(1)
+                  .then((rows) => rows[0] ?? null)
+              : null;
+            return existingRun
+              ? { kind: "coalesced" as const, run: existingRun }
+              : { kind: "skipped" as const };
+          }
+        }
 
         const issue = await tx
           .select({
@@ -25199,6 +25323,32 @@ export function heartbeatService(
       return newRun;
     }
 
+    if (opts.idempotencyKey) {
+      const existingWake = await db
+        .select({ runId: agentWakeupRequests.runId })
+        .from(agentWakeupRequests)
+        .where(
+          and(
+            eq(agentWakeupRequests.companyId, agent.companyId),
+            eq(agentWakeupRequests.agentId, agentId),
+            eq(agentWakeupRequests.idempotencyKey, opts.idempotencyKey),
+          ),
+        )
+        .orderBy(asc(agentWakeupRequests.createdAt))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+      if (existingWake) {
+        return existingWake.runId
+          ? await db
+              .select()
+              .from(heartbeatRuns)
+              .where(eq(heartbeatRuns.id, existingWake.runId))
+              .limit(1)
+              .then((rows) => rows[0] ?? null)
+          : null;
+      }
+    }
+
     const activeRuns = await db
       .select()
       .from(heartbeatRuns)
@@ -25288,6 +25438,34 @@ export function heartbeatService(
       await tx.execute(
         sql`select id from agents where id = ${agentId} and company_id = ${agent.companyId} for update`,
       );
+      if (opts.idempotencyKey) {
+        const existingWake = await tx
+          .select({ runId: agentWakeupRequests.runId })
+          .from(agentWakeupRequests)
+          .where(
+            and(
+              eq(agentWakeupRequests.companyId, agent.companyId),
+              eq(agentWakeupRequests.agentId, agentId),
+              eq(agentWakeupRequests.idempotencyKey, opts.idempotencyKey),
+            ),
+          )
+          .orderBy(asc(agentWakeupRequests.createdAt))
+          .limit(1)
+          .then((rows) => rows[0] ?? null);
+        if (existingWake) {
+          const existingRun = existingWake.runId
+            ? await tx
+                .select()
+                .from(heartbeatRuns)
+                .where(eq(heartbeatRuns.id, existingWake.runId))
+                .limit(1)
+                .then((rows) => rows[0] ?? null)
+            : null;
+          return existingRun
+            ? { kind: "coalesced" as const, run: existingRun }
+            : { kind: "skipped" as const };
+        }
+      }
 
       const dailyCapBlock = await getHeartbeatDailyCapBlock(
         agent,

--- a/server/src/services/pre-start-admission.ts
+++ b/server/src/services/pre-start-admission.ts
@@ -1,0 +1,215 @@
+export type PreStartAdmissionMode = "observe" | "enforce";
+
+export interface CapacityWindowSnapshot {
+  /** Stable provider-defined window identifier. */
+  key: string;
+  /** Inclusive start of this quota window. */
+  startsAt: Date;
+  /** Exclusive reset boundary of this quota window. */
+  resetsAt: Date;
+  /** Units still available in this window. */
+  remaining: number;
+  /** Optional model scope. Null means provider-wide capacity. */
+  model?: string | null;
+}
+
+export interface CapacitySnapshot {
+  provider: string;
+  /** Time the source actually observed the provider, not the cache read time. */
+  observedAt: Date;
+  windows: CapacityWindowSnapshot[];
+}
+
+export interface PreStartAdmissionSubject {
+  companyId: string;
+  agentId: string;
+  issue: {
+    id: string;
+    identifier: string | null;
+    title: string;
+  } | null;
+  issueId: string | null;
+  runId: string;
+  wakeupRequestId: string | null;
+  provider: string;
+  model: string | null;
+}
+
+export interface PreStartAdmissionDecision {
+  allow: boolean;
+  reason: string;
+}
+
+export interface PreStartAdmissionHook {
+  /** Observe is the safe default: decisions are recorded but cannot stop a run. */
+  mode?: PreStartAdmissionMode;
+  /** Maximum accepted age of source telemetry. */
+  maxSnapshotAgeMs: number;
+  /** Reads existing telemetry only. It must not invoke a model/provider. */
+  readCapacitySnapshot(
+    subject: PreStartAdmissionSubject,
+  ): Promise<CapacitySnapshot | null>;
+  /** Atomically reserves capacity or vetoes. It must be idempotent by runId. */
+  evaluate(input: {
+    subject: PreStartAdmissionSubject;
+    capacitySnapshot: CapacitySnapshot;
+    activeWindow: CapacityWindowSnapshot;
+  }): Promise<PreStartAdmissionDecision>;
+}
+
+let registeredPreStartAdmissionHook: PreStartAdmissionHook | null = null;
+
+/**
+ * Installs the process-wide host admission hook used by every heartbeat service.
+ * Passing null restores the default observe-only/no-veto behavior.
+ */
+export function registerPreStartAdmissionHook(
+  hook: PreStartAdmissionHook | null,
+): void {
+  registeredPreStartAdmissionHook = hook;
+}
+
+export function getPreStartAdmissionHook(): PreStartAdmissionHook | null {
+  return registeredPreStartAdmissionHook;
+}
+
+export interface PreStartAdmissionOutcome extends PreStartAdmissionDecision {
+  mode: PreStartAdmissionMode;
+  enforced: boolean;
+  reasonCode:
+    | "allowed"
+    | "hook_veto"
+    | "telemetry_missing"
+    | "telemetry_stale"
+    | "capacity_window_missing"
+    | "hook_error";
+  capacitySnapshot: CapacitySnapshot | null;
+  activeWindow: CapacityWindowSnapshot | null;
+}
+
+function finiteDate(value: Date): boolean {
+  return value instanceof Date && Number.isFinite(value.getTime());
+}
+
+/** Selects the current window, preferring the newest model-specific window after a reset. */
+export function selectActiveCapacityWindow(input: {
+  snapshot: CapacitySnapshot;
+  model: string | null;
+  now: Date;
+}): CapacityWindowSnapshot | null {
+  const eligible = input.snapshot.windows.filter((window) => {
+    if (!finiteDate(window.startsAt) || !finiteDate(window.resetsAt)) return false;
+    if (!Number.isFinite(window.remaining) || window.remaining < 0) return false;
+    if (window.startsAt.getTime() > input.now.getTime()) return false;
+    if (window.resetsAt.getTime() <= input.now.getTime()) return false;
+    return !window.model || window.model === input.model;
+  });
+
+  eligible.sort((left, right) => {
+    const modelRank = Number(Boolean(right.model)) - Number(Boolean(left.model));
+    if (modelRank !== 0) return modelRank;
+    return right.startsAt.getTime() - left.startsAt.getTime();
+  });
+  return eligible[0] ?? null;
+}
+
+export async function evaluatePreStartAdmission(input: {
+  hook: PreStartAdmissionHook;
+  subject: PreStartAdmissionSubject;
+  now?: Date;
+}): Promise<PreStartAdmissionOutcome> {
+  const mode = input.hook.mode ?? "observe";
+  const enforced = mode === "enforce";
+  const now = input.now ?? new Date();
+  let snapshot: CapacitySnapshot | null = null;
+
+  try {
+    snapshot = await input.hook.readCapacitySnapshot(input.subject);
+  } catch {
+    return {
+      allow: !enforced,
+      enforced,
+      mode,
+      reason: "Capacity telemetry could not be read before run start.",
+      reasonCode: "hook_error",
+      capacitySnapshot: null,
+      activeWindow: null,
+    };
+  }
+
+  if (!snapshot || snapshot.provider !== input.subject.provider) {
+    return {
+      allow: !enforced,
+      enforced,
+      mode,
+      reason: "Capacity telemetry is missing for the selected provider.",
+      reasonCode: "telemetry_missing",
+      capacitySnapshot: snapshot,
+      activeWindow: null,
+    };
+  }
+
+  const observedAtMs = snapshot.observedAt.getTime();
+  const ageMs = now.getTime() - observedAtMs;
+  if (
+    !finiteDate(snapshot.observedAt) ||
+    !Number.isFinite(input.hook.maxSnapshotAgeMs) ||
+    input.hook.maxSnapshotAgeMs < 0 ||
+    ageMs < 0 ||
+    ageMs > input.hook.maxSnapshotAgeMs
+  ) {
+    return {
+      allow: !enforced,
+      enforced,
+      mode,
+      reason: "Capacity telemetry is stale at the pre-start boundary.",
+      reasonCode: "telemetry_stale",
+      capacitySnapshot: snapshot,
+      activeWindow: null,
+    };
+  }
+
+  const activeWindow = selectActiveCapacityWindow({
+    snapshot,
+    model: input.subject.model,
+    now,
+  });
+  if (!activeWindow) {
+    return {
+      allow: !enforced,
+      enforced,
+      mode,
+      reason: "Capacity telemetry has no current quota window.",
+      reasonCode: "capacity_window_missing",
+      capacitySnapshot: snapshot,
+      activeWindow: null,
+    };
+  }
+
+  try {
+    const decision = await input.hook.evaluate({
+      subject: input.subject,
+      capacitySnapshot: snapshot,
+      activeWindow,
+    });
+    return {
+      allow: decision.allow || !enforced,
+      enforced,
+      mode,
+      reason: decision.reason,
+      reasonCode: decision.allow ? "allowed" : "hook_veto",
+      capacitySnapshot: snapshot,
+      activeWindow,
+    };
+  } catch {
+    return {
+      allow: !enforced,
+      enforced,
+      mode,
+      reason: "Pre-start admission hook failed closed.",
+      reasonCode: "hook_error",
+      capacitySnapshot: snapshot,
+      activeWindow,
+    };
+  }
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The heartbeat service claims queued runs and starts agent adapters.
> - Hosts could observe provider capacity, but they could not stop a run before provider work started.
> - A late stop can spend quota and can start duplicate work.
> - The service needs one admission gate after claim and before every execution path.
> - This pull request adds that gate, safe rollout modes, and wake deduplication.
> - The benefit is deterministic capacity control without a database migration or a provider call.

## Linked Issues or Issue Description

**What existing behavior does this improve?**

The heartbeat run-start path in `server/`.

**Subsystem affected**

server/ — REST API and orchestration services.

**Current behavior**

The heartbeat service claims a queued run and then starts an adapter or native runner. A host cannot use a recent capacity snapshot to veto the run before provider work starts. Repeated wake requests can also create more than one run when no database uniqueness rule applies.

**Proposed behavior**

A host can register a pre-start admission hook. The hook receives issue, run, wake, provider, model, and capacity data. Observe mode records decisions without stopping runs. Enforce mode stops runs before adapter, native runner, or provider work. Missing or stale telemetry fails closed in enforce mode. Repeated wake requests with the same key return the first run.

**Reason and benefit**

The hook lets a host reserve capacity and reject unsafe starts at the last safe boundary. It avoids paid provider calls when capacity is not available. It also gives operators a safe observe-first rollout path.

**Breaking changes**

None. The hook is not active by default. Observe mode cannot stop a run. Enforce mode requires an explicit host setting.

## What Changed

- Add a typed pre-start admission hook and process-wide registration API.
- Validate snapshot age, provider identity, active reset windows, and model scope.
- Call the gate after the run claim and before every execution path.
- Stop vetoed runs with bounded activity and run-event metadata.
- Deduplicate wake requests under existing issue or agent row locks.
- Document the hook contract and observe-first rollout.
- Add synthetic stale telemetry, quota reset, observe mode, veto, and duplicate wake scenarios.

## Verification

- `pnpm exec vitest run server/src/__tests__/pre-start-admission.test.ts` — 4 tests passed.
- `pnpm --filter @paperclipai/plugin-sdk build` — passed.
- `pnpm --filter @paperclipai/server exec tsc --noEmit` — passed.
- The integration scenario confirmed zero adapter calls after a veto.
- No test used a paid provider call.

## Risks

- Enforce mode stops starts when telemetry is missing, stale, or invalid. This is intentional, but hosts must meet freshness goals before activation.
- Admission reservation is atomic only when the hook implementation uses one atomic operation in its shared capacity store. The hook contract requires this behavior.
- Duplicate wake lookup uses the existing issue or agent row lock. It adds one indexed lookup to keyed wake requests.
- There is no database migration.

## Model Used

- OpenAI Codex, model `openai-codex/gpt-5.6-sol`.
- The context window size was not exposed.
- The model used reasoning, repository tools, code execution, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
