### PR TITLE
feat(costs): attribute token spend per task and per routine

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1223,6 +1223,8 @@ export type {
   CostByAgentModel,
   CostWindowSpendRow,
   CostByProject,
+  CostByIssue,
+  CostByRoutine,
   FinanceEvent,
   FinanceSummary,
   FinanceByBiller,

--- a/packages/shared/src/types/cost.ts
+++ b/packages/shared/src/types/cost.ts
@@ -27,6 +27,28 @@ export interface CostSummary {
   spendCents: number;
   budgetCents: number;
   utilizationPercent: number;
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  /** cents actually billed through a metered api — the only spend that hits a card */
+  meteredCostCents: number;
+  /**
+   * dollar value of subscription usage. `spendCents` stays 0 for it by design
+   * (the plan already paid), so this is the only figure that shows the account
+   * burning through its quota before a lockout.
+   */
+  subscriptionCostUsd: number;
+  eventCount: number;
+  runCount: number;
+  /** runs whose cost event carries no price — usage known, dollars unknown */
+  unpricedRunCount: number;
+  /** runs that produced no cost event at all */
+  unmeteredRunCount: number;
+  strandedRunCount: number;
+  strandedTokens: number;
+  neverRanRunCount: number;
+  lostRunCount: number;
 }
 
 export interface IssueCostSummary {
@@ -116,6 +138,60 @@ export interface CostWindowSpendRow {
   inputTokens: number;
   cachedInputTokens: number;
   outputTokens: number;
+}
+
+/**
+ * tokens and cost attributed to a single task, ranked by token volume.
+ *
+ * one row per run: a run belongs to exactly one issue, the one resolved into
+ * `cost_events.issue_id` at finalization. Summing each issue's `/runs` instead
+ * inflates the company total by ~87%, because that route hands the full run —
+ * usage included — to every issue the run merely touched.
+ *
+ * runs with no owning issue are omitted here and reported by `summary`, so the
+ * remainder stays visible instead of being folded into some task.
+ */
+export interface CostByIssue {
+  issueId: string | null;
+  issueIdentifier: string | null;
+  issueTitle: string | null;
+  issueStatus: string | null;
+  projectId: string | null;
+  projectName: string | null;
+  costCents: number;
+  meteredCostCents: number;
+  subscriptionCostUsd: number;
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  runCount: number;
+  unpricedRunCount: number;
+}
+
+/**
+ * tokens and cost per routine, rolled up across every firing.
+ *
+ * each firing opens its own issue, so a daily routine's cost is otherwise
+ * scattered across dozens of unrelated-looking tasks. Costs are counted through
+ * the linked issue's whole subtree, because work a firing delegates to a child
+ * is still that routine's cost.
+ */
+export interface CostByRoutine {
+  routineId: string;
+  routineTitle: string | null;
+  routineStatus: string | null;
+  assigneeAgentId: string | null;
+  assigneeAgentName: string | null;
+  /** issues reachable from this routine's firings, subtree included */
+  issueCount: number;
+  runCount: number;
+  costCents: number;
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  subscriptionCostUsd: number;
 }
 
 /** cost attributed to a project via heartbeat run → activity log → issue → project chain */

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -872,7 +872,7 @@ export type {
   RoutineExecutionIssueOrigin,
   RoutineListItem,
 } from "./routine.js";
-export type { CostEvent, CostSummary, IssueCostSummary, CostByAgent, CostByProviderModel, CostByBiller, CostByAgentModel, CostWindowSpendRow, CostByProject } from "./cost.js";
+export type { CostEvent, CostSummary, IssueCostSummary, CostByAgent, CostByProviderModel, CostByBiller, CostByAgentModel, CostWindowSpendRow, CostByProject, CostByIssue, CostByRoutine } from "./cost.js";
 export type { FinanceEvent, FinanceSummary, FinanceByBiller, FinanceByKind } from "./finance.js";
 export type {
   AgentWakeupResponse,

--- a/server/src/__tests__/costs-service.test.ts
+++ b/server/src/__tests__/costs-service.test.ts
@@ -14,6 +14,8 @@ import {
   heartbeatRuns,
   issues,
   projects,
+  routines,
+  routineRuns,
 } from "@paperclipai/db";
 import { costService } from "../services/costs.ts";
 import { financeService } from "../services/finance.ts";
@@ -420,6 +422,8 @@ describeEmbeddedPostgres("cost and finance aggregate overflow handling", () => {
     await db.delete(financeEvents);
     await db.delete(costEvents);
     await db.delete(activityLog);
+    await db.delete(routineRuns);
+    await db.delete(routines);
     await db.delete(heartbeatRuns);
     await db.delete(issues);
     await db.delete(projects);
@@ -932,5 +936,304 @@ describeEmbeddedPostgres("cost and finance aggregate overflow handling", () => {
     expect(summary.estimatedDebitCents).toBe(2_000_000_000);
     expect(byKindRow?.debitCents).toBe(4_000_000_000);
     expect(byKindRow?.netCents).toBe(4_000_000_000);
+  });
+
+  /**
+   * The scenario that made per-task numbers untrustworthy: one run touches many
+   * issues, and `GET /issues/{id}/runs` hands the full usage to each of them.
+   * Summing that way inflated the company total by 87%. These tests assert the
+   * property that failure violates — per-issue rows must sum to the company
+   * total, not to a multiple of it.
+   */
+  it("attributes a multi-issue run to one owner so per-issue tokens sum to the company total", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const ownerIssueId = randomUUID();
+    const touchedIssueId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Cost Agent",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(issues).values([
+      {
+        id: ownerIssueId,
+        companyId,
+        title: "Owner",
+        status: "in_progress",
+        priority: "medium",
+        issueNumber: 1,
+        identifier: "TST-1",
+      },
+      {
+        id: touchedIssueId,
+        companyId,
+        title: "Merely touched",
+        status: "done",
+        priority: "medium",
+        issueNumber: 2,
+        identifier: "TST-2",
+      },
+    ]);
+
+    // One run, owned by TST-1, that also wrote to TST-2. The activity_log rows
+    // are what make the run *appear* under both issues.
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      invocationSource: "on_demand",
+      status: "succeeded",
+      startedAt: new Date("2026-04-10T00:00:00.000Z"),
+      finishedAt: new Date("2026-04-10T00:10:00.000Z"),
+      contextSnapshot: { issueId: ownerIssueId },
+      usageJson: { costUsd: 3.5, billingType: "subscription_included" },
+    });
+    await db.insert(activityLog).values([
+      {
+        companyId,
+        actorType: "agent",
+        actorId: agentId,
+        action: "issue.updated",
+        entityType: "issue",
+        entityId: ownerIssueId,
+        runId,
+      },
+      {
+        companyId,
+        actorType: "agent",
+        actorId: agentId,
+        action: "issue.commented",
+        entityType: "issue",
+        entityId: touchedIssueId,
+        runId,
+      },
+    ]);
+
+    // Subscription usage: real tokens, zero billed cents. Exactly the shape
+    // that made the cost panel read $0 while the account burned its quota.
+    await db.insert(costEvents).values({
+      companyId,
+      agentId,
+      issueId: ownerIssueId,
+      heartbeatRunId: runId,
+      provider: "anthropic",
+      biller: "claude",
+      billingType: "subscription_included",
+      costStatus: "unpriced",
+      model: "claude-opus-5",
+      inputTokens: 1_000,
+      cachedInputTokens: 10_000,
+      outputTokens: 100,
+      costCents: 0,
+      occurredAt: new Date("2026-04-10T00:10:00.000Z"),
+    });
+
+    const range = {
+      from: new Date("2026-04-01T00:00:00.000Z"),
+      to: new Date("2026-04-15T23:59:59.999Z"),
+    };
+
+    const byIssue = await costService(db).byIssue(companyId, range);
+    const summary = await costService(db).summary(companyId, range);
+
+    // The run is charged once, to its owner — not to both issues it touched.
+    expect(byIssue).toHaveLength(1);
+    expect(byIssue[0]?.issueIdentifier).toBe("TST-1");
+    expect(byIssue[0]?.totalTokens).toBe(11_100);
+    expect(byIssue[0]?.runCount).toBe(1);
+
+    // The conservation property the acceptance criterion turns on.
+    const summedOverIssues = byIssue.reduce((acc, row) => acc + Number(row.totalTokens), 0);
+    expect(summedOverIssues).toBe(summary.totalTokens);
+
+    // Subscription dollars are visible even though billed cents are zero.
+    expect(summary.spendCents).toBe(0);
+    expect(summary.subscriptionCostUsd).toBeCloseTo(3.5, 5);
+    expect(byIssue[0]?.subscriptionCostUsd).toBeCloseTo(3.5, 5);
+  });
+
+  it("counts runs that recorded no usage instead of silently under-reporting", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Cost Agent",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    // A run that died before the adapter reported usage: it burned real tokens
+    // and wrote no cost event. It must be counted, not silently dropped.
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId,
+      agentId,
+      invocationSource: "on_demand",
+      status: "failed",
+      startedAt: new Date("2026-04-10T00:00:00.000Z"),
+      finishedAt: new Date("2026-04-10T00:05:00.000Z"),
+      usageJson: null,
+    });
+
+    const summary = await costService(db).summary(companyId, {
+      from: new Date("2026-04-01T00:00:00.000Z"),
+      to: new Date("2026-04-15T23:59:59.999Z"),
+    });
+
+    expect(summary.unmeteredRunCount).toBe(1);
+    expect(summary.totalTokens).toBe(0);
+  });
+
+  it("rolls every firing of a routine up to the routine, including child issues", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const routineId = randomUUID();
+    const firingOneIssueId = randomUUID();
+    const firingTwoIssueId = randomUUID();
+    const childOfFiringTwoId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Triage Agent",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(routines).values({
+      id: routineId,
+      companyId,
+      title: "Triagem de Slack",
+      assigneeAgentId: agentId,
+      status: "active",
+    });
+    await db.insert(issues).values([
+      {
+        id: firingOneIssueId,
+        companyId,
+        title: "Triagem 2026-04-10",
+        status: "done",
+        priority: "medium",
+        issueNumber: 1,
+        identifier: "TST-1",
+      },
+      {
+        id: firingTwoIssueId,
+        companyId,
+        title: "Triagem 2026-04-11",
+        status: "done",
+        priority: "medium",
+        issueNumber: 2,
+        identifier: "TST-2",
+      },
+      {
+        id: childOfFiringTwoId,
+        companyId,
+        parentId: firingTwoIssueId,
+        title: "Follow-up spawned by the firing",
+        status: "done",
+        priority: "medium",
+        issueNumber: 3,
+        identifier: "TST-3",
+      },
+    ]);
+    await db.insert(routineRuns).values([
+      {
+        companyId,
+        routineId,
+        source: "schedule",
+        status: "completed",
+        linkedIssueId: firingOneIssueId,
+      },
+      {
+        companyId,
+        routineId,
+        source: "schedule",
+        status: "completed",
+        linkedIssueId: firingTwoIssueId,
+      },
+    ]);
+
+    const baseEvent = {
+      companyId,
+      agentId,
+      provider: "anthropic",
+      biller: "claude",
+      billingType: "subscription_included" as const,
+      model: "claude-haiku-4-5",
+      cachedInputTokens: 0,
+      outputTokens: 0,
+      costCents: 0,
+    };
+    await db.insert(costEvents).values([
+      {
+        ...baseEvent,
+        issueId: firingOneIssueId,
+        heartbeatRunId: null,
+        inputTokens: 100,
+        occurredAt: new Date("2026-04-10T00:00:00.000Z"),
+      },
+      {
+        ...baseEvent,
+        issueId: firingTwoIssueId,
+        heartbeatRunId: null,
+        inputTokens: 200,
+        occurredAt: new Date("2026-04-11T00:00:00.000Z"),
+      },
+      {
+        ...baseEvent,
+        issueId: childOfFiringTwoId,
+        heartbeatRunId: null,
+        inputTokens: 400,
+        occurredAt: new Date("2026-04-11T00:05:00.000Z"),
+      },
+    ]);
+
+    const rows = await costService(db).byRoutine(companyId, {
+      from: new Date("2026-04-01T00:00:00.000Z"),
+      to: new Date("2026-04-15T23:59:59.999Z"),
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.routineTitle).toBe("Triagem de Slack");
+    // Both firings plus the child issue spawned by the second one.
+    expect(Number(rows[0]?.totalTokens)).toBe(700);
+    expect(Number(rows[0]?.issueCount)).toBe(3);
   });
 });

