### PR TITLE
feat(secrets): resolve existing Google Secret Manager versions

### DIFF
--- a/doc/SECRETS-GCP-PROVIDER.md
+++ b/doc/SECRETS-GCP-PROVIDER.md
@@ -1,0 +1,127 @@
+# Google Secret Manager provider
+
+Paperclip can link and resolve existing **global** Google Secret Manager secrets.
+The provider uses the server's Application Default Credentials (ADC). It supports
+UTF-8 secret values up to Google's 64 KiB payload limit and verifies the returned
+CRC32C checksum before returning a value.
+
+This implementation does not create, update, list, disable or delete Google
+secrets. Manage remote values and IAM in Google Cloud. Removing a Paperclip
+reference only changes Paperclip metadata.
+
+## Configure a provider vault
+
+Create a company provider vault with non-sensitive routing metadata:
+
+```json
+{
+  "provider": "gcp_secret_manager",
+  "displayName": "Production Google secrets",
+  "status": "ready",
+  "config": {
+    "projectId": "example-project",
+    "location": "global",
+    "secretNamePrefix": "app-"
+  }
+}
+```
+
+`projectId` accepts a Google project ID or number and is required for resolution.
+`location` can be omitted or `global`; regional resources are not supported.
+`secretNamePrefix` is optional and restricts the names this vault can resolve.
+Legacy `namespace` metadata is informational only; it is not an access boundary.
+No credentials, credential file paths or access tokens belong in this JSON.
+
+A deployment default can instead use `PAPERCLIP_SECRETS_GCP_PROJECT_ID`. An
+explicitly selected vault never falls back to the deployment project. Reference
+project identifiers must exactly match the configured ID or number. Google may
+return the equivalent numeric project number in its response; Paperclip retains
+the configured identifier in its stored reference.
+
+New GCP vaults default to `ready`. Existing vaults explicitly saved as
+`coming_soon` remain locked until an operator changes their status. A health check
+validates routing metadata only and reports credentials/access as unverified;
+it does not read a secret or claim an IAM check succeeded.
+
+## Credentials and permissions
+
+The supported Google authentication library discovers ADC from deployment
+configuration, a local ADC file or an attached workload identity. ADC and the
+credentials used by an ordinary `gcloud` command are distinct. A Windows ADC file
+is not automatically discovered by a Linux server. Operators can set
+`GOOGLE_APPLICATION_CREDENTIALS` to an existing, trusted ADC configuration file
+that the server can read; its path belongs in deployment configuration, not the
+company provider vault.
+
+For local development without existing ADC, Google supports
+`gcloud auth application-default login`. This is a separate sign-in step. For
+hosted use, prefer workload identity configured by the deployment operator.
+Paperclip does not run login commands, change IAM, enable APIs or create service
+accounts.
+
+The server identity needs `secretmanager.versions.access` on each intended
+secret, normally through Secret Manager Secret Accessor (`roles/secretmanager.secretAccessor`).
+Scope that permission to the necessary secrets. The provider does not need
+permissions to list secrets or write versions. User ADC may additionally need
+the quota-project permissions required by Google; a signed-in CLI alone does not
+prove any of these permissions.
+
+## Link and resolve
+
+Use the existing company secret create API in external-reference mode:
+
+```json
+{
+  "name": "Application credential",
+  "provider": "gcp_secret_manager",
+  "managedMode": "external_reference",
+  "providerConfigId": "<company-provider-vault-id>",
+  "externalRef": "projects/example-project/secrets/app-credential",
+  "providerVersionRef": "7"
+}
+```
+
+The reference can also include `/versions/7`. If both selectors are supplied,
+they must agree. An omitted selector or `latest` resolves the latest Google
+version **at link time**. Linking reads that version once to verify access and
+integrity, then pins the returned numeric version. The stored material contains
+the resource reference, version and fingerprint, never the payload.
+
+Subsequent resolutions read the pinned Google version. To adopt a later remote
+rotation, use Paperclip's change-reference action with the new version or
+`latest`; Paperclip creates a new local version record. A Google version that is
+disabled or destroyed causes resolution to fail. Legacy metadata-only GCP links
+with no version selector continue to follow `latest` until relinked.
+
+Calls use Google's fixed HTTPS access endpoint, bounded request timeouts and no
+HTTP redirects. Malformed responses, payload integrity failures and provider or
+authentication errors fail closed. Returned errors contain fixed explanations
+and error codes; raw response bodies, credentials and exception causes are not
+retained in them.
+
+## Where the boundary ends
+
+Company scoping, binding checks, access auditing and run-log redaction remain in
+Paperclip's existing secret service. Resolving a reference on the server avoids
+storing plaintext values in the provider material; it does not make values
+unreadable to their consumers.
+
+An environment binding injects the resolved value into the agent process.
+Paperclip also already exposes `POST /api/agents/me/secrets/:key/value`, which
+returns a raw value to a suitably authorised agent with an active run and a
+granted secret binding. This provider does not add or bypass that API. An agent
+that receives a value can read, log or transmit it. Unrestricted agents running
+under the server's operating-system user may also access its ADC files or other
+process resources. Strong isolation requires separate operating-system
+identities or sandboxes and appropriately scoped Google IAM.
+
+Back up Paperclip's database to preserve vaults, references, bindings and pinned
+version records. The values remain in Google Secret Manager; a restore also
+requires access to those same remote versions.
+
+## References
+
+- [Google Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials)
+- [AccessSecretVersion REST contract and required permission](https://cloud.google.com/secret-manager/docs/reference/rest/v1/projects.secrets.versions/access)
+- [Secret payload encoding and integrity checksum](https://cloud.google.com/secret-manager/docs/reference/rest/v1/SecretPayload)
+- [Google Auth Library for Node.js](https://github.com/googleapis/google-cloud-node-core/tree/main/packages/google-auth-library)

--- a/docs/api/secrets.md
+++ b/docs/api/secrets.md
@@ -221,14 +221,17 @@ Per-provider `config` shapes:
 - `local_encrypted`: optional `backupReminderAcknowledged: boolean`.
 - `aws_secrets_manager`: required `region`; optional `namespace`,
   `secretNamePrefix`, `kmsKeyId`, `ownerTag`, `environmentTag`.
-- `gcp_secret_manager` (coming soon): optional `projectId`, `location`,
-  `namespace`, `secretNamePrefix`.
+- `gcp_secret_manager`: `projectId` (ID or number) required for resolution;
+  optional `location: "global"` and `secretNamePrefix`. Legacy `namespace`
+  is informational metadata only. Supports linking existing secrets and
+  resolution, with no remote writes. Linking verifies access and pins the
+  resolved numeric Google version. See `doc/SECRETS-GCP-PROVIDER.md`.
 - `vault` (coming soon): optional origin-only HTTPS `address`, `namespace`,
   `mountPath`, `secretPathPrefix`. `address` values with embedded credentials,
   paths, query strings, or fragments are rejected.
 
-`status` defaults to `ready` for `local_encrypted` and `aws_secrets_manager`,
-and to `coming_soon` for `gcp_secret_manager` and `vault`. Coming-soon and
+`status` defaults to `ready` for `local_encrypted`, `aws_secrets_manager` and
+`gcp_secret_manager`, and to `coming_soon` for `vault`. Coming-soon and
 disabled vaults cannot be marked `isDefault`. Setting `isDefault: true` clears
 the previous default for the same provider in the same transaction.
 

--- a/docs/deploy/secrets.md
+++ b/docs/deploy/secrets.md
@@ -296,11 +296,14 @@ Each vault carries a status that drives what the runtime can do with it:
 | `coming_soon` | Visible and editable as draft metadata, but locked out of all runtime operations.            |
 | `disabled`    | Soft-deleted. Hidden from the secret create/rotate flow.                                      |
 
-`gcp_secret_manager` and `vault` are pinned to `coming_soon` until their
-runtime modules ship. The settings UI lets you save draft configuration for
-those providers (and surfaces them on the vault list), but secret create,
-rotate, and resolve calls that target a coming-soon vault fail with a clear
-runtime-locked error.
+`gcp_secret_manager` supports linking existing global Google Secret Manager
+versions and resolving them through the server's Application Default Credentials.
+It does not write remote values. New vaults default to `ready`; existing draft
+vaults stay `coming_soon` until edited. See `doc/SECRETS-GCP-PROVIDER.md` for
+configuration, version pinning and the runtime access boundary.
+
+`vault` remains pinned to `coming_soon`. Secret create, rotate and resolve calls
+that target any coming-soon vault fail with a runtime-locked error.
 
 ### Default Vault Behavior
 
@@ -447,7 +450,10 @@ Each provider family has a different backup story:
   role still has `GetSecretValue` plus KMS decrypt for both managed and linked
   user-scoped values. The full restore checklist lives in
   `doc/SECRETS-AWS-PROVIDER.md`.
-- `gcp_secret_manager` and `vault`: while these are coming soon, only the
+- `gcp_secret_manager`: back up Paperclip metadata, including references and
+  pinned version records. Values remain in Google Secret Manager; restoring
+  resolution also requires access to the same remote versions through server ADC.
+- `vault`: while this is coming soon, only the
   draft vault config exists in Paperclip. Database backups capture it. There
   is nothing to restore on the provider side until runtime support lands.
 

--- a/packages/shared/src/types/secrets.ts
+++ b/packages/shared/src/types/secrets.ts
@@ -146,9 +146,12 @@ export interface AwsSecretsManagerProviderConfig {
 }
 
 export interface GcpSecretManagerProviderConfig {
+  /** Project ID or number. Required for runtime resolution. */
   projectId?: string | null;
-  location?: string | null;
+  location?: "global" | null;
+  /** Informational metadata only; Google Secret Manager has no namespaces. */
   namespace?: string | null;
+  /** If set, linked secret names must begin with this prefix. */
   secretNamePrefix?: string | null;
 }
 

--- a/packages/shared/src/validators/secret.test.ts
+++ b/packages/shared/src/validators/secret.test.ts
@@ -142,6 +142,25 @@ describe("secret validators", () => {
     ).not.toThrow();
   });
 
+  it.each(["example-project", "123456789012"])("accepts ready Google vault metadata for project %s", (projectId) => {
+    expect(() => createSecretProviderConfigSchema.parse({
+      provider: "gcp_secret_manager", displayName: "Google", status: "ready", isDefault: true,
+      config: { projectId, location: "global", secretNamePrefix: "app-" },
+    })).not.toThrow();
+  });
+
+  it.each([
+    { projectId: "https://other.example" },
+    { projectId: "example-project", location: "us-east1" },
+    { projectId: "example-project", credentials: "private-value" },
+    { projectId: "example-project", serviceAccountJson: "private-value" },
+    { projectId: "example-project", keyFile: "/private/credential.json" },
+  ])("rejects unsupported routing and credential fields in Google vault metadata", (config) => {
+    expect(() => createSecretProviderConfigSchema.parse({
+      provider: "gcp_secret_manager", displayName: "Google", status: "ready", config,
+    })).toThrow();
+  });
+
   it("accepts origin-only Vault provider vault addresses", () => {
     expect(() =>
       createSecretProviderConfigSchema.parse({

--- a/packages/shared/src/validators/secret.ts
+++ b/packages/shared/src/validators/secret.ts
@@ -257,8 +257,8 @@ export const awsSecretsManagerProviderConfigSchema = z.object({
 }).strict();
 
 export const gcpSecretManagerProviderConfigSchema = z.object({
-  projectId: z.string().trim().min(1).max(128).regex(/^[a-z][a-z0-9-]{4,127}$/).optional().nullable(),
-  location: optionalSafeShortText,
+  projectId: z.string().trim().regex(/^(?:[a-z][a-z0-9-]{4,28}[a-z0-9]|[1-9][0-9]{0,19})$/, "Invalid Google Cloud project ID or number").optional().nullable(),
+  location: z.literal("global").optional().nullable(),
   namespace: optionalSafeShortText,
   secretNamePrefix: optionalSafeShortText,
 }).strict();
@@ -335,8 +335,8 @@ export const createSecretProviderConfigSchema = z.object({
       });
     }
   }
-  const status = value.status ?? (["gcp_secret_manager", "vault"].includes(value.provider) ? "coming_soon" : "ready");
-  if ((value.provider === "gcp_secret_manager" || value.provider === "vault") && status !== "coming_soon" && status !== "disabled") {
+  const status = value.status ?? (value.provider === "vault" ? "coming_soon" : "ready");
+  if (value.provider === "vault" && status !== "coming_soon" && status !== "disabled") {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ["status"],

--- a/server/package.json
+++ b/server/package.json
@@ -74,6 +74,7 @@
     "drizzle-orm": "^0.45.2",
     "embedded-postgres": "^18.1.0-beta.16",
     "express": "^5.1.0",
+    "google-auth-library": "10.5.0",
     "jsdom": "^30.0.1",
     "multer": "^2.2.0",
     "open": "^11.0.1",

--- a/server/src/__tests__/gcp-secret-manager-provider.test.ts
+++ b/server/src/__tests__/gcp-secret-manager-provider.test.ts
@@ -1,0 +1,189 @@
+import { inspect } from "node:util";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createGcpSecretManagerProvider } from "../secrets/gcp-secret-manager-provider.js";
+import { SecretProviderClientError } from "../secrets/types.js";
+
+const { request, authOptions } = vi.hoisted(() => ({ request: vi.fn(), authOptions: vi.fn() }));
+vi.mock("google-auth-library", () => ({
+  GoogleAuth: class {
+    constructor(options: unknown) { authOptions(options); }
+    request = request;
+  },
+}));
+
+const externalRef = "projects/example-project/secrets/example-key";
+const config = {
+  id: "gcp-vault",
+  provider: "gcp_secret_manager" as const,
+  status: "ready",
+  config: { projectId: "example-project", location: "global" },
+};
+const payload = () => ({
+  name: `${externalRef}/versions/7`,
+  payload: { data: Buffer.from("123456789").toString("base64"), dataCrc32c: "3808858755" },
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllEnvs();
+});
+
+describe("Google Secret Manager external references", () => {
+  it("verifies and pins latest on link, then resolves that immutable version without storing its value", async () => {
+    const accessVersion = vi.fn(async () => payload());
+    const provider = createGcpSecretManagerProvider({ accessVersion });
+
+    const prepared = await provider.linkExternalSecret({ externalRef, providerConfig: config });
+    expect(prepared.providerVersionRef).toBe("7");
+    expect(prepared.externalRef).toBe(externalRef);
+    expect(prepared.valueSha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(JSON.stringify(prepared)).not.toContain("123456789");
+    expect(JSON.stringify(prepared)).not.toContain(payload().payload.data);
+    expect(await provider.resolveVersion({ ...prepared, providerConfig: config })).toBe("123456789");
+    expect(accessVersion.mock.calls).toEqual([
+      [`${externalRef}/versions/latest`], [`${externalRef}/versions/7`],
+    ]);
+  });
+
+  it("uses ADC and the fixed, bounded Google REST read endpoint", async () => {
+    request.mockResolvedValue({ data: payload() });
+    const provider = createGcpSecretManagerProvider();
+    await provider.linkExternalSecret({ externalRef: `${externalRef}/versions/7`, providerConfig: config });
+
+    expect(authOptions).toHaveBeenLastCalledWith(expect.objectContaining({
+      scopes: ["https://www.googleapis.com/auth/cloud-platform"],
+    }));
+    expect(request).toHaveBeenCalledWith({
+      url: `https://secretmanager.googleapis.com/v1/${externalRef}/versions/7:access`,
+      method: "GET", timeout: 30_000, retry: false, maxRedirects: 0, responseType: "json",
+    });
+  });
+
+  it("accepts Google's canonical project number while retaining the vault's requested project ID", async () => {
+    const provider = createGcpSecretManagerProvider({ accessVersion: async () => ({
+      ...payload(), name: "projects/123456789012/secrets/example-key/versions/7",
+    }) });
+    const prepared = await provider.linkExternalSecret({ externalRef, providerConfig: config });
+    expect(prepared.externalRef).toBe(externalRef);
+  });
+
+  it("reports rejected ADC refresh as an authentication failure without retaining its description", async () => {
+    const provider = createGcpSecretManagerProvider({ accessVersion: async () => {
+      throw { response: { status: 400, data: {
+        error: "invalid_grant", error_subtype: "invalid_rapt", error_description: "private-token-or-description",
+      } } };
+    } });
+    let failure: unknown;
+    try { await provider.linkExternalSecret({ externalRef, providerConfig: config }); } catch (error) { failure = error; }
+    expect(failure).toMatchObject({ code: "access_denied", rawMessage: null });
+    expect(inspect(failure, { depth: 8, showHidden: true })).not.toContain("private-token-or-description");
+  });
+
+  it.each([
+    "https://other.example/secret", `${externalRef}?token=secret`, `${externalRef}/../other`,
+    "projects/other-project/secrets/example-key", `${externalRef}/versions/0`,
+    `${externalRef}/versions/custom-alias`, "projects/example-project/locations/us-east1/secrets/example-key",
+  ])("rejects invalid or out-of-vault references before authentication: %s", async (reference) => {
+    const accessVersion = vi.fn();
+    const provider = createGcpSecretManagerProvider({ accessVersion });
+    await expect(provider.linkExternalSecret({ externalRef: reference, providerConfig: config }))
+      .rejects.toMatchObject({ code: "invalid_request" });
+    expect(accessVersion).not.toHaveBeenCalled();
+  });
+
+  it("enforces an optional secret-name prefix before reading", async () => {
+    const accessVersion = vi.fn();
+    const provider = createGcpSecretManagerProvider({ accessVersion });
+    await expect(provider.linkExternalSecret({ externalRef, providerConfig: {
+      ...config, config: { ...config.config, secretNamePrefix: "approved-" },
+    } })).rejects.toMatchObject({ code: "invalid_request" });
+    expect(accessVersion).not.toHaveBeenCalled();
+  });
+
+  it("does not replace an incomplete selected vault with deployment defaults", async () => {
+    vi.stubEnv("PAPERCLIP_SECRETS_GCP_PROJECT_ID", "example-project");
+    const accessVersion = vi.fn();
+    const provider = createGcpSecretManagerProvider({ accessVersion });
+    await expect(provider.linkExternalSecret({ externalRef, providerConfig: { ...config, config: {} } }))
+      .rejects.toMatchObject({ code: "invalid_request" });
+    expect(accessVersion).not.toHaveBeenCalled();
+  });
+
+  it.each(["disabled", "coming_soon"])("rejects a %s vault before reading", async (status) => {
+    const accessVersion = vi.fn();
+    const provider = createGcpSecretManagerProvider({ accessVersion });
+    await expect(provider.linkExternalSecret({ externalRef, providerConfig: { ...config, status } }))
+      .rejects.toMatchObject({ code: "invalid_request" });
+    expect(accessVersion).not.toHaveBeenCalled();
+  });
+
+  it("rejects conflicting selectors and tampered stored reference material", async () => {
+    const accessVersion = vi.fn(async () => payload());
+    const provider = createGcpSecretManagerProvider({ accessVersion });
+    await expect(provider.linkExternalSecret({
+      externalRef: `${externalRef}/versions/7`, providerVersionRef: "8", providerConfig: config,
+    })).rejects.toMatchObject({ code: "invalid_request" });
+    const prepared = await provider.linkExternalSecret({ externalRef, providerConfig: config });
+    accessVersion.mockClear();
+    await expect(provider.resolveVersion({ ...prepared, providerVersionRef: "8", providerConfig: config }))
+      .rejects.toMatchObject({ code: "invalid_request" });
+    await expect(provider.resolveVersion({ ...prepared, externalRef: `${externalRef}-other`, providerConfig: config }))
+      .rejects.toMatchObject({ code: "invalid_request" });
+    expect(accessVersion).not.toHaveBeenCalled();
+  });
+
+  it("can resolve a legacy metadata-only link through the configured project", async () => {
+    const accessVersion = vi.fn(async () => payload());
+    const provider = createGcpSecretManagerProvider({ accessVersion });
+    expect(await provider.resolveVersion({
+      material: { scheme: "external_reference_v1", provider: "gcp_secret_manager", externalRef, providerVersionRef: null },
+      externalRef, providerConfig: config,
+    })).toBe("123456789");
+    expect(accessVersion).toHaveBeenCalledWith(`${externalRef}/versions/latest`);
+  });
+
+  it.each([
+    [401, "access_denied"], [403, "access_denied"], [404, "not_found"],
+    [429, "throttled"], [400, "invalid_request"], [409, "conflict"], [503, "provider_unavailable"],
+    [undefined, "provider_unavailable"],
+  ])("sanitises HTTP/auth failures including status %s without retaining tokens or payloads", async (status, code) => {
+    const marker = "private-value-that-must-never-escape";
+    const provider = createGcpSecretManagerProvider({ accessVersion: async () => {
+      throw Object.assign(new Error(marker), { response: { status, data: marker }, config: { headers: { Authorization: marker } } });
+    } });
+    let failure: unknown;
+    try { await provider.linkExternalSecret({ externalRef, providerConfig: config }); } catch (error) { failure = error; }
+    expect(failure).toBeInstanceOf(SecretProviderClientError);
+    expect(failure).toMatchObject({ code, rawMessage: null });
+    expect(inspect(failure, { depth: 8, showHidden: true })).not.toContain(marker);
+    expect(JSON.stringify(failure)).not.toContain(marker);
+    expect(failure).not.toHaveProperty("cause");
+  });
+
+  it.each([
+    null,
+    { ...payload(), name: `${externalRef}/versions/latest` },
+    { ...payload(), name: "projects/example-project/secrets/other/versions/7" },
+    { ...payload(), payload: { data: "private-malformed-payload", dataCrc32c: "0" } },
+    { ...payload(), payload: { ...payload().payload, dataCrc32c: "0" } },
+    { ...payload(), payload: { data: payload().payload.data } },
+  ])("rejects malformed responses and integrity failures without payload disclosure", async (response) => {
+    const provider = createGcpSecretManagerProvider({ accessVersion: async () => response });
+    await expect(provider.linkExternalSecret({ externalRef, providerConfig: config }))
+      .rejects.toMatchObject({ code: "provider_error", rawMessage: null });
+  });
+
+  it("does not claim remote access in health checks or make remote writes on archive/delete", async () => {
+    const accessVersion = vi.fn();
+    const provider = createGcpSecretManagerProvider({ accessVersion });
+    expect(await provider.healthCheck({ providerConfig: config })).toMatchObject({
+      status: "warn", details: { accessVerified: false, credentialSource: "Application Default Credentials" },
+    });
+    expect(provider.descriptor()).toMatchObject({ supportsManagedValues: false, supportsExternalValueWrites: false });
+    await expect(provider.createSecret({ value: "private-value" })).rejects.toThrow(/linking existing secrets only/);
+    await expect(provider.createVersion({ value: "private-value" })).rejects.toThrow(/linking existing secrets only/);
+    await provider.deleteOrArchive({ externalRef, mode: "archive" });
+    await provider.deleteOrArchive({ externalRef, mode: "delete" });
+    expect(accessVersion).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/secret-provider-registry.test.ts
+++ b/server/src/__tests__/secret-provider-registry.test.ts
@@ -43,6 +43,12 @@ describe("secret provider registry", () => {
           supportsExternalReferences: true,
           configured: false,
         }),
+        expect.objectContaining({
+          id: "gcp_secret_manager",
+          supportsManagedValues: false,
+          supportsExternalReferences: true,
+          supportsExternalValueWrites: false,
+        }),
       ]),
     );
   });

--- a/server/src/__tests__/secrets-service.test.ts
+++ b/server/src/__tests__/secrets-service.test.ts
@@ -25,6 +25,7 @@ import {
 import { LOW_TRUST_REVIEW_PRESET } from "@paperclipai/shared";
 import { getEmbeddedPostgresTestSupport, startEmbeddedPostgresTestDatabase } from "./helpers/embedded-postgres.js";
 import { awsSecretsManagerProvider } from "../secrets/aws-secrets-manager-provider.js";
+import { gcpSecretManagerProvider } from "../secrets/gcp-secret-manager-provider.js";
 import { localEncryptedProvider } from "../secrets/local-encrypted-provider.js";
 import { SecretProviderClientError } from "../secrets/types.js";
 import { secretService } from "../services/secrets.js";
@@ -2892,6 +2893,7 @@ describeEmbeddedPostgres("secretService", () => {
     const draftVault = await svc.createProviderConfig(companyId, {
       provider: "gcp_secret_manager",
       displayName: "GCP draft",
+      status: "coming_soon",
       config: { projectId: "paperclip-prod1" },
     });
 
@@ -2904,6 +2906,35 @@ describeEmbeddedPostgres("secretService", () => {
         value: "runtime-secret",
       }),
     ).rejects.toThrow(/coming soon/i);
+  });
+
+  it("links and resolves a Google secret through a ready company vault without persisting its value", async () => {
+    const companyId = await seedCompany();
+    const foreignCompanyId = await seedCompany();
+    const svc = secretService(db);
+    const vault = await svc.createProviderConfig(companyId, {
+      provider: "gcp_secret_manager", displayName: "Google", config: { projectId: "example-project" },
+    });
+    expect(vault.status).toBe("ready");
+    const externalRef = "projects/example-project/secrets/example-key";
+    const material = { scheme: "gcp_secret_manager_v1", externalRef, providerVersionRef: "7" };
+    const link = vi.spyOn(gcpSecretManagerProvider, "linkExternalSecret").mockResolvedValue({
+      material, externalRef, providerVersionRef: "7", valueSha256: "fingerprint", fingerprintSha256: "fingerprint",
+    });
+    const resolve = vi.spyOn(gcpSecretManagerProvider, "resolveVersion").mockResolvedValue("resolved-private-value");
+    const secret = await svc.create(companyId, {
+      name: `google-${randomUUID()}`, provider: "gcp_secret_manager", managedMode: "external_reference",
+      providerConfigId: vault.id, externalRef,
+    });
+    expect(link).toHaveBeenCalledWith(expect.objectContaining({ providerConfig: expect.objectContaining({ id: vault.id }) }));
+    await expect(svc.resolveSecretValue(foreignCompanyId, secret.id, "latest")).rejects.toThrow();
+    expect(resolve).not.toHaveBeenCalled();
+    expect(await svc.resolveSecretValue(companyId, secret.id, "latest")).toBe("resolved-private-value");
+    expect(resolve).toHaveBeenCalledWith(expect.objectContaining({
+      providerConfig: expect.objectContaining({ id: vault.id }), providerVersionRef: "7", material,
+    }));
+    const stored = await db.select().from(companySecretVersions).where(eq(companySecretVersions.secretId, secret.id));
+    expect(JSON.stringify(stored)).not.toContain("resolved-private-value");
   });
 
   it("passes selected provider vault config through create, rotate, and resolve", async () => {

--- a/server/src/secrets/external-stub-providers.ts
+++ b/server/src/secrets/external-stub-providers.ts
@@ -80,8 +80,4 @@ export const awsSecretsManagerProvider = unavailableProvider(
   "aws_secrets_manager",
   "AWS Secrets Manager",
 );
-export const gcpSecretManagerProvider = unavailableProvider(
-  "gcp_secret_manager",
-  "GCP Secret Manager",
-);
 export const vaultProvider = unavailableProvider("vault", "HashiCorp Vault");

--- a/server/src/secrets/gcp-secret-manager-provider.ts
+++ b/server/src/secrets/gcp-secret-manager-provider.ts
@@ -1,0 +1,231 @@
+import { createHash } from "node:crypto";
+import { GoogleAuth } from "google-auth-library";
+import { gcpSecretManagerProviderConfigSchema } from "@paperclipai/shared";
+import type {
+  SecretProviderClientErrorCode,
+  SecretProviderModule,
+  SecretProviderVaultRuntimeConfig,
+} from "./types.js";
+import { SecretProviderClientError } from "./types.js";
+
+const PROVIDER = "gcp_secret_manager";
+const SCHEME = "gcp_secret_manager_v1";
+const REQUEST_TIMEOUT_MS = 30_000;
+const PROJECT = "(?:[a-z][a-z0-9-]{4,28}[a-z0-9]|[1-9][0-9]{0,19})";
+const SECRET_RESOURCE = new RegExp(`^projects/(${PROJECT})/secrets/([A-Za-z0-9_-]{1,255})(?:/versions/([1-9][0-9]*|latest))?$`);
+
+function providerError(operation: string, code: SecretProviderClientErrorCode, message?: string) {
+  const messages: Record<SecretProviderClientErrorCode, string> = {
+    access_denied: "Google Secret Manager access was denied. Check the server's Application Default Credentials and secretmanager.versions.access permission.",
+    throttled: "Google Secret Manager rate limit reached. Try again later.",
+    not_found: "The Google Secret Manager secret or version was not found.",
+    conflict: "The Google Secret Manager version is unavailable in its current state.",
+    invalid_request: "Invalid Google Secret Manager configuration or secret reference.",
+    provider_unavailable: "Google Secret Manager or the server's Application Default Credentials are unavailable.",
+    provider_error: "Google Secret Manager returned an invalid response.",
+  };
+  return new SecretProviderClientError({ provider: PROVIDER, operation, code, message: message ?? messages[code] });
+}
+
+function normalizeError(operation: string, error: unknown): never {
+  if (error instanceof SecretProviderClientError) throw error;
+  const response = (error as { response?: { status?: number; data?: { error?: unknown } } } | null)?.response;
+  const status = response?.status;
+  const authRejected = typeof response?.data?.error === "string" &&
+    ["invalid_grant", "invalid_client", "unauthorized_client", "invalid_scope"].includes(response.data.error);
+  const code: SecretProviderClientErrorCode =
+    authRejected || status === 401 || status === 403 ? "access_denied"
+      : status === 404 ? "not_found"
+        : status === 429 ? "throttled"
+          : status === 400 ? "invalid_request"
+            : status === 409 ? "conflict"
+              : "provider_unavailable";
+  // Auth and HTTP errors can retain tokens, response payloads and request config.
+  // Do not attach their message, rawMessage or cause to the public error.
+  throw providerError(operation, code);
+}
+
+function resolveConfig(providerConfig?: SecretProviderVaultRuntimeConfig | null) {
+  if (providerConfig && (providerConfig.provider !== PROVIDER || !["ready", "warning"].includes(providerConfig.status))) {
+    throw providerError("validateConfig", "invalid_request");
+  }
+  const parsed = gcpSecretManagerProviderConfigSchema.safeParse(providerConfig?.config ?? {
+    projectId: process.env.PAPERCLIP_SECRETS_GCP_PROJECT_ID,
+  });
+  if (!parsed.success || !parsed.data.projectId) {
+    throw providerError("validateConfig", "invalid_request", "Set a Google Cloud project ID or number in the provider vault, or PAPERCLIP_SECRETS_GCP_PROJECT_ID for the deployment default. Only global Secret Manager resources are supported.");
+  }
+  return { ...parsed.data, projectId: parsed.data.projectId };
+}
+
+function parseReference(externalRef: string, providerVersionRef?: string | null) {
+  const match = SECRET_RESOURCE.exec(externalRef.trim());
+  const version = providerVersionRef?.trim() || match?.[3] || "latest";
+  if (!match || !/^(?:[1-9][0-9]*|latest)$/.test(version) || (match[3] && providerVersionRef && match[3] !== version)) {
+    throw providerError("validateReference", "invalid_request");
+  }
+  return {
+    projectId: match[1]!,
+    secretId: match[2]!,
+    externalRef: `projects/${match[1]}/secrets/${match[2]}`,
+    version,
+  };
+}
+
+// Castagnoli CRC32C, as returned by Secret Manager for its decoded payload bytes.
+function crc32c(bytes: Uint8Array): string {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit++) crc = (crc >>> 1) ^ ((crc & 1) ? 0x82f63b78 : 0);
+  }
+  return String((crc ^ 0xffffffff) >>> 0);
+}
+
+export function createGcpSecretManagerProvider(options?: {
+  accessVersion?: (name: string) => Promise<unknown>;
+}): SecretProviderModule {
+  // ADC belongs to the server deployment, never company-controlled vault JSON.
+  const auth = new GoogleAuth({
+    scopes: ["https://www.googleapis.com/auth/cloud-platform"],
+    clientOptions: { transporterOptions: { timeout: REQUEST_TIMEOUT_MS, retry: false } },
+  });
+  const accessVersion = options?.accessVersion ?? (async (name: string) => {
+    const response = await auth.request({
+      url: `https://secretmanager.googleapis.com/v1/${name}:access`,
+      method: "GET",
+      timeout: REQUEST_TIMEOUT_MS,
+      retry: false,
+      maxRedirects: 0,
+      responseType: "json",
+    });
+    return response.data;
+  });
+
+  async function access(input: {
+    externalRef: string;
+    providerVersionRef?: string | null;
+    providerConfig?: SecretProviderVaultRuntimeConfig | null;
+  }, operation: string) {
+    const config = resolveConfig(input.providerConfig);
+    const reference = parseReference(input.externalRef, input.providerVersionRef);
+    if (reference.projectId !== config.projectId || (config.secretNamePrefix && !reference.secretId.startsWith(config.secretNamePrefix))) {
+      throw providerError(operation, "invalid_request", "The secret reference must match the provider vault's project and secret name prefix.");
+    }
+    try {
+      const response = await accessVersion(`${reference.externalRef}/versions/${reference.version}`) as {
+        name?: unknown;
+        payload?: { data?: unknown; dataCrc32c?: unknown };
+      } | null;
+      if (typeof response?.name !== "string" || typeof response.payload?.data !== "string") {
+        throw providerError(operation, "provider_error");
+      }
+      const resolved = parseReference(response.name);
+      // Google can canonicalise a project ID to its numeric project number.
+      const sameProject = resolved.projectId === reference.projectId ||
+        (!/^\d+$/.test(reference.projectId) && /^\d+$/.test(resolved.projectId));
+      if (!sameProject || resolved.secretId !== reference.secretId || resolved.version === "latest" ||
+        (reference.version !== "latest" && resolved.version !== reference.version)) {
+        throw providerError(operation, "provider_error");
+      }
+      const data = response.payload.data;
+      if (data.length > 87_384 || !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(data)) {
+        throw providerError(operation, "provider_error");
+      }
+      const bytes = Buffer.from(data, "base64");
+      if (bytes.length > 65_536 || String(response.payload.dataCrc32c) !== crc32c(bytes)) {
+        throw providerError(operation, "provider_error", "Google Secret Manager payload integrity verification failed.");
+      }
+      let value: string;
+      try {
+        value = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(bytes);
+      } catch {
+        throw providerError(operation, "provider_error", "Google Secret Manager payload must contain UTF-8 text.");
+      }
+      return { value, externalRef: reference.externalRef, version: resolved.version };
+    } catch (error) {
+      normalizeError(operation, error);
+    }
+  }
+
+  const refuseWrite = async () => {
+    throw providerError("write", "invalid_request", "Google Secret Manager supports linking existing secrets only. Manage secret values and versions in Google Cloud.");
+  };
+
+  return {
+    id: PROVIDER,
+    descriptor() {
+      let configured = false;
+      try { resolveConfig(); configured = true; } catch { /* No deployment default configured. */ }
+      return {
+        id: PROVIDER,
+        label: "Google Secret Manager",
+        requiresExternalRef: true,
+        supportsManagedValues: false,
+        supportsExternalReferences: true,
+        supportsExternalValueWrites: false,
+        configured,
+      };
+    },
+    async validateConfig(input) {
+      resolveConfig(input?.providerConfig);
+      return {
+        ok: true,
+        warnings: input?.deploymentMode === "authenticated" && input.strictMode !== true
+          ? ["Strict secret mode should be enabled for authenticated deployments"] : [],
+      };
+    },
+    createSecret: refuseWrite,
+    createVersion: refuseWrite,
+    async linkExternalSecret(input) {
+      const resolved = await access(input, "linkExternalSecret");
+      const fingerprint = createHash("sha256").update(resolved.value).digest("hex");
+      return {
+        material: { scheme: SCHEME, externalRef: resolved.externalRef, providerVersionRef: resolved.version },
+        externalRef: resolved.externalRef,
+        providerVersionRef: resolved.version,
+        valueSha256: fingerprint,
+        fingerprintSha256: fingerprint,
+      };
+    },
+    async resolveVersion(input) {
+      const material = input.material;
+      const legacy = material.scheme === "external_reference_v1" && material.provider === PROVIDER;
+      if ((material.scheme !== SCHEME && !legacy) || typeof material.externalRef !== "string" ||
+        (material.providerVersionRef != null && typeof material.providerVersionRef !== "string") ||
+        (input.externalRef != null && input.externalRef !== material.externalRef) ||
+        (input.providerVersionRef != null && material.providerVersionRef != null && input.providerVersionRef !== material.providerVersionRef)) {
+        throw providerError("resolveVersion", "invalid_request");
+      }
+      const resolved = await access({
+        externalRef: material.externalRef,
+        providerVersionRef: input.providerVersionRef ?? material.providerVersionRef as string | null,
+        providerConfig: input.providerConfig,
+      }, "resolveVersion");
+      return resolved.value;
+    },
+    async deleteOrArchive() {
+      // Removing a Paperclip reference must never delete or disable the remote secret.
+    },
+    async healthCheck(input) {
+      try {
+        const config = resolveConfig(input?.providerConfig);
+        return {
+          provider: PROVIDER,
+          status: "warn",
+          message: "Google Secret Manager routing is configured. Credentials and secret access have not been verified.",
+          warnings: ["The server uses Application Default Credentials, which are separate from gcloud CLI sign-in. Linking a secret verifies access to that version."],
+          details: { projectId: config.projectId, location: "global", credentialSource: "Application Default Credentials", accessVerified: false },
+        };
+      } catch {
+        return {
+          provider: PROVIDER,
+          status: "warn",
+          message: "Google Secret Manager requires a project ID or number and global location. Configure a provider vault or PAPERCLIP_SECRETS_GCP_PROJECT_ID.",
+        };
+      }
+    },
+  };
+}
+
+export const gcpSecretManagerProvider = createGcpSecretManagerProvider();

--- a/server/src/secrets/provider-registry.ts
+++ b/server/src/secrets/provider-registry.ts
@@ -1,10 +1,8 @@
 import type { SecretProvider, SecretProviderDescriptor } from "@paperclipai/shared";
 import { awsSecretsManagerProvider } from "./aws-secrets-manager-provider.js";
 import { localEncryptedProvider } from "./local-encrypted-provider.js";
-import {
-  gcpSecretManagerProvider,
-  vaultProvider,
-} from "./external-stub-providers.js";
+import { gcpSecretManagerProvider } from "./gcp-secret-manager-provider.js";
+import { vaultProvider } from "./external-stub-providers.js";
 import type { SecretProviderHealthCheck, SecretProviderModule } from "./types.js";
 import { unprocessable } from "../errors.js";
 

--- a/server/src/services/secrets.ts
+++ b/server/src/services/secrets.ts
@@ -100,7 +100,6 @@ const SENSITIVE_ENV_KEY_RE =
   /(api[-_]?key|access[-_]?token|auth(?:_?token)?|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring)/i;
 const REDACTED_SENTINEL = "***REDACTED***";
 const COMING_SOON_SECRET_PROVIDERS: ReadonlySet<SecretProvider> = new Set([
-  "gcp_secret_manager",
   "vault",
 ]);
 const FALLBACK_ADAPTER_SCHEMA_SECRET_FIELDS: Readonly<Record<string, readonly string[]>> = {

--- a/ui/src/pages/Secrets.render.test.tsx
+++ b/ui/src/pages/Secrets.render.test.tsx
@@ -397,6 +397,32 @@ describe("Secrets page layout", () => {
     vi.clearAllMocks();
   });
 
+  it("offers ready Google vaults with metadata-only fields and explains external version pinning", async () => {
+    const root = createRoot(container);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    await act(async () => {
+      root.render(<MemoryRouter><QueryClientProvider client={queryClient}><Secrets /></QueryClientProvider></MemoryRouter>);
+    });
+    await flushReact();
+    await flushReact();
+    await openAwsVaultDialog();
+    await act(async () => {
+      setSelectValue(document.getElementById("vault-provider") as HTMLSelectElement, "gcp_secret_manager");
+    });
+    await flushReact();
+
+    const status = document.getElementById("vault-status") as HTMLSelectElement;
+    expect(status.value).toBe("ready");
+    expect(status.querySelector<HTMLOptionElement>('option[value="ready"]')?.disabled).toBe(false);
+    const dialog = status.closest('[role="dialog"]')!;
+    expect(dialog.textContent).toContain("Project ID or number");
+    expect(dialog.textContent).toContain("pins the selected version");
+    expect(dialog.textContent).not.toContain("Namespace");
+    expect(dialog.querySelector('input[type="password"]')).toBeNull();
+    expect([...dialog.querySelectorAll("button")].find((button) => button.textContent?.trim() === "Create vault")?.disabled).toBe(true);
+    await act(async () => { root.unmount(); });
+  });
+
   it("uses the shared search/filter/tab affordances and keeps vault sections quiet", async () => {
     const root = createRoot(container);
     const queryClient = new QueryClient({

--- a/ui/src/pages/Secrets.render.test.tsx
+++ b/ui/src/pages/Secrets.render.test.tsx
@@ -423,6 +423,41 @@ describe("Secrets page layout", () => {
     await act(async () => { root.unmount(); });
   });
 
+  it("keeps Google vault location fixed and submits the supported global location", async () => {
+    mockSecretsApi.createProviderConfig.mockResolvedValueOnce({ displayName: "Google production" });
+    const root = createRoot(container);
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    await act(async () => {
+      root.render(<MemoryRouter><QueryClientProvider client={queryClient}><Secrets /></QueryClientProvider></MemoryRouter>);
+    });
+    await flushReact();
+    await flushReact();
+    await openAwsVaultDialog();
+    await act(async () => {
+      setSelectValue(document.getElementById("vault-provider") as HTMLSelectElement, "gcp_secret_manager");
+    });
+    await flushReact();
+
+    const locationLabel = [...document.querySelectorAll("label")].find((label) => label.textContent?.startsWith("Location"))!;
+    const location = document.getElementById(locationLabel.htmlFor) as HTMLInputElement;
+    expect(location).not.toBeNull();
+    expect(location.value).toBe("global");
+    expect(location.readOnly).toBe(true);
+    await act(async () => {
+      setInputValue(document.getElementById("vault-name") as HTMLInputElement, "Google production");
+      setInputValue(document.getElementById("provider-vault-project-id-or-number") as HTMLInputElement, "example-project");
+    });
+    const create = [...document.querySelectorAll("button")].find((button) => button.textContent?.trim() === "Create vault")!;
+    expect(create.disabled).toBe(false);
+    await act(async () => { create.click(); });
+    await waitForReact(() => mockSecretsApi.createProviderConfig.mock.calls.length === 1);
+
+    expect(mockSecretsApi.createProviderConfig).toHaveBeenCalledWith("company-1", expect.objectContaining({
+      provider: "gcp_secret_manager",
+      config: expect.objectContaining({ projectId: "example-project", location: "global" }),
+    }));
+  });
+
   it("uses the shared search/filter/tab affordances and keeps vault sections quiet", async () => {
     const root = createRoot(container);
     const queryClient = new QueryClient({

--- a/ui/src/pages/Secrets.test.ts
+++ b/ui/src/pages/Secrets.test.ts
@@ -52,6 +52,21 @@ function providerConfig(
 }
 
 describe("Secrets page provider helpers", () => {
+  it("allows a ready Google vault for external links while keeping managed values unavailable", () => {
+    const google: SecretProviderDescriptor = {
+      id: "gcp_secret_manager", label: "Google Secret Manager", requiresExternalRef: true,
+      supportsManagedValues: false, supportsExternalReferences: true, supportsExternalValueWrites: false,
+      configured: false,
+    };
+    const vault = providerConfig({
+      id: "google-vault", provider: "gcp_secret_manager", config: { projectId: "example-project" },
+    });
+    expect(getCreateProviderBlockReason(google, "external", null, vault)).toBeNull();
+    expect(getCreateProviderBlockReason(google, "managed", null, vault)).toMatch(/does not support Paperclip-managed/);
+    expect(getCreateProviderBlockReason(google, "external", null, { ...vault, status: "coming_soon" }))
+      .toMatch(/draft metadata/);
+  });
+
   it("previews the derived AWS managed path from provider health details", () => {
     const health: SecretProviderHealthResponse = {
       providers: [

--- a/ui/src/pages/Secrets.tsx
+++ b/ui/src/pages/Secrets.tsx
@@ -608,7 +608,7 @@ function buildProviderVaultConfig(form: ProviderVaultForm): Record<string, unkno
     case "gcp_secret_manager":
       return {
         projectId: compact(form.projectId),
-        location: compact(form.location),
+        location: "global",
         namespace: compact(form.namespace),
         secretNamePrefix: compact(form.secretNamePrefix),
       };
@@ -3806,7 +3806,10 @@ function ProviderVaultFields({
     return (
       <div className="grid gap-3 sm:grid-cols-2">
         <TextField label="Project ID or number" value={form.projectId} onChange={(value) => setField("projectId", value)} placeholder="paperclip-prod" required />
-        <TextField label="Location (global only)" value={form.location} onChange={(value) => setField("location", value)} placeholder="global" />
+        <div>
+          <label className="text-xs font-medium" htmlFor="provider-vault-location">Location (global only)</label>
+          <Input id="provider-vault-location" value="global" readOnly />
+        </div>
         <TextField label="Secret name prefix" value={form.secretNamePrefix} onChange={(value) => setField("secretNamePrefix", value)} placeholder="paperclip" />
       </div>
     );

--- a/ui/src/pages/Secrets.tsx
+++ b/ui/src/pages/Secrets.tsx
@@ -208,7 +208,7 @@ const PROVIDER_ORDER: SecretProvider[] = [
 ];
 
 function defaultProviderVaultStatus(provider: SecretProvider): SecretProviderConfigStatus {
-  return provider === "gcp_secret_manager" || provider === "vault" ? "coming_soon" : "ready";
+  return provider === "vault" ? "coming_soon" : "ready";
 }
 
 function emptyProviderVaultForm(provider: SecretProvider = "local_encrypted"): ProviderVaultForm {
@@ -2993,10 +2993,10 @@ export function Secrets() {
                     }));
                   }}
                 >
-                  <option value="ready" disabled={vaultForm.provider === "gcp_secret_manager" || vaultForm.provider === "vault"}>
+                  <option value="ready" disabled={vaultForm.provider === "vault"}>
                     Ready
                   </option>
-                  <option value="warning" disabled={vaultForm.provider === "gcp_secret_manager" || vaultForm.provider === "vault"}>
+                  <option value="warning" disabled={vaultForm.provider === "vault"}>
                     Warning
                   </option>
                   <option value="coming_soon">Coming soon</option>
@@ -3034,7 +3034,13 @@ export function Secrets() {
               />
             ) : null}
 
-            {vaultForm.provider === "gcp_secret_manager" || vaultForm.provider === "vault" ? (
+            {vaultForm.provider === "gcp_secret_manager" ? (
+              <p className="text-xs text-muted-foreground">
+                Link existing global secrets using the server's Google Application Default Credentials.
+                Linking verifies access and pins the selected version. Secret values are managed in Google Cloud.
+              </p>
+            ) : null}
+            {vaultForm.provider === "vault" ? (
               <div className="rounded-md border border-sky-500/30 bg-sky-500/5 p-3 text-xs text-sky-700 dark:text-sky-300">
                 This provider can save draft routing metadata, but runtime writes and resolution stay disabled until
                 the provider module is implemented and reviewed.
@@ -3054,7 +3060,8 @@ export function Secrets() {
               disabled={
                 saveVaultMutation.isPending ||
                 !vaultForm.displayName.trim() ||
-                (vaultForm.provider === "aws_secrets_manager" && !vaultForm.region.trim())
+                (vaultForm.provider === "aws_secrets_manager" && !vaultForm.region.trim()) ||
+                (vaultForm.provider === "gcp_secret_manager" && !vaultForm.projectId.trim())
               }
             >
               {saveVaultMutation.isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin mr-1" /> : null}
@@ -3570,7 +3577,7 @@ export function ProviderVaultsTab({
     id: providerId,
     provider: providerMap.get(providerId),
     Icon: providerFamilyIcon(providerId),
-    isComingSoonFamily: providerId === "gcp_secret_manager" || providerId === "vault",
+    isComingSoonFamily: providerId === "vault",
     configs: providerConfigs.filter((config) => config.provider === providerId),
   }));
 
@@ -3798,9 +3805,8 @@ function ProviderVaultFields({
   if (form.provider === "gcp_secret_manager") {
     return (
       <div className="grid gap-3 sm:grid-cols-2">
-        <TextField label="Project id" value={form.projectId} onChange={(value) => setField("projectId", value)} placeholder="paperclip-prod" />
-        <TextField label="Location" value={form.location} onChange={(value) => setField("location", value)} placeholder="global" />
-        <TextField label="Namespace" value={form.namespace} onChange={(value) => setField("namespace", value)} placeholder="production" />
+        <TextField label="Project ID or number" value={form.projectId} onChange={(value) => setField("projectId", value)} placeholder="paperclip-prod" required />
+        <TextField label="Location (global only)" value={form.location} onChange={(value) => setField("location", value)} placeholder="global" />
         <TextField label="Secret name prefix" value={form.secretNamePrefix} onChange={(value) => setField("secretNamePrefix", value)} placeholder="paperclip" />
       </div>
     );


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Company secrets can refer to an external secret provider.
> - Google Secret Manager is listed but has only a placeholder implementation.
> - Teams with existing Google secrets need to resolve those references through the server.
> - This pull request implements reference-only access through Application Default Credentials.
> - Company vault settings define the project and optional secret-name prefix.
> - Secret values remain in Google, with explicit version and integrity checks on resolution.

## Linked Issues or Issue Description

Refs #2989 and #5837. #2989 also introduces a Google provider as part of JWT storage and rotation. Its remote write path differs from this change. This draft targets the current company-vault contracts and reference-only access. It leaves JWT handling unchanged. Maintainer guidance on combining these contributions is welcome.

**Problem**

Google Secret Manager is a placeholder. Company vaults cannot resolve existing Google secrets, although the settings and provider identifier already exist.

**Proposed solution**

Implement linking and resolving existing global secret versions. Use the supported Google authentication library and fixed HTTPS access endpoint. Keep credential configuration in the server deployment.

**Additional context**

Operators can reuse existing Google secrets without importing their plaintext values into Paperclip. This does not hide a resolved value from a consumer that is authorised to receive it.

## What Changed

- Add reference-only Google provider resolution using ADC, request time limits and sanitised errors.
- Validate project and optional name-prefix scope, numeric versions, payload CRC32C and UTF-8 text.
- Pin the resolved numeric version when linking latest.
- Enable provider vault validation and settings for ready or warning configurations. Keep the location field fixed to the supported global value.
- Preserve explicit legacy coming_soon drafts until an operator edits them.
- Add the already resolved google-auth-library version as a direct server dependency. CI owns lockfile regeneration.
- Document setup, supported reference formats, rotation, limits and credential boundaries.

## Verification

- Initial implementation: 148 focused tests passed across provider, registry, secret routes/service integration, shared validation, and settings helpers/rendering.
- The location-field regression failed before the fix. All 45 settings helper/render tests passed after the fix, along with the UI type check and token gates.
- Server, shared-package and UI type checks passed. Their targeted builds passed.
- Token gates and diff checks passed.
- A live link through Paperclip's native API succeeded for one existing Google secret. The provider read and verified its payload, then stored the external reference and pinned version. No raw value was returned to the reviewer and no agent environment binding was created.
- No Google resources, IAM policies or secret versions were changed.
- At 184361cc4, 28 checks pass, including build, typecheck, all test shards, end-to-end tests, canary verification and security. Greptile is 5/5 with no outstanding finding. Storybook is intentionally skipped.
- The sole failed check is the description review from before its required duplicate-search wording was corrected. The current published body passes the exact repository matcher. GitHub requires an upstream administrator to rerun that workflow; the fork author cannot do so.

## Risks

- Supports global Secret Manager resources and UTF-8 payloads only; regional resources and binary values are rejected.
- Linking reads a secret version to verify access and integrity. It requires the existing Google permissions.
- Existing explicitly disabled or coming_soon vaults stay unavailable. Health checks validate configuration, and clearly state that access is unverified.
- Env bindings and the existing authorised agent value API can reveal values to their consumers. Same-user shell access is not a strong credential boundary.
- No remote create, update, list, disable or delete operations are implemented.
- The description-check rerun remains pending, so the PR remains a draft. Maintainer agreement on the related provider contribution also remains open.

## Model Used

OpenAI GPT-6 assisted through Codex with code execution, tests and independent agent review. The exact deployment identifier and context-window size were not exposed in this session.

## Checklist

- [x] I have included a thinking path
- [x] I have specified the available model and capability details
- [x] I have checked ROADMAP.md and identified the related open provider contribution above
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have described the problem and proposed solution
- [x] I have not referenced internal or instance-local issues or URLs
- [x] My branch name describes this change
- [x] Focused tests, type checks and builds pass locally
- [x] I have added tests
- [x] I have updated documentation
- [x] I have documented the risks and the scope of live verification
- [ ] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address reviewer feedback before requesting merge
