### PR TITLE
fix(server): opt into manifest-owned Kubernetes bootstrap configuration

### DIFF
--- a/docs/deploy/environment-variables.md
+++ b/docs/deploy/environment-variables.md
@@ -124,12 +124,14 @@ configuration fails closed.
 
 ## Kubernetes execution policy
 
-Set these to force every agent run onto the Kubernetes sandbox provider from the deployment manifest, with no product API calls. The server reads them at boot, stores `executionMode` in instance settings, and ensures one managed Kubernetes environment per company. The per-run guard in the heartbeat enforces the mode; the variables below only configure the managed environment.
+Set `PAPERCLIP_EXECUTION_MODE=kubernetes` to require the Kubernetes sandbox provider from the deployment manifest. At boot, the server persists `executionMode: "kubernetes"` in instance general settings. It reconciles a single instance-wide managed sandbox environment, with company-scoped stock-tracking bindings. The heartbeat checks the persisted policy for each run and refuses local fallback.
+
+Bootstrap configuration is applied at startup, not continuously. If a run cannot find an active managed Kubernetes environment, it also attempts a lazy ensure with the same environment variables and ownership flag.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `PAPERCLIP_EXECUTION_MODE` | `any` | Set to `kubernetes` to deny local execution and turn the bootstrap on. `any` and unset mean no forced mode, and every `PAPERCLIP_K8S_*` value is then ignored. |
-| `PAPERCLIP_K8S_IN_CLUSTER` | `false` | `true` when the server runs inside the cluster and should use its service account. |
+| `PAPERCLIP_EXECUTION_MODE` | (unset) | `kubernetes` enables bootstrap and persists the Kubernetes-only policy. `any`, empty, or unset disables bootstrap and ignores `PAPERCLIP_K8S_*`; it does not reset the stored policy. |
+| `PAPERCLIP_K8S_IN_CLUSTER` | `false` | `true`, `1`, or `yes` selects in-cluster service-account access. `false`, `0`, `no`, and unrecognized values become `false`. |
 | `PAPERCLIP_K8S_BACKEND` | plugin default | `job` or `sandbox-cr`. |
 | `PAPERCLIP_K8S_EGRESS_MODE` | plugin default | `cilium` or `standard`. |
 | `PAPERCLIP_K8S_EGRESS_ALLOW_FQDNS` | (unset) | Comma-separated hostnames sandboxes may reach. |
@@ -139,11 +141,28 @@ Set these to force every agent run onto the Kubernetes sandbox provider from the
 | `PAPERCLIP_K8S_IMAGE_REGISTRY` | (unset) | Registry that sandbox images are pulled from. |
 | `PAPERCLIP_K8S_RPC_TIMEOUT_MS` | plugin default | Timeout for calls to the sandbox provider, in milliseconds. |
 | `PAPERCLIP_K8S_ADAPTER_TYPE` | (unset) | Adapter type the managed environment is created for. |
-| `PAPERCLIP_K8S_CONFIG_AUTHORITATIVE` | `false` | When `true`, every boot applies the values above over edits an operator made to the managed environment in the board and resets its stock baseline. When `false`, an edited environment keeps the edit and the boot log reports that an update is available. A manually archived environment is never reactivated. |
+| `PAPERCLIP_K8S_CONFIG_AUTHORITATIVE` | `false` | `true`, `1`, or `yes` declares the managed environment's stock fields manifest-owned. Bootstrap can replace operator edits and reset the stock baseline. `false`, `0`, `no`, or unset preserves operator edits and reports the pending update in `environment.managed_stock_skipped` activity. A manually archived environment stays archived in either case. |
 
 Adapter availability inside the managed environment follows `PAPERCLIP_ADAPTERS` and `PAPERCLIP_ADAPTERS_FILE`, the same variables the instance uses.
 
-An invalid value in any of these fails startup. Set `PAPERCLIP_K8S_CONFIG_AUTHORITATIVE=true` when the manifest is the only place the environment is meant to be configured, for example under a GitOps controller; leave it unset when operators tune the environment in the board.
+Set `PAPERCLIP_K8S_CONFIG_AUTHORITATIVE=true` only when the manifest owns the managed environment's stock fields. These are its name, description, entire config, managed metadata markers, and availability status. Config is replaced, not merged, so config keys absent from the manifest are removed. Operator `envVars` and unrelated metadata keys are preserved. An unchanged stock row needs no environment write. To keep board edits instead, leave the flag unset.
+
+Paperclip can reactivate a row it archived for provider unavailability. An operator archive, including a repeated archive after Paperclip's archive, takes precedence over the flag. The operator must restore that environment to active before bootstrap can update it.
+
+Validation differs by variable. An unknown non-empty execution mode fails startup. With Kubernetes bootstrap enabled, an unknown non-empty backend or egress mode, a non-empty timeout that is not a positive integer, or an unrecognized authoritative flag (including an empty value) also fails startup. Boolean parsing ignores case and surrounding whitespace. The in-cluster flag falls back to `false` on invalid input. Hostname and CIDR lists are split on commas, trimmed, and stripped of empty entries without syntax validation here. Other string fields are trimmed; empty optional values are omitted. Successful bootstrap does not prove that the provider can acquire a lease.
+
+### Remove the persisted Kubernetes-only policy
+
+Changing `PAPERCLIP_EXECUTION_MODE` to `any` or removing it only stops bootstrap. A stored `executionMode: "kubernetes"` continues to block local execution, even after the Kubernetes infrastructure is removed.
+
+For a self-hosted instance:
+
+1. Set `PAPERCLIP_EXECUTION_MODE=any` or remove it from the deployment configuration, then restart. This prevents later boots from restoring the Kubernetes-only policy.
+2. As an instance administrator, send `PATCH /api/instance/settings/general` with JSON body `{"executionMode":"any"}` using your normal board authentication.
+3. Read `GET /api/instance/settings/general` and confirm `executionMode` is `any`.
+4. Check the instance and agent environment selections before removing Kubernetes infrastructure. The policy reset does not change environment rows, defaults, or the separate `enableManagedSandboxOnly` restriction.
+
+Cloud-managed instances reject changes to `executionMode` through this API with `403` and code `execution_mode_platform_managed`. The self-hosted reset procedure does not apply to them; their platform operator owns policy changes.
 
 ## Secrets
 

--- a/docs/deploy/environment-variables.md
+++ b/docs/deploy/environment-variables.md
@@ -122,6 +122,29 @@ Unknown field names are logged and ignored (mixed-version fleet safe).
 Malformed JSON or an invalid value for a known field refuses startup — policy
 configuration fails closed.
 
