### PR TITLE
fix(grok): isolate managed instructions for concurrent runs

### DIFF
--- a/packages/adapters/grok-local/src/index.ts
+++ b/packages/adapters/grok-local/src/index.ts
@@ -23,7 +23,7 @@ Don't use when:
 
 Core fields:
 - cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
-- instructionsFilePath (string, optional): absolute path to a markdown instructions file, at most 64 KiB encoded as UTF-8. Paperclip reads its contents and passes them via \`--rules\` for each run, preserving existing project instruction files; larger inline instructions are rejected before launch
+- instructionsFilePath (string, optional): absolute path to a markdown instructions file, at most 64 KiB encoded as UTF-8. Paperclip reads its contents and passes them via \`--rules\` for each run, preserving existing project instruction files; larger inline instructions are rejected before launch. Reads are bounded to 64 KiB plus one overflow byte, even if the file grows; symlinks to regular files are supported, and non-regular files are rejected
 - promptTemplate (string, optional): run prompt template
 - model (string, optional): Grok model id. Defaults to grok-build.
 - permissionMode (string, optional): Grok permission mode passed via \`--permission-mode\`. Unset by default: Grok >= 1.0 enforces \`dontAsk\` as deny-by-default and it overrides \`--always-approve\`, so unattended runs rely on \`--always-approve\` alone unless you explicitly need a mode

--- a/packages/adapters/grok-local/src/index.ts
+++ b/packages/adapters/grok-local/src/index.ts
@@ -14,7 +14,7 @@ Adapter: grok_local
 Use when:
 - You want Paperclip to run the native Grok Build CLI locally on the host machine
 - You want resumable Grok sessions across heartbeats via \`--resume\`
-- You want Paperclip-managed instructions and skills staged into the execution workspace using Grok's native discovery paths (\`Agents.md\` and \`.claude/skills\`)
+- You want Paperclip-managed instructions appended to each run's system prompt and skills staged in \`.claude/skills\`
 
 Don't use when:
 - You need a webhook-style external invocation (use http or openclaw_gateway)
@@ -23,7 +23,7 @@ Don't use when:
 
 Core fields:
 - cwd (string, optional): default absolute working directory fallback for the agent process (created if missing when possible)
-- instructionsFilePath (string, optional): absolute path to a markdown instructions file. Paperclip stages it into the execution workspace as \`Agents.md\` when safe, otherwise falls back to \`--rules @file\`
+- instructionsFilePath (string, optional): absolute path to a markdown instructions file, at most 64 KiB encoded as UTF-8. Paperclip reads its contents and passes them via \`--rules\` for each run, preserving existing project instruction files; larger inline instructions are rejected before launch
 - promptTemplate (string, optional): run prompt template
 - model (string, optional): Grok model id. Defaults to grok-build.
 - permissionMode (string, optional): Grok permission mode passed via \`--permission-mode\`. Unset by default: Grok >= 1.0 enforces \`dontAsk\` as deny-by-default and it overrides \`--always-approve\`, so unattended runs rely on \`--always-approve\` alone unless you explicitly need a mode

--- a/packages/adapters/grok-local/src/server/execute.test.ts
+++ b/packages/adapters/grok-local/src/server/execute.test.ts
@@ -173,7 +173,120 @@ describe("grok_local execute", () => {
     await Promise.all(tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
   });
 
-  it("stages Grok-native instructions and skills into the workspace for the run and cleans them up afterward", async () => {
+  it.each([null, "Project instructions must remain unchanged.\n"])(
+    "keeps concurrent managed instructions separate without changing project Agents.md: %s",
+    async (projectInstructions) => {
+      const cwd = await makeTempRoot();
+      const managed = await makeTempRoot();
+      const projectPath = path.join(cwd, "Agents.md");
+      if (projectInstructions !== null) await fs.writeFile(projectPath, projectInstructions, "utf8");
+      const rules = ["You are Agent Alpha.\nKeep the first task private.\n", "You are Agent Beta.\nKeep the second task private.\n"];
+      const contexts = await Promise.all(rules.map(async (content, index) => {
+        const instructionsFilePath = path.join(managed, `agent-${index}.md`);
+        await fs.writeFile(instructionsFilePath, content, "utf8");
+        const ctx = await makeCtx(`concurrent-${index}`, cwd);
+        ctx.agent.id = `agent-${index}`;
+        ctx.config = { cwd, instructionsFilePath, paperclipRuntimeSkills: [], paperclipSkillSync: { desiredSkills: [] } };
+        ctx.onMeta = vi.fn(async () => {});
+        return ctx;
+      }));
+      let started = 0;
+      let release!: () => void;
+      const bothStarted = new Promise<void>((resolve) => { release = resolve; });
+      const delivered = new Map<string, string>();
+      runProcessMock.mockImplementation(async (runId, _target, _command, args: string[]) => {
+        if (++started === 2) release();
+        await bothStarted;
+        const rulesIndex = args.indexOf("--rules");
+        expect(rulesIndex).toBeGreaterThan(-1);
+        delivered.set(runId, args[rulesIndex + 1]!);
+        if (projectInstructions === null) expect(await pathExists(projectPath)).toBe(false);
+        else expect(await fs.readFile(projectPath, "utf8")).toBe(projectInstructions);
+        return makeSuccessfulRunResult();
+      });
+
+      const results = await Promise.all(contexts.map(execute));
+
+      expect(results.map((result) => result.exitCode)).toEqual([0, 0]);
+      for (const [index, ctx] of contexts.entries()) {
+        expect(delivered.get(ctx.runId)).toBe(rules[index]);
+        const metadata = vi.mocked(ctx.onMeta!).mock.calls[0]![0];
+        expect(metadata.commandArgs).not.toContain(rules[index]);
+      }
+      if (projectInstructions === null) expect(await pathExists(projectPath)).toBe(false);
+      else expect(await fs.readFile(projectPath, "utf8")).toBe(projectInstructions);
+    },
+  );
+
+  it("passes uppercase AGENTS.md through rules without creating a shared alias file", async () => {
+    const cwd = await makeTempRoot();
+    const canonical = path.join(cwd, "AGENTS.md");
+    await fs.writeFile(canonical, "Canonical project instructions.\n", "utf8");
+    runProcessMock.mockImplementation(async (_runId, _target, _command, args: string[]) => {
+      expect(args[args.indexOf("--rules") + 1]).toBe("Canonical project instructions.\n");
+      expect(await pathExists(path.join(cwd, "Agents.md"))).toBe(false);
+      return makeSuccessfulRunResult();
+    });
+
+    await execute(await makeCtx("canonical-instructions", cwd));
+
+    expect(await fs.readFile(canonical, "utf8")).toBe("Canonical project instructions.\n");
+    expect(await pathExists(path.join(cwd, "Agents.md"))).toBe(false);
+  });
+
+  it("rejects unreadable managed instructions even when the project has Agents.md", async () => {
+    const cwd = await makeTempRoot();
+    const projectPath = path.join(cwd, "Agents.md");
+    await fs.writeFile(projectPath, "Existing project policy.\n", "utf8");
+    const ctx = await makeCtx("missing-instructions", cwd);
+    ctx.config.instructionsFilePath = path.join(cwd, "missing.md");
+    runProcessMock.mockResolvedValue(makeSuccessfulRunResult());
+
+    await expect(execute(ctx)).rejects.toMatchObject({ code: "ENOENT" });
+
+    expect(runProcessMock).not.toHaveBeenCalled();
+    expect(await fs.readFile(projectPath, "utf8")).toBe("Existing project policy.\n");
+  });
+
+  it.each([0, 1])("bounds inline instructions by UTF-8 bytes at 64 KiB plus %i", async (extraBytes) => {
+    const cwd = await makeTempRoot();
+    const instructionsFilePath = path.join(cwd, "managed-policy.md");
+    const content = "é".repeat(32 * 1024) + "x".repeat(extraBytes);
+    await fs.writeFile(instructionsFilePath, content, "utf8");
+    const ctx = await makeCtx("instruction-byte-limit", cwd);
+    ctx.config.instructionsFilePath = instructionsFilePath;
+    runProcessMock.mockResolvedValue(makeSuccessfulRunResult());
+
+    if (extraBytes === 0) {
+      await expect(execute(ctx)).resolves.toMatchObject({ exitCode: 0 });
+      const args = runProcessMock.mock.calls[0]![3] as string[];
+      expect(args[args.indexOf("--rules") + 1]).toBe(content);
+    } else {
+      await expect(execute(ctx)).rejects.toThrow(/64 KiB.*UTF-8.*Reduce/i);
+      expect(runProcessMock).not.toHaveBeenCalled();
+      expect(ensureRuntimeInstalledMock).not.toHaveBeenCalled();
+    }
+  });
+
+  it("delivers managed instruction text to remote runs without a host file reference", async () => {
+    const cwd = await makeTempRoot();
+    const managed = await makeTempRoot();
+    const instructionsFilePath = path.join(managed, "instructions.md");
+    await fs.writeFile(instructionsFilePath, "Remote run policy.\n", "utf8");
+    remoteState.isRemote = true;
+    const ctx = await makeCtx("remote-instructions", cwd);
+    ctx.config = { cwd, instructionsFilePath, env: { XAI_API_KEY: "fixture-api-key" } };
+    runProcessMock.mockImplementation(async (_runId, _target, _command, args: string[]) => {
+      expect(args[args.indexOf("--rules") + 1]).toBe("Remote run policy.\n");
+      expect(args).not.toContain(`@${instructionsFilePath}`);
+      expect(await pathExists(path.join(cwd, "Agents.md"))).toBe(false);
+      return makeSuccessfulRunResult();
+    });
+
+    await execute(ctx);
+  });
+
+  it("passes managed rules directly while staging and cleaning up native skills", async () => {
     const root = await makeTempRoot();
     const instructionsPath = path.join(root, "managed", "AGENTS.md");
     const skillSource = path.join(root, "runtime-skills", "paperclip");
@@ -193,7 +306,8 @@ describe("grok_local execute", () => {
       // Grok >= 1.0 enforces `dontAsk` as deny-by-default over --always-approve,
       // so no permission mode may be passed unless explicitly configured.
       expect(args).not.toContain("--permission-mode");
-      expect(await fs.readFile(path.join(root, "Agents.md"), "utf8")).toContain("You are Grok.");
+      expect(args[args.indexOf("--rules") + 1]).toBe("You are Grok.\n");
+      expect(await pathExists(path.join(root, "Agents.md"))).toBe(false);
       expect(await pathExists(path.join(root, ".claude", "skills", "paperclip", "SKILL.md"))).toBe(true);
       await options.onLog?.("stdout", '{"type":"text","data":"done"}\n');
       return {

--- a/packages/adapters/grok-local/src/server/execute.ts
+++ b/packages/adapters/grok-local/src/server/execute.ts
@@ -44,6 +44,7 @@ import { DEFAULT_GROK_LOCAL_MODEL } from "../index.js";
 import { copyBackGrokAuth } from "./grok-auth-copyback.js";
 import { resolveManagedGrokHomeDir, stageGrokHomeForSync } from "./grok-home.js";
 import { isGrokUnknownSessionError, parseGrokJsonl } from "./parse.js";
+import { readGrokInstructions } from "./instructions.js";
 
 const __moduleDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -204,12 +205,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   }
   // Grok's --rules accepts text, not an @file reference. Read once per run so
   // concurrent agents never create, replace or remove a shared Agents.md.
-  const rules = rulesSource ? await fs.readFile(rulesSource, "utf8") : null;
-  if (rules !== null && Buffer.byteLength(rules, "utf8") > 64 * 1024) {
-    throw new Error(
-      "Grok inline instructions exceed the 64 KiB UTF-8 limit for --rules. Reduce the instruction file and keep larger reference material in separate files.",
-    );
-  }
+  const rules = rulesSource ? await readGrokInstructions(rulesSource) : null;
   const stagedAssets = await stageGrokProjectAssets({
     cwd,
     skillEntries: grokSkillEntries,

--- a/packages/adapters/grok-local/src/server/execute.ts
+++ b/packages/adapters/grok-local/src/server/execute.ts
@@ -86,16 +86,9 @@ function renderApiAccessNote(env: Record<string, string>): string {
   ].join("\n");
 }
 
-type StageCleanup = {
-  kind: "file" | "dir";
-  path: string;
-};
-
 type StagedGrokAssets = {
   cleanup: () => Promise<void>;
   stagedSkillsCount: number;
-  stagedInstructionsPath: string | null;
-  rulesFilePath: string | null;
 };
 
 async function pathExists(candidate: string): Promise<boolean> {
@@ -104,44 +97,16 @@ async function pathExists(candidate: string): Promise<boolean> {
 
 async function stageGrokProjectAssets(input: {
   cwd: string;
-  instructionsFilePath: string;
   skillEntries: Array<{ key: string; runtimeName: string; source: string }>;
   desiredSkillNames: string[];
   onLog: AdapterExecutionContext["onLog"];
 }): Promise<StagedGrokAssets> {
-  const cleanup: StageCleanup[] = [];
+  const cleanup: string[] = [];
   const ensureCleanupDir = (candidate: string) => {
-    cleanup.push({ kind: "dir", path: candidate });
-  };
-  const ensureCleanupFile = (candidate: string) => {
-    cleanup.push({ kind: "file", path: candidate });
+    cleanup.push(candidate);
   };
 
-  let stagedInstructionsPath: string | null = null;
-  let rulesFilePath: string | null = null;
   let stagedSkillsCount = 0;
-
-  const instructionsTarget = path.join(input.cwd, "Agents.md");
-  if (input.instructionsFilePath) {
-    if (!await pathExists(instructionsTarget)) {
-      await fs.copyFile(input.instructionsFilePath, instructionsTarget);
-      ensureCleanupFile(instructionsTarget);
-      stagedInstructionsPath = instructionsTarget;
-    } else if (path.resolve(instructionsTarget) !== path.resolve(input.instructionsFilePath)) {
-      rulesFilePath = input.instructionsFilePath;
-      await input.onLog(
-        "stdout",
-        `[paperclip] Grok workspace already contains ${instructionsTarget}; using --rules @${input.instructionsFilePath} instead of overwriting it.\n`,
-      );
-    }
-  } else {
-    const canonicalAgents = path.join(input.cwd, "AGENTS.md");
-    if (!await pathExists(instructionsTarget) && await pathExists(canonicalAgents)) {
-      await fs.copyFile(canonicalAgents, instructionsTarget);
-      ensureCleanupFile(instructionsTarget);
-      stagedInstructionsPath = instructionsTarget;
-    }
-  }
 
   const desiredSet = new Set(input.desiredSkillNames);
   const selectedSkills = input.skillEntries.filter((entry) => desiredSet.has(entry.key));
@@ -174,15 +139,9 @@ async function stageGrokProjectAssets(input: {
 
   return {
     stagedSkillsCount,
-    stagedInstructionsPath,
-    rulesFilePath,
     cleanup: async () => {
       for (const entry of [...cleanup].reverse()) {
-        if (entry.kind === "file") {
-          await fs.rm(entry.path, { force: true }).catch(() => undefined);
-          continue;
-        }
-        await fs.rm(entry.path, { recursive: true, force: true }).catch(() => undefined);
+        await fs.rm(entry, { recursive: true, force: true }).catch(() => undefined);
       }
     },
   };
@@ -238,9 +197,21 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   const grokSkillEntries = await readPaperclipRuntimeSkillEntries(config, __moduleDir);
   const desiredGrokSkillNames = resolveLegacyPaperclipDesiredSkillNames(config, grokSkillEntries);
   const instructionsFilePath = asString(config.instructionsFilePath, "").trim();
+  let rulesSource = instructionsFilePath;
+  if (!rulesSource && !await pathExists(path.join(cwd, "Agents.md"))) {
+    const canonicalAgents = path.join(cwd, "AGENTS.md");
+    if (await pathExists(canonicalAgents)) rulesSource = canonicalAgents;
+  }
+  // Grok's --rules accepts text, not an @file reference. Read once per run so
+  // concurrent agents never create, replace or remove a shared Agents.md.
+  const rules = rulesSource ? await fs.readFile(rulesSource, "utf8") : null;
+  if (rules !== null && Buffer.byteLength(rules, "utf8") > 64 * 1024) {
+    throw new Error(
+      "Grok inline instructions exceed the 64 KiB UTF-8 limit for --rules. Reduce the instruction file and keep larger reference material in separate files.",
+    );
+  }
   const stagedAssets = await stageGrokProjectAssets({
     cwd,
-    instructionsFilePath,
     skillEntries: grokSkillEntries,
     desiredSkillNames: desiredGrokSkillNames,
     onLog,
@@ -453,11 +424,8 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     const commandNotes = (() => {
       const notes: string[] = ["Prompt is passed to Grok via --single in headless mode."];
       if (alwaysApprove) notes.push("Added --always-approve for unattended execution.");
-      if (stagedAssets.stagedInstructionsPath) {
-        notes.push(`Staged project instructions at ${stagedAssets.stagedInstructionsPath} for native Grok discovery.`);
-      }
-      if (stagedAssets.rulesFilePath) {
-        notes.push(`Applied fallback instructions via --rules @${stagedAssets.rulesFilePath}.`);
+      if (rules !== null) {
+        notes.push(`Appended instructions from ${rulesSource} to the system prompt via --rules.`);
       }
       if (stagedAssets.stagedSkillsCount > 0) {
         notes.push(`Staged ${stagedAssets.stagedSkillsCount} Paperclip skill(s) into .claude/skills for native Grok discovery.`);
@@ -506,7 +474,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       if (permissionMode) args.push("--permission-mode", permissionMode);
       if (alwaysApprove) args.push("--always-approve");
       if (disableWebSearch) args.push("--disable-web-search");
-      if (stagedAssets.rulesFilePath) args.push("--rules", `@${stagedAssets.rulesFilePath}`);
+      if (rules !== null) args.push("--rules", rules);
       const extraArgs = (() => {
         const fromExtraArgs = asStringArray(config.extraArgs);
         if (fromExtraArgs.length > 0) return fromExtraArgs;
@@ -525,9 +493,11 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
           command: resolvedCommand,
           cwd: effectiveExecutionCwd,
           commandNotes,
-          commandArgs: args.map((value, index) => (
-            index === args.length - 1 ? `<prompt ${prompt.length} chars>` : value
-          )),
+          commandArgs: args.map((value, index) => {
+            if (index === args.length - 1) return `<prompt ${prompt.length} chars>`;
+            if (index > 0 && args[index - 1] === "--rules") return `<instructions ${value.length} chars>`;
+            return value;
+          }),
           env: loggedEnv,
           prompt,
           promptMetrics,

--- a/packages/adapters/grok-local/src/server/instructions.test.ts
+++ b/packages/adapters/grok-local/src/server/instructions.test.ts
@@ -1,0 +1,164 @@
+import { constants } from "node:fs";
+import fs, { type FileHandle } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { readGrokInstructions } from "./instructions.js";
+
+const limit = 64 * 1024;
+const roots: string[] = [];
+
+async function fixture(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "grok-instruction-read-"));
+  roots.push(root);
+  return path.join(root, "rules.md");
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+describe("readGrokInstructions", () => {
+  it.each(["", "é".repeat(limit / 2), "🙂".repeat(limit / 4)])(
+    "reads UTF-8 within the byte bound (case %#)",
+    async (content) => {
+      const file = await fixture();
+      await fs.writeFile(file, content);
+      expect(await readGrokInstructions(file)).toBe(content);
+    },
+  );
+
+  it("rejects oversized sparse files before allocating or reading their contents", async () => {
+    const file = await fixture();
+    await fs.writeFile(file, "");
+    await fs.truncate(file, 1024 * 1024 * 1024);
+    const open = fs.open.bind(fs);
+    const read = vi.fn();
+    const close = vi.fn();
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await open(...args);
+      read.mockImplementation(handle.read.bind(handle));
+      close.mockImplementation(handle.close.bind(handle));
+      handle.read = read;
+      handle.close = close;
+      return handle;
+    });
+
+    await expect(readGrokInstructions(file)).rejects.toThrow(/64 KiB/);
+    expect(read).not.toHaveBeenCalled();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the encoded-text limit when invalid UTF-8 expands during decoding", async () => {
+    const file = await fixture();
+    await fs.writeFile(file, Buffer.alloc(limit, 0x80));
+    await expect(readGrokInstructions(file)).rejects.toThrow(/64 KiB/);
+  });
+
+  it("assembles short reads before decoding split multibyte characters", async () => {
+    const file = await fixture();
+    const content = "🙂é".repeat(200);
+    await fs.writeFile(file, content);
+    const open = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await open(...args);
+      const read = handle.read.bind(handle);
+      handle.read = vi.fn(async (buffer: Buffer, offset: number, length: number, position: number) =>
+        read(buffer, offset, Math.min(length, 7), position),
+      ) as unknown as FileHandle["read"];
+      return handle;
+    });
+
+    expect(await readGrokInstructions(file)).toBe(content);
+  });
+
+  it("bounds reads if a file grows after stat, including repeated short reads", async () => {
+    const file = await fixture();
+    await fs.writeFile(file, "original");
+    const open = fs.open.bind(fs);
+    let consumed = 0;
+    const capacities: number[] = [];
+    const close = vi.fn();
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await open(...args);
+      const stat = handle.stat.bind(handle);
+      const read = handle.read.bind(handle);
+      close.mockImplementation(handle.close.bind(handle));
+      handle.close = close;
+      handle.stat = vi.fn(async () => {
+        const before = await stat();
+        await fs.writeFile(file, "é".repeat(limit));
+        return before;
+      }) as unknown as FileHandle["stat"];
+      handle.read = vi.fn(async (buffer: Buffer, offset: number, length: number, position: number) => {
+        capacities.push(buffer.length);
+        const result = await read(buffer, offset, Math.min(length, 997), position);
+        consumed += result.bytesRead;
+        return result;
+      }) as unknown as FileHandle["read"];
+      return handle;
+    });
+
+    await expect(readGrokInstructions(file)).rejects.toThrow(/64 KiB/);
+    expect(consumed).toBe(limit + 1);
+    expect(new Set(capacities)).toEqual(new Set([limit + 1]));
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("accepts a managed symlink and pins its opened target across replacement", async () => {
+    const file = await fixture();
+    const link = `${file}.link`;
+    const replacement = `${file}.replacement`;
+    await fs.writeFile(file, "Original target policy");
+    await fs.writeFile(replacement, "Replacement policy");
+    await fs.symlink(file, link);
+    const open = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await open(...args);
+      await fs.unlink(link);
+      await fs.symlink(replacement, link);
+      return handle;
+    });
+
+    expect(await readGrokInstructions(link)).toBe("Original target policy");
+  });
+
+  it("rejects non-regular targets before reading and uses nonblocking open", async () => {
+    const file = await fixture();
+    const open = fs.open.bind(fs);
+    const read = vi.fn();
+    const close = vi.fn();
+    const opened = vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await open(...args);
+      read.mockImplementation(handle.read.bind(handle));
+      close.mockImplementation(handle.close.bind(handle));
+      handle.read = read;
+      handle.close = close;
+      return handle;
+    });
+
+    await expect(readGrokInstructions(path.dirname(file))).rejects.toThrow(/regular file/);
+    expect(opened).toHaveBeenCalledWith(path.dirname(file), constants.O_RDONLY | constants.O_NONBLOCK);
+    expect(read).not.toHaveBeenCalled();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it.each(["stat", "read"] as const)("closes the file after a %s failure", async (operation) => {
+    const file = await fixture();
+    await fs.writeFile(file, "Policy");
+    const open = fs.open.bind(fs);
+    const close = vi.fn();
+    const failure = new Error("Synthetic IO failure");
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await open(...args);
+      close.mockImplementation(handle.close.bind(handle));
+      handle.close = close;
+      handle[operation] = vi.fn().mockRejectedValue(failure);
+      return handle;
+    });
+
+    await expect(readGrokInstructions(file)).rejects.toBe(failure);
+    expect(close).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/adapters/grok-local/src/server/instructions.ts
+++ b/packages/adapters/grok-local/src/server/instructions.ts
@@ -1,0 +1,39 @@
+import { constants } from "node:fs";
+import fs from "node:fs/promises";
+
+const MAX_INSTRUCTION_BYTES = 64 * 1024;
+
+function oversizedInstructions(): Error {
+  return new Error(
+    "Grok inline instructions exceed the 64 KiB UTF-8 limit for --rules. Reduce the instruction file and keep larger reference material in separate files.",
+  );
+}
+
+export async function readGrokInstructions(filePath: string): Promise<string> {
+  // Follow managed symlinks, but validate and read the same opened target.
+  // Nonblocking open lets us reject FIFOs without waiting for a writer.
+  const handle = await fs.open(filePath, constants.O_RDONLY | constants.O_NONBLOCK);
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) throw new Error("Grok instructions must resolve to a regular file.");
+    if (stat.size > MAX_INSTRUCTION_BYTES) throw oversizedInstructions();
+
+    // A stat-only limit races with appends. Read at most one byte beyond the
+    // limit, even if the file grows after stat or read returns short chunks.
+    const buffer = Buffer.alloc(MAX_INSTRUCTION_BYTES + 1);
+    let offset = 0;
+    while (offset < buffer.length) {
+      const { bytesRead } = await handle.read(buffer, offset, buffer.length - offset, offset);
+      if (bytesRead === 0) break;
+      offset += bytesRead;
+    }
+    if (offset > MAX_INSTRUCTION_BYTES) throw oversizedInstructions();
+    const rules = buffer.subarray(0, offset).toString("utf8");
+    // Keep the encoded-text limit when malformed input expands to UTF-8
+    // replacement characters during decoding, matching fs.readFile's behaviour.
+    if (Buffer.byteLength(rules, "utf8") > MAX_INSTRUCTION_BYTES) throw oversizedInstructions();
+    return rules;
+  } finally {
+    await handle.close();
+  }
+}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The Grok adapter supplies managed instructions to each local run.
> - Two runs can use the same working directory.
> - Both runs previously used a shared Agents.md file for different instructions.
> - A run could read the other agent's instructions, or remove the file while that agent still needed it.
> - This pull request passes instruction text through Grok's native --rules option for each run.
> - Each run receives its own instructions without changing project instruction files.

## Linked Issues or Issue Description

Refs #6087, which introduced the adapter. A search of open and closed pull requests found no direct fix for this race.

**What happened?**

A native concurrent test returned the other agent's account-bound policy. The adapter copied instructions to a common Agents.md file. Its fallback passed @file to --rules, which accepts text rather than a file reference.

**Expected behavior**

Each run receives its configured instruction text. Existing project instruction files remain intact.

**Steps to reproduce**

1. Configure two local Grok agents with different instruction files and the same working directory.
2. Start both agents at the same time. Ask each to return a distinct instruction marker without tools.
3. Observe the shared file or returned markers. Before this fix, one run can consume the other file.

## What Changed

- Read managed instructions once and pass their text through --rules.
- Preserve native Agents.md discovery and the uppercase AGENTS.md fallback without writing project files.
- Validate the opened regular-file target and read at most 65,537 bytes. Reject oversized files before reading their contents. Preserve the bound if a file grows after the size check.
- Support managed symlinks without reopening the target. Reject non-regular targets and close the file on every path.
- Hide inline instruction contents in command metadata.
- Add regression tests for concurrency, existing files, fallback, read failures and byte limits.

## Verification

- At commit 4ed0ec344, all 136 source tests across 13 files pass with `pnpm exec vitest run packages/adapters/grok-local/src`.
- Grok adapter typecheck and build pass. Full repository checks were not rerun locally for this follow-up; all required code, build, typecheck and end-to-end CI gates passed for commit 4ed0ec344.
- New cases cover UTF-8 boundaries, invalid input expansion, short reads, sparse files, growth after stat, symlink replacement and cleanup on failure.
- A fresh native concurrent test passed after the fix. Both runs returned their own expected policy. No tool calls or shared Agents.md file changes were observed.
- The exact 65,536-byte UTF-8 boundary succeeds; one extra byte fails before runtime installation or process launch.
- No database migration or dependency change.

## Risks

- Native --rules appends text to the system prompt. This changes delivery from a project discovery file.
- Inline instructions now have an explicit 64 KiB UTF-8 limit to avoid operating-system argument-size errors. Larger material must stay in reference files.
- Instructions remain visible to a user who can inspect process arguments on the host. They must not contain credentials.
- Existing shared skill staging is unchanged. This fix does not make all shared-directory execution safe.
- This PR remains a draft. The process-argument instruction exposure finding is unresolved. ACP supports additive `_meta.rules`, but a safe integration still needs session, permission, cancellation and usage support. The bounded-read change does not resolve that transport finding.

## Model Used

OpenAI GPT-6 assisted with implementation and review through Codex, using code execution and tests. The exact deployment identifier and context-window size were not exposed in this session. Native Grok verification reported grok-4.6-build; it performed instruction probes rather than code generation.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used, with available version and capability details
- [x] I have checked ROADMAP.md; this is a focused adapter bug fix
- [x] I have searched GitHub for duplicate or related PRs and linked the adapter origin above
- [x] I have described the issue using the bug report fields
- [x] I have not referenced internal or instance-local issues or links
- [x] My branch name describes the change and contains no internal ticket identifiers
- [x] Focused local tests pass
- [x] I have added regression tests
- [x] I have updated adapter documentation
- [x] I have documented the risks
- [x] All Paperclip CI gates are green for the current head
- [ ] No unresolved security findings or reviewer follow-ups remain
- [x] I will address reviewer comments before requesting merge