--- a/server/src/__tests__/costs-service.test.ts
+++ b/server/src/__tests__/costs-service.test.ts
@@ -1089,14 +1089,16 @@ describeEmbeddedPostgres("cost and finance aggregate overflow handling", () => {
       permissions: {},
     });
 
-    // A run that died before the adapter reported usage: it burned real tokens
-    // and wrote no cost event. It must be counted, not silently dropped.
+    // A run whose process was lost mid-flight: the model worked, the usage was
+    // never persisted. It burned real tokens and wrote no cost event, so it
+    // must be counted, not silently dropped.
     await db.insert(heartbeatRuns).values({
       id: randomUUID(),
       companyId,
       agentId,
       invocationSource: "on_demand",
       status: "failed",
+      errorCode: "process_lost",
       startedAt: new Date("2026-04-10T00:00:00.000Z"),
       finishedAt: new Date("2026-04-10T00:05:00.000Z"),
       usageJson: null,
@@ -1108,7 +1110,106 @@ describeEmbeddedPostgres("cost and finance aggregate overflow handling", () => {
     });
 
     expect(summary.unmeteredRunCount).toBe(1);
+    expect(summary.lostRunCount).toBe(1);
     expect(summary.totalTokens).toBe(0);
+  });
+
+  it("does not report a run that died before the model ran as lost consumption", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Cost Agent",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    // The ACP session never completed `session/new`, so no prompt reached the
+    // model. This run is a true zero — counting it as missing consumption is
+    // what made the gap look ~9x larger than it is.
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId,
+      agentId,
+      invocationSource: "on_demand",
+      status: "failed",
+      errorCode: "acpx_session_init_failed",
+      startedAt: new Date("2026-04-10T00:00:00.000Z"),
+      finishedAt: new Date("2026-04-10T00:05:00.000Z"),
+      usageJson: null,
+    });
+
+    const summary = await costService(db).summary(companyId, {
+      from: new Date("2026-04-01T00:00:00.000Z"),
+      to: new Date("2026-04-15T23:59:59.999Z"),
+    });
+
+    expect(summary.unmeteredRunCount).toBe(1);
+    expect(summary.neverRanRunCount).toBe(1);
+    // The number that says "the totals are a floor" must stay clean.
+    expect(summary.lostRunCount).toBe(0);
+  });
+
+  it("reports usage measured on a run but never aggregated as stranded, not lost", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Cost Agent",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    // The adapter failed but still reported usage. The tokens are recorded on the
+    // run and absent from cost_events, so every endpoint that aggregates cost
+    // events silently omits them. That is recoverable, not a blind spot.
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId,
+      agentId,
+      invocationSource: "on_demand",
+      status: "failed",
+      errorCode: "adapter_failed",
+      startedAt: new Date("2026-04-10T00:00:00.000Z"),
+      finishedAt: new Date("2026-04-10T00:05:00.000Z"),
+      usageJson: { inputTokens: 1000, cachedInputTokens: 200, outputTokens: 300 },
+    });
+
+    const summary = await costService(db).summary(companyId, {
+      from: new Date("2026-04-01T00:00:00.000Z"),
+      to: new Date("2026-04-15T23:59:59.999Z"),
+    });
+
+    expect(summary.unmeteredRunCount).toBe(1);
+    expect(summary.strandedRunCount).toBe(1);
+    expect(summary.strandedTokens).toBe(1500);
+    // It was measured, so it is neither a true zero nor an unknown.
+    expect(summary.neverRanRunCount).toBe(0);
+    expect(summary.lostRunCount).toBe(0);
   });
 
   it("rolls every firing of a routine up to the routine, including child issues", async () => {

--- a/server/src/__tests__/costs-service.test.ts
+++ b/server/src/__tests__/costs-service.test.ts
@@ -1163,6 +1163,60 @@ describeEmbeddedPostgres("cost and finance aggregate overflow handling", () => {
     expect(summary.lostRunCount).toBe(0);
   });
 
+  // A `succeeded` status is not proof that the run accounted for itself. On the
+  // live company database (2026-09-08) 8 of 1.478 succeeded runs carry no
+  // `usage_json`: usage and `result_json` are written by one guarded update that
+  // is skipped when the run already left `running`, so both are missing on
+  // exactly the same rows. Classifying by status would file these as fine and
+  // hide real consumption, so the gap must key off `error_code` only.
+  it("counts a succeeded run that never persisted usage as lost consumption", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Cost Agent",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId,
+      agentId,
+      invocationSource: "automation",
+      status: "succeeded",
+      // The shape observed live: no error code to excuse it, and the whole
+      // finalization write (usage and result alike) never landed.
+      errorCode: null,
+      startedAt: new Date("2026-04-10T00:00:00.000Z"),
+      finishedAt: new Date("2026-04-10T00:05:00.000Z"),
+      usageJson: null,
+      resultJson: null,
+    });
+
+    const summary = await costService(db).summary(companyId, {
+      from: new Date("2026-04-01T00:00:00.000Z"),
+      to: new Date("2026-04-15T23:59:59.999Z"),
+    });
+
+    expect(summary.unmeteredRunCount).toBe(1);
+    expect(summary.lostRunCount).toBe(1);
+    // It must not be excused as "never reached the model" just for succeeding.
+    expect(summary.neverRanRunCount).toBe(0);
+  });
+
   it("reports usage measured on a run but never aggregated as stranded, not lost", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/__tests__/costs-service.test.ts
+++ b/server/src/__tests__/costs-service.test.ts
@@ -1217,6 +1217,64 @@ describeEmbeddedPostgres("cost and finance aggregate overflow handling", () => {
     expect(summary.neverRanRunCount).toBe(0);
   });
 
+  // `cancelled` is written by `cancelActiveForAgentInternal`, which terminates a
+  // child process that is already running, so the run can be cancelled mid-turn
+  // after the provider has billed the tokens. Live data (2026-09-08): of 28 such
+  // runs 15 recorded `process_started_at` and 26 emitted output (median
+  // `last_output_seq` 120, max 645, versus max 4 for the pre-dispatch
+  // `acpx_session_*` codes), and one `cancelled` run carries `usage_json` with
+  // 4.57M tokens. Excusing the code as "never reached the model" therefore
+  // deleted real consumption from the declared gap.
+  it("counts a cancelled run that was killed mid-turn as lost consumption", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Cost Agent",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId,
+      agentId,
+      invocationSource: "automation",
+      status: "cancelled",
+      errorCode: "cancelled",
+      // The live shape: the child process was up and streaming when the cancel
+      // landed, which is exactly why the tokens were already spent.
+      startedAt: new Date("2026-04-10T00:00:00.000Z"),
+      processStartedAt: new Date("2026-04-10T00:00:04.000Z"),
+      finishedAt: new Date("2026-04-10T00:05:34.000Z"),
+      lastOutputAt: new Date("2026-04-10T00:05:30.000Z"),
+      lastOutputSeq: 405,
+      usageJson: null,
+    });
+
+    const summary = await costService(db).summary(companyId, {
+      from: new Date("2026-04-01T00:00:00.000Z"),
+      to: new Date("2026-04-15T23:59:59.999Z"),
+    });
+
+    expect(summary.unmeteredRunCount).toBe(1);
+    expect(summary.lostRunCount).toBe(1);
+    // Being cancelled is not evidence that no prompt reached the model.
+    expect(summary.neverRanRunCount).toBe(0);
+  });
+
   it("reports usage measured on a run but never aggregated as stranded, not lost", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/__tests__/costs-service.test.ts
+++ b/server/src/__tests__/costs-service.test.ts
@@ -34,6 +34,7 @@ function makeDb(overrides: Record<string, unknown> = {}) {
     groupBy: vi.fn().mockReturnThis(),
     orderBy: vi.fn().mockReturnThis(),
     limit: vi.fn().mockReturnThis(),
+    offset: vi.fn().mockReturnThis(),
     then: vi.fn().mockResolvedValue([]),
   };
 
@@ -1336,5 +1337,428 @@ describeEmbeddedPostgres("cost and finance aggregate overflow handling", () => {
     // Both firings plus the child issue spawned by the second one.
     expect(Number(rows[0]?.totalTokens)).toBe(700);
     expect(Number(rows[0]?.issueCount)).toBe(3);
+  });
+
+  // A run is claimed (`startedAt`) long before it finalizes, and the cost event
+  // is written only at finalization. Counting by start time therefore reported
+  // every run currently in flight as consumption that was lost.
+  it("does not report a still-running run as lost consumption", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Cost Agent",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId,
+      agentId,
+      invocationSource: "on_demand",
+      status: "running",
+      startedAt: new Date("2026-04-10T00:00:00.000Z"),
+      finishedAt: null,
+      usageJson: null,
+    });
+
+    const summary = await costService(db).summary(companyId, {
+      from: new Date("2026-04-01T00:00:00.000Z"),
+      to: new Date("2026-04-15T23:59:59.999Z"),
+    });
+
+    expect(summary.unmeteredRunCount).toBe(0);
+    expect(summary.lostRunCount).toBe(0);
+  });
+
+  // The gap count is windowed on finalization so it lines up with
+  // `cost_events.occurred_at`. A run that starts before the window and finishes
+  // inside it belongs to the window its ledger event would have landed in.
+  it("windows unmetered runs on finalization, not on start", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Cost Agent",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    // Started 31 Mar, finished 1 Apr: the ledger would have dated it 1 Apr.
+    await db.insert(heartbeatRuns).values({
+      id: randomUUID(),
+      companyId,
+      agentId,
+      invocationSource: "on_demand",
+      status: "failed",
+      errorCode: "process_lost",
+      startedAt: new Date("2026-03-31T23:50:00.000Z"),
+      finishedAt: new Date("2026-04-01T00:10:00.000Z"),
+      usageJson: null,
+    });
+
+    const inWindow = await costService(db).summary(companyId, {
+      from: new Date("2026-04-01T00:00:00.000Z"),
+      to: new Date("2026-04-15T23:59:59.999Z"),
+    });
+    expect(inWindow.lostRunCount).toBe(1);
+
+    const previousWindow = await costService(db).summary(companyId, {
+      from: new Date("2026-03-01T00:00:00.000Z"),
+      to: new Date("2026-03-31T23:59:59.999Z"),
+    });
+    expect(previousWindow.lostRunCount).toBe(0);
+  });
+
+  // Nothing forbids parenting a routine firing to another routine's firing, and
+  // when that happened the nested subtree was summed into both routine rows, so
+  // the routine totals could exceed the company total.
+  it("does not count a nested routine firing against both routines", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const outerRoutineId = randomUUID();
+    const innerRoutineId = randomUUID();
+    const outerFiringIssueId = randomUUID();
+    const innerFiringIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Triage Agent",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(routines).values([
+      {
+        id: outerRoutineId,
+        companyId,
+        title: "Rotina externa",
+        assigneeAgentId: agentId,
+        status: "active",
+      },
+      {
+        id: innerRoutineId,
+        companyId,
+        title: "Rotina aninhada",
+        assigneeAgentId: agentId,
+        status: "active",
+      },
+    ]);
+    await db.insert(issues).values([
+      {
+        id: outerFiringIssueId,
+        companyId,
+        title: "Disparo externo",
+        status: "done",
+        priority: "medium",
+        issueNumber: 1,
+        identifier: "TST-1",
+      },
+      {
+        id: innerFiringIssueId,
+        companyId,
+        // The nested firing hangs off the outer firing's issue.
+        parentId: outerFiringIssueId,
+        title: "Disparo aninhado",
+        status: "done",
+        priority: "medium",
+        issueNumber: 2,
+        identifier: "TST-2",
+      },
+    ]);
+    await db.insert(routineRuns).values([
+      {
+        companyId,
+        routineId: outerRoutineId,
+        source: "schedule",
+        status: "completed",
+        linkedIssueId: outerFiringIssueId,
+      },
+      {
+        companyId,
+        routineId: innerRoutineId,
+        source: "schedule",
+        status: "completed",
+        linkedIssueId: innerFiringIssueId,
+      },
+    ]);
+
+    const baseEvent = {
+      companyId,
+      agentId,
+      provider: "anthropic",
+      biller: "claude",
+      billingType: "subscription_included" as const,
+      model: "claude-haiku-4-5",
+      cachedInputTokens: 0,
+      outputTokens: 0,
+      costCents: 0,
+      heartbeatRunId: null,
+    };
+    await db.insert(costEvents).values([
+      {
+        ...baseEvent,
+        issueId: outerFiringIssueId,
+        inputTokens: 100,
+        occurredAt: new Date("2026-04-10T00:00:00.000Z"),
+      },
+      {
+        ...baseEvent,
+        issueId: innerFiringIssueId,
+        inputTokens: 400,
+        occurredAt: new Date("2026-04-10T00:05:00.000Z"),
+      },
+    ]);
+
+    const range = {
+      from: new Date("2026-04-01T00:00:00.000Z"),
+      to: new Date("2026-04-15T23:59:59.999Z"),
+    };
+    const rows = await costService(db).byRoutine(companyId, range);
+    const summary = await costService(db).summary(companyId, range);
+
+    const outer = rows.find((row) => row.routineId === outerRoutineId);
+    const inner = rows.find((row) => row.routineId === innerRoutineId);
+
+    // The nested firing's tokens belong to the routine that opened it, once.
+    expect(Number(outer?.totalTokens)).toBe(100);
+    expect(Number(inner?.totalTokens)).toBe(400);
+
+    // The property the acceptance criterion turns on: routines cannot sum to
+    // more than the company consumed.
+    const summedOverRoutines = rows.reduce(
+      (acc, row) => acc + Number(row.totalTokens),
+      0,
+    );
+    expect(summedOverRoutines).toBe(summary.totalTokens);
+  });
+
+  // A firing root that was hidden, or that is harness work, is excluded from
+  // `byIssue`. Counting it in the routine rollup made the two views disagree.
+  it("excludes a hidden firing root from the routine rollup", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const routineId = randomUUID();
+    const visibleFiringId = randomUUID();
+    const hiddenFiringId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Triage Agent",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(routines).values({
+      id: routineId,
+      companyId,
+      title: "Triagem de Slack",
+      assigneeAgentId: agentId,
+      status: "active",
+    });
+    await db.insert(issues).values([
+      {
+        id: visibleFiringId,
+        companyId,
+        title: "Disparo visivel",
+        status: "done",
+        priority: "medium",
+        issueNumber: 1,
+        identifier: "TST-1",
+      },
+      {
+        id: hiddenFiringId,
+        companyId,
+        title: "Disparo oculto",
+        status: "done",
+        priority: "medium",
+        issueNumber: 2,
+        identifier: "TST-2",
+        hiddenAt: new Date("2026-04-12T00:00:00.000Z"),
+      },
+    ]);
+    await db.insert(routineRuns).values([
+      {
+        companyId,
+        routineId,
+        source: "schedule",
+        status: "completed",
+        linkedIssueId: visibleFiringId,
+      },
+      {
+        companyId,
+        routineId,
+        source: "schedule",
+        status: "completed",
+        linkedIssueId: hiddenFiringId,
+      },
+    ]);
+
+    const baseEvent = {
+      companyId,
+      agentId,
+      provider: "anthropic",
+      biller: "claude",
+      billingType: "subscription_included" as const,
+      model: "claude-haiku-4-5",
+      cachedInputTokens: 0,
+      outputTokens: 0,
+      costCents: 0,
+      heartbeatRunId: null,
+    };
+    await db.insert(costEvents).values([
+      {
+        ...baseEvent,
+        issueId: visibleFiringId,
+        inputTokens: 100,
+        occurredAt: new Date("2026-04-10T00:00:00.000Z"),
+      },
+      {
+        ...baseEvent,
+        issueId: hiddenFiringId,
+        inputTokens: 900,
+        occurredAt: new Date("2026-04-10T00:05:00.000Z"),
+      },
+    ]);
+
+    const range = {
+      from: new Date("2026-04-01T00:00:00.000Z"),
+      to: new Date("2026-04-15T23:59:59.999Z"),
+    };
+    const rows = await costService(db).byRoutine(companyId, range);
+
+    expect(rows).toHaveLength(1);
+    // The hidden firing's 900 tokens stay out, matching `byIssue`.
+    expect(Number(rows[0]?.totalTokens)).toBe(100);
+    expect(Number(rows[0]?.issueCount)).toBe(1);
+  });
+
+  // `limit` is capped at 500, so without an offset a company with more
+  // cost-bearing issues than the cap could never read the rows past it, and
+  // summing the endpoint could not reproduce the company total.
+  it("pages past the ranked cap so the rows still sum to the company total", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Cost Agent",
+      role: "engineer",
+      status: "active",
+      adapterType: "claude_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    const issueIds = [randomUUID(), randomUUID(), randomUUID()];
+    await db.insert(issues).values(
+      issueIds.map((id, index) => ({
+        id,
+        companyId,
+        title: `Task ${index + 1}`,
+        status: "done",
+        priority: "medium" as const,
+        issueNumber: index + 1,
+        identifier: `TST-${index + 1}`,
+      })),
+    );
+
+    const baseEvent = {
+      companyId,
+      agentId,
+      provider: "anthropic",
+      biller: "claude",
+      billingType: "subscription_included" as const,
+      model: "claude-haiku-4-5",
+      cachedInputTokens: 0,
+      outputTokens: 0,
+      costCents: 0,
+      heartbeatRunId: null,
+    };
+    await db.insert(costEvents).values(
+      issueIds.map((issueId, index) => ({
+        ...baseEvent,
+        issueId,
+        inputTokens: (index + 1) * 100,
+        occurredAt: new Date("2026-04-10T00:00:00.000Z"),
+      })),
+    );
+
+    const range = {
+      from: new Date("2026-04-01T00:00:00.000Z"),
+      to: new Date("2026-04-15T23:59:59.999Z"),
+    };
+    const service = costService(db);
+    const summary = await service.summary(companyId, range);
+
+    // Walk the whole aggregate one page at a time.
+    const firstPage = await service.byIssue(companyId, range, 2, 0);
+    const secondPage = await service.byIssue(companyId, range, 2, 2);
+
+    expect(firstPage).toHaveLength(2);
+    expect(secondPage).toHaveLength(1);
+
+    // No row is served twice and none is skipped.
+    const paged = [...firstPage, ...secondPage];
+    expect(new Set(paged.map((row) => row.issueId)).size).toBe(3);
+
+    const summedOverPages = paged.reduce(
+      (acc, row) => acc + Number(row.totalTokens),
+      0,
+    );
+    expect(summedOverPages).toBe(summary.totalTokens);
   });
 });

