### PR TITLE
docs: formalize worktree-based contribution policy

### DIFF
--- a/doc/DEVELOPING.md
+++ b/doc/DEVELOPING.md
@@ -2,6 +2,11 @@
 
 This project can run fully in local dev without setting up PostgreSQL manually.
 
+> **Repository workflow.** All code changes go through a git worktree — never
+> by committing directly to `master`, which is the running production
+> checkout. Read `doc/WORKTREE-POLICY.md` before opening any worktree, PR, or
+> rebuild. It is the contract for the local checkout, merge, and deploy rules.
+
 ## Deployment Modes
 
 For mode definitions and intended CLI behavior, see `doc/DEPLOYMENT-MODES.md`.

--- a/doc/WORKTREE-POLICY.md
+++ b/doc/WORKTREE-POLICY.md
@@ -1,0 +1,115 @@
+# Worktree Development Policy
+
+This document is the canonical policy for how code changes reach `master` in
+this repository. It is the contract followed by humans, AI agents, and CI when
+working from the production checkout.
+
+## Why this policy exists
+
+The local `master` checkout is a **production instance**: `pnpm dev` runs on it
+with hot-reload enabled, and the Paperclip server (plus the linked Hermes
+gateway) is the live deployment. Direct writes to that checkout — a
+`checkout`, `rebase`, `merge`, or `commit` on `master`, a fast-forward, or a
+rebuild — can tear down running agents and the gateway. Nothing dirty, brained,
+or speculative ever touches `master` directly.
+
+## Non-negotiable rules
+
+1. **Never commit directly to `master`.** No direct `git commit`, `git merge`,
+   `git rebase`, or `git checkout` of branches onto the production checkout.
+2. **Never run `git pull` or `--fast-forward` on `master`.** `master` only
+   advances by PR merges against the upstream `paperclipai/paperclip`
+   repository, brought down deliberately and only after those merges.
+3. **No rebuilds or restarts without a scheduled window.** A rebuild of the
+   server restarts the gateway and drops active agent runs. Rebuilds happen
+   only in a window agreed with a human operator. Until then, "rebuild
+   pending" is the normal resting state.
+4. **Never force-push to a shared branch**, and never rewrite a branch that is
+   already the head of an open PR (use stacked PRs or a new branch instead).
+
+## The lifecycle of a change
+
+Work on a change via a git worktree, never on `master`.
+
+### 1. Create the worktree from the issue
+
+```sh
+# From the production checkout root (read-only here — this never writes master):
+git worktree add ../PAPERCLIP-SERVER-wt-<slug> -b plv-<id>-<slug> origin/master
+```
+
+- `<slug>` is a short kebab-case description of the change.
+- `<id>` is the Paperclip issue id.
+- Base the branch on `origin/master` (the upstream source of truth), **not**
+  on the local `master` (which is the running production state and may carry
+  unmerged work).
+
+### 2. Do the work entirely inside the worktree
+
+- Edit, commit, and test inside the worktree. A worktree has its own
+  `.git/private` and working files, so it cannot disturb the running instance.
+- Never `pnpm dev` against the production instance's database from a worktree;
+  use `paperclipai worktree init` for an isolated instance when a dev server is
+  needed (see `doc/DEVELOPING.md` → "Worktree-local Instances").
+
+### 3. Open a pull request
+
+```sh
+# From the worktree:
+git push -u origin plv-<id>-<slug>        # or your fork
+gh pr create --base master
+```
+
+- Follow the PR template in `.github/PULL_REQUEST_TEMPLATE.md` fully.
+- PR CI runs the validation gates; merge only after the checks pass.
+
+### 4. Merge through GitHub
+
+- Merge the PR on upstream GitHub. `master` is never merged locally.
+- After the PR is merged upstream, `origin/master` advances. The production
+  checkout's `master` is brought up to date **only** by a deliberate
+  `git fetch origin` + `git merge --ff-only origin/master` performed in a
+  scheduled maintenance window — never as part of routine work and never while
+  agent runs are active.
+
+## Dirty work
+
+Uncommitted work on the production `master` is the one exception to
+"never touch master", and it has a strict deadline:
+
+- **Same day.** Any dirty change in the production checkout is captured into a
+  worktree the same day it appears: `git diff > patch`, apply the patch in the
+  worktree, commit, open the PR. Dirty work does not accumulate.
+- Never commit the dirty `master` state itself.
+
+## Untracked data
+
+Data files (databases, dumps, generated artifacts) are not PR material:
+
+- Add data paths to `.git/info/exclude` in the production checkout so they stay
+  out of `git status` and out of history.
+- Do not `git add` untracked data into a worktree branch or include it in a PR.
+
+## Rebuilds
+
+A change to server or gateway code is not "done" until it is deployed, and
+deployment means a rebuild:
+
+- Rebuilds happen only in an agreed window with a human operator.
+- Before a rebuild, record which PR merges are riding the next deploy so the
+  operator can confirm scope.
+- When work lands without a scheduled rebuild, the resting state is
+  **"rebuild pending"** — the code is merged but not yet running in the
+  production instance.
+
+## Definition of done
+
+A change is done when:
+
+1. It is committed on a worktree branch, pushed, and merged into upstream
+   `master` via a green PR.
+2. The production checkout's `master` has not been written to directly.
+3. Data paths are excluded, and dirty work either is merged or is captured in a
+   worktree.
+4. If a rebuild was required but no window was agreed, the state is recorded as
+   "rebuild pending".


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source control plane for AI-agent companies
> - The local `master` checkout is a production instance: `pnpm dev` runs on it with hot-reload, and the server plus a linked Hermes gateway are the live deployment
> - Direct writes to that checkout can tear down running agents and the gateway, so they are dangerous
> - A few months of work made clear that the team (and its agents) repeatedly drifted toward committing to `master`, so the working rules existed only as tribal knowledge
> - This pull request formalizes the worktree-based contribution contract in `doc/WORKTREE-POLICY.md` and links it from `doc/DEVELOPING.md`
> - The benefit is a single, discoverable contract: worktrees for all changes, PR-merge-only `master`, and rebuilds only in an agreed window

## Linked Issues or Issue Description

**Enhancement**

**What is the problem?**
The repository had no formal policy covering the production `master` checkout. Committing, rebasing, merging, or rebuilding directly on `master` can restart the live server/gateway and drop agent runs, but the rule lived only as tribal knowledge and was repeatedly violated.

**Expected behavior**
A discoverable document states the rules: no commits on `master`, worktrees for every change, PR merge on upstream, ff-only fetch/merge in a scheduled window, same-day dirty-work capture, `.git/info/exclude` for untracked data, and no rebuilds without an agreed window.

**What is being added?**
- `doc/WORKTREE-POLICY.md` — the canonical worktree contribution and deploy policy
- A pointer from `doc/DEVELOPING.md` so contributors surface the policy up front

## What Changed

- Add `doc/WORKTREE-POLICY.md` covering: non-negotiable rules (no commit/rebase/merge/ff-on-master, no rebuild outside a window), the worktree lifecycle (issue → worktree → PR → merge), same-day dirty-work capture, untracked-data exclusion, rebuild windows, and the definition of done
- Link the policy from the top of `doc/DEVELOPING.md`

## Verification

- Documentation-only change; verify the doc renders and the link resolves
- No behavior or code paths change

## Risks

- Low. Docs-only. The policy changes no runtime behavior; it codifies the working rules already in effect

## Model Used

DeepSeek V4 Flash (deepseek/deepseek-v4-flash-0731, via OpenRouter) authored the document and PR text. No other model contributed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [ ] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [ ] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge