### PR TITLE
fix(adapters): honour the documented timeoutSec field in the http adapter

### DIFF
--- a/server/src/adapters/http/execute.test.ts
+++ b/server/src/adapters/http/execute.test.ts
@@ -10,7 +10,43 @@ vi.mock("./remote-fetch.js", () => ({
 
 afterEach(() => {
   guardedFetchMock.mockReset();
+  vi.useRealTimers();
 });
+
+function mockNeverResolvingFetch(): void {
+  guardedFetchMock.mockImplementation(
+    (_url: string, init?: RequestInit) => new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => {
+        reject(new DOMException("Aborted", "AbortError"));
+      });
+    }),
+  );
+}
+
+function buildTimeoutContext(timeoutConfig: Record<string, number>): Parameters<typeof execute>[0] {
+  return {
+    runId: "run-1",
+    agent: {
+      id: "agent-1",
+      companyId: "company-1",
+      name: "Agent",
+      adapterType: "http",
+      adapterConfig: {},
+    },
+    runtime: {
+      sessionId: null,
+      sessionParams: null,
+      sessionDisplayId: null,
+      taskKey: null,
+    },
+    config: {
+      url: "https://example.test/webhook",
+      ...timeoutConfig,
+    },
+    context: {},
+    onLog: async () => {},
+  };
+}
 
 describe("http adapter execute", () => {
   it("delivers the complete runtime connection descriptor and shared guidance", async () => {
@@ -71,39 +107,49 @@ describe("http adapter execute", () => {
   });
 
   it("reports configured request timeout as timed_out", async () => {
-    guardedFetchMock.mockImplementation(
-      (_url: string, init?: RequestInit) => new Promise((_resolve, reject) => {
-        init?.signal?.addEventListener("abort", () => {
-          reject(new DOMException("Aborted", "AbortError"));
-        });
-      }),
-    );
+    mockNeverResolvingFetch();
 
-    const result = await execute({
-      runId: "run-1",
-      agent: {
-        id: "agent-1",
-        companyId: "company-1",
-        name: "Agent",
-        adapterType: "http",
-        adapterConfig: {},
-      },
-      runtime: {
-        sessionId: null,
-        sessionParams: null,
-        sessionDisplayId: null,
-        taskKey: null,
-      },
-      config: {
-        url: "https://example.test/webhook",
-        timeoutMs: 1,
-      },
-      context: {},
-      onLog: async () => {},
-    });
+    const result = await execute(buildTimeoutContext({ timeoutMs: 1 }));
 
     expect(result.timedOut).toBe(true);
     expect(result.errorCode).toBe("timeout");
     expect(result.errorMessage).toContain("timed out after 1ms");
+  });
+
+  it("arms the timeout from the documented timeoutSec field", async () => {
+    vi.useFakeTimers();
+    mockNeverResolvingFetch();
+
+    const pending = execute(buildTimeoutContext({ timeoutSec: 2 }));
+    await vi.advanceTimersByTimeAsync(2000);
+    const result = await pending;
+
+    expect(result.timedOut).toBe(true);
+    expect(result.errorCode).toBe("timeout");
+    expect(result.errorMessage).toContain("timed out after 2000ms");
+  });
+
+  it("prefers timeoutMs when both timeout fields are present", async () => {
+    vi.useFakeTimers();
+    mockNeverResolvingFetch();
+
+    const pending = execute(buildTimeoutContext({ timeoutMs: 1000, timeoutSec: 9 }));
+    await vi.advanceTimersByTimeAsync(1000);
+    const result = await pending;
+
+    expect(result.timedOut).toBe(true);
+    expect(result.errorMessage).toContain("timed out after 1000ms");
+  });
+
+  it("arms no timeout when neither timeout field is set", async () => {
+    guardedFetchMock.mockImplementation(async (_url: string, init?: RequestInit) => {
+      expect(init?.signal).toBeUndefined();
+      return new Response(null, { status: 204 });
+    });
+
+    const result = await execute(buildTimeoutContext({}));
+
+    expect(result.timedOut).toBe(false);
+    expect(guardedFetchMock).toHaveBeenCalledOnce();
   });
 });

--- a/server/src/adapters/http/execute.test.ts
+++ b/server/src/adapters/http/execute.test.ts
@@ -23,7 +23,7 @@ function mockNeverResolvingFetch(): void {
   );
 }
 
-function buildTimeoutContext(timeoutConfig: Record<string, number>): Parameters<typeof execute>[0] {
+function buildTimeoutContext(timeoutConfig: Record<string, unknown>): Parameters<typeof execute>[0] {
   return {
     runId: "run-1",
     agent: {
@@ -126,6 +126,18 @@ describe("http adapter execute", () => {
 
     expect(result.timedOut).toBe(true);
     expect(result.errorCode).toBe("timeout");
+    expect(result.errorMessage).toContain("timed out after 2000ms");
+  });
+
+  it("falls through to timeoutSec when timeoutMs carries no number", async () => {
+    vi.useFakeTimers();
+    mockNeverResolvingFetch();
+
+    const pending = execute(buildTimeoutContext({ timeoutMs: null, timeoutSec: 2 }));
+    await vi.advanceTimersByTimeAsync(2000);
+    const result = await pending;
+
+    expect(result.timedOut).toBe(true);
     expect(result.errorMessage).toContain("timed out after 2000ms");
   });
 

--- a/server/src/adapters/http/execute.ts
+++ b/server/src/adapters/http/execute.ts
@@ -8,7 +8,10 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (!url) throw new Error("HTTP adapter missing url");
 
   const method = asString(config.method, "POST");
-  const timeoutMs = asNumber(config.timeoutMs, 0);
+  // `timeoutSec` is the field this adapter documents in agentConfigurationDoc.
+  // `timeoutMs` stays supported as an undocumented alias so existing configs
+  // keep working.
+  const timeoutMs = asNumber(config.timeoutMs, asNumber(config.timeoutSec, 0) * 1000);
   const headers = parseObject(config.headers) as Record<string, string>;
   const payloadTemplate = parseObject(config.payloadTemplate);
   const body = {

--- a/server/src/adapters/http/execute.ts
+++ b/server/src/adapters/http/execute.ts
@@ -1,6 +1,7 @@
 import type { AdapterExecutionContext, AdapterExecutionResult } from "../types.js";
-import { asString, asNumber, parseObject } from "../utils.js";
+import { asString, parseObject } from "../utils.js";
 import { guardedHttpAdapterFetch } from "./remote-fetch.js";
+import { resolveHttpTimeoutMs } from "./timeout.js";
 
 export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExecutionResult> {
   const { config, runId, agent, context } = ctx;
@@ -8,10 +9,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
   if (!url) throw new Error("HTTP adapter missing url");
 
   const method = asString(config.method, "POST");
-  // `timeoutSec` is the field this adapter documents in agentConfigurationDoc.
-  // `timeoutMs` stays supported as an undocumented alias so existing configs
-  // keep working.
-  const timeoutMs = asNumber(config.timeoutMs, asNumber(config.timeoutSec, 0) * 1000);
+  const timeoutMs = resolveHttpTimeoutMs(config);
   const headers = parseObject(config.headers) as Record<string, string>;
   const payloadTemplate = parseObject(config.payloadTemplate);
   const body = {

--- a/server/src/adapters/http/timeout.test.ts
+++ b/server/src/adapters/http/timeout.test.ts
@@ -36,4 +36,11 @@ describe("resolveHttpTimeoutMs", () => {
   it("floors a fractional millisecond value", () => {
     expect(resolveHttpTimeoutMs({ timeoutSec: 0.0015 })).toBe(1);
   });
+
+  it("holds a positive sub-millisecond timeout at 1ms", () => {
+    // Flooring must not turn a configured timeout into the no-timeout
+    // sentinel, which would leave a stalled request unbounded.
+    expect(resolveHttpTimeoutMs({ timeoutSec: 0.0005 })).toBe(1);
+    expect(resolveHttpTimeoutMs({ timeoutMs: 0.4 })).toBe(1);
+  });
 });

--- a/server/src/adapters/http/timeout.test.ts
+++ b/server/src/adapters/http/timeout.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { MAX_HTTP_TIMEOUT_MS, resolveHttpTimeoutMs } from "./timeout.js";
+
+describe("resolveHttpTimeoutMs", () => {
+  it("converts the documented timeoutSec field to milliseconds", () => {
+    expect(resolveHttpTimeoutMs({ timeoutSec: 2 })).toBe(2000);
+  });
+
+  it("prefers timeoutMs when both fields hold a number", () => {
+    expect(resolveHttpTimeoutMs({ timeoutMs: 1000, timeoutSec: 9 })).toBe(1000);
+  });
+
+  it("falls through to timeoutSec when timeoutMs is present but unusable", () => {
+    // `adapterConfig` holds arbitrary JSON, so the alias can be present and
+    // still carry no number. The documented field then supplies the timeout.
+    expect(resolveHttpTimeoutMs({ timeoutMs: null, timeoutSec: 5 })).toBe(5000);
+    expect(resolveHttpTimeoutMs({ timeoutMs: "1000", timeoutSec: 5 })).toBe(5000);
+  });
+
+  it("arms no timeout for a missing, unusable or non-positive value", () => {
+    expect(resolveHttpTimeoutMs({})).toBe(0);
+    expect(resolveHttpTimeoutMs({ timeoutSec: "2" })).toBe(0);
+    expect(resolveHttpTimeoutMs({ timeoutSec: 0 })).toBe(0);
+    expect(resolveHttpTimeoutMs({ timeoutSec: -5 })).toBe(0);
+    expect(resolveHttpTimeoutMs({ timeoutMs: Number.NaN })).toBe(0);
+  });
+
+  it("holds an oversized timeout at Node's timer ceiling", () => {
+    // Node coerces a delay beyond a 32-bit signed integer to 1ms, which would
+    // abort the request at once rather than after the configured wait.
+    expect(resolveHttpTimeoutMs({ timeoutSec: 3_000_000_000 })).toBe(MAX_HTTP_TIMEOUT_MS);
+    expect(resolveHttpTimeoutMs({ timeoutMs: Number.MAX_VALUE })).toBe(MAX_HTTP_TIMEOUT_MS);
+    expect(MAX_HTTP_TIMEOUT_MS).toBeLessThanOrEqual(2 ** 31 - 1);
+  });
+
+  it("floors a fractional millisecond value", () => {
+    expect(resolveHttpTimeoutMs({ timeoutSec: 0.0015 })).toBe(1);
+  });
+});

--- a/server/src/adapters/http/timeout.ts
+++ b/server/src/adapters/http/timeout.ts
@@ -1,0 +1,21 @@
+import { asNumber } from "../utils.js";
+
+// Node holds a setTimeout delay in a 32-bit signed integer. It coerces a larger
+// delay to 1ms, which would abort the request almost at once, so a longer
+// configured timeout is held at this ceiling instead.
+export const MAX_HTTP_TIMEOUT_MS = 2_147_483_647;
+
+/**
+ * Resolve the http adapter request timeout, in milliseconds. `0` means no
+ * timeout, which is the default and matches the process adapter.
+ *
+ * `timeoutSec` is the field the adapter documents in `agentConfigurationDoc`.
+ * `timeoutMs` stays supported as an undocumented alias, and wins when it holds
+ * a usable number. Both the adapter and the run stop metadata read the timeout
+ * through here, so the recorded policy cannot drift from the timer that runs.
+ */
+export function resolveHttpTimeoutMs(config: Record<string, unknown>): number {
+  const timeoutMs = asNumber(config.timeoutMs, asNumber(config.timeoutSec, 0) * 1000);
+  if (!(timeoutMs > 0)) return 0;
+  return Math.min(Math.floor(timeoutMs), MAX_HTTP_TIMEOUT_MS);
+}

--- a/server/src/adapters/http/timeout.ts
+++ b/server/src/adapters/http/timeout.ts
@@ -17,5 +17,7 @@ export const MAX_HTTP_TIMEOUT_MS = 2_147_483_647;
 export function resolveHttpTimeoutMs(config: Record<string, unknown>): number {
   const timeoutMs = asNumber(config.timeoutMs, asNumber(config.timeoutSec, 0) * 1000);
   if (!(timeoutMs > 0)) return 0;
-  return Math.min(Math.floor(timeoutMs), MAX_HTTP_TIMEOUT_MS);
+  // Anything past this line is positive, so hold it at 1ms rather than let
+  // flooring turn a sub-millisecond timeout into the no-timeout sentinel.
+  return Math.min(Math.max(1, Math.floor(timeoutMs)), MAX_HTTP_TIMEOUT_MS);
 }

--- a/server/src/services/heartbeat-stop-metadata.test.ts
+++ b/server/src/services/heartbeat-stop-metadata.test.ts
@@ -42,6 +42,33 @@ describe("heartbeat stop metadata", () => {
     });
   });
 
+  it("resolves the http timeout policy from the documented timeoutSec field", () => {
+    expect(resolveHeartbeatRunTimeoutPolicy("http", { timeoutSec: 2 })).toEqual({
+      effectiveTimeoutSec: 2,
+      effectiveTimeoutMs: 2000,
+      timeoutConfigured: true,
+      timeoutSource: "config",
+    });
+  });
+
+  it("prefers timeoutMs over timeoutSec for the http adapter", () => {
+    expect(resolveHeartbeatRunTimeoutPolicy("http", { timeoutMs: 1000, timeoutSec: 9 })).toEqual({
+      effectiveTimeoutSec: 1,
+      effectiveTimeoutMs: 1000,
+      timeoutConfigured: true,
+      timeoutSource: "config",
+    });
+  });
+
+  it("keeps the http adapter at no timeout when neither field is set", () => {
+    expect(resolveHeartbeatRunTimeoutPolicy("http", {})).toEqual({
+      effectiveTimeoutSec: 0,
+      effectiveTimeoutMs: 0,
+      timeoutConfigured: false,
+      timeoutSource: "default",
+    });
+  });
+
   it("distinguishes budget cancellation from manual cancellation", () => {
     expect(
       buildHeartbeatRunStopMetadata({

--- a/server/src/services/heartbeat-stop-metadata.test.ts
+++ b/server/src/services/heartbeat-stop-metadata.test.ts
@@ -4,6 +4,7 @@ import {
   mergeHeartbeatRunStopMetadata,
   resolveHeartbeatRunTimeoutPolicy,
 } from "./heartbeat-stop-metadata.js";
+import { MAX_HTTP_TIMEOUT_MS } from "../adapters/http/timeout.js";
 
 describe("heartbeat stop metadata", () => {
   it("keeps local coding adapters at no timeout by default", () => {
@@ -66,6 +67,36 @@ describe("heartbeat stop metadata", () => {
       effectiveTimeoutMs: 0,
       timeoutConfigured: false,
       timeoutSource: "default",
+    });
+  });
+
+  it("keeps the http policy in step with the timeout the adapter arms", () => {
+    // `adapterConfig` holds arbitrary JSON, so the `timeoutMs` alias can be
+    // present and carry no number. The adapter then falls back to `timeoutSec`,
+    // and the recorded policy has to follow it rather than report no timeout.
+    expect(resolveHeartbeatRunTimeoutPolicy("http", { timeoutMs: null, timeoutSec: 5 })).toEqual({
+      effectiveTimeoutSec: 5,
+      effectiveTimeoutMs: 5000,
+      timeoutConfigured: true,
+      timeoutSource: "config",
+    });
+  });
+
+  it("records no http timeout for a value the adapter cannot use", () => {
+    expect(resolveHeartbeatRunTimeoutPolicy("http", { timeoutMs: "1000" })).toEqual({
+      effectiveTimeoutSec: 0,
+      effectiveTimeoutMs: 0,
+      timeoutConfigured: false,
+      timeoutSource: "config",
+    });
+  });
+
+  it("holds an oversized http timeout at the same ceiling the adapter uses", () => {
+    expect(resolveHeartbeatRunTimeoutPolicy("http", { timeoutSec: 3_000_000_000 })).toEqual({
+      effectiveTimeoutSec: MAX_HTTP_TIMEOUT_MS / 1000,
+      effectiveTimeoutMs: MAX_HTTP_TIMEOUT_MS,
+      timeoutConfigured: true,
+      timeoutSource: "config",
     });
   });
 

--- a/server/src/services/heartbeat-stop-metadata.ts
+++ b/server/src/services/heartbeat-stop-metadata.ts
@@ -1,3 +1,5 @@
+import { resolveHttpTimeoutMs } from "../adapters/http/timeout.js";
+
 export type HeartbeatRunOutcome = "succeeded" | "interrupted" | "failed" | "cancelled" | "timed_out";
 
 export type HeartbeatRunStopReason =
@@ -56,19 +58,14 @@ export function resolveHeartbeatRunTimeoutPolicy(
   const config = adapterConfig ?? {};
 
   if (adapterType === "http") {
-    // Mirror the precedence in adapters/http/execute.ts: `timeoutMs` wins, and
-    // the documented `timeoutSec` supplies the value when it is absent.
-    const hasTimeoutMs = hasOwn(config, "timeoutMs");
-    const hasTimeoutSec = hasOwn(config, "timeoutSec");
-    const rawTimeoutMs = hasTimeoutMs
-      ? readFiniteNumber(config.timeoutMs)
-      : (readFiniteNumber(config.timeoutSec) ?? 0) * 1000;
-    const timeoutMs = Math.max(0, Math.floor(rawTimeoutMs ?? 0));
+    // The adapter owns this resolution, so the recorded policy cannot drift
+    // from the timer the adapter actually arms.
+    const timeoutMs = resolveHttpTimeoutMs(config);
     return {
       effectiveTimeoutSec: timeoutMs / 1000,
       effectiveTimeoutMs: timeoutMs,
       timeoutConfigured: timeoutMs > 0,
-      timeoutSource: hasTimeoutMs || hasTimeoutSec ? "config" : "default",
+      timeoutSource: hasOwn(config, "timeoutMs") || hasOwn(config, "timeoutSec") ? "config" : "default",
     };
   }
 

--- a/server/src/services/heartbeat-stop-metadata.ts
+++ b/server/src/services/heartbeat-stop-metadata.ts
@@ -56,14 +56,19 @@ export function resolveHeartbeatRunTimeoutPolicy(
   const config = adapterConfig ?? {};
 
   if (adapterType === "http") {
+    // Mirror the precedence in adapters/http/execute.ts: `timeoutMs` wins, and
+    // the documented `timeoutSec` supplies the value when it is absent.
     const hasTimeoutMs = hasOwn(config, "timeoutMs");
-    const rawTimeoutMs = hasTimeoutMs ? readFiniteNumber(config.timeoutMs) : 0;
+    const hasTimeoutSec = hasOwn(config, "timeoutSec");
+    const rawTimeoutMs = hasTimeoutMs
+      ? readFiniteNumber(config.timeoutMs)
+      : (readFiniteNumber(config.timeoutSec) ?? 0) * 1000;
     const timeoutMs = Math.max(0, Math.floor(rawTimeoutMs ?? 0));
     return {
       effectiveTimeoutSec: timeoutMs / 1000,
       effectiveTimeoutMs: timeoutMs,
       timeoutConfigured: timeoutMs > 0,
-      timeoutSource: hasTimeoutMs ? "config" : "default",
+      timeoutSource: hasTimeoutMs || hasTimeoutSec ? "config" : "default",
     };
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Paperclip runs every agent through an adapter, and the `http` adapter calls a remote endpoint once per run
> - The `http` adapter documents a `timeoutSec` field in `agentConfigurationDoc`, which is also served at `/api/llms/agent-configuration/http.txt`
> - But `execute()` read `config.timeoutMs`, so `asNumber` returned `0` and the `AbortController` was never armed
> - An endpoint that accepts the connection and then never answers blocks the run for ever, and the configured timeout does nothing
> - This pull request makes the `http` adapter honour the documented `timeoutSec` field, and keeps `timeoutMs` working
> - The benefit is that a configured timeout stops a hung run, and the run stop metadata reports the same timeout the adapter arms

## Linked Issues or Issue Description

Fixes #12816

Related issues about timeout field units in other adapters:

- Refs #3305
- Refs #6291

Related PR: #12625 (open) changes the same lines in `server/src/adapters/http/execute.ts`. That PR removes the drift in the other direction. It rewrites `agentConfigurationDoc` to document `timeoutMs` as part of a larger polling feature. This pull request keeps the documented `timeoutSec` and repairs the code instead, so it stays a small bug fix. If #12625 lands first, this change is easy to rebase onto it.

## What Changed

- `server/src/adapters/http/timeout.ts` (new): `resolveHttpTimeoutMs` resolves the request timeout in one place. `timeoutSec` is the documented field. `timeoutMs` still wins when it holds a usable number. The result is held at `MAX_HTTP_TIMEOUT_MS` (2147483647), because Node holds a `setTimeout` delay in a 32-bit signed integer and coerces a larger delay to 1ms.
- `server/src/adapters/http/execute.ts`: calls the resolver instead of reading `config.timeoutMs` directly.
- `server/src/services/heartbeat-stop-metadata.ts`: `resolveHeartbeatRunTimeoutPolicy` reads the same adapter config to write the run stop metadata. Its `http` branch calls the same resolver, so the recorded policy cannot drift from the timer the adapter arms.
- Tests: a unit suite for the resolver, plus cases in the adapter and metadata suites for the documented `timeoutSec` path, `timeoutMs` precedence, the fall-through when `timeoutMs` carries no number, the no-timeout default, and the bounded oversized value.
- No documentation change is needed. `agentConfigurationDoc` in `server/src/adapters/http/index.ts` already documents `timeoutSec`. The code now matches it.

## Verification

Run the changed suites:

```
npx vitest run server/src/adapters/http server/src/services/heartbeat-stop-metadata.test.ts
# Test Files 3 passed (3), Tests 25 passed (25)
```

The bug is real. Revert only `execute.ts` to master and run again:

```
× arms the timeout from the documented timeoutSec field 15005ms
Tests 1 failed | 4 passed (5)
```

The request never aborts, so the test reaches the vitest timeout. This is the reported failure.

Suites that read the timeout policy also pass:

```
npx vitest run server/src/adapters \
  server/src/services/heartbeat-stop-metadata.test.ts \
  server/src/__tests__/heartbeat-run-summary.test.ts \
  server/src/__tests__/heartbeat-process-recovery.test.ts \
  server/src/__tests__/activity-service.test.ts \
  ui/src/components/IssueRunLedger.test.tsx
# Test Files 10 passed (10), Tests 237 passed (237)
```

Typecheck and the module boundary gate are clean:

```
cd server && npx tsc --noEmit    # exit 0
pnpm check:module-boundaries     # passed
```

## Risks

Low risk.

- An agent configured with a numeric `timeoutMs` keeps the exact behaviour it has today, because `timeoutMs` still wins.
- An agent configured with `timeoutSec` gets a timeout that was documented but never armed. A long request that used to hang can now abort. This is the intended repair, and the field is optional, so an agent with neither field still has no timeout.
- The run stop metadata now reports a timeout for a `timeoutSec` config, and reports none for a numeric string. Both changes make the record agree with the timer the adapter arms. Only the `http` adapter is affected.
- A configured timeout above 2147483647ms is now held at that ceiling instead of aborting the request at once. Any real timeout is far below it.
- No database migration. No API change. No telemetry event change.

## Model Used

Anthropic Claude Opus 5 (`claude-opus-5`), used through Claude Code with extended thinking and tool use. The model read the repository, wrote the fix and the tests, and ran the test and typecheck commands above. A human reviewed the diff and the reasoning.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