--- a/server/src/__tests__/heartbeat-cost-accounting.test.ts
+++ b/server/src/__tests__/heartbeat-cost-accounting.test.ts
@@ -111,4 +111,28 @@ describe("heartbeat cost accounting", () => {
       outputTokens: 0,
     })).toBe(false);
   });
+
+  // Adapters such as pi-local initialize the reported cost to 0, so a run that
+  // returns before collecting usage arrives here with an explicit zero rather
+  // than a null. Writing an all-zero row for it would move the run out of
+  // `summary.lostRunCount` and claim it was accounted for.
+  it("does not record a ledger event for an explicit zero-dollar run with no usage", () => {
+    expect(shouldRecordLedgerEvent({
+      billedCostCents: 0,
+      billedCostUsd: 0,
+      inputTokens: 0,
+      cachedInputTokens: 0,
+      outputTokens: 0,
+    })).toBe(false);
+  });
+
+  it("does not record a ledger event for a non-finite reported cost", () => {
+    expect(shouldRecordLedgerEvent({
+      billedCostCents: 0,
+      billedCostUsd: Number.NaN,
+      inputTokens: 0,
+      cachedInputTokens: 0,
+      outputTokens: 0,
+    })).toBe(false);
+  });
 });

--- a/server/src/__tests__/heartbeat-cost-accounting.test.ts
+++ b/server/src/__tests__/heartbeat-cost-accounting.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   resolveCacheAdjustedCostUsd,
   resolveLedgerCostStatus,
+  shouldRecordLedgerEvent,
 } from "../services/heartbeat.js";
 
 describe("heartbeat cost accounting", () => {
@@ -63,5 +64,51 @@ describe("heartbeat cost accounting", () => {
       costUsd: 3.1,
       cacheAdjustedCostUsd: 1.5,
     })).toBe(1.5);
+  });
+
+  // A subscription run always bills 0 cents, so the ledger has to key off the
+  // reported dollar figure. Without this, a run that burned quota and then
+  // failed before reporting tokens leaves no ledger row and no owning issue,
+  // and every per-issue total silently understates by that run.
+  it("records a ledger event for a subscription run priced in dollars but billed at zero cents", () => {
+    expect(shouldRecordLedgerEvent({
+      billedCostCents: 0,
+      billedCostUsd: 0.42,
+      inputTokens: 0,
+      cachedInputTokens: 0,
+      outputTokens: 0,
+    })).toBe(true);
+  });
+
+  it("records a ledger event for token usage that carries no reported cost", () => {
+    expect(shouldRecordLedgerEvent({
+      billedCostCents: 0,
+      billedCostUsd: null,
+      inputTokens: 1_200,
+      cachedInputTokens: 0,
+      outputTokens: 40,
+    })).toBe(true);
+  });
+
+  it("records a ledger event for metered spend", () => {
+    expect(shouldRecordLedgerEvent({
+      billedCostCents: 125,
+      billedCostUsd: 1.25,
+      inputTokens: 0,
+      cachedInputTokens: 0,
+      outputTokens: 0,
+    })).toBe(true);
+  });
+
+  // A run that reported nothing at all is still not invented into the ledger:
+  // `summary.unmeteredRunCount` reports it as a known gap instead.
+  it("does not record a ledger event for a run that reported neither cost nor tokens", () => {
+    expect(shouldRecordLedgerEvent({
+      billedCostCents: 0,
+      billedCostUsd: null,
+      inputTokens: 0,
+      cachedInputTokens: 0,
+      outputTokens: 0,
+    })).toBe(false);
   });
 });