+## Kubernetes execution policy
+
+Set these to force every agent run onto the Kubernetes sandbox provider from the deployment manifest, with no product API calls. The server reads them at boot, stores `executionMode` in instance settings, and ensures one managed Kubernetes environment per company. The per-run guard in the heartbeat enforces the mode; the variables below only configure the managed environment.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PAPERCLIP_EXECUTION_MODE` | `any` | Set to `kubernetes` to deny local execution and turn the bootstrap on. `any` and unset mean no forced mode, and every `PAPERCLIP_K8S_*` value is then ignored. |
+| `PAPERCLIP_K8S_IN_CLUSTER` | `false` | `true` when the server runs inside the cluster and should use its service account. |
+| `PAPERCLIP_K8S_BACKEND` | plugin default | `job` or `sandbox-cr`. |
+| `PAPERCLIP_K8S_EGRESS_MODE` | plugin default | `cilium` or `standard`. |
+| `PAPERCLIP_K8S_EGRESS_ALLOW_FQDNS` | (unset) | Comma-separated hostnames sandboxes may reach. |
+| `PAPERCLIP_K8S_EGRESS_ALLOW_CIDRS` | (unset) | Comma-separated CIDR ranges sandboxes may reach. |
+| `PAPERCLIP_K8S_RUNTIME_CLASS_NAME` | (unset) | RuntimeClass for sandbox pods. |
+| `PAPERCLIP_K8S_NAMESPACE_PREFIX` | plugin default | Prefix for per-company sandbox namespaces. |
+| `PAPERCLIP_K8S_IMAGE_REGISTRY` | (unset) | Registry that sandbox images are pulled from. |
+| `PAPERCLIP_K8S_RPC_TIMEOUT_MS` | plugin default | Timeout for calls to the sandbox provider, in milliseconds. |
+| `PAPERCLIP_K8S_ADAPTER_TYPE` | (unset) | Adapter type the managed environment is created for. |
+| `PAPERCLIP_K8S_CONFIG_AUTHORITATIVE` | `false` | When `true`, every boot applies the values above over edits an operator made to the managed environment in the board and resets its stock baseline. When `false`, an edited environment keeps the edit and the boot log reports that an update is available. A manually archived environment is never reactivated. |
+
+Adapter availability inside the managed environment follows `PAPERCLIP_ADAPTERS` and `PAPERCLIP_ADAPTERS_FILE`, the same variables the instance uses.
+
+An invalid value in any of these fails startup. Set `PAPERCLIP_K8S_CONFIG_AUTHORITATIVE=true` when the manifest is the only place the environment is meant to be configured, for example under a GitOps controller; leave it unset when operators tune the environment in the board.
+
 ## Secrets
 
 | Variable | Default | Description |

--- a/server/src/__tests__/environment-service.test.ts
+++ b/server/src/__tests__/environment-service.test.ts
@@ -1418,6 +1418,36 @@ describeEmbeddedPostgres("environmentService leases", () => {
     expect((await svc.getById(created!.id))?.updatedAt).toEqual(applied?.updatedAt);
   });
 
+  it("refreshes every company binding after a scoped authoritative update", async () => {
+    const companyIds = [await seedCompany("First", "FIRST"), await seedCompany("Second", "SECOND")];
+    const bootEnv = { PAPERCLIP_EXECUTION_MODE: "kubernetes", PAPERCLIP_K8S_BACKEND: "job" };
+    await bootstrapExecutionPolicyFromEnv(db, bootEnv);
+    const created = await svc.findKubernetesEnvironment();
+    expect(created).not.toBeNull();
+    const beforeBindings = await db.select().from(builtInManagedResources);
+    const beforeHashes = new Map(beforeBindings.map((binding) => [binding.companyId, binding.stockHash]));
+
+    await svc.update(created!.id, { config: { provider: "kubernetes", runtimeClassName: "operator" } });
+    const desiredConfig = {
+      provider: "kubernetes",
+      inCluster: false,
+      backend: "job" as const,
+      runtimeClassName: "manifest",
+    };
+    await svc.ensureKubernetesEnvironment(companyIds[0]!, desiredConfig, {
+      applyOverOperatorEdits: true,
+    });
+
+    const bindings = await db.select().from(builtInManagedResources);
+    expect(bindings).toHaveLength(2);
+    for (const binding of bindings) {
+      expect(binding.resourceId).toBe(created!.id);
+      expect(binding.stockHash).not.toBe(beforeHashes.get(binding.companyId));
+      expect(binding.defaultsJson).toMatchObject({ config: desiredConfig });
+    }
+    expect(new Set(bindings.map((binding) => binding.stockHash)).size).toBe(1);
+  });
+
   it.each([undefined, "any"])("retains persisted Kubernetes policy when bootstrap mode becomes %j", async (mode) => {
     await seedCompany();
     await bootstrapExecutionPolicyFromEnv(db, { PAPERCLIP_EXECUTION_MODE: "kubernetes" });

--- a/server/src/__tests__/environment-service.test.ts
+++ b/server/src/__tests__/environment-service.test.ts
@@ -23,6 +23,9 @@ import {
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { environmentService } from "../services/environments.ts";
+import { bootstrapExecutionPolicyFromEnv } from "../services/execution-policy-bootstrap.js";
+import { instanceSettingsService } from "../services/instance-settings.js";
+import { evaluateExecutionAllowlist } from "../services/execution-allowlist.js";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -118,11 +121,12 @@ describeEmbeddedPostgres("environmentService leases", () => {
     return { companyId, agentId, environmentId, runId };
   }
 
-  async function seedCompany(name = "Acme") {
+  async function seedCompany(name = "Acme", issuePrefix = "PAP") {
     const companyId = randomUUID();
     await db.insert(companies).values({
       id: companyId,
       name,
+      issuePrefix,
       status: "active",
       createdAt: new Date(),
       updatedAt: new Date(),
@@ -1389,6 +1393,53 @@ describeEmbeddedPostgres("environmentService leases", () => {
     expect(activity.at(-1)?.action).toBe("environment.managed_stock_skipped");
   });
 
+  it("reconciles one instance-wide Kubernetes row across boots and company bindings", async () => {
+    const companyIds = [await seedCompany("First", "FIRST"), await seedCompany("Second", "SECOND")];
+    const bootEnv = { PAPERCLIP_EXECUTION_MODE: "kubernetes", PAPERCLIP_K8S_BACKEND: "job" };
+    await bootstrapExecutionPolicyFromEnv(db, bootEnv);
+    const created = await svc.findKubernetesEnvironment();
+    expect(created).not.toBeNull();
+    await svc.update(created!.id, { config: { provider: "kubernetes", runtimeClassName: "operator" } });
+
+    const changedEnv = { ...bootEnv, PAPERCLIP_K8S_RUNTIME_CLASS_NAME: "manifest" };
+    await bootstrapExecutionPolicyFromEnv(db, changedEnv);
+    expect((await svc.getById(created!.id))?.config.runtimeClassName).toBe("operator");
+
+    const authoritativeEnv = { ...changedEnv, PAPERCLIP_K8S_CONFIG_AUTHORITATIVE: "true" };
+    await bootstrapExecutionPolicyFromEnv(db, authoritativeEnv);
+    const applied = await svc.getById(created!.id);
+    expect(applied?.config).toEqual({ provider: "kubernetes", inCluster: false, backend: "job", runtimeClassName: "manifest" });
+    const bindings = await db.select().from(builtInManagedResources);
+    expect(bindings.map((binding) => binding.companyId).sort()).toEqual(companyIds.sort());
+    expect(bindings.every((binding) => binding.resourceId === created!.id)).toBe(true);
+    expect(await db.select().from(environments)).toHaveLength(1);
+
+    await bootstrapExecutionPolicyFromEnv(db, authoritativeEnv);
+    expect((await svc.getById(created!.id))?.updatedAt).toEqual(applied?.updatedAt);
+  });
+
+  it.each([undefined, "any"])("retains persisted Kubernetes policy when bootstrap mode becomes %j", async (mode) => {
+    await seedCompany();
+    await bootstrapExecutionPolicyFromEnv(db, { PAPERCLIP_EXECUTION_MODE: "kubernetes" });
+    const before = await db.select().from(instanceSettings);
+    const environmentBefore = await db.select().from(environments);
+
+    expect(await bootstrapExecutionPolicyFromEnv(db, {
+      PAPERCLIP_EXECUTION_MODE: mode,
+      PAPERCLIP_K8S_CONFIG_AUTHORITATIVE: "true",
+    })).toBeNull();
+    expect(await db.select().from(instanceSettings)).toEqual(before);
+    expect(await db.select().from(environments)).toEqual(environmentBefore);
+    const settings = instanceSettingsService(db);
+    const local = { driver: "local", provider: null };
+    expect(evaluateExecutionAllowlist(await settings.getGeneral(), local).allowed).toBe(false);
+
+    await settings.updateGeneral({ executionMode: "any" });
+    expect((await settings.getGeneral()).executionMode).toBe("any");
+    expect(evaluateExecutionAllowlist(await settings.getGeneral(), local).allowed).toBe(true);
+    expect(await db.select().from(environments)).toEqual(environmentBefore);
+  });
+
   it("applies the desired config over operator drift when the caller declares it authoritative", async () => {
     const companyId = await seedCompany();
     const created = await svc.ensureManagedSandboxEnvironment({
@@ -1401,7 +1452,14 @@ describeEmbeddedPostgres("environmentService leases", () => {
     });
     await db
       .update(environments)
-      .set({ config: { provider: "daytona", target: "operator" }, updatedAt: new Date("2026-08-06T12:01:00.000Z") })
+      .set({
+        name: "Operator name",
+        description: "Operator description",
+        config: { provider: "daytona", target: "operator", operatorOnly: true },
+        envVars: { OPERATOR_FLAG: "kept" },
+        metadata: { ...created.environment.metadata, managedSandboxProvider: "operator", operatorNote: "keep me" },
+        updatedAt: new Date("2026-08-06T12:01:00.000Z"),
+      })
       .where(eq(environments.id, created.environment.id));
 
     const reconciled = await svc.ensureManagedSandboxEnvironment({
@@ -1419,10 +1477,18 @@ describeEmbeddedPostgres("environmentService leases", () => {
       .where(eq(builtInManagedResources.companyId, companyId));
 
     expect(reconciled).toMatchObject({ action: "updated", stockStatus: "operator_modified", updateAvailable: false });
+    expect(reconciled.environment).toMatchObject({
+      name: "Daytona",
+      description: "Managed stock",
+      envVars: { OPERATOR_FLAG: "kept" },
+      metadata: { managedSandboxProvider: "daytona", operatorNote: "keep me" },
+    });
     expect(reconciled.environment.config).toEqual({ provider: "daytona", target: "eu" });
     expect(binding?.stockHash).toBe(reconciled.stockHash);
     expect(binding?.stockVersion).toBe("v2");
     expect(binding?.defaultsJson).toMatchObject({ config: reconciled.environment.config });
+    expect(binding?.defaultsJson).not.toHaveProperty("envVars");
+    expect(binding?.defaultsJson.metadata).not.toHaveProperty("operatorNote");
 
     const again = await svc.ensureManagedSandboxEnvironment({
       companyId,
@@ -1474,7 +1540,7 @@ describeEmbeddedPostgres("environmentService leases", () => {
     expect(applied.environment.config).toEqual({ provider: "daytona", target: "eu" });
   });
 
-  it("ensureKubernetesEnvironment applies the supplied config over operator drift only with applyOverOperatorEdits", async () => {
+  it("replaces Kubernetes operator config only with manifest ownership enabled", async () => {
     const companyId = await seedCompany();
     const created = await svc.ensureKubernetesEnvironment(companyId, { inCluster: true, backend: "job" });
     const operatorConfig = { provider: "kubernetes", inCluster: true, backend: "job", runtimeClassName: "operator" };
@@ -1716,7 +1782,7 @@ describeEmbeddedPostgres("environmentService leases", () => {
     expect(restored.stockHash).not.toBe(reactivatedBinding?.stockHash);
   });
 
-  it("preserves an operator archive decision made after provider archival", async () => {
+  it.each([false, true])("preserves a later operator archive with manifest ownership %j", async (applyOverOperatorEdits) => {
     const companyId = await seedCompany();
     const created = await svc.ensureManagedSandboxEnvironment({
       companyId,
@@ -1726,20 +1792,34 @@ describeEmbeddedPostgres("environmentService leases", () => {
     });
     expect((await svc.archiveManagedSandboxEnvironment({ provider: "daytona" }))?.status)
       .toBe("archived");
-    expect((await svc.update(created.environment.id, { status: "archived" }))?.status)
-      .toBe("archived");
+    const operatorArchived = await svc.update(created.environment.id, { status: "archived" });
+    expect(operatorArchived?.status).toBe("archived");
+    expect(operatorArchived?.metadata).not.toHaveProperty("_paperclipManagedArchiveToken");
 
     const reconciled = await svc.ensureManagedSandboxEnvironment({
       companyId,
       name: "Daytona",
       provider: "daytona",
       config: { target: "us" },
+      applyOverOperatorEdits,
     });
     expect(reconciled).toMatchObject({
       action: "skipped",
       stockStatus: "operator_modified",
       updateAvailable: true,
       environment: { status: "archived" },
+    });
+    expect(reconciled.environment.updatedAt).toEqual(operatorArchived?.updatedAt);
+    const nextBoot = await svc.ensureManagedSandboxEnvironment({
+      companyId,
+      name: "Daytona",
+      provider: "daytona",
+      config: { target: "eu" },
+      applyOverOperatorEdits,
+    });
+    expect(nextBoot).toMatchObject({
+      action: "skipped",
+      environment: { status: "archived", config: { provider: "daytona", target: "us" } },
     });
   });
 

--- a/server/src/__tests__/environment-service.test.ts
+++ b/server/src/__tests__/environment-service.test.ts
@@ -1389,6 +1389,202 @@ describeEmbeddedPostgres("environmentService leases", () => {
     expect(activity.at(-1)?.action).toBe("environment.managed_stock_skipped");
   });
 
+  it("applies the desired config over operator drift when the caller declares it authoritative", async () => {
+    const companyId = await seedCompany();
+    const created = await svc.ensureManagedSandboxEnvironment({
+      companyId,
+      name: "Daytona",
+      description: "Managed stock",
+      provider: "daytona",
+      config: { target: "us" },
+      stockVersion: "v1",
+    });
+    await db
+      .update(environments)
+      .set({ config: { provider: "daytona", target: "operator" }, updatedAt: new Date("2026-08-06T12:01:00.000Z") })
+      .where(eq(environments.id, created.environment.id));
+
+    const reconciled = await svc.ensureManagedSandboxEnvironment({
+      companyId,
+      name: "Daytona",
+      description: "Managed stock",
+      provider: "daytona",
+      config: { target: "eu" },
+      stockVersion: "v2",
+      applyOverOperatorEdits: true,
+    });
+    const [binding] = await db
+      .select()
+      .from(builtInManagedResources)
+      .where(eq(builtInManagedResources.companyId, companyId));
+
+    expect(reconciled).toMatchObject({ action: "updated", stockStatus: "operator_modified", updateAvailable: false });
+    expect(reconciled.environment.config).toEqual({ provider: "daytona", target: "eu" });
+    expect(binding?.stockHash).toBe(reconciled.stockHash);
+    expect(binding?.stockVersion).toBe("v2");
+    expect(binding?.defaultsJson).toMatchObject({ config: reconciled.environment.config });
+
+    const again = await svc.ensureManagedSandboxEnvironment({
+      companyId,
+      name: "Daytona",
+      description: "Managed stock",
+      provider: "daytona",
+      config: { target: "eu" },
+      stockVersion: "v2",
+      applyOverOperatorEdits: true,
+    });
+    expect(again).toMatchObject({ action: "unchanged", stockStatus: "stock_current" });
+  });
+
+  it("applies the desired config over a row that predates stock tracking when the caller is authoritative", async () => {
+    const companyId = await seedCompany();
+    const now = new Date();
+    const [legacy] = await db
+      .insert(environments)
+      .values({
+        name: "Daytona",
+        driver: "sandbox",
+        status: "active",
+        config: { provider: "daytona", target: "legacy" },
+        envVars: {},
+        metadata: { managedByPaperclip: true, managedSandboxProvider: "daytona" },
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning();
+
+    const preserved = await svc.ensureManagedSandboxEnvironment({
+      companyId,
+      name: "Daytona",
+      provider: "daytona",
+      config: { target: "eu" },
+    });
+    expect(preserved).toMatchObject({ action: "skipped", stockStatus: "operator_modified" });
+    expect(preserved.environment.config).toEqual({ provider: "daytona", target: "legacy" });
+
+    const applied = await svc.ensureManagedSandboxEnvironment({
+      companyId,
+      name: "Daytona",
+      provider: "daytona",
+      config: { target: "eu" },
+      applyOverOperatorEdits: true,
+    });
+    expect(applied.environment.id).toBe(legacy.id);
+    expect(applied).toMatchObject({ action: "updated", stockStatus: "operator_modified", updateAvailable: false });
+    expect(applied.environment.config).toEqual({ provider: "daytona", target: "eu" });
+  });
+
+  it("ensureKubernetesEnvironment applies the supplied config over operator drift only with applyOverOperatorEdits", async () => {
+    const companyId = await seedCompany();
+    const created = await svc.ensureKubernetesEnvironment(companyId, { inCluster: true, backend: "job" });
+    const operatorConfig = { provider: "kubernetes", inCluster: true, backend: "job", runtimeClassName: "operator" };
+    await db
+      .update(environments)
+      .set({ config: operatorConfig })
+      .where(eq(environments.id, created.id));
+
+    const preserved = await svc.ensureKubernetesEnvironment(companyId, {
+      inCluster: true,
+      backend: "job",
+      egressAllowFqdns: ["api.anthropic.com"],
+    });
+    expect(preserved.id).toBe(created.id);
+    expect(preserved.config).toEqual(operatorConfig);
+
+    const applied = await svc.ensureKubernetesEnvironment(
+      companyId,
+      { inCluster: true, backend: "job", egressAllowFqdns: ["api.anthropic.com"] },
+      { applyOverOperatorEdits: true },
+    );
+    expect(applied.id).toBe(created.id);
+    expect(applied.config).toEqual({
+      provider: "kubernetes",
+      inCluster: true,
+      backend: "job",
+      egressAllowFqdns: ["api.anthropic.com"],
+    });
+    expect(applied.metadata?.managedKubernetesSandbox).toBe(true);
+  });
+
+  it("leaves a manually archived row alone even when the caller is authoritative", async () => {
+    const companyId = await seedCompany();
+    const created = await svc.ensureManagedSandboxEnvironment({
+      companyId,
+      name: "Daytona",
+      provider: "daytona",
+      config: { target: "us" },
+      stockVersion: "v1",
+    });
+    await db
+      .update(environments)
+      .set({ status: "archived", config: { provider: "daytona", target: "operator" } })
+      .where(eq(environments.id, created.environment.id));
+
+    const reconciled = await svc.ensureManagedSandboxEnvironment({
+      companyId,
+      name: "Daytona",
+      provider: "daytona",
+      config: { target: "eu" },
+      stockVersion: "v2",
+      applyOverOperatorEdits: true,
+    });
+
+    expect(reconciled).toMatchObject({
+      action: "skipped",
+      stockStatus: "operator_modified",
+      updateAvailable: true,
+      environment: {
+        status: "archived",
+        config: { provider: "daytona", target: "operator" },
+      },
+    });
+  });
+
+  it("reactivates and updates a reconciler-archived row in one pass when the caller is authoritative", async () => {
+    const companyId = await seedCompany();
+    const created = await svc.ensureManagedSandboxEnvironment({
+      companyId,
+      name: "Daytona",
+      provider: "daytona",
+      config: { target: "us" },
+      stockVersion: "v1",
+    });
+    await db
+      .update(environments)
+      .set({ config: { provider: "daytona", target: "operator" } })
+      .where(eq(environments.id, created.environment.id));
+    expect((await svc.archiveManagedSandboxEnvironment({ provider: "daytona" }))?.status).toBe("archived");
+
+    const reconciled = await svc.ensureManagedSandboxEnvironment({
+      companyId,
+      name: "Daytona",
+      provider: "daytona",
+      config: { target: "eu" },
+      stockVersion: "v2",
+      applyOverOperatorEdits: true,
+    });
+
+    expect(reconciled).toMatchObject({ action: "updated", updateAvailable: false });
+    expect(reconciled.environment.status).toBe("active");
+    expect(reconciled.environment.config).toEqual({ provider: "daytona", target: "eu" });
+    expect(reconciled.environment.metadata).not.toHaveProperty("_paperclipManagedArchiveToken");
+    const [binding] = await db
+      .select()
+      .from(builtInManagedResources)
+      .where(eq(builtInManagedResources.companyId, companyId));
+    expect(binding?.stockHash).toBe(reconciled.stockHash);
+    expect(binding?.defaultsJson).toMatchObject({ status: "active", config: reconciled.environment.config });
+    const activity = await db
+      .select({ action: activityLog.action, details: activityLog.details })
+      .from(activityLog)
+      .where(eq(activityLog.companyId, companyId))
+      .orderBy(activityLog.createdAt);
+    expect(activity.at(-1)).toMatchObject({
+      action: "environment.managed_stock_updated",
+      details: { stockStatus: "operator_modified", providerReactivated: true },
+    });
+  });
+
   it("adopts the managed slot on a provider switch and drops the stale kubernetes marker", async () => {
     const companyId = await seedCompany();
     const kubernetes = await svc.ensureKubernetesEnvironment(companyId, { inCluster: true, backend: "job" });

--- a/server/src/__tests__/instance-settings-routes.test.ts
+++ b/server/src/__tests__/instance-settings-routes.test.ts
@@ -738,7 +738,7 @@ describe("instance settings routes", () => {
       expect(mockInstanceSettingsService.updateGeneral).toHaveBeenCalledWith({ keyboardShortcuts: true });
     });
 
-    it("keeps executionMode writable on self-hosted instances", async () => {
+    it.each(["kubernetes", "any"])("allows an instance admin to set self-hosted executionMode to %j", async (executionMode) => {
       delete process.env.PAPERCLIP_CLOUD_TENANT_SERVER_TOKEN;
       const app = await createApp({
         type: "board",
@@ -749,10 +749,10 @@ describe("instance settings routes", () => {
 
       const res = await request(app)
         .patch("/api/instance/settings/general")
-        .send({ executionMode: "kubernetes" });
+        .send({ executionMode });
 
       expect(res.status).toBe(200);
-      expect(mockInstanceSettingsService.updateGeneral).toHaveBeenCalledWith({ executionMode: "kubernetes" });
+      expect(mockInstanceSettingsService.updateGeneral).toHaveBeenCalledWith({ executionMode });
     });
   });
 

--- a/server/src/services/environments.ts
+++ b/server/src/services/environments.ts
@@ -50,7 +50,7 @@ const DEFAULT_KUBERNETES_ENVIRONMENT_DESCRIPTION =
   "Managed Kubernetes sandbox environment for hosted tenant execution.";
 /** Provider key (== plugin driverKey) of the first-party Kubernetes sandbox provider. */
 const KUBERNETES_PROVIDER_KEY = "kubernetes";
-/** Metadata marker for the company's managed-by-config Kubernetes sandbox environment. */
+/** Legacy lookup marker for the instance-wide managed Kubernetes environment. */
 const KUBERNETES_MANAGED_MARKER = "managedKubernetesSandbox";
 const ACTIVE_CUSTOM_IMAGE_SETUP_STATUSES = ["starting", "waiting_for_user", "capturing"] as const;
 
@@ -106,15 +106,10 @@ export interface ManagedSandboxEnvironmentInput {
   /** Version label recorded with the stock binding; hashes remain the drift authority. */
   stockVersion?: string;
   /**
-   * Apply the desired stock over an operator-modified row. By default the
-   * reconciler preserves a row whose stock fields (name, description, config,
-   * managed metadata markers, status) differ from the recorded baseline and
-   * only reports that an update is available. With this flag the caller
-   * declares that its input is the source of truth: the reconciler overwrites
-   * every stock field and resets the baseline, so a board edit or a row that
-   * predates stock tracking no longer freezes later updates. A row an operator
-   * archived by hand stays archived. A row the reconciler archived for
-   * provider unavailability is reactivated and updated in the same pass.
+   * Declares stock fields (name, description, config, managed metadata, status)
+   * caller-owned, replacing operator edits and resetting the baseline. envVars
+   * and unrelated metadata remain operator-owned. Operator archives take
+   * precedence; only a reconciler-owned archive may be reactivated.
    */
   applyOverOperatorEdits?: boolean;
 }
@@ -331,8 +326,9 @@ export function environmentService(db: Db) {
    * - A stock-controlled managed row advances to a new stock hash in the same
    *   transaction as its managed fields, including provider switches.
    * - A stock-current row is returned without an environment write.
-   * - An operator-modified or previously unmanaged row is preserved and
-   *   reported as skipped; its user-owned fields are never folded into stock.
+   * - An operator-modified or previously unmanaged row is preserved unless the
+   *   caller opts into replacing its stock fields. Operator-owned fields are
+   *   excluded from the baseline.
    */
   const ensureManagedSandboxEnvironment = async (
     input: ManagedSandboxEnvironmentInput,
@@ -551,9 +547,8 @@ export function environmentService(db: Db) {
           },
         );
         if (operatorReaffirmedArchive) stockStatus = "operator_modified";
-        // Provider unavailability is an operational state transition, not an
-        // operator edit. The binding records that Paperclip archived this row.
-        // A manually archived row still has an active binding baseline.
+        // Status alone cannot prove archive ownership. An operator's later
+        // archive clears the row token, even if the row was already archived.
         const archivedByReconciler = row.status === "archived" &&
           typeof rowArchiveToken === "string" &&
           matchingBindings.some((binding) => {
@@ -561,12 +556,8 @@ export function environmentService(db: Db) {
             return bindingDefaults.status === "archived" &&
               bindingDefaults[MANAGED_ENVIRONMENT_ARCHIVE_TOKEN_DEFAULTS_KEY] === rowArchiveToken;
           });
-        // The caller declared its input authoritative: apply it over operator
-        // drift through the same update path a stock-controlled row takes. The
-        // result still reports the observed `operator_modified` status, so the
-        // activity log shows that an operator edit was overwritten. A row an
-        // operator archived by hand is left alone; a reconciler-archived row
-        // is reactivated by the update.
+        // Keep the observed stockStatus so activity records disclose overwrites.
+        // Manifest ownership does not grant permission to undo operator archives.
         const applyOverOperatorEdits = stockStatus === "operator_modified" &&
           input.applyOverOperatorEdits === true &&
           (row.status !== "archived" || (archivedByReconciler && !operatorReaffirmedArchive));
@@ -579,10 +570,8 @@ export function environmentService(db: Db) {
             : desiredStock;
           let baselineHash = baseline?.stockHash ?? latestStockHash;
 
-          // If Paperclip archived this row, restore only its availability
-          // status. Keep every other operator-modified field intact and leave
-          // the stock update pending. A manually archived row remains
-          // operator_modified and is not reactivated here.
+          // Without manifest ownership, provider recovery restores availability
+          // but must not replace operator config or mark the stock update applied.
           if (archivedByReconciler) {
             const reactivated = await tx
               .update(environments)
@@ -951,14 +940,8 @@ export function environmentService(db: Db) {
     archiveManagedSandboxEnvironment,
 
     /**
-     * Idempotently ensure a managed Kubernetes sandbox environment exists for
-     * an instance, configured from instance/operator-supplied config. A thin
-     * wrapper over `ensureManagedSandboxEnvironment` that pins the provider to
-     * "kubernetes" and stamps the legacy marker `findKubernetesEnvironment`
-     * keys on. On subsequent calls stock-controlled config advances in place;
-     * operator modifications remain untouched for explicit review unless
-     * `options.applyOverOperatorEdits` declares the supplied config
-     * authoritative (see `ManagedSandboxEnvironmentInput`).
+     * The legacy Kubernetes marker is required by findKubernetesEnvironment.
+     * Operator edits win unless the caller explicitly declares manifest ownership.
      */
     ensureKubernetesEnvironment: async (
       companyIdOrConfig: string | KubernetesEnvironmentConfigInput,

--- a/server/src/services/environments.ts
+++ b/server/src/services/environments.ts
@@ -105,6 +105,18 @@ export interface ManagedSandboxEnvironmentInput {
   extraMetadata?: Record<string, unknown>;
   /** Version label recorded with the stock binding; hashes remain the drift authority. */
   stockVersion?: string;
+  /**
+   * Apply the desired stock over an operator-modified row. By default the
+   * reconciler preserves a row whose stock fields (name, description, config,
+   * managed metadata markers, status) differ from the recorded baseline and
+   * only reports that an update is available. With this flag the caller
+   * declares that its input is the source of truth: the reconciler overwrites
+   * every stock field and resets the baseline, so a board edit or a row that
+   * predates stock tracking no longer freezes later updates. A row an operator
+   * archived by hand stays archived. A row the reconciler archived for
+   * provider unavailability is reactivated and updated in the same pass.
+   */
+  applyOverOperatorEdits?: boolean;
 }
 
 export type ManagedSandboxEnvironmentReconcileAction =
@@ -539,27 +551,38 @@ export function environmentService(db: Db) {
           },
         );
         if (operatorReaffirmedArchive) stockStatus = "operator_modified";
+        // Provider unavailability is an operational state transition, not an
+        // operator edit. The binding records that Paperclip archived this row.
+        // A manually archived row still has an active binding baseline.
+        const archivedByReconciler = row.status === "archived" &&
+          typeof rowArchiveToken === "string" &&
+          matchingBindings.some((binding) => {
+            const bindingDefaults = binding.defaultsJson;
+            return bindingDefaults.status === "archived" &&
+              bindingDefaults[MANAGED_ENVIRONMENT_ARCHIVE_TOKEN_DEFAULTS_KEY] === rowArchiveToken;
+          });
+        // The caller declared its input authoritative: apply it over operator
+        // drift through the same update path a stock-controlled row takes. The
+        // result still reports the observed `operator_modified` status, so the
+        // activity log shows that an operator edit was overwritten. A row an
+        // operator archived by hand is left alone; a reconciler-archived row
+        // is reactivated by the update.
+        const applyOverOperatorEdits = stockStatus === "operator_modified" &&
+          input.applyOverOperatorEdits === true &&
+          (row.status !== "archived" || (archivedByReconciler && !operatorReaffirmedArchive));
+        if (applyOverOperatorEdits && row.status === "archived") providerReactivated = true;
 
-        if (stockStatus === "operator_modified") {
+        if (stockStatus === "operator_modified" && !applyOverOperatorEdits) {
           const baseline = matchingBindings[0];
           let baselineDefaults = baseline
             ? managedEnvironmentBaselineDefaults(baseline.defaultsJson)
             : desiredStock;
           let baselineHash = baseline?.stockHash ?? latestStockHash;
 
-          // Provider unavailability is an operational state transition, not
-          // an operator edit. If the binding records that Paperclip archived
-          // this row, restore only its availability status. Keep every other
-          // operator-modified field intact and leave the stock update pending.
-          // A manually archived row still has an active binding baseline, so
-          // it remains operator_modified and is not reactivated here.
-          const archivedByReconciler = row.status === "archived" &&
-            typeof rowArchiveToken === "string" &&
-            matchingBindings.some((binding) => {
-              const bindingDefaults = binding.defaultsJson;
-              return bindingDefaults.status === "archived" &&
-                bindingDefaults[MANAGED_ENVIRONMENT_ARCHIVE_TOKEN_DEFAULTS_KEY] === rowArchiveToken;
-            });
+          // If Paperclip archived this row, restore only its availability
+          // status. Keep every other operator-modified field intact and leave
+          // the stock update pending. A manually archived row remains
+          // operator_modified and is not reactivated here.
           if (archivedByReconciler) {
             const reactivated = await tx
               .update(environments)
@@ -933,11 +956,14 @@ export function environmentService(db: Db) {
      * wrapper over `ensureManagedSandboxEnvironment` that pins the provider to
      * "kubernetes" and stamps the legacy marker `findKubernetesEnvironment`
      * keys on. On subsequent calls stock-controlled config advances in place;
-     * operator modifications remain untouched for explicit review.
+     * operator modifications remain untouched for explicit review unless
+     * `options.applyOverOperatorEdits` declares the supplied config
+     * authoritative (see `ManagedSandboxEnvironmentInput`).
      */
     ensureKubernetesEnvironment: async (
       companyIdOrConfig: string | KubernetesEnvironmentConfigInput,
       maybeConfig?: KubernetesEnvironmentConfigInput,
+      options?: { applyOverOperatorEdits?: boolean },
     ): Promise<Environment> => {
       const config = resolveKubernetesConfig(companyIdOrConfig, maybeConfig);
       return ensureManagedSandboxEnvironment({
@@ -947,6 +973,7 @@ export function environmentService(db: Db) {
         provider: KUBERNETES_PROVIDER_KEY,
         config,
         extraMetadata: { [KUBERNETES_MANAGED_MARKER]: true },
+        applyOverOperatorEdits: options?.applyOverOperatorEdits === true,
       }).then((result) => result.environment);
     },
 

--- a/server/src/services/environments.ts
+++ b/server/src/services/environments.ts
@@ -428,6 +428,28 @@ export function environmentService(db: Db) {
           });
         };
 
+        const refreshAttachedBindings = async (
+          environmentId: string,
+          stockVersion: string,
+          installedStockHash: string,
+          defaultsJson: Record<string, unknown>,
+        ) => {
+          await tx
+            .update(builtInManagedResources)
+            .set({
+              stockVersion,
+              stockHash: installedStockHash,
+              defaultsJson,
+              updatedAt: new Date(),
+            })
+            .where(and(
+              eq(builtInManagedResources.bundleKey, MANAGED_ENVIRONMENT_BUNDLE_KEY),
+              eq(builtInManagedResources.resourceKind, MANAGED_ENVIRONMENT_RESOURCE_KIND),
+              eq(builtInManagedResources.resourceKey, MANAGED_ENVIRONMENT_RESOURCE_KEY),
+              eq(builtInManagedResources.resourceId, environmentId),
+            ));
+        };
+
         if (!row) {
           const nameOwner = await tx
             .select()
@@ -629,12 +651,15 @@ export function environmentService(db: Db) {
         }
 
         if (stockStatus === "stock_current") {
+          const hasStaleBinding = matchingBindings.some(
+            (binding) => binding.stockHash !== latestStockHash,
+          );
           await writeBindings(
             row.id,
             input.stockVersion ?? MANAGED_ENVIRONMENT_STOCK_VERSION,
             latestStockHash,
             desiredStock,
-            false,
+            hasStaleBinding,
           );
           return {
             environment: toEnvironment(row),
@@ -661,6 +686,12 @@ export function environmentService(db: Db) {
           .returning()
           .then((rows) => rows[0] ?? null);
         if (!updated) throw new Error("Managed sandbox environment changed during reconciliation");
+        await refreshAttachedBindings(
+          updated.id,
+          input.stockVersion ?? MANAGED_ENVIRONMENT_STOCK_VERSION,
+          latestStockHash,
+          desiredStock,
+        );
         await writeBindings(
           updated.id,
           input.stockVersion ?? MANAGED_ENVIRONMENT_STOCK_VERSION,

--- a/server/src/services/execution-policy-bootstrap.test.ts
+++ b/server/src/services/execution-policy-bootstrap.test.ts
@@ -39,7 +39,7 @@ const bootstrap: ExecutionPolicyBootstrap = {
 const fakeDb = {} as never;
 
 describe("parseExecutionPolicyBootstrapEnv", () => {
-  it("returns null when no execution mode is set (default unrestricted)", () => {
+  it("disables bootstrap when no execution mode is set", () => {
     expect(parseExecutionPolicyBootstrapEnv(env({}))).toBeNull();
   });
 
@@ -127,25 +127,45 @@ describe("parseExecutionPolicyBootstrapEnv", () => {
     expect(parsed?.kubernetesConfig).not.toHaveProperty("applyOverOperatorEdits");
   });
 
-  it("reads PAPERCLIP_K8S_CONFIG_AUTHORITATIVE into applyOverOperatorEdits", () => {
+  it.each([
+    ["true", true], ["1", true], [" YES ", true],
+    ["false", false], ["0", false], [" NO ", false],
+  ])("parses authoritative flag %j as %j without storing it in provider config", (value, expected) => {
     const parsed = parseExecutionPolicyBootstrapEnv(
-      env({ PAPERCLIP_EXECUTION_MODE: "kubernetes", PAPERCLIP_K8S_CONFIG_AUTHORITATIVE: "true" }),
+      env({ PAPERCLIP_EXECUTION_MODE: "kubernetes", PAPERCLIP_K8S_CONFIG_AUTHORITATIVE: value }),
     );
-    expect(parsed?.applyOverOperatorEdits).toBe(true);
+    expect(parsed?.applyOverOperatorEdits).toBe(expected);
     expect(parsed?.kubernetesConfig).not.toHaveProperty("applyOverOperatorEdits");
-    expect(
-      parseExecutionPolicyBootstrapEnv(
-        env({ PAPERCLIP_EXECUTION_MODE: "kubernetes", PAPERCLIP_K8S_CONFIG_AUTHORITATIVE: "false" }),
-      )?.applyOverOperatorEdits,
-    ).toBe(false);
   });
 
-  it("throws when PAPERCLIP_K8S_CONFIG_AUTHORITATIVE is not a boolean", () => {
+  it.each(["sometimes", "", " "])("rejects authoritative flag %j", (value) => {
     expect(() =>
       parseExecutionPolicyBootstrapEnv(
-        env({ PAPERCLIP_EXECUTION_MODE: "kubernetes", PAPERCLIP_K8S_CONFIG_AUTHORITATIVE: "sometimes" }),
+        env({ PAPERCLIP_EXECUTION_MODE: "kubernetes", PAPERCLIP_K8S_CONFIG_AUTHORITATIVE: value }),
       ),
     ).toThrow(/PAPERCLIP_K8S_CONFIG_AUTHORITATIVE/);
+  });
+
+  it("falls back to out-of-cluster access and leaves list syntax validation to the provider", () => {
+    const parsed = parseExecutionPolicyBootstrapEnv(env({
+      PAPERCLIP_EXECUTION_MODE: "kubernetes",
+      PAPERCLIP_K8S_IN_CLUSTER: "sometimes",
+      PAPERCLIP_K8S_EGRESS_ALLOW_FQDNS: " not a hostname, , example.com ",
+      PAPERCLIP_K8S_EGRESS_ALLOW_CIDRS: " not a CIDR, , ",
+    }));
+    expect(parsed?.kubernetesConfig).toEqual({
+      inCluster: false,
+      egressAllowFqdns: ["not a hostname", "example.com"],
+      egressAllowCidrs: ["not a CIDR"],
+    });
+  });
+
+  it.each([undefined, "", "any"])("ignores Kubernetes variables when execution mode is %j", (mode) => {
+    expect(parseExecutionPolicyBootstrapEnv(env({
+      PAPERCLIP_EXECUTION_MODE: mode,
+      PAPERCLIP_K8S_CONFIG_AUTHORITATIVE: "invalid",
+      PAPERCLIP_K8S_BACKEND: "invalid",
+    }))).toBeNull();
   });
 
   it("throws when PAPERCLIP_K8S_RPC_TIMEOUT_MS is not a positive integer", () => {

--- a/server/src/services/execution-policy-bootstrap.test.ts
+++ b/server/src/services/execution-policy-bootstrap.test.ts
@@ -31,6 +31,7 @@ function env(overrides: Record<string, string | undefined>): ExecutionPolicyBoot
 const bootstrap: ExecutionPolicyBootstrap = {
   executionMode: "kubernetes",
   kubernetesConfig: { inCluster: true, backend: "job" },
+  applyOverOperatorEdits: false,
 };
 
 // `applyExecutionPolicyBootstrap` constructs its services internally from the
@@ -120,6 +121,33 @@ describe("parseExecutionPolicyBootstrapEnv", () => {
     expect(parsed?.kubernetesConfig.timeoutMs).toBeUndefined();
   });
 
+  it("defaults applyOverOperatorEdits to false and keeps the flag out of the stored config", () => {
+    const parsed = parseExecutionPolicyBootstrapEnv(env({ PAPERCLIP_EXECUTION_MODE: "kubernetes" }));
+    expect(parsed?.applyOverOperatorEdits).toBe(false);
+    expect(parsed?.kubernetesConfig).not.toHaveProperty("applyOverOperatorEdits");
+  });
+
+  it("reads PAPERCLIP_K8S_CONFIG_AUTHORITATIVE into applyOverOperatorEdits", () => {
+    const parsed = parseExecutionPolicyBootstrapEnv(
+      env({ PAPERCLIP_EXECUTION_MODE: "kubernetes", PAPERCLIP_K8S_CONFIG_AUTHORITATIVE: "true" }),
+    );
+    expect(parsed?.applyOverOperatorEdits).toBe(true);
+    expect(parsed?.kubernetesConfig).not.toHaveProperty("applyOverOperatorEdits");
+    expect(
+      parseExecutionPolicyBootstrapEnv(
+        env({ PAPERCLIP_EXECUTION_MODE: "kubernetes", PAPERCLIP_K8S_CONFIG_AUTHORITATIVE: "false" }),
+      )?.applyOverOperatorEdits,
+    ).toBe(false);
+  });
+
+  it("throws when PAPERCLIP_K8S_CONFIG_AUTHORITATIVE is not a boolean", () => {
+    expect(() =>
+      parseExecutionPolicyBootstrapEnv(
+        env({ PAPERCLIP_EXECUTION_MODE: "kubernetes", PAPERCLIP_K8S_CONFIG_AUTHORITATIVE: "sometimes" }),
+      ),
+    ).toThrow(/PAPERCLIP_K8S_CONFIG_AUTHORITATIVE/);
+  });
+
   it("throws when PAPERCLIP_K8S_RPC_TIMEOUT_MS is not a positive integer", () => {
     expect(() =>
       parseExecutionPolicyBootstrapEnv(
@@ -149,6 +177,27 @@ describe("applyExecutionPolicyBootstrap", () => {
 
     expect(result).toEqual({ executionMode: "kubernetes", companiesConfigured: 3 });
     expect(ensureKubernetesEnvironment).toHaveBeenCalledTimes(3);
+    expect(ensureKubernetesEnvironment).toHaveBeenCalledWith(
+      "c1",
+      bootstrap.kubernetesConfig,
+      { applyOverOperatorEdits: false },
+    );
+  });
+
+  it("passes applyOverOperatorEdits through to every managed environment ensure", async () => {
+    listCompanyIds.mockResolvedValue(["c1", "c2"]);
+    ensureKubernetesEnvironment.mockResolvedValue({ id: "env" });
+
+    await applyExecutionPolicyBootstrap(fakeDb, { ...bootstrap, applyOverOperatorEdits: true });
+
+    expect(ensureKubernetesEnvironment).toHaveBeenCalledTimes(2);
+    for (const companyId of ["c1", "c2"]) {
+      expect(ensureKubernetesEnvironment).toHaveBeenCalledWith(
+        companyId,
+        bootstrap.kubernetesConfig,
+        { applyOverOperatorEdits: true },
+      );
+    }
   });
 
   it("throws when at least one company fails, after attempting every company", async () => {

--- a/server/src/services/execution-policy-bootstrap.ts
+++ b/server/src/services/execution-policy-bootstrap.ts
@@ -10,6 +10,13 @@
  *   3. Idempotently ensure a configured Kubernetes sandbox environment for every
  *      company (mirrors `ensureLocalEnvironment`).
  *
+ * The managed-environment reconciler preserves a row whose stock fields were
+ * edited in the board (or that predates stock tracking) and only reports that
+ * an update is available, so by default a changed `PAPERCLIP_K8S_*` value does
+ * not reach such a row. `PAPERCLIP_K8S_CONFIG_AUTHORITATIVE=true` declares the
+ * env-supplied config the source of truth: every boot applies it over operator
+ * edits and resets the stock baseline.
+ *
  * The boot hook is *configuration convenience*; the actual security gate is the
  * per-run guard in the heartbeat (see `execution-allowlist.ts`). Even with no
  * boot hook, setting `executionMode=kubernetes` denies local execution.
@@ -29,6 +36,14 @@ export type ExecutionPolicyBootstrapEnv = Record<string, string | undefined>;
 export interface ExecutionPolicyBootstrap {
   executionMode: Extract<InstanceExecutionMode, "kubernetes">;
   kubernetesConfig: KubernetesEnvironmentConfigInput;
+  /**
+   * `PAPERCLIP_K8S_CONFIG_AUTHORITATIVE=true`. When set, the managed
+   * Kubernetes environment's stock fields are overwritten with the env-declared
+   * config on every boot, even when an operator edited the row in the board.
+   * Kept outside `kubernetesConfig` because that object is stored verbatim in
+   * `environment.config`.
+   */
+  applyOverOperatorEdits: boolean;
 }
 
 function parseBool(value: string | undefined): boolean | undefined {
@@ -128,7 +143,19 @@ export function parseExecutionPolicyBootstrapEnv(
   const adapters = parseAdapterRegistryEnv(env);
   if (adapters) kubernetesConfig.adapters = adapters;
 
-  return { executionMode: "kubernetes", kubernetesConfig };
+  const rawAuthoritative = env.PAPERCLIP_K8S_CONFIG_AUTHORITATIVE;
+  const applyOverOperatorEdits = parseBool(rawAuthoritative);
+  if (rawAuthoritative !== undefined && applyOverOperatorEdits === undefined) {
+    throw new Error(
+      `PAPERCLIP_K8S_CONFIG_AUTHORITATIVE must be "true" or "false" (got "${rawAuthoritative}").`,
+    );
+  }
+
+  return {
+    executionMode: "kubernetes",
+    kubernetesConfig,
+    applyOverOperatorEdits: applyOverOperatorEdits ?? false,
+  };
 }
 
 /**
@@ -150,7 +177,9 @@ export async function applyExecutionPolicyBootstrap(
   const failedCompanyIds: string[] = [];
   for (const companyId of companyIds) {
     try {
-      await environments.ensureKubernetesEnvironment(companyId, bootstrap.kubernetesConfig);
+      await environments.ensureKubernetesEnvironment(companyId, bootstrap.kubernetesConfig, {
+        applyOverOperatorEdits: bootstrap.applyOverOperatorEdits,
+      });
       configured += 1;
     } catch (err) {
       logger.error(
@@ -168,6 +197,7 @@ export async function applyExecutionPolicyBootstrap(
       backend: bootstrap.kubernetesConfig.backend,
       runtimeClassName: bootstrap.kubernetesConfig.runtimeClassName,
       egressMode: bootstrap.kubernetesConfig.egressMode,
+      configAuthoritative: bootstrap.applyOverOperatorEdits,
     },
     "applied forced Kubernetes execution policy",
   );

--- a/server/src/services/execution-policy-bootstrap.ts
+++ b/server/src/services/execution-policy-bootstrap.ts
@@ -1,27 +1,11 @@
 /**
- * Cloud execution-policy bootstrap.
+ * Bootstrap persists the Kubernetes-only execution policy and reconciles one
+ * instance-wide managed environment with company-scoped tracking bindings.
+ * Operator edits win unless PAPERCLIP_K8S_CONFIG_AUTHORITATIVE opts into
+ * manifest ownership; operator archives remain protected in either mode.
  *
- * Lets an operator / gitops deployment force the instance onto the Kubernetes
- * sandbox provider purely via environment variables, with no manual product-API
- * calls. On startup we:
- *   1. Parse `PAPERCLIP_EXECUTION_MODE` (+ `PAPERCLIP_K8S_*`) from the env.
- *   2. Persist `executionMode` into instance general settings (so the per-run
- *      heartbeat guard enforces it).
- *   3. Idempotently ensure a configured Kubernetes sandbox environment for every
- *      company (mirrors `ensureLocalEnvironment`).
- *
- * The managed-environment reconciler preserves a row whose stock fields were
- * edited in the board (or that predates stock tracking) and only reports that
- * an update is available, so by default a changed `PAPERCLIP_K8S_*` value does
- * not reach such a row. `PAPERCLIP_K8S_CONFIG_AUTHORITATIVE=true` declares the
- * env-supplied config the source of truth: every boot applies it over operator
- * edits and resets the stock baseline.
- *
- * The boot hook is *configuration convenience*; the actual security gate is the
- * per-run guard in the heartbeat (see `execution-allowlist.ts`). Even with no
- * boot hook, setting `executionMode=kubernetes` denies local execution.
- *
- * The env-var parsing is a pure function so it is trivially unit-testable.
+ * The heartbeat enforces the persisted policy, not this boot hook. Disabling
+ * bootstrap does not reset executionMode or permit local fallback.
  */
 
 import type { Db } from "@paperclipai/db";
@@ -36,13 +20,7 @@ export type ExecutionPolicyBootstrapEnv = Record<string, string | undefined>;
 export interface ExecutionPolicyBootstrap {
   executionMode: Extract<InstanceExecutionMode, "kubernetes">;
   kubernetesConfig: KubernetesEnvironmentConfigInput;
-  /**
-   * `PAPERCLIP_K8S_CONFIG_AUTHORITATIVE=true`. When set, the managed
-   * Kubernetes environment's stock fields are overwritten with the env-declared
-   * config on every boot, even when an operator edited the row in the board.
-   * Kept outside `kubernetesConfig` because that object is stored verbatim in
-   * `environment.config`.
-   */
+  /** Kept outside kubernetesConfig because that object is stored as provider config. */
   applyOverOperatorEdits: boolean;
 }
 
@@ -77,10 +55,8 @@ function parseList(value: string | undefined): string[] | undefined {
 }
 
 /**
- * Parse the forced-execution-mode env config. Returns null when execution is
- * unrestricted (no env, or `PAPERCLIP_EXECUTION_MODE=any`). Throws on an
- * unrecognized mode so a misconfigured deployment fails loudly instead of
- * silently allowing local execution.
+ * A null result disables bootstrap; it says nothing about persisted policy.
+ * Reject unknown modes so a typo cannot silently skip the policy write.
  */
 export function parseExecutionPolicyBootstrapEnv(
   env: ExecutionPolicyBootstrapEnv,
@@ -158,11 +134,6 @@ export function parseExecutionPolicyBootstrapEnv(
   };
 }
 
-/**
- * Apply the parsed bootstrap to the database: persist `executionMode` into
- * instance settings and ensure a configured Kubernetes environment for every
- * company. Idempotent; safe to call on every boot.
- */
 export async function applyExecutionPolicyBootstrap(
   db: Db,
   bootstrap: ExecutionPolicyBootstrap,
@@ -211,9 +182,6 @@ export async function applyExecutionPolicyBootstrap(
   return { executionMode: bootstrap.executionMode, companiesConfigured: configured };
 }
 
-/**
- * Convenience: parse + apply from a raw env map. Returns null when unrestricted.
- */
 export async function bootstrapExecutionPolicyFromEnv(
   db: Db,
   env: ExecutionPolicyBootstrapEnv = process.env,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -18684,6 +18684,7 @@ export function heartbeatService(
             await environmentsSvc.ensureKubernetesEnvironment(
               agent.companyId,
               bootstrap.kubernetesConfig,
+              { applyOverOperatorEdits: bootstrap.applyOverOperatorEdits },
             );
             kubernetesEnvironment =
               await environmentsSvc.findKubernetesEnvironment(agent.companyId);

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -18658,14 +18658,9 @@ export function heartbeatService(
         let kubernetesEnvironment =
           await environmentsSvc.findKubernetesEnvironment(agent.companyId);
         if (!kubernetesEnvironment) {
-          // Lazy recovery for companies created after the startup bootstrap ran
-          // (the boot hook only provisions environments for companies that exist
-          // at boot). Re-derive the managed-env config from the bootstrap env.
-          // If the process env no longer forces Kubernetes (rollback / config
-          // drift relative to the persisted executionMode setting), skip the
-          // provisioning gracefully: the guard below still refuses local
-          // fallback with the explicit error, instead of crashing here on
-          // undefined config.
+          // An instance booted without companies has no managed environment yet.
+          // Reuse bootstrap config for lazy recovery, but missing or invalid env
+          // must not bypass the persisted policy or permit local fallback.
           let bootstrap: ReturnType<typeof parseExecutionPolicyBootstrapEnv> =
             null;
           let bootstrapSkipReason: string | null = null;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - A deployment can require Kubernetes execution and declare its sandbox config through environment variables.
> - The managed-environment reconciler protects operator edits, as intended by #10979.
> - That protection also prevents a manifest change from replacing a board edit or updating a row without a recorded stock baseline.
> - Some operators want the manifest to own those fields. Other operators want board edits to remain in place.
> - This PR adds an explicit, default-off ownership flag. It preserves the operator's archive decision in both modes.

## Linked Issues or Issue Description

Refs #10979: preserve managed environment drift on boot. This PR keeps that default and adds an explicit opt-in for manifest-owned configuration.

Refs #9001: the open provider-agnostic sandbox execution-mode proposal also touches bootstrap. This flag stays outside provider config and does not add an execution mode.

**What happened?**

On a self-hosted Kubernetes deployment, an operator edits the managed environment in the board. A later restart with changed `PAPERCLIP_K8S_*` values preserves that edit and records `environment.managed_stock_skipped`. A legacy row without stock tracking follows the same protection. There is no explicit bootstrap option to declare those fields manifest-owned.

**Expected behavior**

Keep operator-edit protection by default. Let the deployment explicitly opt into replacing the managed row's stock fields from its manifest. Do not undo an operator archive.

**Steps to reproduce**

1. Boot with `PAPERCLIP_EXECUTION_MODE=kubernetes`, `PAPERCLIP_K8S_IN_CLUSTER=true`, and `PAPERCLIP_K8S_BACKEND=job`.
2. Edit the managed environment's config in the board.
3. Change `PAPERCLIP_K8S_RUNTIME_CLASS_NAME` in the deployment manifest and restart.
4. Without the new flag, the config keeps the board edit. With `PAPERCLIP_K8S_CONFIG_AUTHORITATIVE=true`, an active managed row receives the manifest config.

**Paperclip version or commit**

Submission base: `d96452db059338b329b458ba8fe359fef72f1363`.

**Deployment mode**

Self-hosted Kubernetes with manifest-declared execution configuration. No adapter-specific change.

Public GitHub searches checked the flag name, `PAPERCLIP_K8S`, and managed-environment PRs. #10979 is merged; #9001 remains open as of 2026-09-06.

## What Changed

- Add `PAPERCLIP_K8S_CONFIG_AUTHORITATIVE`, default `false`. Accept `true|1|yes` and `false|0|no`, ignoring case and surrounding whitespace. Reject other values when Kubernetes bootstrap is enabled.
- Pass the ownership option through startup and the heartbeat's lazy ensure. Keep it out of stored provider config and include `configAuthoritative` in the bootstrap log.
- Use the existing reconciliation update path to replace stock fields and record the applied baseline across every company binding attached to the instance-wide environment. Retain the observed `operator_modified` status in update activity so overwrites remain visible.
- Preserve operator archives, including an archive reaffirmed after provider archival. An archive still owned by the reconciler can be reactivated and updated in one pass.
- Document one instance-wide managed environment with company-scoped tracking bindings. Explain that config is replaced, while operator `envVars` and unrelated metadata are preserved.
- Correct execution-policy rollback instructions and parser-validation claims. Add PostgreSQL restart, ownership, and persisted-policy tests, plus admin API reset coverage.

An always-on override would silently remove the protection that #10979 deliberately added. The opt-in makes ownership visible in the deployment manifest without changing existing installations.

## Verification

Final commit: `ba9bf7798c7e914f691cfe57dda42cb1abf3698f`.

Use Node 24.15.0 and pnpm 9.15.4. The commands below run from the repository root. The explicit Volta invocation also pins the runtime used by pnpm child processes.

```sh
volta run --node 24.15.0 --pnpm 9.15.4 pnpm exec node -v
volta run --node 24.15.0 --pnpm 9.15.4 pnpm install --frozen-lockfile
mkdir -p /var/tmp/paperclip-pr-2-tests
TMPDIR=/var/tmp/paperclip-pr-2-tests \
  volta run --node 24.15.0 --pnpm 9.15.4 pnpm exec vitest run \
  --maxWorkers=1 --disableConsoleIntercept \
  server/src/__tests__/environment-service.test.ts \
  server/src/services/execution-policy-bootstrap.test.ts \
  server/src/services/execution-allowlist.test.ts \
  server/src/__tests__/instance-settings-routes.test.ts
