### PR TITLE
fix(tool-gateway): preserve gateway attribution and replay scope

### DIFF
--- a/server/src/__tests__/tool-access-policy-service.test.ts
+++ b/server/src/__tests__/tool-access-policy-service.test.ts
@@ -18,6 +18,7 @@ import {
   toolCallEvents,
   toolConnections,
   toolInvocations,
+  toolMcpGateways,
   toolPolicies,
   toolProfileBindings,
   toolProfileEntries,
@@ -119,6 +120,7 @@ async function createApprovedToolAction(input: {
   connectionId: string;
   catalogEntryId: string;
   issueId?: string | null;
+  gatewayId?: string | null;
   argumentsValue: Record<string, unknown>;
   status?: "approved" | "executed";
 }) {
@@ -126,7 +128,7 @@ async function createApprovedToolAction(input: {
   const decisionInput = {
     companyId: input.companyId,
     actor: { actorType: "agent" as const, actorId: input.agentId, agentId: input.agentId },
-    runContext: { issueId: input.issueId ?? null },
+    runContext: { issueId: input.issueId ?? null, gatewayId: input.gatewayId ?? null },
     request: {
       connectionId: input.connectionId,
       catalogEntryId: input.catalogEntryId,
@@ -167,6 +169,7 @@ describeEmbeddedPostgres("tool access policy service", () => {
     await db.delete(toolPolicies);
     await db.delete(toolProfileEntries);
     await db.delete(toolProfileBindings);
+    await db.delete(toolMcpGateways);
     await db.delete(toolProfiles);
     await db.delete(toolCatalogEntries);
     await db.delete(toolConnections);
@@ -736,6 +739,59 @@ describeEmbeddedPostgres("tool access policy service", () => {
     });
   });
 
+  it.each(["missing", "foreign", "disabled-own", "own-disabled-connection"] as const)(
+    "keeps gateway audit attribution company-scoped for %s context",
+    async (kind) => {
+      const company = await createCompany(db);
+      const { connection } = await createTool(db, company.id);
+      let gatewayId: string = randomUUID();
+      if (kind !== "missing") {
+        const gatewayCompany = kind === "foreign" ? await createCompany(db) : company;
+        const [profile] = await db.insert(toolProfiles).values({
+          companyId: gatewayCompany.id,
+          profileKey: `gateway-${randomUUID()}`,
+          name: "Gateway audit fixture",
+          defaultAction: "deny",
+        }).returning();
+        const [gateway] = await db.insert(toolMcpGateways).values({
+          companyId: gatewayCompany.id,
+          profileId: profile!.id,
+          name: "Gateway audit fixture",
+          slug: `gateway-${randomUUID()}`,
+          status: kind === "disabled-own" ? "disabled" : "active",
+        }).returning();
+        gatewayId = gateway!.id;
+      }
+      if (kind === "own-disabled-connection") {
+        await db.update(toolConnections).set({ enabled: false }).where(eq(toolConnections.id, connection.id));
+      }
+      const input = {
+        companyId: company.id,
+        actor: { actorType: "system" as const, actorId: randomUUID() },
+        runContext: { gatewayId },
+        request: { connectionId: connection.id, toolName: "send_email" },
+      };
+      const svc = toolAccessPolicyService(db);
+      const decision = await svc.decide(input);
+      const knownOwnGateway = kind === "disabled-own" || kind === "own-disabled-connection";
+      expect(decision).toMatchObject({
+        allowed: false,
+        reasonCode: kind === "disabled-own" ? "deny_default"
+          : kind === "own-disabled-connection" ? "deny_disabled_connection" : "deny_company_boundary",
+      });
+      const audit = await svc.writeAudit(input, decision);
+      for (const row of [audit.legacyAuditEvent, audit.toolCallEvent]) {
+        expect(row).toMatchObject({ companyId: company.id, gatewayId: knownOwnGateway ? gatewayId : null });
+      }
+      if (kind === "disabled-own") {
+        const recorded = await svc.recordInvocation(input, decision);
+        expect(recorded.invocation).toMatchObject({ gatewayId, agentId: null, runId: null, status: "denied" });
+      } else {
+        await expect(svc.recordInvocation(input, decision)).rejects.toThrow("Cannot record invocation for invalid tool access context");
+      }
+    },
+  );
+
   it("audits denied calls without storing secret argument values", async () => {
     const company = await createCompany(db);
     const agent = await createAgent(db, company.id);
@@ -1232,11 +1288,27 @@ describeEmbeddedPostgres("tool access policy service", () => {
     });
   });
 
-  it("promotes repeated approved actions into a scoped trust rule with audited hits", async () => {
+  it.each([false, true])("promotes repeated approved actions with audited hits (named gateway: %s)", async (namedGateway) => {
     const company = await createCompany(db);
     const agent = await createAgent(db, company.id);
     const issue = await createIssue(db, company.id);
     const { connection, catalogEntry } = await createTool(db, company.id);
+    let gatewayId: string | null = null;
+    if (namedGateway) {
+      const [profile] = await db.insert(toolProfiles).values({
+        companyId: company.id,
+        profileKey: `gateway-${randomUUID()}`,
+        name: "Trust rule gateway",
+        defaultAction: "deny",
+      }).returning();
+      const [gateway] = await db.insert(toolMcpGateways).values({
+        companyId: company.id,
+        profileId: profile!.id,
+        name: "Trust rule gateway",
+        slug: `gateway-${randomUUID()}`,
+      }).returning();
+      gatewayId = gateway!.id;
+    }
     await db.insert(toolPolicies).values({
       companyId: company.id,
       name: "Review send_email",
@@ -1254,6 +1326,7 @@ describeEmbeddedPostgres("tool access policy service", () => {
       issueId: issue.id,
       argumentsValue: args,
       status: "executed",
+      gatewayId,
     });
     await createApprovedToolAction({
       db,
@@ -1263,6 +1336,7 @@ describeEmbeddedPostgres("tool access policy service", () => {
       catalogEntryId: catalogEntry.id,
       issueId: issue.id,
       argumentsValue: args,
+      gatewayId,
     });
 
     const trustRule = await toolAccessPolicyService(db).createTrustRuleFromActionRequest({
@@ -1282,6 +1356,7 @@ describeEmbeddedPostgres("tool access policy service", () => {
     const [updatedRule] = await db.select().from(toolPolicies).where(eq(toolPolicies.id, trustRule.id));
     const trustConfig = updatedRule.config as { trustRule?: { hitCount?: number; lastHitAt?: string | null } };
     const trustEvents = await db.select().from(toolCallEvents);
+    const legacyTrustEvents = await db.select().from(toolAccessAuditEvents);
 
     expect(trustRule).toMatchObject({
       policyType: "trust_rule",
@@ -1302,8 +1377,14 @@ describeEmbeddedPostgres("tool access policy service", () => {
     });
     expect(trustConfig.trustRule?.hitCount).toBe(1);
     expect(trustConfig.trustRule?.lastHitAt).toEqual(expect.any(String));
-    expect(trustEvents.some((event) => event.eventType === "trust_rule_created")).toBe(true);
-    expect(trustEvents.some((event) => event.eventType === "trust_rule_used")).toBe(true);
+    for (const eventType of ["trust_rule_created", "trust_rule_used"]) {
+      expect(trustEvents.filter((event) => event.eventType === eventType)).toMatchObject([
+        { companyId: company.id, gatewayId },
+      ]);
+      expect(legacyTrustEvents.filter((event) => event.action === `tool_access.${eventType}`)).toMatchObject([
+        { companyId: company.id, gatewayId },
+      ]);
+    }
   });
 
   it("does not count approved actions outside the final trust-rule agent scope", async () => {

--- a/server/src/__tests__/tool-access-policy-service.test.ts
+++ b/server/src/__tests__/tool-access-policy-service.test.ts
@@ -941,6 +941,78 @@ describeEmbeddedPostgres("tool access policy service", () => {
     expect(replay.invocation.id).toBe(first.invocation.id);
   });
 
+  it.each([
+    ["derived", "named-to-named"],
+    ["derived", "named-to-null"],
+    ["derived", "null-to-named"],
+    ["explicit", "named-to-named"],
+    ["explicit", "named-to-null"],
+    ["explicit", "null-to-named"],
+  ] as const)("scopes side-effecting invocation replay for %s keys across %s", async (keyKind, boundary) => {
+    const company = await createCompany(db);
+    const { connection, catalogEntry } = await createTool(db, company.id);
+    const [profile] = await db.insert(toolProfiles).values({
+      companyId: company.id,
+      profileKey: `replay-${randomUUID()}`,
+      name: "Replay boundary fixture",
+      defaultAction: "deny",
+    }).returning();
+    await db.insert(toolProfileEntries).values({
+      companyId: company.id,
+      profileId: profile!.id,
+      selectorType: "tool_name",
+      effect: "include",
+      toolName: "send_email",
+    });
+    await db.insert(toolProfileBindings).values({
+      companyId: company.id,
+      profileId: profile!.id,
+      targetType: "company",
+      targetId: company.id,
+    });
+    const gateways = await db.insert(toolMcpGateways).values([0, 1].map((index) => ({
+      companyId: company.id,
+      profileId: profile!.id,
+      name: `Replay gateway ${index}`,
+      slug: `replay-${randomUUID()}`,
+    }))).returning();
+    const ownerGatewayId = boundary === "null-to-named" ? null : gateways[0]!.id;
+    const otherGatewayId = boundary === "named-to-null" ? null : gateways[1]!.id;
+    const input = {
+      companyId: company.id,
+      actor: { actorType: "system" as const, actorId: randomUUID() },
+      runContext: { gatewayId: ownerGatewayId },
+      request: {
+        connectionId: connection.id,
+        catalogEntryId: catalogEntry.id,
+        toolName: "send_email",
+        arguments: { to: "ops@example.com", body: "only once" },
+        sideEffecting: true,
+        ...(keyKind === "explicit" ? { idempotencyKey: "shared-send-1" } : {}),
+      },
+    };
+    const svc = toolAccessPolicyService(db);
+    const decision = await svc.decide(input);
+    expect(decision.allowed).toBe(true);
+    const first = await svc.recordInvocation(input, decision);
+    const replay = await svc.recordInvocation(input, decision);
+    expect(first.replayed).toBe(false);
+    expect(first.invocation.gatewayId).toBe(ownerGatewayId);
+    expect(replay).toMatchObject({ replayed: true, invocation: { id: first.invocation.id, gatewayId: ownerGatewayId } });
+    if (keyKind === "explicit") expect(first.invocation.idempotencyKey).toBe("shared-send-1");
+    else expect(first.invocation.idempotencyKey).toMatch(/^side_effect:/);
+
+    const otherInput = { ...input, runContext: { gatewayId: otherGatewayId } };
+    const otherDecision = await svc.decide(otherInput);
+    expect(otherDecision.allowed).toBe(true);
+    await expect(svc.recordInvocation(otherInput, otherDecision)).rejects.toMatchObject({
+      status: 409, details: { reasonCode: "idempotency_gateway_mismatch" },
+    });
+    const invocations = await db.select().from(toolInvocations);
+    expect(invocations).toHaveLength(1);
+    expect(invocations[0]).toMatchObject({ id: first.invocation.id, gatewayId: ownerGatewayId });
+  });
+
   it("enforces rate-limit policies before explicit grants", async () => {
     const company = await createCompany(db);
     const agent = await createAgent(db, company.id);

--- a/server/src/__tests__/tool-gateway.test.ts
+++ b/server/src/__tests__/tool-gateway.test.ts
@@ -731,6 +731,92 @@ describeEmbeddedPostgres("tool gateway acceptance", () => {
     }
   });
 
+  it.each(["derived", "explicit"] as const)("isolates named gateway side-effect results for %s keys", async (keyKind) => {
+    const company = await createCompany(db);
+    const remote = await startFakeRemoteMcpServer(({ body }) => ({
+      body: {
+        jsonrpc: "2.0",
+        id: body?.id,
+        result: { content: [{ type: "text", text: "first gateway private result" }], isError: false },
+      },
+    }));
+    try {
+      const { application, connection, catalogEntry } = await createRemoteMcpTool(db, company.id, {
+        url: remote.url,
+        toolName: "update_note",
+        riskLevel: "write",
+      });
+      const toolName = expectedConnectedToolName({
+        applicationKey: application.applicationKey,
+        connectionId: connection.id,
+        toolName: catalogEntry.toolName,
+      });
+      const [profile] = await db.insert(toolProfiles).values({
+        companyId: company.id,
+        profileKey: `gateway-replay-${randomUUID()}`,
+        name: "Gateway replay writer",
+        defaultAction: "deny",
+      }).returning();
+      await db.insert(toolProfileEntries).values({
+        companyId: company.id,
+        profileId: profile!.id,
+        selectorType: "catalog_entry",
+        effect: "include",
+        applicationId: application.id,
+        connectionId: connection.id,
+        catalogEntryId: catalogEntry.id,
+      });
+      const gateway = createTestToolGatewayService(db);
+      const clients = [];
+      for (const name of ["First writer", "Second writer"]) {
+        const created = await gateway.createNamedGateway({ companyId: company.id, body: { name, profileId: profile!.id } });
+        const token = await gateway.createNamedGatewayToken({
+          companyId: company.id,
+          gatewayId: created.id,
+          body: { name, allowedActions: ["tools/call"] },
+        });
+        clients.push({ gatewayId: created.id, endpointPath: created.endpointPath, token: token.token });
+      }
+      const app = createGatewayRouteApp(db, gateway);
+      const call = (token: string) => request(app).post("/api/tool-gateway/tools/call")
+        .set("x-paperclip-tool-gateway-token", token)
+        .send({
+          tool: toolName,
+          parameters: { key: "a", value: "b" },
+          timeoutMs: 2_000,
+          ...(keyKind === "explicit" ? { idempotencyKey: "shared-update-1" } : {}),
+        });
+      const first = await call(clients[0]!.token).expect(200);
+      expect(first.body).toMatchObject({ status: "completed", result: { content: "first gateway private result" } });
+      const replay = await call(clients[0]!.token).expect(200);
+      expect(replay.body).toMatchObject({ status: "replayed", invocationId: first.body.invocationId });
+      const collision = await call(clients[1]!.token);
+      expect.soft(collision.status).toBe(409);
+      expect.soft(collision.body.reasonCode).toBe("idempotency_gateway_mismatch");
+      expect.soft(JSON.stringify(collision.body)).not.toContain("first gateway private result");
+      expect.soft(collision.body.invocationId).not.toBe(first.body.invocationId);
+      if (keyKind === "derived") {
+        const protocolCollision = await request(app).post(clients[1]!.endpointPath)
+          .set("authorization", `Bearer ${clients[1]!.token}`)
+          .send({ jsonrpc: "2.0", id: "gateway-collision", method: "tools/call", params: {
+            name: toolName, arguments: { key: "a", value: "b" },
+          } });
+        expect.soft(protocolCollision.status).toBe(409);
+        expect.soft(protocolCollision.body).toMatchObject({
+          jsonrpc: "2.0", id: "gateway-collision", error: { code: -32000, data: { reasonCode: "idempotency_gateway_mismatch" } },
+        });
+        expect.soft(JSON.stringify(protocolCollision.body)).not.toContain("first gateway private result");
+        expect.soft(protocolCollision.body.result).toBeUndefined();
+      }
+      expect(remote.requests.filter(({ body }) => body?.method === "tools/call")).toHaveLength(1);
+      const invocations = await db.select().from(toolInvocations);
+      expect(invocations).toHaveLength(1);
+      expect(invocations[0]).toMatchObject({ id: first.body.invocationId, gatewayId: clients[0]!.gatewayId });
+    } finally {
+      await remote.close();
+    }
+  });
+
   it("persists named gateway attribution and scopes audit to the requested gateway", async () => {
     const company = await createCompany(db);
     const otherCompany = await createCompany(db);
@@ -3789,6 +3875,94 @@ rl.on("line", (line) => {
     } finally {
       releaseApprovedExecution();
       await fake.close();
+    }
+  });
+
+  it.each(["matching", "explicit"] as const)("isolates named gateway approved actions from %s reuse", async (reuse) => {
+    const company = await createCompany(db);
+    const agent = await createAgent(db, company.id);
+    const { issue, run } = await createIssueAndRun(db, company.id, agent.id);
+    const remote = await startFakeRemoteMcpServer(({ body }) => ({
+      body: {
+        jsonrpc: "2.0",
+        id: body?.id,
+        result: { content: [{ type: "text", text: "approved first gateway result" }], isError: false },
+      },
+    }));
+    try {
+      const { application, connection, catalogEntry } = await createRemoteMcpTool(db, company.id, {
+        url: remote.url, toolName: "update_note", riskLevel: "write",
+      });
+      const toolName = expectedConnectedToolName({
+        applicationKey: application.applicationKey, connectionId: connection.id, toolName: catalogEntry.toolName,
+      });
+      const [profile] = await db.insert(toolProfiles).values({
+        companyId: company.id, profileKey: `approval-boundary-${randomUUID()}`,
+        name: "Gateway approved writer", defaultAction: "deny",
+      }).returning();
+      await db.insert(toolProfileEntries).values({
+        companyId: company.id, profileId: profile!.id, selectorType: "catalog_entry", effect: "include",
+        applicationId: application.id, connectionId: connection.id, catalogEntryId: catalogEntry.id,
+      });
+      await db.insert(toolPolicies).values({
+        companyId: company.id, name: "Review gateway writes", policyType: "require_approval",
+        selectors: { connectionId: connection.id }, priority: 10,
+      });
+      const gateway = createTestToolGatewayService(db);
+      const clients = [];
+      for (const name of ["Approved writer", "Sibling writer"]) {
+        const created = await gateway.createNamedGateway({
+          companyId: company.id, body: { name, profileId: profile!.id, defaultProfileMode: "gateway_only" },
+        });
+        const token = await gateway.createNamedGatewayToken({
+          companyId: company.id, gatewayId: created.id,
+          body: {
+            name, subjectType: "heartbeat_run", subjectId: run.id,
+            clientLabel: "Heartbeat fixture", ownerNote: "Gateway approval boundary regression",
+            allowedActions: ["tools/call"], expiresAt: new Date(Date.now() + 60_000),
+          },
+          actor: { agentId: agent.id },
+        });
+        clients.push({ gatewayId: created.id, token: token.token });
+      }
+      const call = { tool: toolName, parameters: { key: "a", value: "b" } };
+      await expect(gateway.executeTool({ ...call, sessionToken: clients[0]!.token }))
+        .rejects.toMatchObject({ status: 409, reasonCode: "approval_required" });
+      const [action] = await db.select().from(toolActionRequests);
+      expect(action).toMatchObject({ issueId: issue.id, status: "pending" });
+      await db.update(issueThreadInteractions).set({
+        status: "accepted", resolvedByAgentId: agent.id, resolvedAt: new Date(),
+      }).where(eq(issueThreadInteractions.id, action!.interactionId!));
+      await db.update(toolActionRequests).set({ status: "approved", resolvedAt: new Date() })
+        .where(eq(toolActionRequests.id, action!.id));
+      if (reuse === "matching") {
+        const first = await gateway.executeTool({
+          ...call, sessionToken: clients[0]!.token, approvedActionRequestId: action!.id,
+        });
+        expect(first).toMatchObject({ status: "completed", result: { content: "approved first gateway result" } });
+      }
+      const other = await gateway.executeTool({
+        ...call, sessionToken: clients[1]!.token,
+        ...(reuse === "explicit" ? { approvedActionRequestId: action!.id } : {}),
+      }).then((value) => ({ value, error: null }), (error: unknown) => ({ value: null, error }));
+      expect.soft(other.error).toMatchObject(reuse === "explicit"
+        ? { status: 403, reasonCode: "action_scope_mismatch" }
+        : { status: 409, details: { reasonCode: "idempotency_gateway_mismatch" } });
+      expect.soft(other.value).toBeNull();
+      expect(remote.requests.filter(({ body }) => body?.method === "tools/call")).toHaveLength(reuse === "matching" ? 1 : 0);
+      const actions = await db.select().from(toolActionRequests);
+      expect(actions).toHaveLength(1);
+      expect(actions[0]).toMatchObject({
+        id: action!.id, invocationId: action!.invocationId, status: reuse === "matching" ? "executed" : "approved",
+      });
+      const invocations = await db.select().from(toolInvocations);
+      expect(invocations).toHaveLength(1);
+      expect(invocations[0]).toMatchObject({
+        id: action!.invocationId, gatewayId: clients[0]!.gatewayId, agentId: agent.id, runId: run.id,
+        status: reuse === "matching" ? "succeeded" : "awaiting_approval",
+      });
+    } finally {
+      await remote.close();
     }
   });
 

--- a/server/src/__tests__/tool-gateway.test.ts
+++ b/server/src/__tests__/tool-gateway.test.ts
@@ -731,6 +731,173 @@ describeEmbeddedPostgres("tool gateway acceptance", () => {
     }
   });
 
+  it("persists named gateway attribution and scopes audit to the requested gateway", async () => {
+    const company = await createCompany(db);
+    const otherCompany = await createCompany(db);
+    const remote = await startFakeRemoteMcpServer(({ body }) => ({
+      body: {
+        jsonrpc: "2.0",
+        id: body?.id ?? "test",
+        result: { content: [{ type: "text", text: "read ok" }], isError: false },
+      },
+    }));
+    try {
+      const gateway = createTestToolGatewayService(db);
+      const app = createGatewayRouteApp(db, gateway, {
+        type: "board",
+        userId: "instance-admin",
+        source: "session",
+        companyIds: [company.id, otherCompany.id],
+        memberships: [company, otherCompany].map(({ id }) => ({
+          companyId: id, membershipRole: "owner", status: "active",
+        })),
+        isInstanceAdmin: true,
+      });
+      const completed: Array<{
+        companyId: string; gatewayId: string; tokenId: string; invocationId: string;
+        token: string; toolName: string;
+      }> = [];
+      for (const owner of [company, company, otherCompany]) {
+        const { application, connection, catalogEntry } = await createRemoteMcpTool(db, owner.id, {
+          url: remote.url,
+          toolName: "read_note",
+          riskLevel: "read",
+          connectionConfig: { onDemandTools: { enabled: true } },
+        });
+        const toolName = expectedConnectedToolName({
+          applicationKey: application.applicationKey,
+          connectionId: connection.id,
+          toolName: catalogEntry.toolName,
+        });
+        const [profile] = await db.insert(toolProfiles).values({
+          companyId: owner.id,
+          profileKey: `gateway-audit-${randomUUID()}`,
+          name: `Gateway audit reader ${randomUUID()}`,
+          defaultAction: "deny",
+        }).returning();
+        await db.insert(toolProfileEntries).values({
+          companyId: owner.id,
+          profileId: profile!.id,
+          selectorType: "catalog_entry",
+          effect: "include",
+          applicationId: application.id,
+          connectionId: connection.id,
+          catalogEntryId: catalogEntry.id,
+        });
+        const created = await gateway.createNamedGateway({
+          companyId: owner.id,
+          body: { name: `Audit reader ${randomUUID()}`, profileId: profile!.id },
+        });
+        const token = await gateway.createNamedGatewayToken({
+          companyId: owner.id,
+          gatewayId: created.id,
+          body: { name: "Audit fixture", allowedActions: ["tools/list", "tools/call"] },
+        });
+        const response = await request(app)
+          .post("/api/tool-gateway/tools/call")
+          .set("x-paperclip-tool-gateway-token", token.token)
+          .send({ tool: toolName, parameters: { key: "a", value: "b" }, timeoutMs: 2_000 })
+          .expect(200);
+        expect(response.body).toMatchObject({
+          status: "completed",
+          tool: toolName,
+          result: { content: "read ok", data: { isError: false, transport: "mcp_http" } },
+        });
+        completed.push({
+          companyId: owner.id, gatewayId: created.id, tokenId: token.id,
+          invocationId: response.body.invocationId as string,
+          token: token.token, toolName,
+        });
+      }
+      expect(remote.requests.filter(({ body }) => body?.method === "tools/call")).toHaveLength(3);
+      for (const call of completed) {
+        const [invocation] = await db.select().from(toolInvocations)
+          .where(eq(toolInvocations.id, call.invocationId));
+        const events = await db.select().from(toolCallEvents).where(and(
+          eq(toolCallEvents.invocationId, call.invocationId),
+          eq(toolCallEvents.eventType, "call_completed"),
+        ));
+        const audit = await request(app).get("/api/tool-gateway/audit")
+          .query({ companyId: call.companyId, gateway: call.gatewayId, limit: 100, window: "all" })
+          .expect(200);
+        expect(events).toHaveLength(1);
+        const expectedActor = {
+          companyId: call.companyId,
+          actorType: "system",
+          actorId: call.tokenId,
+          agentId: null,
+          runId: null,
+          issueId: null,
+        };
+        expect(invocation).toMatchObject({ ...expectedActor, status: "succeeded" });
+        expect(events[0]).toMatchObject({ ...expectedActor, outcome: "success" });
+        expect.soft(invocation?.gatewayId).toBe(call.gatewayId);
+        expect.soft(events[0]?.gatewayId).toBe(call.gatewayId);
+        const auditCompletions = audit.body.events.filter((event: { action: string }) =>
+          event.action === "tool_gateway.call_completed");
+        expect.soft(auditCompletions).toMatchObject([{
+          actorType: "system",
+          actorId: call.tokenId,
+          companyId: call.companyId,
+          agentId: null,
+          runId: null,
+          details: { gatewayId: call.gatewayId, invocationId: call.invocationId },
+          invocation: { id: call.invocationId, status: "succeeded", policyDecision: "allow" },
+        }]);
+        expect.soft(auditCompletions.map((event: { invocation: { id: string } }) => event.invocation.id))
+          .toEqual([call.invocationId]);
+      }
+      const firstCall = completed[0]!;
+      await db.update(toolCallEvents).set({
+        gatewayId: null,
+        metadata: { gatewayId: completed[1]!.gatewayId },
+      }).where(and(
+        eq(toolCallEvents.invocationId, firstCall.invocationId),
+        eq(toolCallEvents.eventType, "call_completed"),
+      ));
+      const fallbackAudit = await request(app).get("/api/tool-gateway/audit")
+        .query({ companyId: company.id, gateway: firstCall.gatewayId, limit: 100, window: "all" })
+        .expect(200);
+      expect(fallbackAudit.body.events.filter((event: { action: string }) =>
+        event.action === "tool_gateway.call_completed")).toMatchObject([{
+          details: { gatewayId: firstCall.gatewayId, invocationId: firstCall.invocationId },
+          invocation: { id: firstCall.invocationId, status: "succeeded" },
+        }]);
+      const crossCompany = await request(app).get("/api/tool-gateway/audit")
+        .query({ companyId: company.id, gateway: completed[2]!.gatewayId, limit: 100, window: "all" })
+        .expect(200);
+      expect(crossCompany.body.events).toEqual([]);
+      const search = await request(app)
+        .post("/api/tool-gateway/tools/call")
+        .set("x-paperclip-tool-gateway-token", firstCall.token)
+        .send({ tool: "search_tools", parameters: { query: "read_note", limit: 5 } })
+        .expect(200);
+      expect(search.body).toMatchObject({
+        status: "completed",
+        tool: "search_tools",
+        result: { data: { tools: [{ name: firstCall.toolName }] } },
+      });
+      const [searchInvocation] = await db.select().from(toolInvocations)
+        .where(eq(toolInvocations.id, search.body.invocationId as string));
+      const searchEvents = await db.select().from(toolCallEvents).where(and(
+        eq(toolCallEvents.invocationId, search.body.invocationId as string),
+        eq(toolCallEvents.eventType, "call_completed"),
+      ));
+      const expectedSearchActor = {
+        companyId: company.id, gatewayId: firstCall.gatewayId,
+        actorType: "system", actorId: firstCall.tokenId,
+        agentId: null, runId: null, issueId: null, toolName: "search_tools",
+      };
+      expect(searchInvocation).toMatchObject({
+        ...expectedSearchActor, providerType: "paperclip_virtual", status: "succeeded",
+      });
+      expect(searchEvents).toMatchObject([{ ...expectedSearchActor, outcome: "success" }]);
+      expect(remote.requests.filter(({ body }) => body?.method === "tools/call")).toHaveLength(3);
+    } finally {
+      await remote.close();
+    }
+  });
+
   it("keeps additive app-gallery assignments out of gateway-only runtimes", async () => {
     const company = await createCompany(db);
     const assigned = await createRemoteMcpTool(db, company.id, {
@@ -1354,6 +1521,7 @@ describeEmbeddedPostgres("tool gateway acceptance", () => {
       agentId: agent.id,
       issueId: issue.id,
       runId: run.id,
+      gatewayId: null,
       toolName: "mcp-remote-fixture:add",
       status: "succeeded",
     });
@@ -1363,6 +1531,7 @@ describeEmbeddedPostgres("tool gateway acceptance", () => {
       agentId: agent.id,
       issueId: issue.id,
       runId: run.id,
+      gatewayId: null,
       toolName: "mcp-remote-fixture:add",
       outcome: "success",
     });
@@ -1373,6 +1542,7 @@ describeEmbeddedPostgres("tool gateway acceptance", () => {
     expect(dedicatedAudit).toMatchObject({
       issueId: issue.id,
       runId: run.id,
+      gatewayId: null,
       toolName: "mcp-remote-fixture:add",
     });
   });

--- a/server/src/routes/tool-gateway.ts
+++ b/server/src/routes/tool-gateway.ts
@@ -202,12 +202,16 @@ async function handleMcpGatewayProtocol(
     }
     res.status(404).json({ jsonrpc: "2.0", id, error: { code: -32601, message: "Method not found" } });
   } catch (err) {
-    if (err instanceof ToolGatewayHttpError) {
+    if (err instanceof ToolGatewayHttpError || err instanceof HttpError) {
       const id = (req.body as { id?: unknown } | undefined)?.id ?? null;
       res.status(err.status).json({
         jsonrpc: "2.0",
         id,
-        error: { code: err.status >= 500 ? -32603 : -32000, message: err.message, data: { reasonCode: err.reasonCode, ...err.details } },
+        error: {
+          code: err.status >= 500 ? -32603 : -32000,
+          message: err.message,
+          data: err instanceof ToolGatewayHttpError ? { reasonCode: err.reasonCode, ...err.details } : err.details,
+        },
       });
       return;
     }

--- a/server/src/routes/tool-gateway.ts
+++ b/server/src/routes/tool-gateway.ts
@@ -834,6 +834,7 @@ export function toolGatewayRoutes(db: Db, toolGateway: ToolGatewayService) {
         .select({
           row: toolCallEvents,
           invocationId: toolInvocations.id,
+          invocationGatewayId: toolInvocations.gatewayId,
           invocationAgentId: toolInvocations.agentId,
           invocationApplicationId: toolInvocations.applicationId,
           invocationConnectionId: toolInvocations.connectionId,
@@ -968,6 +969,7 @@ export function toolGatewayRoutes(db: Db, toolGateway: ToolGatewayService) {
 
         const item = candidate.item;
         const row = item.row;
+        const gatewayId = row.gatewayId ?? item.invocationGatewayId;
         const agentId = row.agentId ?? item.invocationAgentId;
         const connectionId = row.connectionId ?? item.invocationConnectionId;
         const connection = connectionId ? connectionsById.get(connectionId) ?? null : null;
@@ -983,7 +985,7 @@ export function toolGatewayRoutes(db: Db, toolGateway: ToolGatewayService) {
           ...(row.metadata ?? {}),
           invocationId: row.invocationId,
           actionRequestId: row.actionRequestId,
-          gatewayId: row.gatewayId,
+          gatewayId,
           agentId,
           issueId: row.issueId,
           runId: row.runId,

--- a/server/src/services/tool-access-policy.ts
+++ b/server/src/services/tool-access-policy.ts
@@ -1423,7 +1423,14 @@ export function toolAccessPolicyService(db: Db) {
         eq(toolInvocations.companyId, input.companyId),
         eq(toolInvocations.idempotencyKey, idempotencyKey),
       ));
-      if (existing) return { invocation: existing, replayed: true, actionRequest: null };
+      if (existing) {
+        if (existing.gatewayId !== ctx.gatewayId) {
+          throw conflict("Tool invocation idempotency key belongs to a different gateway", {
+            reasonCode: "idempotency_gateway_mismatch",
+          });
+        }
+        return { invocation: existing, replayed: true, actionRequest: null };
+      }
     }
     const status = accessDecision.decision === "allow"
       ? "authorized"

--- a/server/src/services/tool-access-policy.ts
+++ b/server/src/services/tool-access-policy.ts
@@ -838,6 +838,15 @@ export function toolAccessPolicyService(db: Db) {
     return deleted;
   }
 
+  async function resolveCompanyGatewayId(companyId: string, gatewayId?: string | null): Promise<string | null> {
+    if (!gatewayId) return null;
+    const [gateway] = await db.select({ id: toolMcpGateways.id }).from(toolMcpGateways).where(and(
+      eq(toolMcpGateways.companyId, companyId),
+      eq(toolMcpGateways.id, gatewayId),
+    )).limit(1);
+    return gateway?.id ?? null;
+  }
+
   async function loadContext(input: ToolAccessDecisionInput): Promise<
     | { ok: true; ctx: ToolAccessContext; redaction: RedactionResult }
     | { ok: false; decision: ToolAccessDecision; redaction: RedactionResult }
@@ -849,6 +858,10 @@ export function toolAccessPolicyService(db: Db) {
     let projectId = input.runContext?.projectId ?? null;
     let routineId = input.runContext?.routineId ?? null;
     const gatewayId = input.runContext?.gatewayId ?? null;
+
+    if (gatewayId && !(await resolveCompanyGatewayId(input.companyId, gatewayId))) {
+      return { ok: false, redaction, decision: decision("deny", "deny_company_boundary", "Gateway context is outside the company or no longer exists.", [], [], { redactionPlan: redaction.redactionPlan }) };
+    }
 
     if (input.actor.actorType === "agent") {
       const [agent] = await db.select().from(agents).where(and(eq(agents.id, agentId ?? ""), eq(agents.companyId, input.companyId)));
@@ -1136,6 +1149,7 @@ export function toolAccessPolicyService(db: Db) {
       .where(eq(toolPolicies.id, policy.id));
     await db.insert(toolAccessAuditEvents).values({
       companyId: ctx.companyId,
+      gatewayId: ctx.gatewayId,
       connectionId: ctx.connectionId,
       catalogEntryId: ctx.catalogEntryId,
       actorType: ctx.actorType,
@@ -1155,6 +1169,7 @@ export function toolAccessPolicyService(db: Db) {
     });
     await db.insert(toolCallEvents).values({
       companyId: ctx.companyId,
+      gatewayId: ctx.gatewayId,
       eventType: "trust_rule_used",
       actorType: ctx.actorType,
       actorId: ctx.actorId,
@@ -1306,13 +1321,15 @@ export function toolAccessPolicyService(db: Db) {
   ) {
     const loaded = await loadContext(input);
     const redaction = loaded.redaction;
+    const gatewayId = loaded.ok ? loaded.ctx.gatewayId
+      : await resolveCompanyGatewayId(input.companyId, input.runContext?.gatewayId);
     const ctx = loaded.ok ? loaded.ctx : {
       companyId: input.companyId,
       actorType: input.actor.actorType,
       actorId: input.actor.actorId,
       agentId: input.actor.agentId ?? null,
       issueId: input.runContext?.issueId ?? null,
-      gatewayId: input.runContext?.gatewayId ?? null,
+      gatewayId,
       runId: input.runContext?.heartbeatRunId ?? null,
       connectionId: input.request.connectionId ?? null,
       catalogEntryId: input.request.catalogEntryId ?? null,
@@ -1327,6 +1344,7 @@ export function toolAccessPolicyService(db: Db) {
     try {
       const [legacyAuditEvent] = await db.insert(toolAccessAuditEvents).values({
         companyId: input.companyId,
+        gatewayId,
         connectionId: ctx.connectionId,
         catalogEntryId: ctx.catalogEntryId,
         actorType: ctx.actorType,
@@ -1355,6 +1373,7 @@ export function toolAccessPolicyService(db: Db) {
       }).returning();
       const [toolCallEvent] = await db.insert(toolCallEvents).values({
         companyId: input.companyId,
+        gatewayId,
         eventType: eventType as typeof toolCallEvents.$inferInsert["eventType"],
         actorType: ctx.actorType,
         actorId: ctx.actorId,
@@ -1415,6 +1434,7 @@ export function toolAccessPolicyService(db: Db) {
           : "denied";
     const [invocation] = await db.insert(toolInvocations).values({
       companyId: ctx.companyId,
+      gatewayId: ctx.gatewayId,
       idempotencyKey,
       actorType: ctx.actorType,
       actorId: ctx.actorId,
@@ -1689,6 +1709,7 @@ export function toolAccessPolicyService(db: Db) {
     if (approvedCount < approvalThreshold) {
       throw unprocessable(`Trust rule requires ${approvalThreshold} matching approved actions in the final rule scope; found ${approvedCount}`);
     }
+    const gatewayId = await resolveCompanyGatewayId(input.companyId, invocation.gatewayId);
     const now = new Date();
     const expiresAt = isoDateOrNull(input.body.expiresAt);
     const name = input.body.name ?? `Trust ${invocation.toolName} ${actionRequest.id.slice(0, 8)}`;
@@ -1726,6 +1747,7 @@ export function toolAccessPolicyService(db: Db) {
 
     await db.insert(toolAccessAuditEvents).values({
       companyId: input.companyId,
+      gatewayId,
       connectionId: invocation.connectionId,
       catalogEntryId: invocation.catalogEntryId,
       actorType: input.actor?.agentId ? "agent" : input.actor?.userId ? "user" : "system",
@@ -1746,6 +1768,7 @@ export function toolAccessPolicyService(db: Db) {
     });
     await db.insert(toolCallEvents).values({
       companyId: input.companyId,
+      gatewayId,
       eventType: "trust_rule_created",
       actorType: input.actor?.agentId ? "agent" : input.actor?.userId ? "user" : "system",
       actorId: input.actor?.agentId ?? input.actor?.userId ?? null,

--- a/server/src/services/tool-gateway.ts
+++ b/server/src/services/tool-gateway.ts
@@ -5787,6 +5787,7 @@ export function createToolGatewayService(
         eq(toolActionRequests.issueId, input.session.issueId),
         eq(toolActionRequests.canonicalArgumentsHash, input.argumentsHash),
         eq(toolInvocations.agentId, input.session.agentId),
+        input.session.gatewayId ? eq(toolInvocations.gatewayId, input.session.gatewayId) : isNull(toolInvocations.gatewayId),
         eq(toolInvocations.toolName, input.toolName),
         inArray(toolActionRequests.status, ["pending", "approved", "executing", "rejected", "executed"]),
       ))
@@ -6876,6 +6877,7 @@ export function createToolGatewayService(
         const [invocation] = request ? await db.select().from(toolInvocations).where(and(
           eq(toolInvocations.id, request.invocationId), eq(toolInvocations.companyId, session.companyId),
           eq(toolInvocations.runId, session.runId!), eq(toolInvocations.agentId, session.agentId!),
+          session.gatewayId ? eq(toolInvocations.gatewayId, session.gatewayId) : isNull(toolInvocations.gatewayId),
         )) : [];
         const payload = request && invocation ? readSignedToolArgumentsPayload({
           signedArguments: request.signedArguments, invocationId: invocation.id,
@@ -7041,6 +7043,7 @@ export function createToolGatewayService(
           || storedInvocation.issueId !== session.issueId
           || storedInvocation.agentId !== session.agentId
           || storedInvocation.runId !== session.runId
+          || storedInvocation.gatewayId !== (session.gatewayId ?? null)
           || actionRequest.requestedByAgentId !== session.agentId
         ) {
           throw new ToolGatewayHttpError(403, "Approved action request is not scoped to this gateway session", "action_scope_mismatch");

--- a/server/src/services/tool-gateway.ts
+++ b/server/src/services/tool-gateway.ts
@@ -1522,6 +1522,7 @@ export function createToolGatewayService(
     const metadata = input.tool ? toolAuditMetadata(input.tool) : {};
     await db.insert(toolCallEvents).values({
       companyId: input.session.companyId,
+      gatewayId: input.session.gatewayId ?? null,
       invocationId: input.invocationId ?? null,
       actionRequestId: input.actionRequestId ?? null,
       eventType: input.eventType,
@@ -6910,6 +6911,7 @@ export function createToolGatewayService(
         });
         const [invocation] = await db.insert(toolInvocations).values({
           companyId: session.companyId,
+          gatewayId: session.gatewayId ?? null,
           actorType: session.actorType ?? (session.agentId ? "agent" : "system"),
           actorId: session.actorId ?? session.agentId ?? session.gatewayTokenId ?? session.companyId,
           agentId: session.agentId,


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages agent work and tool access.
> - Named MCP gateways give each tool session a defined access profile.
> - Operators use gateway filters to inspect the calls from that gateway.
> - Several shared writers omit the gateway ID from the existing audit columns.
> - Successful calls can therefore disappear from the gateway audit filter.
> - This fix preserves validated gateway IDs so operators can inspect those calls.
> - Replays must also remain within that gateway, including approved actions.

## Linked Issues or Issue Description

**What happened?**

A successful call through a named gateway creates an invocation and completion event with null gateway IDs. The company audit shows the event, but the gateway filter can return no completed calls. The response mapper also replaces a gateway ID in metadata with the null event column.

**Expected behavior**

Persist the gateway ID on new invocations and audit events. A filter for one gateway must return only that gateway's events within the requested company. Ordinary agent sessions must retain null gateway IDs. A retry may reuse an invocation only when its persisted gateway matches the current gateway, including null.

**Steps to reproduce**

1. Connect a local MCP fixture and grant one tool to a named gateway profile.
2. Create a token for that gateway and call the permitted tool.
3. Compare the company audit with `/api/tool-gateway/audit?companyId=<company>&gateway=<gateway>&window=all`.
4. Inspect the invocation and completion event gateway columns. Both are null before this fix.

**Paperclip version or commit**

The contribution branch starts at `d8b95805314c70b13d9efce338cbc287c2afb4e1`. The regression first reproduced against the same affected writers in an earlier source checkout.

**Deployment mode**

Built from source. Verification uses temporary PostgreSQL and a loopback MCP fixture.

Related changes: #12340 introduced the audit filters; #13005 adds managed identity context. #9743 covers other audit operations. This patch addresses the missing gateway columns in the existing writers.

## What Changed

- Preserve gateway IDs in policy invocations, policy audits, trust-rule events, shared gateway events and virtual search invocations.
- Validate gateway ownership before policy writers persist the foreign key. Failed requests retain a valid company gateway, including a disabled gateway, but cannot attribute a missing or foreign gateway.
- Use the company-scoped joined invocation when an audit event lacks its own gateway ID. JSON metadata cannot replace the structured relationship.
- Keep idempotency keys unchanged and reject a replay from a different gateway with a controlled conflict. Scope automatic approval matching and explicit approved-action retries to the same gateway.
- Preserve the JSON-RPC error envelope when the MCP endpoint returns this shared HTTP conflict.
- Extend existing tests for gateway/company filters, null attribution, invalid contexts, trust events, virtual search, joined-invocation fallback, replay isolation and approval reuse.

## Verification

- All **113 gateway and policy tests passed**, with no skips, on the frozen follow-up source.
- New real-database and loopback-provider regressions cover derived and explicit keys, both null/named directions, named/named collisions, same-gateway retries, automatic approved-result replay, explicit approved execution, and the canonical MCP conflict response.
- The original version reproduced the replay defect; the corrected approval fixture also demonstrated a sibling gateway executing a still-approved operation. That fixture correction and the earlier failed attempt remain in the local evidence.
- Final follow-up `pnpm -r typecheck` and `pnpm build` passed.
- Final follow-up `pnpm test:run` passed: **17,994 passed, 33 skipped, 0 failed** across all 158 native test invocations. Existing gated skips are excluded from the pass count.

Repository checks use an isolated CI environment with a loopback telemetry endpoint. CI disables normal Paperclip telemetry; the unchanged CLI telemetry fixture clears CI variables and mocks fetch to exercise its enabled-client contract. No personal credentials are inherited. This is not a network-sandbox claim. Source hashes are checked throughout.

## Risks

Policy requests with an unknown or foreign gateway now receive a company-boundary denial. The gateway lookup adds a database read when gateway context is supplied. Valid disabled gateways remain usable for audit attribution; this does not reactivate their tokens.

No schema migration is needed. This patch does not backfill historical rows. Old rows missing both structured gateway fields remain unattributed. Rows with an existing same-company invocation link can use that relationship. Token permissions, provider result handling and model routing are unchanged.

Idempotency keys and the company-wide unique index retain their existing semantics. Reusing a stored key through a different gateway returns HTTP 409 with `idempotency_gateway_mismatch`; it does not replay the result or automatically execute the operation again. A historical null-gateway row is not inferred to belong to a named gateway. A deliberately separate operation needs its own explicit idempotency key. Approval retries also require the originating gateway; the existing run, agent, issue, signature and approval checks remain in force.

## Model Used

Codex session configured with OpenAI `gpt-6-astra` and ultra reasoning, using tools for source editing, execution and independent subagent review. The local session reports a 258,400-token effective context window; this is the session setting, not a claim about the model's maximum capacity.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (Not applicable: this fixes existing audit attribution; no documentation files changed.)
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