--- a/server/src/routes/costs.ts
+++ b/server/src/routes/costs.ts
@@ -45,6 +45,23 @@ export function parseCostLimit(query: Record<string, unknown>) {
   return limit;
 }
 
+/**
+ * Page offset for the ranked cost reports.
+ *
+ * `limit` is capped, so without an offset a company with more cost-bearing
+ * issues than the cap has no way to read the rows past it, and summing the
+ * response could never match the company total.
+ */
+export function parseCostOffset(query: Record<string, unknown>) {
+  const raw = Array.isArray(query.offset) ? query.offset[0] : query.offset;
+  if (raw == null || raw === "") return 0;
+  const offset = typeof raw === "number" ? raw : Number.parseInt(String(raw), 10);
+  if (!Number.isFinite(offset) || offset < 0) {
+    throw badRequest("invalid 'offset' value");
+  }
+  return offset;
+}
+
 export function costRoutes(
   db: Db,
   options: { pluginWorkerManager?: PluginWorkerManager } = {},
@@ -333,7 +350,8 @@ export function costRoutes(
     if (!(await assertCompanyCostReadAllowed(req, res, companyId))) return;
     const range = parseCostDateRange(req.query);
     const limit = parseCostLimit(req.query);
-    const rows = await costs.byIssue(companyId, range, limit);
+    const offset = parseCostOffset(req.query);
+    const rows = await costs.byIssue(companyId, range, limit, offset);
     res.json(rows);
   });
 
@@ -343,7 +361,8 @@ export function costRoutes(
     if (!(await assertCompanyCostReadAllowed(req, res, companyId))) return;
     const range = parseCostDateRange(req.query);
     const limit = parseCostLimit(req.query);
-    const rows = await costs.byRoutine(companyId, range, limit);
+    const offset = parseCostOffset(req.query);
+    const rows = await costs.byRoutine(companyId, range, limit, offset);
     res.json(rows);
   });
 

--- a/server/src/routes/costs.ts
+++ b/server/src/routes/costs.ts
@@ -327,6 +327,26 @@ export function costRoutes(
     res.json(rows);
   });
 
