### PR TITLE
fix: bind timer checkout writes to run

### DIFF
--- a/server/src/__tests__/cross-issue-influence-limit-postgres.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit-postgres.test.ts
@@ -15,6 +15,7 @@ import {
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import {
+  authorizeCrossIssueInfluence,
   CROSS_ISSUE_INFLUENCE_ENFORCE_AT,
   observeCrossIssueInfluence,
 } from "../services/cross-issue-influence-limit.js";
@@ -188,27 +189,28 @@ describeEmbeddedPostgres("cross-issue influence limit PostgreSQL serialization",
       agentId,
       targetIssueId: checkedOutIssueId,
     } as const;
-    await expect(observeCrossIssueInfluence(db, {
+    const commentAuthorization = await authorizeCrossIssueInfluence(db, {
       ...guardedWrite,
       kind: "comment",
-    })).resolves.toBeNull();
-    await db.insert(issueComments).values({
-      companyId,
-      issueId: checkedOutIssueId,
-      authorAgentId: agentId,
-      authorType: "agent",
-      createdByRunId: runId,
-      body: "Timer checkout comment",
+    });
+    expect(commentAuthorization.decision).toBeNull();
+    await issueService(db).addComment(checkedOutIssueId, "Timer checkout comment", {
+      agentId,
+      runId,
+    }, {
+      crossIssueMutationAuthority: commentAuthorization.mutationAuthority,
     });
 
-    await expect(observeCrossIssueInfluence(db, {
+    const updateAuthorization = await authorizeCrossIssueInfluence(db, {
       ...guardedWrite,
       kind: "update",
-    })).resolves.toBeNull();
-    await db
-      .update(issues)
-      .set({ status: "done", checkoutRunId: null, executionRunId: null })
-      .where(eq(issues.id, checkedOutIssueId));
+    });
+    expect(updateAuthorization.decision).toBeNull();
+    await issueService(db).update(checkedOutIssueId, {
+      status: "done",
+      actorAgentId: agentId,
+      crossIssueMutationAuthority: updateAuthorization.mutationAuthority,
+    });
 
     await expect(observeCrossIssueInfluence(db, {
       companyId,
@@ -230,5 +232,86 @@ describeEmbeddedPostgres("cross-issue influence limit PostgreSQL serialization",
       { id: checkedOutIssueId, status: "done" },
       { id: unrelatedIssueId, status: "todo" },
     ]));
+  });
+
+  it("fails closed when timer checkout authority is revoked before the protected mutation", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const issueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `R${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Timer Coder",
+      role: "engineer",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      nativeIssueId: null,
+      contextSnapshot: { issueId: null, taskId: null, wakeReason: "timer" },
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Timer-selected issue",
+      status: "in_progress",
+      assigneeAgentId: agentId,
+      checkoutRunId: runId,
+      executionRunId: runId,
+      issueNumber: 1,
+      identifier: "REV-1",
+    });
+
+    const authorization = await authorizeCrossIssueInfluence(db, {
+      companyId,
+      runId,
+      agentId,
+      targetIssueId: issueId,
+      kind: "comment",
+    });
+    expect(authorization).toMatchObject({
+      decision: null,
+      mutationAuthority: { requiredCheckoutRunId: runId },
+    });
+
+    await db.update(issues).set({ checkoutRunId: null, executionRunId: null }).where(eq(issues.id, issueId));
+
+    await expect(issueService(db).addComment(issueId, "Stale authorized comment", {
+      agentId,
+      runId,
+    }, {
+      crossIssueMutationAuthority: authorization.mutationAuthority,
+    })).rejects.toMatchObject({
+      status: 403,
+      details: { code: "cross_issue_influence_run_context_required" },
+    });
+    await expect(issueService(db).update(issueId, {
+      status: "done",
+      actorAgentId: agentId,
+      crossIssueMutationAuthority: authorization.mutationAuthority,
+    })).rejects.toMatchObject({
+      status: 403,
+      details: { code: "cross_issue_influence_run_context_required" },
+    });
+
+    const [comments, issue] = await Promise.all([
+      db.select({ id: issueComments.id }).from(issueComments).where(eq(issueComments.issueId, issueId)),
+      db.select({ status: issues.status }).from(issues).where(eq(issues.id, issueId)).then((rows) => rows[0]),
+    ]);
+    expect(comments).toEqual([]);
+    expect(issue?.status).toBe("in_progress");
   });
 });

--- a/server/src/__tests__/cross-issue-influence-limit-postgres.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit-postgres.test.ts
@@ -7,6 +7,8 @@ import {
   companies,
   createDb,
   heartbeatRuns,
+  issueComments,
+  issues,
 } from "@paperclipai/db";
 import {
   getEmbeddedPostgresTestSupport,
@@ -16,6 +18,7 @@ import {
   CROSS_ISSUE_INFLUENCE_ENFORCE_AT,
   observeCrossIssueInfluence,
 } from "../services/cross-issue-influence-limit.js";
+import { issueService } from "../services/issues.js";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -31,6 +34,8 @@ describeEmbeddedPostgres("cross-issue influence limit PostgreSQL serialization",
 
   afterEach(async () => {
     await db.delete(activityLog);
+    await db.delete(issueComments);
+    await db.delete(issues);
     await db.delete(heartbeatRuns);
     await db.delete(agents);
     await db.delete(companies);
@@ -112,5 +117,118 @@ describeEmbeddedPostgres("cross-issue influence limit PostgreSQL serialization",
       .where(and(eq(activityLog.companyId, companyId), eq(activityLog.runId, runId)));
     expect(recorded.filter((row) => row.action === "issue.cross_issue_influence_observed")).toHaveLength(20);
     expect(recorded.filter((row) => row.action === "issue.cross_issue_influence_cap_rejected")).toHaveLength(1);
+  });
+
+  it("allows a timer run to comment and finish only the issue it checked out", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const runId = randomUUID();
+    const checkedOutIssueId = randomUUID();
+    const unrelatedIssueId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Timer Coder",
+      role: "engineer",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      nativeIssueId: null,
+      contextSnapshot: { issueId: null, taskId: null, wakeReason: "timer" },
+    });
+    await db.insert(issues).values([
+      {
+        id: checkedOutIssueId,
+        companyId,
+        title: "Timer-selected issue",
+        status: "todo",
+        assigneeAgentId: agentId,
+        issueNumber: 1,
+        identifier: "TIM-1",
+      },
+      {
+        id: unrelatedIssueId,
+        companyId,
+        title: "Unrelated issue",
+        status: "todo",
+        assigneeAgentId: agentId,
+        issueNumber: 2,
+        identifier: "TIM-2",
+      },
+    ]);
+
+    const checkedOut = await issueService(db).checkout(
+      checkedOutIssueId,
+      agentId,
+      ["todo"],
+      runId,
+    );
+    expect(checkedOut).toMatchObject({
+      id: checkedOutIssueId,
+      status: "in_progress",
+      checkoutRunId: runId,
+    });
+
+    const guardedWrite = {
+      companyId,
+      runId,
+      agentId,
+      targetIssueId: checkedOutIssueId,
+    } as const;
+    await expect(observeCrossIssueInfluence(db, {
+      ...guardedWrite,
+      kind: "comment",
+    })).resolves.toBeNull();
+    await db.insert(issueComments).values({
+      companyId,
+      issueId: checkedOutIssueId,
+      authorAgentId: agentId,
+      authorType: "agent",
+      createdByRunId: runId,
+      body: "Timer checkout comment",
+    });
+
+    await expect(observeCrossIssueInfluence(db, {
+      ...guardedWrite,
+      kind: "update",
+    })).resolves.toBeNull();
+    await db
+      .update(issues)
+      .set({ status: "done", checkoutRunId: null, executionRunId: null })
+      .where(eq(issues.id, checkedOutIssueId));
+
+    await expect(observeCrossIssueInfluence(db, {
+      companyId,
+      runId,
+      agentId,
+      targetIssueId: unrelatedIssueId,
+      kind: "comment",
+    })).rejects.toMatchObject({
+      status: 403,
+      details: { code: "cross_issue_influence_run_context_required" },
+    });
+
+    const [commentRows, issueRows] = await Promise.all([
+      db.select({ issueId: issueComments.issueId }).from(issueComments),
+      db.select({ id: issues.id, status: issues.status }).from(issues),
+    ]);
+    expect(commentRows).toEqual([{ issueId: checkedOutIssueId }]);
+    expect(issueRows).toEqual(expect.arrayContaining([
+      { id: checkedOutIssueId, status: "done" },
+      { id: unrelatedIssueId, status: "todo" },
+    ]));
   });
 });

--- a/server/src/__tests__/cross-issue-influence-limit.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  authorizeCrossIssueInfluence,
   CROSS_ISSUE_INFLUENCE_ENFORCE_AT,
   CROSS_ISSUE_INFLUENCE_LIMIT,
   crossIssueInfluenceLimitError,
@@ -183,6 +184,16 @@ describe("cross-issue influence limit rollout", () => {
       agentId: "33333333-3333-4333-8333-333333333333",
       targetIssueId: "55555555-5555-4555-8555-555555555555",
     } as const;
+
+    await expect(authorizeCrossIssueInfluence(checkoutAttributed.db as never, {
+      ...input,
+      kind: "comment",
+    })).resolves.toMatchObject({
+      decision: null,
+      mutationAuthority: {
+        requiredCheckoutRunId: "11111111-1111-4111-8111-111111111111",
+      },
+    });
 
     // These are the two guarded writes in the checkout -> comment -> terminal
     // status flow. Neither consumes cross-issue influence after checkout.

--- a/server/src/__tests__/cross-issue-influence-limit.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit.test.ts
@@ -10,6 +10,7 @@ import {
 function counterDb(
   initialCount = 0,
   runOverrides: Record<string, unknown> | null = {},
+  targetCheckout: Record<string, unknown> | null = null,
 ) {
   let observedCount = initialCount;
   const inserted: Array<Record<string, unknown>> = [];
@@ -22,6 +23,11 @@ function counterDb(
               then: (resolve: (rows: unknown[]) => unknown) => resolve([{ count: observedCount }]),
             };
           }
+          if (Object.keys(selection).includes("checkoutRunId")) {
+            return {
+              then: (resolve: (rows: unknown[]) => unknown) => resolve(targetCheckout ? [targetCheckout] : []),
+            };
+          }
           return {
             for: () => ({
               then: (resolve: (rows: unknown[]) => unknown) => resolve(runOverrides === null ? [] : [{
@@ -29,6 +35,7 @@ function counterDb(
                 companyId: "22222222-2222-4222-8222-222222222222",
                 agentId: "33333333-3333-4333-8333-333333333333",
                 responsibleUserId: "user-1",
+                nativeIssueId: null,
                 contextSnapshot: { issueId: "44444444-4444-4444-8444-444444444444" },
                 ...runOverrides,
               }]),
@@ -160,6 +167,45 @@ describe("cross-issue influence limit rollout", () => {
       kind: "comment",
     })).resolves.toBeNull();
     expect(fake.inserted).toEqual([]);
+  });
+
+  it("accepts only the checked-out issue for a timer wake with no initial issue", async () => {
+    const timerRun = {
+      nativeIssueId: null,
+      contextSnapshot: { issueId: null, taskId: null, wakeReason: "timer" },
+    };
+    const checkoutAttributed = counterDb(0, timerRun, {
+      checkoutRunId: "11111111-1111-4111-8111-111111111111",
+    });
+    const input = {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+    } as const;
+
+    // These are the two guarded writes in the checkout -> comment -> terminal
+    // status flow. Neither consumes cross-issue influence after checkout.
+    await expect(observeCrossIssueInfluence(checkoutAttributed.db as never, {
+      ...input,
+      kind: "comment",
+    })).resolves.toBeNull();
+    await expect(observeCrossIssueInfluence(checkoutAttributed.db as never, {
+      ...input,
+      kind: "update",
+    })).resolves.toBeNull();
+    expect(checkoutAttributed.inserted).toEqual([]);
+
+    const unrelatedTarget = counterDb(0, timerRun, { checkoutRunId: null });
+    await expect(observeCrossIssueInfluence(unrelatedTarget.db as never, {
+      ...input,
+      targetIssueId: "66666666-6666-4666-8666-666666666666",
+      kind: "comment",
+    })).rejects.toMatchObject({
+      status: 403,
+      details: { code: "cross_issue_influence_run_context_required" },
+    });
+    expect(unrelatedTarget.inserted).toEqual([]);
   });
 
   it.each([

--- a/server/src/__tests__/issue-activity-events-routes.test.ts
+++ b/server/src/__tests__/issue-activity-events-routes.test.ts
@@ -171,6 +171,7 @@ function issueUpdateWithReceipt(issue: ReturnType<typeof makeIssue>, patch: Reco
     actorAgentId: _actorAgentId,
     actorUserId: _actorUserId,
     blockedByIssueIds: _blockedByIssueIds,
+    crossIssueMutationAuthority: _crossIssueMutationAuthority,
     ...issuePatch
   } = patch;
   const updated = {

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -189,6 +189,10 @@ function registerRouteMocks() {
   }));
 
   vi.doMock("../services/cross-issue-influence-limit.js", () => ({
+    authorizeCrossIssueInfluence: async (...args: unknown[]) => ({
+      decision: await mockObserveCrossIssueInfluence(...args),
+      mutationAuthority: { requiredCheckoutRunId: null },
+    }),
     observeCrossIssueInfluence: mockObserveCrossIssueInfluence,
     crossIssueInfluenceLimitError: vi.fn(),
     crossIssueInfluenceRunContextError: () => new HttpError(

--- a/server/src/__tests__/issue-assignee-invokability-routes.test.ts
+++ b/server/src/__tests__/issue-assignee-invokability-routes.test.ts
@@ -44,6 +44,10 @@ const mockObserveCrossIssueInfluence = vi.hoisted(() => vi.fn(async () => null))
 
 vi.mock("../services/cross-issue-influence-limit.js", async (importOriginal) => ({
   ...await importOriginal<typeof import("../services/cross-issue-influence-limit.js")>(),
+  authorizeCrossIssueInfluence: async (...args: unknown[]) => ({
+    decision: await mockObserveCrossIssueInfluence(...args),
+    mutationAuthority: { requiredCheckoutRunId: null },
+  }),
   observeCrossIssueInfluence: mockObserveCrossIssueInfluence,
 }));
 

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -178,6 +178,10 @@ vi.mock("../services/external-objects.js", () => ({
 }));
 
 vi.mock("../services/cross-issue-influence-limit.js", () => ({
+  authorizeCrossIssueInfluence: async (...args: unknown[]) => ({
+    decision: await mockObserveCrossIssueInfluence(...args),
+    mutationAuthority: { requiredCheckoutRunId: null },
+  }),
   observeCrossIssueInfluence: mockObserveCrossIssueInfluence,
   crossIssueInfluenceLimitError: mockCrossIssueInfluenceLimitError,
   crossIssueInfluenceRunContextError: mockCrossIssueInfluenceRunContextError,
@@ -1158,6 +1162,7 @@ describe.sequential("issue comment reopen routes", () => {
         presentation: { kind: "system_notice", tone: "warning", detailsDefaultOpen: false },
         metadata,
         sourceTrust: null,
+        crossIssueMutationAuthority: { requiredCheckoutRunId: null },
       },
     );
   });

--- a/server/src/__tests__/issue-thread-interaction-routes.test.ts
+++ b/server/src/__tests__/issue-thread-interaction-routes.test.ts
@@ -2358,6 +2358,7 @@ describe.sequential("issue thread interaction routes", () => {
         runId: RUN_2,
         userId: null,
         resolverPolicyRestriction: "anyone",
+        crossIssueMutationAuthority: { requiredCheckoutRunId: null },
         suggestedTaskEffectsAuthorized: true,
       },
     );

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -261,10 +261,11 @@ import {
 } from "../services/issue-thread-interaction-resolution.js";
 import { resolveSelectedSuggestedTasks } from "../services/issue-thread-interactions.js";
 import {
+  authorizeCrossIssueInfluence,
   crossIssueInfluenceLimitError,
   crossIssueInfluenceRunContextError,
-  observeCrossIssueInfluence,
   type CrossIssueInfluenceKind,
+  type CrossIssueInfluenceMutationAuthority,
 } from "../services/cross-issue-influence-limit.js";
 import {
   getNativeSessionSteeringState,
@@ -3062,12 +3063,14 @@ export function issueRoutes(
     issue: { id: string; identifier?: string | null; companyId: string },
     kind: CrossIssueInfluenceKind,
   ) {
-    if (req.actor.type !== "agent") return true;
+    if (req.actor.type !== "agent") {
+      return { requiredCheckoutRunId: null } satisfies CrossIssueInfluenceMutationAuthority;
+    }
     if (!req.actor.agentId || !req.actor.runId) throw crossIssueInfluenceRunContextError();
 
     // The counter transaction locks and validates the persisted run before it
     // derives the source issue. Never trust the API-key run header by itself.
-    const decision = await observeCrossIssueInfluence(db, {
+    const { decision, mutationAuthority } = await authorizeCrossIssueInfluence(db, {
       companyId: issue.companyId,
       runId: req.actor.runId,
       agentId: req.actor.agentId,
@@ -3076,7 +3079,7 @@ export function issueRoutes(
       targetIssueIdentifier: issue.identifier ?? null,
       kind,
     });
-    if (!decision || decision.allowed) return true;
+    if (!decision || decision.allowed) return mutationAuthority;
 
     const labels = await issueWriteDenialLabels(req, {
       identifier: issue.identifier ?? null,
@@ -4524,8 +4527,14 @@ export function issueRoutes(
     // activity, tool, and wake side effect is still downstream. Same-issue
     // resolutions short-circuit inside the counter transaction and are not
     // charged, matching comment/update semantics.
-    if (!(await assertCrossIssueInfluenceWithinRunCap(req, res, issue, "interaction_resolution"))) return false;
-    return { decision, resolverPolicyRestriction } as const;
+    const crossIssueMutationAuthority = await assertCrossIssueInfluenceWithinRunCap(
+      req,
+      res,
+      issue,
+      "interaction_resolution",
+    );
+    if (!crossIssueMutationAuthority) return false;
+    return { decision, resolverPolicyRestriction, crossIssueMutationAuthority } as const;
   }
 
   async function getIssueThreadInteractionResolutionAuthorization(
@@ -7400,6 +7409,7 @@ export function issueRoutes(
     if (!existing) return;
     if (!(await assertIssueReadAllowed(req, res, existing))) return;
     if (await assertLowTrustControlPlaneDenied(req, res, existing.companyId, existing)) return;
+    let recoveryMutationAuthority: CrossIssueInfluenceMutationAuthority | null = null;
     if (req.actor.type === "agent") {
       const boundaryDecision = await decideIssueAccess(req, existing, "issue:mutate");
       if (!boundaryDecision.allowed) {
@@ -7407,7 +7417,9 @@ export function issueRoutes(
         return;
       }
       if (!requireAgentRunId(req, res)) return;
-      if (!(await assertCrossIssueInfluenceWithinRunCap(req, res, existing, "update"))) return;
+      const authority = await assertCrossIssueInfluenceWithinRunCap(req, res, existing, "update");
+      if (!authority) return;
+      recoveryMutationAuthority = authority;
     }
 
     const { actionId, outcome, sourceIssueStatus, resolutionNote } = req.body;
@@ -7427,6 +7439,12 @@ export function issueRoutes(
         .for("update")
         .then((rows) => rows[0] ?? null);
       if (!lockedIssue) throw notFound("Issue not found");
+      if (
+        recoveryMutationAuthority?.requiredCheckoutRunId
+        && lockedIssue.checkoutRunId !== recoveryMutationAuthority.requiredCheckoutRunId
+      ) {
+        throw crossIssueInfluenceRunContextError();
+      }
 
       const activeRecoveryAction = await recoveryActionsSvc.getActiveForIssue(
         lockedIssue.companyId,
@@ -10148,14 +10166,18 @@ export function issueRoutes(
       req.actor.type === "agent" &&
       (Object.keys(updateFields).length > 0 || reviewRequest !== undefined || hiddenAtRaw !== undefined);
 
-    if (
-      isAgentWorkUpdate &&
-      !(await assertCrossIssueInfluenceWithinRunCap(req, res, existing, "update"))
-    ) return;
-    if (
-      commentBody &&
-      !(await assertCrossIssueInfluenceWithinRunCap(req, res, existing, "comment"))
-    ) return;
+    let issueUpdateMutationAuthority: CrossIssueInfluenceMutationAuthority | null = null;
+    if (isAgentWorkUpdate) {
+      const authority = await assertCrossIssueInfluenceWithinRunCap(req, res, existing, "update");
+      if (!authority) return;
+      issueUpdateMutationAuthority = authority;
+    }
+    let commentMutationAuthority: CrossIssueInfluenceMutationAuthority | null = null;
+    if (commentBody) {
+      const authority = await assertCrossIssueInfluenceWithinRunCap(req, res, existing, "comment");
+      if (!authority) return;
+      commentMutationAuthority = authority;
+    }
 
     if (interruptRequested) {
       if (!commentBody) {
@@ -10433,6 +10455,7 @@ export function issueRoutes(
       ...updateFields,
       actorAgentId: actor.agentId ?? null,
       actorUserId: actor.actorType === "user" ? actor.actorId : null,
+      crossIssueMutationAuthority: issueUpdateMutationAuthority,
     };
     const shouldCollectCompletionPublication =
       actor.actorType === "user" && existing.status !== "done" && updateFields.status === "done";
@@ -11025,6 +11048,15 @@ export function issueRoutes(
       }, {
         authorizationReason: issueMutationAuthorizationReason,
         sourceTrust: await sourceTrustForActorWrite(issue, actor),
+        // A terminal update in this same request clears its own checkout after
+        // the guarded issue write commits. Otherwise the comment revalidates
+        // the timer checkout while holding the issue row through its insert.
+        crossIssueMutationAuthority:
+          commentMutationAuthority?.requiredCheckoutRunId
+          && issueUpdateMutationAuthority?.requiredCheckoutRunId === commentMutationAuthority.requiredCheckoutRunId
+          && issue.checkoutRunId !== commentMutationAuthority.requiredCheckoutRunId
+            ? null
+            : commentMutationAuthority,
       });
       await issueReferencesSvc.syncComment(comment.id);
       await externalObjectsSvc.syncCommentSafely(comment.id);
@@ -12352,6 +12384,7 @@ export function issueRoutes(
         runId: actor.runId,
         userId: actor.actorType === "user" ? actor.actorId : null,
         resolverPolicyRestriction: resolutionAuthorization.resolverPolicyRestriction,
+        crossIssueMutationAuthority: resolutionAuthorization.crossIssueMutationAuthority,
         suggestedTaskEffectsAuthorized,
       });
       const toolAction = interaction.payload && typeof interaction.payload === "object"
@@ -12596,6 +12629,7 @@ export function issueRoutes(
         runId: actor.runId,
         userId: actor.actorType === "user" ? actor.actorId : null,
         resolverPolicyRestriction: resolutionAuthorization.resolverPolicyRestriction,
+        crossIssueMutationAuthority: resolutionAuthorization.crossIssueMutationAuthority,
       });
 
       await logActivity(db, {
@@ -12668,6 +12702,7 @@ export function issueRoutes(
         runId: actor.runId,
         userId: actor.actorType === "user" ? actor.actorId : null,
         resolverPolicyRestriction: resolutionAuthorization.resolverPolicyRestriction,
+        crossIssueMutationAuthority: resolutionAuthorization.crossIssueMutationAuthority,
       });
 
       await logActivity(db, {
@@ -12737,6 +12772,7 @@ export function issueRoutes(
           runId: actor.runId,
           userId: actor.actorType === "user" ? actor.actorId : null,
           resolverPolicyRestriction: resolutionAuthorization.resolverPolicyRestriction,
+          crossIssueMutationAuthority: resolutionAuthorization.crossIssueMutationAuthority,
         },
       );
 
@@ -13378,7 +13414,8 @@ export function issueRoutes(
       res.status(409).json({ error: "Issue follow-up blocked by unresolved blockers" });
       return;
     }
-    if (!(await assertCrossIssueInfluenceWithinRunCap(req, res, issue, "comment"))) return;
+    const commentMutationAuthority = await assertCrossIssueInfluenceWithinRunCap(req, res, issue, "comment");
+    if (!commentMutationAuthority) return;
     // Reopen the closed isolated workspace only after every access, resume-intent,
     // blocker, and run-cap gate passes. A rejected comment must not rebuild and
     // republish the workspace as active, because the issue stays terminal and the
@@ -13563,6 +13600,7 @@ export function issueRoutes(
         presentation: commentPresentation,
         metadata: req.body.metadata ?? null,
         sourceTrust,
+        crossIssueMutationAuthority: commentMutationAuthority,
       };
       let txResult: { comment: Awaited<ReturnType<typeof svc.addComment>>; issue: NonNullable<Awaited<ReturnType<typeof svc.update>>> };
       const postCommitActivityPublications: ActivityPublication[] = [];
@@ -13657,6 +13695,7 @@ export function issueRoutes(
         metadata: req.body.metadata ?? null,
         authorizationReason: commentAuthorizationReason,
         sourceTrust: await sourceTrustForActorWrite(currentIssue, actor),
+        crossIssueMutationAuthority: commentMutationAuthority,
       });
     }
 

--- a/server/src/services/cross-issue-influence-limit.ts
+++ b/server/src/services/cross-issue-influence-limit.ts
@@ -27,6 +27,15 @@ export type CrossIssueInfluenceDecision = {
   enforceAt: string;
 };
 
+export type CrossIssueInfluenceMutationAuthority = {
+  requiredCheckoutRunId: string | null;
+};
+
+export type CrossIssueInfluenceObservation = {
+  decision: CrossIssueInfluenceDecision | null;
+  mutationAuthority: CrossIssueInfluenceMutationAuthority;
+};
+
 export function crossIssueInfluenceRunContextError() {
   // Copy comes from the shared issue-write denial contract (the open cross-task write design (failure UX))
   // so the agent reading this 403 is told the fix, not just the refusal.
@@ -68,7 +77,7 @@ export function evaluateCrossIssueInfluenceLimit(input: {
  * rollout reaches enforcement, failures cannot be used to race or probe past
  * the fail-closed backstop.
  */
-export async function observeCrossIssueInfluence(
+export async function authorizeCrossIssueInfluence(
   db: Db,
   input: {
     companyId: string;
@@ -80,7 +89,7 @@ export async function observeCrossIssueInfluence(
     kind: CrossIssueInfluenceKind;
     now?: Date;
   },
-): Promise<CrossIssueInfluenceDecision | null> {
+): Promise<CrossIssueInfluenceObservation> {
   // API-key callers control the run header. Reject malformed UUIDs before the
   // database can turn an untrusted identifier into a PostgreSQL cast error.
   if (!isUuidLike(input.runId)) throw crossIssueInfluenceRunContextError();
@@ -126,14 +135,22 @@ export async function observeCrossIssueInfluence(
           eq(issues.companyId, input.companyId),
         ))
         .then((rows) => rows[0] ?? null);
-      if (targetCheckout?.checkoutRunId === run.id) return null;
+      if (targetCheckout?.checkoutRunId === run.id) {
+        return {
+          decision: null,
+          mutationAuthority: { requiredCheckoutRunId: run.id },
+        };
+      }
       throw crossIssueInfluenceRunContextError();
     }
     if (
       sourceIssueId === input.targetIssueId ||
       (input.targetIssueIdentifier && sourceIssueId.toUpperCase() === input.targetIssueIdentifier.toUpperCase())
     ) {
-      return null;
+      return {
+        decision: null,
+        mutationAuthority: { requiredCheckoutRunId: null },
+      };
     }
 
     const priorCount = await tx
@@ -192,8 +209,49 @@ export async function observeCrossIssueInfluence(
       logger.warn(logContext, "cross-issue influence cap exceeded");
     }
 
-    return decision;
+    return {
+      decision,
+      mutationAuthority: { requiredCheckoutRunId: null },
+    };
   });
+}
+
+export async function observeCrossIssueInfluence(
+  db: Db,
+  input: Parameters<typeof authorizeCrossIssueInfluence>[1],
+): Promise<CrossIssueInfluenceDecision | null> {
+  return (await authorizeCrossIssueInfluence(db, input)).decision;
+}
+
+/**
+ * Revalidates timer-checkout authority while holding the target issue row.
+ * The protected mutation must use the same transaction so release,
+ * reassignment, and run cleanup cannot revoke the checkout between this check
+ * and the write.
+ */
+export async function assertCrossIssueMutationAuthority(
+  dbOrTx: Db | any,
+  input: {
+    companyId: string;
+    issueId: string;
+    authority?: CrossIssueInfluenceMutationAuthority | null;
+  },
+) {
+  const requiredCheckoutRunId = input.authority?.requiredCheckoutRunId ?? null;
+  if (!requiredCheckoutRunId) return;
+
+  const target = await dbOrTx
+    .select({ checkoutRunId: issues.checkoutRunId })
+    .from(issues)
+    .where(and(
+      eq(issues.id, input.issueId),
+      eq(issues.companyId, input.companyId),
+    ))
+    .for("update")
+    .then((rows: Array<{ checkoutRunId: string | null }>) => rows[0] ?? null);
+  if (target?.checkoutRunId !== requiredCheckoutRunId) {
+    throw crossIssueInfluenceRunContextError();
+  }
 }
 
 export function crossIssueInfluenceLimitError(

--- a/server/src/services/cross-issue-influence-limit.ts
+++ b/server/src/services/cross-issue-influence-limit.ts
@@ -1,6 +1,6 @@
 import { and, count, eq } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { activityLog, heartbeatRuns } from "@paperclipai/db";
+import { activityLog, heartbeatRuns, issues } from "@paperclipai/db";
 import { isUuidLike, issueWriteDenialResponse } from "@paperclipai/shared";
 import { forbidden } from "../errors.js";
 import { logger } from "../middleware/logger.js";
@@ -34,7 +34,8 @@ export function crossIssueInfluenceRunContextError() {
   return forbidden(body.error, body.details);
 }
 
-function readRunSourceIssueId(contextSnapshot: unknown) {
+function readRunSourceIssueId(nativeIssueId: string | null, contextSnapshot: unknown) {
+  if (nativeIssueId) return nativeIssueId;
   if (!contextSnapshot || typeof contextSnapshot !== "object" || Array.isArray(contextSnapshot)) return null;
   const context = contextSnapshot as Record<string, unknown>;
   for (const candidate of [context.issueId, context.taskId]) {
@@ -91,6 +92,7 @@ export async function observeCrossIssueInfluence(
         companyId: heartbeatRuns.companyId,
         agentId: heartbeatRuns.agentId,
         responsibleUserId: heartbeatRuns.responsibleUserId,
+        nativeIssueId: heartbeatRuns.nativeIssueId,
         contextSnapshot: heartbeatRuns.contextSnapshot,
       })
       .from(heartbeatRuns)
@@ -109,8 +111,24 @@ export async function observeCrossIssueInfluence(
       throw crossIssueInfluenceRunContextError();
     }
 
-    const sourceIssueId = readRunSourceIssueId(run.contextSnapshot);
-    if (!sourceIssueId) throw crossIssueInfluenceRunContextError();
+    const sourceIssueId = readRunSourceIssueId(run.nativeIssueId, run.contextSnapshot);
+    if (!sourceIssueId) {
+      // Timer wakes legitimately start without an issue source. Once such a run
+      // checks out an issue, the checkout row is the narrow persisted proof that
+      // writes to that exact issue are same-issue writes. Do not infer a source
+      // from assignee/company visibility: a different target must still fail
+      // closed when the run did not start with an issue.
+      const targetCheckout = await tx
+        .select({ checkoutRunId: issues.checkoutRunId })
+        .from(issues)
+        .where(and(
+          eq(issues.id, input.targetIssueId),
+          eq(issues.companyId, input.companyId),
+        ))
+        .then((rows) => rows[0] ?? null);
+      if (targetCheckout?.checkoutRunId === run.id) return null;
+      throw crossIssueInfluenceRunContextError();
+    }
     if (
       sourceIssueId === input.targetIssueId ||
       (input.targetIssueIdentifier && sourceIssueId.toUpperCase() === input.targetIssueIdentifier.toUpperCase())

--- a/server/src/services/issue-thread-interactions.ts
+++ b/server/src/services/issue-thread-interactions.ts
@@ -85,6 +85,10 @@ import {
 } from "./issues.js";
 import { questionResponseDeliveryValues } from "./question-response-delivery.js";
 import {
+  assertCrossIssueMutationAuthority,
+  type CrossIssueInfluenceMutationAuthority,
+} from "./cross-issue-influence-limit.js";
+import {
   assertIssueThreadInteractionResolverAudience,
   canonicalizeStoredResolverPolicy,
   issueThreadInteractionResolutionError,
@@ -112,8 +116,21 @@ type InteractionActor = {
     | IssueThreadInteractionResolverRestriction
     | null;
   suggestedTaskEffectsAuthorized?: boolean;
+  crossIssueMutationAuthority?: CrossIssueInfluenceMutationAuthority | null;
   resolutionDetails?: Record<string, unknown>;
 };
+
+async function assertInteractionMutationAuthority(
+  dbOrTx: Db | any,
+  issue: { id: string; companyId: string },
+  actor: InteractionActor,
+) {
+  await assertCrossIssueMutationAuthority(dbOrTx, {
+    companyId: issue.companyId,
+    issueId: issue.id,
+    authority: actor.crossIssueMutationAuthority,
+  });
+}
 
 type CreateInteractionOptions = {
   /** Keep independently owned pending cards actionable. Internal runtime bridges use this. */
@@ -1681,15 +1698,19 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
     interaction: IssueThreadInteraction;
     continuationIssue: IssueWakeTarget | null;
   }> {
-    const expired = await expireStaleRequestConfirmationTarget(db, {
-      row: args.current,
-      actor: args.actor,
+    const expired = await db.transaction(async (tx) => {
+      await assertInteractionMutationAuthority(tx, args.issue, args.actor);
+      return expireStaleRequestConfirmationTarget(tx, {
+        row: args.current,
+        actor: args.actor,
+      });
     });
     if (expired) throw interactionTerminalError({ status: expired.status, result: expired.result });
 
     const now = new Date();
     const postCommitActivityPublications: ActivityPublication[] = [];
     const result = await db.transaction(async (tx) => {
+      await assertInteractionMutationAuthority(tx, args.issue, args.actor);
       // Policy mutations and review transitions use the same issue-row lock,
       // so the authoritative review policy and requester are stable through
       // the verdict write. Terminal issue transitions also lock the issue
@@ -1887,9 +1908,12 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
     input: RejectIssueThreadInteraction;
     actor: InteractionActor;
   }): Promise<IssueThreadInteraction> {
-    const expired = await expireStaleRequestConfirmationTarget(db, {
-      row: args.current,
-      actor: args.actor,
+    const expired = await db.transaction(async (tx) => {
+      await assertInteractionMutationAuthority(tx, args.issue, args.actor);
+      return expireStaleRequestConfirmationTarget(tx, {
+        row: args.current,
+        actor: args.actor,
+      });
     });
     if (expired) throw interactionTerminalError({ status: expired.status, result: expired.result });
 
@@ -1901,6 +1925,7 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
 
     const now = new Date();
     const updated = await db.transaction(async (tx) => {
+      await assertInteractionMutationAuthority(tx, args.issue, args.actor);
       const issueContext = await tx
         .select({
           id: issues.id,
@@ -2989,6 +3014,7 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
       const createdWakeTargets: IssueWakeTarget[] = [];
 
       await db.transaction(async (tx) => {
+        await assertInteractionMutationAuthority(tx, issue, actor);
         const resolvedAt = new Date();
         const [claimed] = await tx
           .update(issueThreadInteractions)
@@ -3121,6 +3147,7 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
       assertIssueOpenForInteractionResolution(issue);
       const data = submitIssueThreadInteractionVerdictsSchema.parse(input);
       const submission = await db.transaction(async (tx) => {
+        await assertInteractionMutationAuthority(tx, issue, actor);
         const current = await tx
           .select()
           .from(issueThreadInteractions)
@@ -3238,31 +3265,33 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
         throw interactionTerminalError(current);
       }
 
-      const [updated] = await db
-        .update(issueThreadInteractions)
-        .set({
-          status: "rejected",
-          result: {
-            version: 1,
-            rejectionReason: input.reason?.trim() || null,
-          },
-          resolvedByAgentId: actor.agentId ?? null,
-          resolvedByRunId: actor.runId ?? null,
-          resolvedByUserId: actor.userId ?? null,
-          resolvedAt: new Date(),
-          updatedAt: new Date(),
-        })
-        .where(and(
-          eq(issueThreadInteractions.id, interactionId),
-          eq(issueThreadInteractions.status, "pending"),
-        ))
-        .returning();
+      const updated = await db.transaction(async (tx) => {
+        await assertInteractionMutationAuthority(tx, issue, actor);
+        const [row] = await tx
+          .update(issueThreadInteractions)
+          .set({
+            status: "rejected",
+            result: {
+              version: 1,
+              rejectionReason: input.reason?.trim() || null,
+            },
+            resolvedByAgentId: actor.agentId ?? null,
+            resolvedByRunId: actor.runId ?? null,
+            resolvedByUserId: actor.userId ?? null,
+            resolvedAt: new Date(),
+            updatedAt: new Date(),
+          })
+          .where(and(
+            eq(issueThreadInteractions.id, interactionId),
+            eq(issueThreadInteractions.status, "pending"),
+          ))
+          .returning();
 
-      if (!updated) {
-        throw interactionAlreadyResolvedError();
-      }
+        if (!row) throw interactionAlreadyResolvedError();
+        await touchIssue(tx, issue.id);
+        return row;
+      });
 
-      await touchIssue(db, issue.id);
       const rejected = hydrateInteraction(updated);
       await emitInteractionResolvedTelemetry(db, rejected);
       return rejected;
@@ -3760,6 +3789,7 @@ export function issueThreadInteractionService(db: Db, opts: IssueThreadInteracti
       });
 
       const updated = await db.transaction(async (tx) => {
+        await assertInteractionMutationAuthority(tx, issue, actor);
         const resolvedAt = new Date();
         const [row] = await tx
           .update(issueThreadInteractions)

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -101,6 +101,10 @@ import {
   projectHistoricalHeartbeatRunComment,
 } from "./heartbeat-run-summary.js";
 import { DEFAULT_INSERT_CHUNK_ROWS, insertRowsInChunks } from "./batch-insert.js";
+import {
+  assertCrossIssueMutationAuthority,
+  type CrossIssueInfluenceMutationAuthority,
+} from "./cross-issue-influence-limit.js";
 import type {
   ImportIssueRow,
   ImportIssueCommentRow,
@@ -7771,6 +7775,7 @@ export function issueService(db: Db) {
         blockedByIssueIds?: string[];
         actorAgentId?: string | null;
         actorUserId?: string | null;
+        crossIssueMutationAuthority?: CrossIssueInfluenceMutationAuthority | null;
       },
       dbOrTx: any = db,
       postCommitActivityPublications?: ActivityPublication[],
@@ -7792,6 +7797,7 @@ export function issueService(db: Db) {
         blockedByIssueIds,
         actorAgentId,
         actorUserId,
+        crossIssueMutationAuthority,
         ...issueData
       } = data;
       const isolatedWorkspacesEnabled = (await instanceSettings.getExperimental()).enableIsolatedWorkspaces;
@@ -7937,6 +7943,11 @@ export function issueService(db: Db) {
       }
 
       const runUpdate = async (tx: any) => {
+        await assertCrossIssueMutationAuthority(tx, {
+          companyId: existing.companyId,
+          issueId: id,
+          authority: crossIssueMutationAuthority,
+        });
         // The receipt baseline must be read under the same row lock as the
         // write. Otherwise a concurrent update can be mistaken for a change
         // made by this request.
@@ -8981,6 +8992,7 @@ export function issueService(db: Db) {
         authorizationReason?: string | null;
         sourceTrust?: typeof issueComments.$inferInsert.sourceTrust;
         createdAt?: Date | string | null;
+        crossIssueMutationAuthority?: CrossIssueInfluenceMutationAuthority | null;
       },
       dbOrTx: any = db,
     ): Promise<IssueComment> {
@@ -9005,6 +9017,11 @@ export function issueService(db: Db) {
         .then((rows: Array<{ companyId: string }>) => rows[0] ?? null);
 
       if (!issue) throw notFound("Issue not found");
+      await assertCrossIssueMutationAuthority(dbOrTx, {
+        companyId: issue.companyId,
+        issueId,
+        authority: options?.crossIssueMutationAuthority,
+      });
 
       const currentUserRedactionOptions = {
         enabled: (await instanceSettings.getGeneral()).censorUsernameInLogs,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The issue write guard limits work outside the issue that started a run.
> - Timer wakes can start without a native or snapshot issue ID.
> - A later checkout binds the selected issue to the exact run.
> - The guard did not use that checkout binding.
> - This pull request uses the exact checkout run only when both source IDs are absent.
> - The benefit is that timer runs can finish their checked-out issue without authority over another issue.

## Linked Issues or Issue Description

**What happened?**

A timer-woken agent run started with no native issue ID and no snapshot issue ID. The run then checked out an issue. Paperclip stored the run ID in the issue checkout row. A later comment or terminal status update still failed with `403 cross_issue_influence_run_context_required`.

**Expected behavior**

The validated run can comment on and finish only the same-company issue whose `checkout_run_id` exactly matches that run. A write to any other issue must remain denied.

**Steps to reproduce**

1. Create a running heartbeat with `nativeIssueId: null` and snapshot `issueId: null` and `taskId: null`.
2. Check out one assigned issue with that run ID.
3. Try to add a comment to the checked-out issue.
4. Try to set that issue to a terminal status.
5. Try to comment on a second issue.
6. Before this fix, steps 3 and 4 fail with the run-context error. After this fix, steps 3 and 4 pass. Step 5 still fails with the same run-context error.

**Paperclip version or commit**

The fix is based on current `master` at `d8b95805314c70b13d9efce338cbc287c2afb4e1` and has head commit `9514530b02c7e709a1648b8ff7a973271d0d38b9`.

**Deployment mode**

Built from source. The regression uses the local embedded PostgreSQL test harness.

## What Changed

- Prefer the persisted native issue ID over the snapshot source ID when it exists.
- Read the target issue checkout binding only when both source IDs are absent.
- Allow the write only when company, agent, validated run, target issue, and checkout run match.
- Add a unit regression for timer checkout comment and update writes.
- Add a PostgreSQL integration regression for checkout, comment, terminal status, unrelated-issue denial, and revoked-checkout denial.
- Revalidate checkout authority under the target issue row lock in the protected comment, update, recovery, and interaction mutation transactions.
- Keep malformed, missing, wrong-agent, wrong-company, and unrelated-target paths fail closed.

## Verification

- `TMPDIR="$PAPERCLIP_TMPDIR/ove3039-vitest" PATH=/opt/homebrew/opt/node@24/bin:/opt/homebrew/bin:/usr/bin:/bin corepack pnpm exec vitest run server/src/__tests__/cross-issue-influence-limit.test.ts server/src/__tests__/cross-issue-influence-limit-postgres.test.ts` passed 2 files and 14 tests.
- `PATH="$PAPERCLIP_RUN_SCRATCH_DIR/bin:/opt/homebrew/opt/node@24/bin:/opt/homebrew/bin:/usr/bin:/bin pnpm --filter @paperclipai/paperclip-runner build:typescript` completed successfully.
- `PATH="$PAPERCLIP_RUN_SCRATCH_DIR/bin:/opt/homebrew/opt/node@24/bin:/opt/homebrew/bin:/usr/bin:/bin ./server/node_modules/.bin/tsc -p server/tsconfig.json --noEmit` completed successfully.
- `PATH=... corepack pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-activity-events-routes.test.ts src/__tests__/issue-assignee-invokability-routes.test.ts src/__tests__/issue-agent-mutation-ownership-routes.test.ts` passed 3 files and 103 tests.
- `PATH=... corepack pnpm --filter @paperclipai/shared exec vitest run src/worktree-port-registry.test.ts` passed 1 file and 5 tests on rerun; the prior CI failure was not reproduced.
- `git diff --check origin/master...HEAD` completed successfully.
- `git show --check --oneline HEAD` completed successfully.
- Before proof: the prior guard threw the run-context error whenever both persisted source IDs were absent. It did not read `issues.checkout_run_id`.
- After proof: the timer-shaped integration test checks out one issue, inserts its comment, moves it to `done`, and confirms a second issue stays `todo` and rejects the same run.
- Adjacent checks cover native source attribution, snapshot source attribution, the shared comment/update/interaction counter, cap serialization, invalid run IDs, missing runs, wrong agents, and wrong companies.
- Screenshots: not UI.
- Human approval status: pending.

## Risks

- Risk level: medium. This change affects the agent issue-mutation authorization boundary.
- The main risk is that a timer run could gain authority over an unrelated issue.
- The fallback is narrow. It runs only when both native and snapshot source IDs are absent.
- Checkout authority is revalidated while holding the target issue row through the protected mutation, so release, reassignment, and run cleanup cannot create stale authorization.
- The target must be in the validated company and have `checkout_run_id` equal to the validated run ID.
- Existing malformed-run, agent-boundary, company-boundary, unrelated-target, and cross-issue-cap tests stay in place.
- Protected surface: issue comment and status-write authorization.
- Not included: assignment changes, cross-company access, interaction audience changes, budget changes, or wider delegation authority.
- No documentation change is required because this restores the existing checkout contract and adds no command or API shape.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with exact model ID `gpt-5.6-sol`.
- High reasoning effort was used.
- Tool use and code execution were enabled.
- The context window size was not disclosed by the runtime.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge