### PR TITLE
fix(ui): let contentClassName override the MarkdownEditor min height

### DIFF
--- a/ui/src/components/MarkdownEditor.tsx
+++ b/ui/src/components/MarkdownEditor.tsx
@@ -1310,7 +1310,8 @@ export const MarkdownEditor = forwardRef<MarkdownEditorRef, MarkdownEditorProps>
             }
           }}
           className={cn(
-            "min-h-(--sz-12rem) w-full resize-none bg-transparent px-3 pb-3 pt-2 font-mono text-sm leading-6 outline-none",
+            "w-full resize-none bg-transparent px-3 pb-3 pt-2 font-mono text-sm leading-6 outline-none",
+            !contentClassName?.includes("min-h-") && "min-h-(--sz-12rem)",
             contentClassName,
           )}
         />


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane for AI-agent companies
> - The board UI ships a rich markdown editor component (`MarkdownEditor`) used across issue, goal, document, and chat surfaces
> - The editor's textarea hard-codes a minimum height ahead of any caller-supplied class, so callers cannot win the cascade
> - This pull request applies the default minimum height only when the caller has not supplied one via `contentClassName`
> - The benefit is that surfaces needing a smaller or larger editor height can override it reliably

## Linked Issues or Issue Description

**Bug**

**What is the bug?**
`MarkdownEditor` hard-codes `min-h-(--sz-12rem)` on the textarea ahead of `contentClassName`, so a caller passing its own `min-h` cannot override it.

**Steps to reproduce**
1. Render `MarkdownEditor` with a `contentClassName` that sets a different `min-h`.
2. Observe the hard-coded minimum height wins the cascade.

**Expected result**
The caller-supplied class overrides the default.

**Actual result**
The hard-coded value stays.

**What is the fix?**
Apply the default `min-h` only when the caller has not supplied one.

## What Changed

- Apply `min-h-(--sz-12rem)` conditionally in `MarkdownEditor` instead of unconditionally ahead of `contentClassName`

## Verification

- UI check: render the editor with and without a caller `min-h` class and confirm the cascade behaves
- No behavior change for existing callers that do not pass a min-height class

## Risks

- Low. Only the default-min-height application path changes; callers that relied on the old hard-coded value are unaffected

## Model Used

DeepSeek V4 Flash (deepseek/deepseek-v4-flash-0731, via OpenRouter) assisted with cherry-picking against the current upstream master and PR preparation. The change itself was authored locally by the repository owner.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