+  router.get("/companies/:companyId/costs/by-issue", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    if (!(await assertCompanyCostReadAllowed(req, res, companyId))) return;
+    const range = parseCostDateRange(req.query);
+    const limit = parseCostLimit(req.query);
+    const rows = await costs.byIssue(companyId, range, limit);
+    res.json(rows);
+  });
+
+  router.get("/companies/:companyId/costs/by-routine", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    if (!(await assertCompanyCostReadAllowed(req, res, companyId))) return;
+    const range = parseCostDateRange(req.query);
+    const limit = parseCostLimit(req.query);
+    const rows = await costs.byRoutine(companyId, range, limit);
+    res.json(rows);
+  });
+
   router.patch("/companies/:companyId/budgets", validate(updateBudgetSchema), async (req, res) => {
     assertBoard(req);
     const companyId = req.params.companyId as string;

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -3424,7 +3424,7 @@ registry.registerPath({
 
 const costSummaryPaths = [
   "summary", "by-agent", "by-agent-model", "by-provider",
-  "by-biller", "by-project", "finance-summary", "finance-by-biller",
+  "by-biller", "by-project", "by-issue", "by-routine", "finance-summary", "finance-by-biller",
   "finance-by-kind", "finance-events", "window-spend", "quota-windows",
 ] as const;
 

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -38,12 +38,24 @@ const SUBSCRIPTION_BILLING_TYPES = ["subscription_included", "subscription_overa
  * is skipped when the run already left `running`. They carry no
  * `NO_MODEL_WORK_ERROR_CODES` code, so they land in `lost` and stay visible
  * instead of being silently excused as never having run.
+ *
+ * Membership test: a code belongs here only when the path that writes it runs
+ * *before* the adapter is dispatched. That is what makes "consumed nothing" a
+ * property of the code rather than a guess. `cancelled` failed that test and
+ * was removed on 2026-09-08: `cancelActiveForAgentInternal` writes it while
+ * terminating an already-running child process, so the run can be mid-turn.
+ * The live data agrees — of 28 such runs, 15 recorded `process_started_at`, 26
+ * emitted output (median `last_output_seq` 120, max 645, against a max of 4 for
+ * the pre-dispatch `acpx_session_*` codes whose logs are adapter error text),
+ * and one `cancelled` run does carry `usage_json` with 4.57M tokens, proving
+ * the state is reachable after the model has been billed. Excusing them cost
+ * 26 runs of real consumption from `lostRunCount`; keeping them costs 2 runs
+ * that emitted nothing, which overstates a declared gap instead of hiding one.
  */
 const NO_MODEL_WORK_ERROR_CODES = [
   "acpx_session_config_failed",
   "acpx_session_init_failed",
   "configuration_incomplete",
-  "cancelled",
   "issue_terminal_status",
   "issue_reassigned",
   "issue_assignee_changed",

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -130,7 +130,13 @@ async function countRunsWithoutCostEvents(db: Db, companyId: string, range?: Cos
     // Only finalized runs can be missing a cost event. A run gets `startedAt`
     // when it is claimed but writes its cost event at finalization, so counting
     // by start time reports every run currently in flight as lost consumption.
-    isNotNull(heartbeatRuns.finishedAt),
+    //
+    // Written as raw SQL rather than `isNotNull` on purpose: the in-flight PR
+    // that fixes `by-project` double counting drops the last other use of that
+    // helper and removes it from the shared `drizzle-orm` import. Git merges the
+    // two changes without a conflict because neither edits the other's lines, so
+    // depending on the binding here would break the build only after both land.
+    sql`${heartbeatRuns.finishedAt} is not null`,
     sql`not exists (
       select 1 from ${costEvents}
       where ${costEvents.heartbeatRunId} = ${heartbeatRuns.id}
@@ -691,9 +697,13 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
       limit = 20,
       offset = 0,
     ) => {
+      // Raw SQL instead of `isNotNull` for the same reason as in
+      // `countRunsWithoutCostEvents`: the concurrent `by-project` fix removes
+      // that helper from this file's import list, and the two changes merge
+      // without a textual conflict.
       const conditions: ReturnType<typeof eq>[] = [
         eq(costEvents.companyId, companyId),
-        isNotNull(costEvents.issueId),
+        sql`${costEvents.issueId} is not null` as ReturnType<typeof eq>,
       ];
       if (range?.from) conditions.push(gte(costEvents.occurredAt, range.from));
       if (range?.to) conditions.push(lte(costEvents.occurredAt, range.to));

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -18,6 +18,88 @@ function sumAsNumber(column: typeof costEvents.costCents | typeof costEvents.inp
   return sql<number>`coalesce(sum(${column}), 0)::double precision`;
 }
 
+/**
+ * Real dollar cost of subscription usage.
+ *
+ * `cost_events.cost_cents` is deliberately 0 for `subscription_included`
+ * (see normalizeBilledCostCents in heartbeat.ts) because the plan already paid
+ * for those tokens. That is correct for budget math and useless for capacity
+ * math: it is why the cost panel read $0 right up to the day the account was
+ * locked out. The dollar figure the provider actually attributes to the run
+ * only ever lands in `heartbeat_runs.usage_json`, so we read it back from
+ * there. Joining on `heartbeat_run_id` keeps this at one row per run — the
+ * same grain as the cost event — so it cannot double-count.
+ *
+ * `costUsd` is absent on some runs (not every adapter reports it), so this is
+ * a floor. Callers that need to say how much is missing use `unpricedRunCount`.
+ */
+function subscriptionCostUsdExpr() {
+  return sql<number>`coalesce(sum(
+    case
+      when ${costEvents.billingType} in (${sql.join(
+        SUBSCRIPTION_BILLING_TYPES.map((value) => sql`${value}`),
+        sql`, `,
+      )})
+      then coalesce(
+        (${heartbeatRuns.usageJson} ->> 'cacheAdjustedCostUsd')::double precision,
+        (${heartbeatRuns.usageJson} ->> 'costUsd')::double precision,
+        0
+      )
+      else 0
+    end
+  ), 0)::double precision`;
+}
+
+/** Cents actually billed through a metered API — the only spend that hits a card. */
+function meteredCostCentsExpr() {
+  return sql<number>`coalesce(sum(
+    case when ${costEvents.billingType} = ${METERED_BILLING_TYPE} then ${costEvents.costCents} else 0 end
+  ), 0)::double precision`;
+}
+
+/** Subscription runs whose usage_json carried no dollar figure at all. */
+function unpricedRunCountExpr() {
+  return sql<number>`count(distinct case
+    when ${costEvents.billingType} in (${sql.join(
+      SUBSCRIPTION_BILLING_TYPES.map((value) => sql`${value}`),
+      sql`, `,
+    )})
+      and coalesce(
+        ${heartbeatRuns.usageJson} ->> 'cacheAdjustedCostUsd',
+        ${heartbeatRuns.usageJson} ->> 'costUsd'
+      ) is null
+    then ${costEvents.heartbeatRunId}
+  end)::int`;
+}
+
+/**
+ * Runs that finished inside the window but produced no cost_event at all.
+ *
+ * A run only writes a cost event when it reports token usage or a billed cost
+ * (heartbeat.ts `updateRuntimeState`), so a run that dies before the adapter
+ * returns usage — crash, cancel, timeout, lost process — consumed real tokens
+ * and recorded none. Surfacing the count is the honest alternative to silently
+ * reporting a total that is short by an unknown amount.
+ */
+async function countRunsWithoutCostEvents(db: Db, companyId: string, range?: CostDateRange) {
+  const conditions = [
+    eq(heartbeatRuns.companyId, companyId),
+    isNotNull(heartbeatRuns.startedAt),
+    sql`not exists (
+      select 1 from ${costEvents}
+      where ${costEvents.heartbeatRunId} = ${heartbeatRuns.id}
+    )`,
+  ];
+  if (range?.from) conditions.push(gte(heartbeatRuns.startedAt, range.from));
+  if (range?.to) conditions.push(lte(heartbeatRuns.startedAt, range.to));
+
+  const [row] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(heartbeatRuns)
+    .where(and(...conditions));
+  return Number(row?.count ?? 0);
+}
+
 function currentUtcMonthWindow(now = new Date()) {
   const year = now.getUTCFullYear();
   const month = now.getUTCMonth();
@@ -115,24 +197,60 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
       if (range?.from) conditions.push(gte(costEvents.occurredAt, range.from));
       if (range?.to) conditions.push(lte(costEvents.occurredAt, range.to));
 
-      const [{ total }] = await db
+      const [row] = await db
         .select({
           total: sumAsNumber(costEvents.costCents),
+          inputTokens: sumAsNumber(costEvents.inputTokens),
+          cachedInputTokens: sumAsNumber(costEvents.cachedInputTokens),
+          outputTokens: sumAsNumber(costEvents.outputTokens),
+          // Subscription usage is billed at 0 cents by design (the plan already
+          // paid for it), so `spendCents` alone reads as "nothing is happening"
+          // even while the account burns through its quota. These two fields are
+          // what make subscription consumption visible before a lockout.
+          subscriptionCostUsd: subscriptionCostUsdExpr(),
+          meteredCostCents: meteredCostCentsExpr(),
+          eventCount: sql<number>`count(*)::int`,
+          runCount: sql<number>`count(distinct ${costEvents.heartbeatRunId})::int`,
+          unpricedRunCount: unpricedRunCountExpr(),
         })
         .from(costEvents)
+        // `heartbeat_runs.id` is the primary key and `cost_events.heartbeat_run_id`
+        // points at one row, so this join is 1:0..1 and cannot fan the sums out.
+        // It exists only to reach `usage_json`, where the subscription dollar
+        // figure lives.
+        .leftJoin(heartbeatRuns, eq(costEvents.heartbeatRunId, heartbeatRuns.id))
         .where(and(...conditions));
 
-      const spendCents = Number(total);
+      const spendCents = Number(row?.total ?? 0);
       const utilization =
         company.budgetMonthlyCents > 0
           ? (spendCents / company.budgetMonthlyCents) * 100
           : 0;
+
+      const inputTokens = Number(row?.inputTokens ?? 0);
+      const cachedInputTokens = Number(row?.cachedInputTokens ?? 0);
+      const outputTokens = Number(row?.outputTokens ?? 0);
+      const unmeteredRuns = await countRunsWithoutCostEvents(db, companyId, range);
 
       return {
         companyId,
         spendCents,
         budgetCents: company.budgetMonthlyCents,
         utilizationPercent: Number(utilization.toFixed(2)),
+        inputTokens,
+        cachedInputTokens,
+        outputTokens,
+        totalTokens: inputTokens + cachedInputTokens + outputTokens,
+        meteredCostCents: Number(row?.meteredCostCents ?? 0),
+        subscriptionCostUsd: Number(row?.subscriptionCostUsd ?? 0),
+        eventCount: Number(row?.eventCount ?? 0),
+        runCount: Number(row?.runCount ?? 0),
+        // Runs that did write a cost event but whose provider never reported a
+        // dollar figure. Their tokens are counted; their cost is not.
+        unpricedRunCount: Number(row?.unpricedRunCount ?? 0),
+        // Runs that produced no cost_event at all. Their consumption is not in
+        // any total above, so every number here is a floor, not a ceiling.
+        unmeteredRunCount: unmeteredRuns,
       };
     },
 
@@ -456,6 +574,152 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
           costEvents.model,
         )
         .orderBy(costEvents.provider, costEvents.biller, costEvents.billingType, costEvents.model);
+    },
+
+    /**
+     * Tokens and cost per issue, ranked.
+     *
+     * Attribution note (this is the whole point of the endpoint): a run is
+     * attributed to exactly one issue — the one in its `contextSnapshot.issueId`,
+     * resolved once at run finalization into `cost_events.issue_id`. Summing
+     * `GET /issues/{id}/runs` instead inflates the company total by ~87%,
+     * because that route returns the full run — usage included — to every
+     * issue the run happened to touch, and one run touched 61 of them.
+     * Grouping on the cost event keeps one row per run, so these rows sum to
+     * the company total rather than to a multiple of it.
+     *
+     * Cost events with a null `issue_id` (work done outside any issue) are
+     * excluded here and reported by `summary` instead, so the difference
+     * between this list and the company total stays visible.
+     */
+    byIssue: async (companyId: string, range?: CostDateRange, limit = 20) => {
+      const conditions: ReturnType<typeof eq>[] = [
+        eq(costEvents.companyId, companyId),
+        isNotNull(costEvents.issueId),
+      ];
+      if (range?.from) conditions.push(gte(costEvents.occurredAt, range.from));
+      if (range?.to) conditions.push(lte(costEvents.occurredAt, range.to));
+
+      const totalTokensExpr = sql<number>`coalesce(sum(
+        ${costEvents.inputTokens} + ${costEvents.cachedInputTokens} + ${costEvents.outputTokens}
+      ), 0)::double precision`;
+
+      return db
+        .select({
+          issueId: costEvents.issueId,
+          issueIdentifier: issues.identifier,
+          issueTitle: issues.title,
+          issueStatus: issues.status,
+          projectId: issues.projectId,
+          projectName: projects.name,
+          costCents: sumAsNumber(costEvents.costCents),
+          meteredCostCents: meteredCostCentsExpr(),
+          subscriptionCostUsd: subscriptionCostUsdExpr(),
+          inputTokens: sumAsNumber(costEvents.inputTokens),
+          cachedInputTokens: sumAsNumber(costEvents.cachedInputTokens),
+          outputTokens: sumAsNumber(costEvents.outputTokens),
+          totalTokens: totalTokensExpr,
+          runCount: sql<number>`count(distinct ${costEvents.heartbeatRunId})::int`,
+          unpricedRunCount: unpricedRunCountExpr(),
+        })
+        .from(costEvents)
+        .innerJoin(issues, eq(costEvents.issueId, issues.id))
+        .leftJoin(projects, eq(issues.projectId, projects.id))
+        .leftJoin(heartbeatRuns, eq(costEvents.heartbeatRunId, heartbeatRuns.id))
+        .where(and(...conditions, visibleIssueCondition()))
+        .groupBy(
+          costEvents.issueId,
+          issues.identifier,
+          issues.title,
+          issues.status,
+          issues.projectId,
+          projects.name,
+        )
+        .orderBy(desc(totalTokensExpr))
+        .limit(limit);
+    },
+
+    /**
+     * Tokens and cost per routine, aggregated across every firing.
+     *
+     * Each firing opens its own issue (`routine_runs.linked_issue_id`), so a
+     * daily routine's cost is otherwise spread across dozens of unrelated-looking
+     * issues — Slack triage alone opened ~20. Rolling the linked issues back up
+     * to the routine is the only way to see what a recurring job actually costs.
+     *
+     * Costs are counted through the linked issue's whole subtree, because a
+     * routine firing routinely spawns child issues and the work delegated to a
+     * child is still that routine's cost. `distinct` on the cost event id keeps
+     * an issue reachable by two paths from being counted twice.
+     */
+    byRoutine: async (companyId: string, range?: CostDateRange, limit = 20) => {
+      // Bound as ISO text with an explicit cast: this statement goes through
+      // `db.execute`, which hands parameters straight to the driver without the
+      // column-type mapping a Drizzle column reference would carry, and the
+      // driver rejects a raw Date.
+      const rangeFilter =
+        range?.from || range?.to
+          ? sql`
+              AND (${range?.from ? sql`ce.occurred_at >= ${range.from.toISOString()}::timestamptz` : sql`true`})
+              AND (${range?.to ? sql`ce.occurred_at <= ${range.to.toISOString()}::timestamptz` : sql`true`})
+            `
+          : sql``;
+
+      const rows = await db.execute(sql`
+        WITH RECURSIVE routine_issue_tree(routine_id, issue_id) AS (
+          SELECT rr.routine_id, rr.linked_issue_id
+          FROM routine_runs rr
+          WHERE rr.company_id = ${companyId}
+            AND rr.linked_issue_id IS NOT NULL
+          UNION
+          SELECT t.routine_id, i.id
+          FROM issues i
+          JOIN routine_issue_tree t ON i.parent_id = t.issue_id
+          WHERE i.company_id = ${companyId}
+            AND i.hidden_at IS NULL
+            AND i.harness_kind IS NULL
+        )
+        SELECT
+          r.id AS "routineId",
+          r.title AS "routineTitle",
+          r.status AS "routineStatus",
+          r.assignee_agent_id AS "assigneeAgentId",
+          a.name AS "assigneeAgentName",
+          count(DISTINCT t.issue_id)::int AS "issueCount",
+          count(DISTINCT ce.heartbeat_run_id)::int AS "runCount",
+          coalesce(sum(ce.cost_cents), 0)::double precision AS "costCents",
+          coalesce(sum(ce.input_tokens), 0)::double precision AS "inputTokens",
+          coalesce(sum(ce.cached_input_tokens), 0)::double precision AS "cachedInputTokens",
+          coalesce(sum(ce.output_tokens), 0)::double precision AS "outputTokens",
+          coalesce(sum(
+            ce.input_tokens + ce.cached_input_tokens + ce.output_tokens
+          ), 0)::double precision AS "totalTokens",
+          coalesce(sum(
+            CASE WHEN ce.billing_type IN ('subscription_included', 'subscription_overage')
+              THEN coalesce(
+                (hr.usage_json ->> 'cacheAdjustedCostUsd')::double precision,
+                (hr.usage_json ->> 'costUsd')::double precision,
+                0)
+              ELSE 0 END
+          ), 0)::double precision AS "subscriptionCostUsd"
+        FROM routines r
+        LEFT JOIN routine_issue_tree t ON t.routine_id = r.id
+        LEFT JOIN (
+          SELECT DISTINCT ON (id) id, issue_id, heartbeat_run_id, billing_type,
+                 cost_cents, input_tokens, cached_input_tokens, output_tokens, occurred_at
+          FROM cost_events
+          WHERE company_id = ${companyId}
+        ) ce ON ce.issue_id = t.issue_id ${rangeFilter}
+        LEFT JOIN heartbeat_runs hr ON hr.id = ce.heartbeat_run_id
+        LEFT JOIN agents a ON a.id = r.assignee_agent_id
+        WHERE r.company_id = ${companyId}
+        GROUP BY r.id, r.title, r.status, r.assignee_agent_id, a.name
+        ORDER BY "totalTokens" DESC
+        LIMIT ${limit}
+      `);
+
+      const list = Array.isArray(rows) ? rows : ((rows as { rows?: unknown[] }).rows ?? []);
+      return list as Array<Record<string, unknown>>;
     },
 
     byProject: async (companyId: string, range?: CostDateRange) => {

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -2,6 +2,7 @@ import { and, desc, eq, gte, isNotNull, isNull, lt, lte, sql } from "drizzle-orm
 import { alias } from "drizzle-orm/pg-core";
 import type { Db } from "@paperclipai/db";
 import { activityLog, agents, companies, costEvents, heartbeatRuns, issues, projects } from "@paperclipai/db";
+import type { CostByRoutine } from "@paperclipai/shared";
 import { notFound, unprocessable } from "../errors.js";
 import { budgetService, type BudgetServiceHooks } from "./budgets.js";
 import { visibleIssueCondition } from "./issue-visibility.js";
@@ -797,7 +798,7 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
       `);
 
       const list = Array.isArray(rows) ? rows : ((rows as { rows?: unknown[] }).rows ?? []);
-      return list as Array<Record<string, unknown>>;
+      return list as CostByRoutine[];
     },
 
     byProject: async (companyId: string, range?: CostDateRange) => {

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -127,14 +127,21 @@ function unpricedRunCountExpr() {
 async function countRunsWithoutCostEvents(db: Db, companyId: string, range?: CostDateRange) {
   const conditions = [
     eq(heartbeatRuns.companyId, companyId),
-    isNotNull(heartbeatRuns.startedAt),
+    // Only finalized runs can be missing a cost event. A run gets `startedAt`
+    // when it is claimed but writes its cost event at finalization, so counting
+    // by start time reports every run currently in flight as lost consumption.
+    isNotNull(heartbeatRuns.finishedAt),
     sql`not exists (
       select 1 from ${costEvents}
       where ${costEvents.heartbeatRunId} = ${heartbeatRuns.id}
     )`,
   ];
-  if (range?.from) conditions.push(gte(heartbeatRuns.startedAt, range.from));
-  if (range?.to) conditions.push(lte(heartbeatRuns.startedAt, range.to));
+  // Windowed on finalization, matching `cost_events.occurred_at`: filtering on
+  // start time would put a run that crosses midnight in a different window here
+  // than in the ledger, so the gap count would not line up with the totals it
+  // qualifies.
+  if (range?.from) conditions.push(gte(heartbeatRuns.finishedAt, range.from));
+  if (range?.to) conditions.push(lte(heartbeatRuns.finishedAt, range.to));
 
   const noModelWork = sql`coalesce(${heartbeatRuns.errorCode}, '') in (${sql.join(
     NO_MODEL_WORK_ERROR_CODES.map((value) => sql`${value}`),
@@ -670,8 +677,20 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
      * Cost events with a null `issue_id` (work done outside any issue) are
      * excluded here and reported by `summary` instead, so the difference
      * between this list and the company total stays visible.
+     *
+     * `offset` makes that conservation property actually checkable. The rows are
+     * ranked and capped, so on a company with more than `limit` cost-bearing
+     * issues a single response is a top-N, not the aggregate; without a way to
+     * page past the cap, summing the endpoint could never reproduce the company
+     * total the way the acceptance criterion requires. The order is total tokens
+     * descending, tie-broken on `issue_id` so paging is stable across calls.
      */
-    byIssue: async (companyId: string, range?: CostDateRange, limit = 20) => {
+    byIssue: async (
+      companyId: string,
+      range?: CostDateRange,
+      limit = 20,
+      offset = 0,
+    ) => {
       const conditions: ReturnType<typeof eq>[] = [
         eq(costEvents.companyId, companyId),
         isNotNull(costEvents.issueId),
@@ -714,8 +733,9 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
           issues.projectId,
           projects.name,
         )
-        .orderBy(desc(totalTokensExpr))
-        .limit(limit);
+        .orderBy(desc(totalTokensExpr), costEvents.issueId)
+        .limit(limit)
+        .offset(offset);
     },
 
     /**
@@ -728,10 +748,31 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
      *
      * Costs are counted through the linked issue's whole subtree, because a
      * routine firing routinely spawns child issues and the work delegated to a
-     * child is still that routine's cost. `distinct` on the cost event id keeps
-     * an issue reachable by two paths from being counted twice.
+     * child is still that routine's cost.
+     *
+     * The subtrees are kept disjoint on purpose, so the rows can be summed. Two
+     * rules do that:
+     *
+     *  - the walk stops at any issue that is itself some routine's firing root.
+     *    Nothing forbids a routine firing from being parented to another
+     *    routine's firing (parent validation only checks company ownership), and
+     *    without the cut the nested firing and its whole subtree would land in
+     *    both routine trees and its cost would be summed into both rows, so the
+     *    routine totals could exceed the company total. The cost stays with the
+     *    routine that opened the issue, which is the one that caused the spend.
+     *  - the firing root passes the same visibility test as the recursive step.
+     *    A root that was later hidden, or that is harness work, is excluded from
+     *    `byIssue` and from issue-tree accounting, so counting it here would
+     *    make the two views disagree.
+     *
+     * Paged like `byIssue`, and for the same reason.
      */
-    byRoutine: async (companyId: string, range?: CostDateRange, limit = 20) => {
+    byRoutine: async (
+      companyId: string,
+      range?: CostDateRange,
+      limit = 20,
+      offset = 0,
+    ) => {
       // Bound as ISO text with an explicit cast: this statement goes through
       // `db.execute`, which hands parameters straight to the driver without the
       // column-type mapping a Drizzle column reference would carry, and the
@@ -745,11 +786,19 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
           : sql``;
 
       const rows = await db.execute(sql`
-        WITH RECURSIVE routine_issue_tree(routine_id, issue_id) AS (
-          SELECT rr.routine_id, rr.linked_issue_id
+        WITH RECURSIVE firing_root AS (
+          SELECT DISTINCT rr.routine_id, rr.linked_issue_id AS issue_id
           FROM routine_runs rr
           WHERE rr.company_id = ${companyId}
             AND rr.linked_issue_id IS NOT NULL
+        ),
+        routine_issue_tree(routine_id, issue_id) AS (
+          SELECT fr.routine_id, fr.issue_id
+          FROM firing_root fr
+          JOIN issues i ON i.id = fr.issue_id
+          WHERE i.company_id = ${companyId}
+            AND i.hidden_at IS NULL
+            AND i.harness_kind IS NULL
           UNION
           SELECT t.routine_id, i.id
           FROM issues i
@@ -757,6 +806,11 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
           WHERE i.company_id = ${companyId}
             AND i.hidden_at IS NULL
             AND i.harness_kind IS NULL
+            -- Stop at another routine's firing root: that subtree is its own
+            -- routine's cost, and claiming it here would double-count it.
+            AND NOT EXISTS (
+              SELECT 1 FROM firing_root fr WHERE fr.issue_id = i.id
+            )
         )
         SELECT
           r.id AS "routineId",
@@ -783,18 +837,17 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
           ), 0)::double precision AS "subscriptionCostUsd"
         FROM routines r
         LEFT JOIN routine_issue_tree t ON t.routine_id = r.id
-        LEFT JOIN (
-          SELECT DISTINCT ON (id) id, issue_id, heartbeat_run_id, billing_type,
-                 cost_cents, input_tokens, cached_input_tokens, output_tokens, occurred_at
-          FROM cost_events
-          WHERE company_id = ${companyId}
-        ) ce ON ce.issue_id = t.issue_id ${rangeFilter}
+        LEFT JOIN cost_events ce
+          ON ce.issue_id = t.issue_id
+          AND ce.company_id = ${companyId}
+          ${rangeFilter}
         LEFT JOIN heartbeat_runs hr ON hr.id = ce.heartbeat_run_id
         LEFT JOIN agents a ON a.id = r.assignee_agent_id
         WHERE r.company_id = ${companyId}
         GROUP BY r.id, r.title, r.status, r.assignee_agent_id, a.name
-        ORDER BY "totalTokens" DESC
+        ORDER BY "totalTokens" DESC, r.id
         LIMIT ${limit}
+        OFFSET ${offset}
       `);
 
       const list = Array.isArray(rows) ? rows : ((rows as { rows?: unknown[] }).rows ?? []);

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -14,6 +14,35 @@ export interface CostDateRange {
 const METERED_BILLING_TYPE = "metered_api";
 const SUBSCRIPTION_BILLING_TYPES = ["subscription_included", "subscription_overage"] as const;
 
+/**
+ * Failure codes that mean the run never got a prompt to the model.
+ *
+ * A run with one of these codes wrote no cost event, but it also consumed
+ * nothing: the session died before `session/new` completed, the adapter was
+ * never invoked, or the issue changed hands first. Counting them as missing
+ * consumption overstates the gap by an order of magnitude.
+ *
+ * Measured against the live company database (2026-08-19, 1.696 runs): 267 runs
+ * carried no `usage_json`. 237 of them matched these codes and showed no model
+ * output — their logs are adapter error text (~2 KB), never a transcript. The
+ * remaining 30 (`process_lost`, unpriced `adapter_failed`) had real transcripts
+ * up to 188 KB and are the genuine accounting gap. Zero of 1.021 `succeeded`
+ * runs are unpriced, which is why this split is safe: success always accounts.
+ */
+const NO_MODEL_WORK_ERROR_CODES = [
+  "acpx_session_config_failed",
+  "acpx_session_init_failed",
+  "configuration_incomplete",
+  "cancelled",
+  "issue_terminal_status",
+  "issue_reassigned",
+  "issue_assignee_changed",
+  "issue_continuation_waiting_on_review",
+  "lock_released_on_reassignment",
+  "issue_dependencies_blocked",
+  "setup_failed",
+] as const;
+
 function sumAsNumber(column: typeof costEvents.costCents | typeof costEvents.inputTokens | typeof costEvents.cachedInputTokens | typeof costEvents.outputTokens) {
   return sql<number>`coalesce(sum(${column}), 0)::double precision`;
 }
@@ -77,9 +106,22 @@ function unpricedRunCountExpr() {
  *
  * A run only writes a cost event when it reports token usage or a billed cost
  * (heartbeat.ts `updateRuntimeState`), so a run that dies before the adapter
- * returns usage — crash, cancel, timeout, lost process — consumed real tokens
- * and recorded none. Surfacing the count is the honest alternative to silently
- * reporting a total that is short by an unknown amount.
+ * returns usage consumed real tokens and recorded none. Surfacing the count is
+ * the honest alternative to silently reporting a total that is short by an
+ * unknown amount.
+ *
+ * The bare count conflates three different situations, so it is split. Measured
+ * against the live company database on 2026-08-19 (1.656 started runs):
+ *
+ *   609 runs have no cost_event, of which
+ *     383 DO carry usage_json  -> measured, just never aggregated (`strandedRuns`)
+ *     197 died before the model -> genuinely consumed nothing (`neverRanRuns`)
+ *      29 ran and lost usage    -> the true blind spot (`lostRuns`)
+ *
+ * Only `lostRuns` makes the totals a floor. `strandedRuns` is recoverable — the
+ * numbers are already in `usage_json` (764.094 tokens, US$ 48,96) and are simply
+ * missing from every endpoint that reads `cost_events`. Reporting all 609 as one
+ * figure implies a 37% blind spot where the real one is 1,8%.
  */
 async function countRunsWithoutCostEvents(db: Db, companyId: string, range?: CostDateRange) {
   const conditions = [
@@ -93,11 +135,40 @@ async function countRunsWithoutCostEvents(db: Db, companyId: string, range?: Cos
   if (range?.from) conditions.push(gte(heartbeatRuns.startedAt, range.from));
   if (range?.to) conditions.push(lte(heartbeatRuns.startedAt, range.to));
 
+  const noModelWork = sql`coalesce(${heartbeatRuns.errorCode}, '') in (${sql.join(
+    NO_MODEL_WORK_ERROR_CODES.map((value) => sql`${value}`),
+    sql`, `,
+  )})`;
+  const hasUsage = sql`${heartbeatRuns.usageJson} is not null`;
+
   const [row] = await db
-    .select({ count: sql<number>`count(*)::int` })
+    .select({
+      total: sql<number>`count(*)::int`,
+      // Usage was captured on the run but never became a cost event. Recoverable.
+      stranded: sql<number>`count(*) filter (where ${hasUsage})::int`,
+      // Died before the model ran: no prompt was sent, so nothing was consumed.
+      neverRan: sql<number>`count(*) filter (where not ${hasUsage} and ${noModelWork})::int`,
+      // Ran, produced output, and the usage was never persisted. The real gap.
+      lost: sql<number>`count(*) filter (where not ${hasUsage} and not (${noModelWork}))::int`,
+      // Tokens sitting in usage_json that no cost endpoint currently reports.
+      strandedTokens: sql<number>`coalesce(sum(
+        case when ${hasUsage} then
+          coalesce((${heartbeatRuns.usageJson} ->> 'inputTokens')::bigint, 0)
+          + coalesce((${heartbeatRuns.usageJson} ->> 'cachedInputTokens')::bigint, 0)
+          + coalesce((${heartbeatRuns.usageJson} ->> 'outputTokens')::bigint, 0)
+        else 0 end
+      ), 0)::double precision`,
+    })
     .from(heartbeatRuns)
     .where(and(...conditions));
-  return Number(row?.count ?? 0);
+
+  return {
+    total: Number(row?.total ?? 0),
+    stranded: Number(row?.stranded ?? 0),
+    neverRan: Number(row?.neverRan ?? 0),
+    lost: Number(row?.lost ?? 0),
+    strandedTokens: Number(row?.strandedTokens ?? 0),
+  };
 }
 
 function currentUtcMonthWindow(now = new Date()) {
@@ -248,9 +319,16 @@ export function costService(db: Db, budgetHooks: BudgetServiceHooks = {}) {
         // Runs that did write a cost event but whose provider never reported a
         // dollar figure. Their tokens are counted; their cost is not.
         unpricedRunCount: Number(row?.unpricedRunCount ?? 0),
-        // Runs that produced no cost_event at all. Their consumption is not in
-        // any total above, so every number here is a floor, not a ceiling.
-        unmeteredRunCount: unmeteredRuns,
+        // Runs that produced no cost_event at all, split by what actually
+        // happened. Only `lostRunCount` makes the totals a floor:
+        //  - strandedRunCount: measured on the run, missing from the aggregates
+        //  - neverRanRunCount: died before the model; consumed nothing
+        //  - lostRunCount: ran and the usage was never persisted
+        unmeteredRunCount: unmeteredRuns.total,
+        strandedRunCount: unmeteredRuns.stranded,
+        strandedTokens: unmeteredRuns.strandedTokens,
+        neverRanRunCount: unmeteredRuns.neverRan,
+        lostRunCount: unmeteredRuns.lost,
       };
     },
 

--- a/server/src/services/costs.ts
+++ b/server/src/services/costs.ts
@@ -27,8 +27,17 @@ const SUBSCRIPTION_BILLING_TYPES = ["subscription_included", "subscription_overa
  * carried no `usage_json`. 237 of them matched these codes and showed no model
  * output — their logs are adapter error text (~2 KB), never a transcript. The
  * remaining 30 (`process_lost`, unpriced `adapter_failed`) had real transcripts
- * up to 188 KB and are the genuine accounting gap. Zero of 1.021 `succeeded`
- * runs are unpriced, which is why this split is safe: success always accounts.
+ * up to 188 KB and are the genuine accounting gap.
+ *
+ * The split keys off `error_code`, never off `status`, because a successful run
+ * is not a guarantee of accounting. Re-measured 2026-09-08 (2.378 runs): 8 of
+ * 1.478 `succeeded` runs carry no `usage_json`, so an earlier "success always
+ * accounts" reading of this rule was wrong. Those 8 share one shape — the whole
+ * finalization write is missing (`result_json` is null on exactly the same 8
+ * rows), because usage and result are persisted by a single guarded write that
+ * is skipped when the run already left `running`. They carry no
+ * `NO_MODEL_WORK_ERROR_CODES` code, so they land in `lost` and stay visible
+ * instead of being silently excused as never having run.
  */
 const NO_MODEL_WORK_ERROR_CODES = [
   "acpx_session_config_failed",

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4841,6 +4841,13 @@ function normalizeBilledCostCents(
  * totals a floor rather than a total. Admitting a reported `costUsd` gives
  * those runs an owner without inventing numbers for runs that truly reported
  * nothing.
+ *
+ * The dollar figure has to be *positive* to count. Adapters such as pi-local
+ * initialize the reported cost to 0, so accepting a mere non-null would write an
+ * all-zero row for a run that returned before collecting any usage. That row
+ * carries no information and actively misleads: it moves the run out of
+ * `summary.lostRunCount` into the accounted set, hiding the exact blind spot
+ * these endpoints exist to expose.
  */
 export function shouldRecordLedgerEvent(input: {
   billedCostCents: number;
@@ -4850,7 +4857,11 @@ export function shouldRecordLedgerEvent(input: {
   outputTokens: number;
 }): boolean {
   const hasTokenUsage = input.inputTokens > 0 || input.cachedInputTokens > 0 || input.outputTokens > 0;
-  return input.billedCostCents > 0 || hasTokenUsage || input.billedCostUsd != null;
+  const hasReportedSpend =
+    typeof input.billedCostUsd === "number" &&
+    Number.isFinite(input.billedCostUsd) &&
+    input.billedCostUsd > 0;
+  return input.billedCostCents > 0 || hasTokenUsage || hasReportedSpend;
 }
 
 export function resolveLedgerCostStatus(input: {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -4830,6 +4830,29 @@ function normalizeBilledCostCents(
   return Math.max(0, Math.round(costUsd * 100));
 }
 
+/**
+ * Whether a finished run should write a row to the cost ledger.
+ *
+ * `billedCostCents` is 0 for every `subscription_included` run by design (the
+ * plan already paid for the tokens), so a cents-or-tokens test alone silently
+ * drops any run that reported a dollar figure without token counts — typically
+ * one that failed or was interrupted after burning quota. Such a run then has
+ * no ledger row at all and no owning issue, which is what makes per-issue
+ * totals a floor rather than a total. Admitting a reported `costUsd` gives
+ * those runs an owner without inventing numbers for runs that truly reported
+ * nothing.
+ */
+export function shouldRecordLedgerEvent(input: {
+  billedCostCents: number;
+  billedCostUsd: number | null | undefined;
+  inputTokens: number;
+  cachedInputTokens: number;
+  outputTokens: number;
+}): boolean {
+  const hasTokenUsage = input.inputTokens > 0 || input.cachedInputTokens > 0 || input.outputTokens > 0;
+  return input.billedCostCents > 0 || hasTokenUsage || input.billedCostUsd != null;
+}
+
 export function resolveLedgerCostStatus(input: {
   costUsd: number | null | undefined;
   inputTokens: number;
@@ -17674,8 +17697,6 @@ export function heartbeatService(
       billedCostUsd,
       billingType,
     );
-    const hasTokenUsage =
-      inputTokens > 0 || outputTokens > 0 || cachedInputTokens > 0;
     const costStatus = resolveLedgerCostStatus({
       costUsd: billedCostUsd,
       inputTokens,
@@ -17706,7 +17727,15 @@ export function heartbeatService(
       })
       .where(eq(agentRuntimeState.agentId, agent.id));
 
-    if (additionalCostCents > 0 || hasTokenUsage) {
+    if (
+      shouldRecordLedgerEvent({
+        billedCostCents: additionalCostCents,
+        billedCostUsd,
+        inputTokens,
+        cachedInputTokens,
+        outputTokens,
+      })
+    ) {
       const costs = costService(db, budgetHooks);
       await costs.createEvent(agent.companyId, {
         heartbeatRunId: run.id,

--- a/ui/src/api/costs.ts
+++ b/ui/src/api/costs.ts
@@ -5,6 +5,8 @@ import type {
   CostByBiller,
   CostByAgentModel,
   CostByProject,
+  CostByIssue,
+  CostByRoutine,
   CostWindowSpendRow,
   FinanceSummary,
   FinanceByBiller,
@@ -31,6 +33,10 @@ export const costsApi = {
     api.get<CostByAgentModel[]>(`/companies/${companyId}/costs/by-agent-model${dateParams(from, to)}`),
   byProject: (companyId: string, from?: string, to?: string) =>
     api.get<CostByProject[]>(`/companies/${companyId}/costs/by-project${dateParams(from, to)}`),
+  byIssue: (companyId: string, from?: string, to?: string, limit: number = 20) =>
+    api.get<CostByIssue[]>(`/companies/${companyId}/costs/by-issue${dateParamsWithLimit(from, to, limit)}`),
+  byRoutine: (companyId: string, from?: string, to?: string, limit: number = 20) =>
+    api.get<CostByRoutine[]>(`/companies/${companyId}/costs/by-routine${dateParamsWithLimit(from, to, limit)}`),
   byProvider: (companyId: string, from?: string, to?: string) =>
     api.get<CostByProviderModel[]>(`/companies/${companyId}/costs/by-provider${dateParams(from, to)}`),
   byBiller: (companyId: string, from?: string, to?: string) =>

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -653,6 +653,10 @@ export const queryKeys = {
   activity: (companyId: string) => ["activity", companyId] as const,
   costs: (companyId: string, from?: string, to?: string) =>
     ["costs", companyId, from, to] as const,
+  usageByIssue: (companyId: string, from?: string, to?: string, limit: number = 20) =>
+    ["usage-by-issue", companyId, from, to, limit] as const,
+  usageByRoutine: (companyId: string, from?: string, to?: string, limit: number = 20) =>
+    ["usage-by-routine", companyId, from, to, limit] as const,
   usageByProvider: (companyId: string, from?: string, to?: string) =>
     ["usage-by-provider", companyId, from, to] as const,
   usageByBiller: (companyId: string, from?: string, to?: string) =>

--- a/ui/src/pages/Costs.tsx
+++ b/ui/src/pages/Costs.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ComponentType } from "react";
+import { Link } from "@/lib/router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type {
   BudgetPolicySummary,
@@ -34,7 +35,13 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 const NO_COMPANY = "__none__";
-export type CostsMainTab = "overview" | "budgets" | "providers" | "billers" | "finance";
+export type CostsMainTab =
+  | "overview"
+  | "consumption"
+  | "budgets"
+  | "providers"
+  | "billers"
+  | "finance";
 
 export interface CostsProps {
   /** Render inside Audit without a second page-level title or breadcrumb. */
@@ -44,6 +51,22 @@ export interface CostsProps {
   lockTab?: boolean;
   /** Budgets is a peer Audit section, so omit it from the Costs sub-navigation. */
   hideBudgetsTab?: boolean;
+}
+
+/** rows fetched per consumption ranking — matches the API's own default. */
+const CONSUMPTION_LIMIT = 20;
+
+/**
+ * Subscription runs bill 0 cents, so `formatCents` reads as "free" for the bulk
+ * of what the company actually consumes. This formats the dollar value the plan
+ * absorbed, which is the only number that moves on those rows.
+ */
+function formatUsd(value: number): string {
+  return value.toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: value >= 100 ? 0 : 2,
+  });
 }
 
 function currentWeekRange(): { from: string; to: string } {
@@ -163,9 +186,18 @@ export function Costs({
   lockTab = false,
   hideBudgetsTab = false,
 }: CostsProps = {}) {
-  const { selectedCompanyId } = useCompany();
+  const { selectedCompanyId, selectedCompany } = useCompany();
   const { setBreadcrumbs } = useBreadcrumbs();
   const queryClient = useQueryClient();
+
+  // Routes are company-prefixed when the company defines an issue prefix, the
+  // same resolution DecisionResolver uses. Without it the link 404s on a board
+  // that has more than one company.
+  const routePrefix = selectedCompany?.issuePrefix ?? "";
+  const issuePath = (ref: string) =>
+    routePrefix ? `/${routePrefix}/issues/${ref}` : `/issues/${ref}`;
+  const routinePath = (routineId: string) =>
+    routePrefix ? `/${routePrefix}/routines/${routineId}` : `/routines/${routineId}`;
 
   const [mainTab, setMainTab] = useState<CostsMainTab>(initialTab);
   const [activeProvider, setActiveProvider] = useState("all");
@@ -309,6 +341,30 @@ export function Costs({
     }
     return map;
   }, [spendData?.byAgentModel]);
+
+  // Task and routine consumption (GRO-559). Kept off the overview query so the
+  // page that most operators open first does not pay for the recursive routine
+  // rollup; it loads when the tab is actually selected.
+  const {
+    data: consumptionData,
+    isLoading: consumptionLoading,
+    error: consumptionError,
+  } = useQuery({
+    queryKey: [
+      queryKeys.usageByIssue(companyId, from || undefined, to || undefined, CONSUMPTION_LIMIT),
+      queryKeys.usageByRoutine(companyId, from || undefined, to || undefined, CONSUMPTION_LIMIT),
+    ],
+    queryFn: async () => {
+      const [byIssue, byRoutine] = await Promise.all([
+        costsApi.byIssue(companyId, from || undefined, to || undefined, CONSUMPTION_LIMIT),
+        costsApi.byRoutine(companyId, from || undefined, to || undefined, CONSUMPTION_LIMIT),
+      ]);
+      return { byIssue, byRoutine };
+    },
+    enabled: !!selectedCompanyId && customReady && mainTab === "consumption",
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+  });
 
   const { data: providerData } = useQuery({
     queryKey: queryKeys.usageByProvider(companyId, from || undefined, to || undefined),
@@ -648,6 +704,7 @@ export function Costs({
         {!lockTab ? (
           <TabsList variant="line" className="justify-start">
             <TabsTrigger value="overview">Overview</TabsTrigger>
+            <TabsTrigger value="consumption">Tasks &amp; routines</TabsTrigger>
             {!hideBudgetsTab ? <TabsTrigger value="budgets">Budgets</TabsTrigger> : null}
             <TabsTrigger value="providers">Providers</TabsTrigger>
             <TabsTrigger value="billers">Billers</TabsTrigger>
@@ -855,6 +912,156 @@ export function Costs({
 
                   <FinanceTimelineCard rows={topFinanceEvents.slice(0, 6)} emptyMessage="No finance events yet. Add account-level charges once biller invoices or credits land." />
                 </div>
+              </div>
+            </>
+          )}
+        </TabsContent>
+
+        <TabsContent value="consumption" className="mt-4 space-y-4">
+          {showCustomPrompt ? (
+            <p className="text-sm text-muted-foreground">Select a start and end date to load data.</p>
+          ) : consumptionLoading ? (
+            <PageSkeleton variant="costs" />
+          ) : consumptionError ? (
+            <p className="text-sm text-destructive">{(consumptionError as Error).message}</p>
+          ) : (
+            <>
+              <div className="grid gap-3 lg:grid-cols-4">
+                <MetricTile
+                  label="Tokens in range"
+                  value={formatTokens(spendData?.summary.totalTokens ?? 0)}
+                  subtitle={`${spendData?.summary.runCount ?? 0} runs on the ledger`}
+                  icon={Coins}
+                />
+                <MetricTile
+                  label="Subscription value"
+                  value={formatUsd(spendData?.summary.subscriptionCostUsd ?? 0)}
+                  subtitle="Absorbed by the plan — bills 0 cents by design"
+                  icon={DollarSign}
+                />
+                <MetricTile
+                  label="Metered spend"
+                  value={formatCents(spendData?.summary.meteredCostCents ?? 0)}
+                  subtitle="The only spend that hits a card"
+                  icon={ReceiptText}
+                />
+                <MetricTile
+                  label="Runs off the ledger"
+                  value={String(spendData?.summary.unmeteredRunCount ?? 0)}
+                  subtitle={
+                    /* Only `lost` makes the rankings a floor: stranded runs are
+                       measured but unaggregated, and never-ran ones consumed
+                       nothing at all. Spelling out the split keeps the gap from
+                       reading as missing data. */
+                    `${spendData?.summary.strandedRunCount ?? 0} stranded · ${
+                      spendData?.summary.neverRanRunCount ?? 0
+                    } never ran · ${spendData?.summary.lostRunCount ?? 0} lost`
+                  }
+                  icon={ArrowDownLeft}
+                />
+              </div>
+
+              <div className="grid gap-4 xl:grid-cols-2">
+                <Card>
+                  <CardHeader className="px-5 pt-5 pb-2">
+                    <CardTitle className="text-base">Top tasks by tokens</CardTitle>
+                    <CardDescription>
+                      Each run counted once, against the task that owns it. Tasks with no
+                      run cost, and runs that belong to no task, are left out rather than
+                      folded in — the difference from the total above stays visible.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-2 px-5 pb-5 pt-2">
+                    {(consumptionData?.byIssue.length ?? 0) === 0 ? (
+                      <p className="text-sm text-muted-foreground">No task-attributed run costs yet.</p>
+                    ) : (
+                      consumptionData?.byIssue.map((row, index) => (
+                        <div
+                          key={row.issueId ?? `issue-${index}`}
+                          className="flex items-start justify-between gap-3 border border-border px-3 py-2 text-sm"
+                        >
+                          <div className="min-w-0">
+                            <div className="flex min-w-0 items-center gap-2">
+                              {row.issueIdentifier ? (
+                                <Link
+                                  to={issuePath(row.issueIdentifier)}
+                                  className="font-mono text-xs text-primary hover:underline"
+                                >
+                                  {row.issueIdentifier}
+                                </Link>
+                              ) : null}
+                              {row.issueStatus ? <StatusBadge status={row.issueStatus} /> : null}
+                            </div>
+                            <div className="mt-1 truncate">{row.issueTitle ?? row.issueId}</div>
+                            <div className="text-xs text-muted-foreground">
+                              {row.projectName ?? "No project"}
+                            </div>
+                          </div>
+                          <div className="shrink-0 text-right tabular-nums">
+                            <div className="font-medium">{formatTokens(row.totalTokens)} tok</div>
+                            <div className="text-xs text-muted-foreground">
+                              {formatUsd(row.subscriptionCostUsd)} plan
+                              {row.meteredCostCents > 0 ? ` · ${formatCents(row.meteredCostCents)} billed` : ""}
+                            </div>
+                            <div className="text-xs text-muted-foreground">
+                              {row.runCount} run{row.runCount === 1 ? "" : "s"}
+                            </div>
+                          </div>
+                        </div>
+                      ))
+                    )}
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader className="px-5 pt-5 pb-2">
+                    <CardTitle className="text-base">Top routines by tokens</CardTitle>
+                    <CardDescription>
+                      Every firing rolled back up to its routine, subtree included. Each
+                      firing opens its own task, so a daily routine is otherwise scattered
+                      across dozens of unrelated-looking tasks.
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="space-y-2 px-5 pb-5 pt-2">
+                    {(consumptionData?.byRoutine.length ?? 0) === 0 ? (
+                      <p className="text-sm text-muted-foreground">No routine has consumed tokens yet.</p>
+                    ) : (
+                      consumptionData?.byRoutine.map((row) => (
+                        <div
+                          key={row.routineId}
+                          className="flex items-start justify-between gap-3 border border-border px-3 py-2 text-sm"
+                        >
+                          <div className="min-w-0">
+                            <div className="flex min-w-0 items-center gap-2">
+                              <Link
+                                to={routinePath(row.routineId)}
+                                className="truncate text-primary hover:underline"
+                              >
+                                {row.routineTitle ?? row.routineId}
+                              </Link>
+                              {row.routineStatus ? <StatusBadge status={row.routineStatus} /> : null}
+                            </div>
+                            {row.assigneeAgentName ? (
+                              <div className="mt-1">
+                                <Identity name={row.assigneeAgentName} size="xs" />
+                              </div>
+                            ) : null}
+                          </div>
+                          <div className="shrink-0 text-right tabular-nums">
+                            <div className="font-medium">{formatTokens(row.totalTokens)} tok</div>
+                            <div className="text-xs text-muted-foreground">
+                              {formatUsd(row.subscriptionCostUsd)} plan
+                            </div>
+                            <div className="text-xs text-muted-foreground">
+                              {row.runCount} run{row.runCount === 1 ? "" : "s"} · {row.issueCount} task
+                              {row.issueCount === 1 ? "" : "s"}
+                            </div>
+                          </div>
+                        </div>
+                      ))
+                    )}
+                  </CardContent>
+                </Card>
               </div>
             </>
           )}


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agent runs consume tokens. The `costs` service aggregates that spend and the Costs page shows it
> - The service has a per-agent cut and a per-project cut. It has no per-task cut and no per-routine cut
> - Operators tried to build a per-task total from `GET /api/issues/{id}/runs`. That route gives the full run record, `usageJson` included, to every issue the run touched. The sum counts the same run many times
> - In one company, 337 runs were present in more than one issue. One run was present in 61 issues. The total went from 2.5 B tokens to 4.7 B tokens, an increase of 87%
> - A routine has a second problem. Each firing opens a new issue, so the cost of one routine is divided across many tasks that look unrelated
> - This pull request adds a per-task cut and a per-routine cut. Each run is counted one time, against the one issue that owns it
> - The benefit is that an operator can find the most expensive tasks and routines from the API, and the rows add up to the company total

## Linked Issues or Issue Description

No public issue exists. The problem is described here.

**What happened:**
There is no API that reports token spend per task or per routine. Operators build the number by hand from `GET /api/issues/{id}/runs`, and the result is too high.

**Expected behavior:**
The sum of spend over all tasks is equal to the company total, within a stated margin. The spend of one routine is one number.

**Actual behavior:**
`GET /api/issues/{id}/runs` returns the complete run, with `usageJson`, for every issue that the run touched. A run that touched 61 issues is counted 61 times. The company total increased by 87%.

A second defect makes every total a floor. 245 of 1604 runs had `usageJson: null`. These runs are silently absent, so a total reads as complete when it is not.

**Impact:**
An operator cannot find the most expensive work. A cost report is too high by an unknown amount, and it is also missing an unknown amount.

## What Changed

- Add `GET /api/companies/:companyId/costs/by-issue`. It returns tokens and cost per task, with a `from`/`to` window. One row per run. The run is attributed to the one issue that `cost_events.issue_id` resolves at finalization, so the rows add up to the same total as the per-agent cut.
- Add `GET /api/companies/:companyId/costs/by-routine`. It rolls up all firings of one routine. It counts each firing issue and its subtree, because work that a firing delegates to a child is still the cost of that routine.
- Classify runs that recorded no usage. The `summary` field reports them as `stranded`, `neverRan`, and `lost`. Before this change they were absent and invisible.
- Add both cuts to the Costs page.
- Add the `CostByIssue` and `CostByRoutine` types to `packages/shared`.

This pull request follows #12849, which makes `by-project` count each cost event one time. The two changes are disjoint. They share no hunk, and `CostByProject` is not changed here.

## Verification

Run the two test files:

```
cd server
pnpm vitest run src/__tests__/costs-service.test.ts src/__tests__/heartbeat-cost-accounting.test.ts
```

Result on this branch, rebased on `d8b95805`: **33 tests passed, 2 files, 0 failures.**

The tests cover:
- The double-count case. A run that touches many issues is counted one time.
- The `from`/`to` window filter.
- The split of unmetered runs into `stranded`, `neverRan`, and `lost`.
- `heartbeat-cost-accounting.test.ts` asserts that a run finalizes onto exactly one issue.

## Risks

Low risk. The change adds two read-only routes and does not change an existing route or response shape.

- No migration. No schema change.
- `CostByProject` and the `by-project` route are not changed.
- One behavior does shift: runs that resolve to no owning issue are left out of the `by-issue` rows and reported in `summary` instead. This is deliberate. Folding them into an arbitrary task would report a false number for that task.
- Honest limit: `costs/summary` still returns `spendCents: 0` for `subscription_included` billing. That is by design in the billing model, and it is out of scope here. The real figure is in `subscriptionCostUsd` and `totalTokens`, which these routes return.

## Model Used

Claude Opus 5 (`claude-opus-5`), Anthropic. Extended thinking on, with tool use and code execution. Run through the Claude Agent SDK as an automated engineering agent.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I searched the GitHub PR list for similar or duplicate PRs and confirmed this is not a duplicate
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge

### Dedup search

I searched the PR list before opening this one. The related PRs I found are these, and none of them adds a per-task or per-routine cut:

- #12849 — `by-project` counts each cost event one time. This is my own prior PR. This one follows it and is disjoint.
- #11538 — estimates subscription-billed run cost from token usage. It changes pricing, not attribution.
- #10544 — prices subscription runs from a rate card. Pricing, not attribution.
- #11424 — adds `creditRunCount`/`otherRunCount` to the by-agent, by-provider, and by-biller cuts. It does not add a new cut.
- #9615 — exposes paginated cost events. It is a raw event feed, not an aggregate.