volta run --node 24.15.0 --pnpm 9.15.4 pnpm -r typecheck
volta run --node 24.15.0 --pnpm 9.15.4 pnpm test:run
volta run --node 24.15.0 --pnpm 9.15.4 pnpm build
```

- Verified pnpm child runtime: `v24.15.0`.
- Focused tests: 140 tests passed across 4 files, including 49 PostgreSQL environment tests. The combined post-rebase run passed without skips.
- Full workspace typecheck and production build passed after rebasing onto the submission base.
- GitHub CI passed on the final commit. Greptile scored the PR 5/5, with no unresolved review threads.
- The stock `pnpm test:run` failed before test execution with `/tmp` quota error `-122`: 493 suite-load failures. Its runner hardcodes `/tmp`, so setting `TMPDIR` alone cannot redirect it. A temp-directory-adjusted retry was stopped during the general-server group after a separate port-ownership test confirmed a host blocker. It has no complete suite result.
- The port-ownership test in `local-service-supervisor.test.ts` fails on both this head and the fixed base: `readLocalServicePortOwner` returns `null` instead of the listener PID because `lsof` is absent. The full suite needs a host with working temp storage and `lsof`; no full test pass is claimed.
- Live Kubernetes smoke tests and browser suites were not run. No pre-publication CI or Greptile review was requested.

The automated restart checks verify that a default boot preserves drift, an authoritative boot replaces it, and the next identical boot does not write the environment row. They also verify that `PAPERCLIP_EXECUTION_MODE=any` or unset leaves the stored policy and environment unchanged.

## Risks

- With the flag enabled, reconciliation can replace the entire managed config, name, description, and managed metadata markers. Config keys absent from the manifest are removed. Operator `envVars` and unrelated metadata remain outside that ownership boundary.
- Operator archives stay archived. A run that requires Kubernetes can fail until an operator restores the environment to active.
- Disabling bootstrap does not reset the persisted Kubernetes-only policy. For a self-hosted instance, disable bootstrap and restart, then use an instance-admin `PATCH /api/instance/settings/general` with `{"executionMode":"any"}`. Confirm with `GET` before removing infrastructure. Environment selections and `enableManagedSandboxOnly` are separate settings. Cloud-managed instances reject this policy change through the API.
- Invalid authoritative-flag values fail startup when Kubernetes bootstrap is enabled. Existing parser behavior is unchanged: invalid in-cluster values fall back to `false`, and list syntax is not validated by bootstrap.
- No schema or migration change. Existing callers without the option keep operator-edit protection. This is startup reconciliation, with lazy recovery when no active managed Kubernetes row is found, not a continuous manifest controller.

> For core feature work, check `ROADMAP.md` and discuss it in `#dev` before opening a PR. This is a focused option on the existing Kubernetes bootstrap path; no new provider or execution mode is proposed.

## Model Used

- Original work: Anthropic Claude Fable 5.1, `claude-fable-5-1`, through Claude Code, with extended thinking and tools. The exact context window was not recorded.
- Revision work: OpenAI `gpt-6-astra` through pi / `openai-codex`, high thinking with tools. The pi catalog lists a 272K context window. This is catalog information, not a claim about unrecorded serving details.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass (140 focused tests pass; the local full-suite runner is host-blocked as disclosed above)
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
