### PR TITLE
fix(auth): let the legacy gateway MCP path accept its own bearer

### DIFF
--- a/server/src/__tests__/mcp-gateway-legacy-path-bearer.test.ts
+++ b/server/src/__tests__/mcp-gateway-legacy-path-bearer.test.ts
@@ -1,0 +1,153 @@
+import { randomUUID } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { actorMiddleware } from "../middleware/auth.js";
+import { errorHandler } from "../middleware/error-handler.js";
+import { mcpGatewayProtocolRoutes, toolGatewayRoutes } from "../routes/tool-gateway.js";
+import type { ToolGatewayService } from "../services/tool-gateway.js";
+
+/**
+ * A `pcgw_` gateway bearer is not a board key, an agent API key, or an agent
+ * JWT — it is verified by the gateway service inside the protocol handler. The
+ * database therefore holds no row that could match it, which is exactly the
+ * live shape: the only lookups `actorMiddleware` performs must all miss.
+ */
+function createEmptyDb() {
+  const selectChain = {
+    from() {
+      return {
+        where() {
+          return Promise.resolve([]);
+        },
+      };
+    },
+  };
+  return {
+    select: () => selectChain,
+    update: () => ({ set: () => ({ where: () => Promise.resolve([]) }) }),
+    insert: () => ({ values: () => Promise.resolve([]) }),
+  } as any;
+}
+
+/**
+ * The MCP protocol handler is reached only if `actorMiddleware` lets the
+ * request through, so the gateway service is stubbed down to the two calls the
+ * `initialize` and `tools/list` methods make. Each records that it ran, which
+ * is the assertion that matters: the pre-route middleware did not reject the
+ * gateway's own bearer before the route could verify it.
+ */
+function createStubGateway(seen: { bearerTokens: string[] }) {
+  return {
+    async initializeNamedGatewayProtocol(input: { bearerToken: string }) {
+      seen.bearerTokens.push(input.bearerToken);
+      return { ok: true };
+    },
+    async listToolsForNamedGateway(input: { bearerToken: string }) {
+      seen.bearerTokens.push(input.bearerToken);
+      return [
+        {
+          name: "hindsight_recall",
+          displayName: "Hindsight recall",
+          description: "Recall prior context",
+          parametersSchema: { type: "object", properties: {} },
+        },
+      ];
+    },
+    async createNamedGatewayToken() {
+      throw new Error("createNamedGatewayToken must not be reached in these tests");
+    },
+  } as unknown as ToolGatewayService;
+}
+
+/**
+ * Mirrors `createApp`'s ordering in `app.ts`: `actorMiddleware` is mounted
+ * globally, then the public MCP protocol router, then the `/api` router that
+ * carries the legacy gateway MCP path. A test that mounts the routers without
+ * the middleware cannot observe this behaviour at all.
+ */
+function createAppWithActorMiddleware(gateway: ToolGatewayService) {
+  const db = createEmptyDb();
+  const app = express();
+  app.use(express.json());
+  app.use(actorMiddleware(db, { deploymentMode: "authenticated", resolveSession: async () => null }));
+  app.use(mcpGatewayProtocolRoutes(gateway));
+  const api = express.Router();
+  api.use(toolGatewayRoutes(db, gateway));
+  app.use("/api", api);
+  app.use(errorHandler);
+  return app;
+}
+
+function gatewayBearer() {
+  return `pcgw_${randomUUID()}.${Buffer.from(randomUUID()).toString("base64url")}`;
+}
+
+function publicGatewayId() {
+  return `gw_${randomUUID().replace(/-/g, "")}`;
+}
+
+describe("MCP gateway protocol bearer reaches its route through actorMiddleware", () => {
+  it("does not reject a pcgw_ bearer on the public gateway protocol path", async () => {
+    const seen = { bearerTokens: [] as string[] };
+    const token = gatewayBearer();
+
+    const res = await request(createAppWithActorMiddleware(createStubGateway(seen)))
+      .post(`/mcp/gateways/${publicGatewayId()}`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+
+    expect(res.status).toBe(200);
+    expect(res.body.result?.serverInfo?.name).toBe("Paperclip MCP Gateway");
+    expect(seen.bearerTokens).toEqual([token]);
+  });
+
+  it("does not reject a pcgw_ bearer on the legacy /api gateway MCP path", async () => {
+    const seen = { bearerTokens: [] as string[] };
+    const token = gatewayBearer();
+
+    const res = await request(createAppWithActorMiddleware(createStubGateway(seen)))
+      .post(`/api/tool-gateway/gateways/${randomUUID()}/mcp`)
+      .set("Authorization", `Bearer ${token}`)
+      .send({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+
+    expect(res.status).toBe(200);
+    expect(res.body.result?.serverInfo?.name).toBe("Paperclip MCP Gateway");
+    expect(seen.bearerTokens).toEqual([token]);
+  });
+
+  it("carries a pcgw_ bearer through tools/list on the legacy path", async () => {
+    const seen = { bearerTokens: [] as string[] };
+    const token = gatewayBearer();
+
+    const res = await request(createAppWithActorMiddleware(createStubGateway(seen)))
+      .post(`/api/tool-gateway/gateways/${randomUUID()}/mcp`)
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Paperclip-Run-Id", randomUUID())
+      .send({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
+
+    expect(res.status).toBe(200);
+    expect(res.body.result?.tools?.[0]?.name).toBe("hindsight_recall");
+    expect(seen.bearerTokens).toEqual([token]);
+  });
+
+  /**
+   * The exemption must stay anchored on the trailing `/mcp` segment. The token
+   * mint route sits directly beside the protocol route under the same
+   * `/api/tool-gateway/gateways/:gatewayId/` prefix, so it is the closest thing
+   * the exemption could wrongly swallow. An unverifiable bearer there must
+   * still be rejected rather than downgraded to an unauthenticated actor.
+   */
+  it("still rejects an unverifiable bearer on the sibling gateway token mint route", async () => {
+    const seen = { bearerTokens: [] as string[] };
+    const app = createAppWithActorMiddleware(createStubGateway(seen));
+
+    const res = await request(app)
+      .post(`/api/tool-gateway/gateways/${randomUUID()}/tokens`)
+      .set("Authorization", `Bearer ${gatewayBearer()}`)
+      .send({ companyId: randomUUID(), name: "probe" });
+
+    expect(res.status).toBe(401);
+    expect(seen.bearerTokens).toEqual([]);
+  });
+});

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -213,6 +213,16 @@ interface ActorMiddlewareOptions {
 
 const publicMcpGatewayProtocolPath = /^\/mcp\/gateways\/gw_[a-f0-9]{32}\/?$/i;
 
+// The same MCP protocol handler is also mounted on an older `/api` path, which
+// `GET /api/tool-gateway/gateways/:gatewayId/mcp` still advertises as the
+// endpoint to call. Clients that read that response, or that were configured
+// before the public path existed, send the same `pcgw_*` bearer here. Match the
+// gateway id as a UUID and require `/mcp` as the final segment, so the sibling
+// routes under the same prefix — `/tokens` above all — keep the normal actor
+// authentication path.
+const legacyMcpGatewayProtocolPath =
+  /^\/api\/tool-gateway\/gateways\/[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/mcp\/?$/i;
+
 export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHandler {
   const boardAuth = boardAuthService(db);
   return async (req, _res, next) => {
@@ -237,9 +247,12 @@ export function actorMiddleware(db: Db, opts: ActorMiddlewareOptions): RequestHa
     // validated by the gateway service itself. Do not interpret that bearer as
     // a board key or agent JWT here: doing so rejects the MCP handshake before
     // the protocol route can verify its run-scoped credential. Keep this bypass
-    // restricted to the unguessable public gateway path; all /api routes retain
+    // restricted to the two MCP protocol paths; every other /api route retains
     // the normal actor authentication path below.
-    if (hasBearerCredentials && publicMcpGatewayProtocolPath.test(req.path)) {
+    if (
+      hasBearerCredentials &&
+      (publicMcpGatewayProtocolPath.test(req.path) || legacyMcpGatewayProtocolPath.test(req.path))
+    ) {
       if (runIdHeader) req.actor.runId = runIdHeader;
       next();
       return;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Paperclip gives an agent governed access to MCP tools through the tool gateway
> - The gateway mints its own `pcgw_` bearer token, and the protocol route verifies that token itself
> - `actorMiddleware` runs before every route and knows only three credential families: board API keys, agent API keys, and agent JWTs
> - A `pcgw_` bearer matches none of the three, so the middleware answers 401 before the route that knows how to verify it can run
> - `master` already exempts the public protocol path `/mcp/gateways/gw_…`, but the older `/api` protocol path is still mounted, still advertised, and still not exempt
> - This pull request adds the legacy path to the exemption that already exists
> - The benefit is that a client which uses the endpoint Paperclip advertises to it can complete the MCP handshake

## Linked Issues or Issue Description

No public issue exists for this defect. The problem is described below, following
`.github/ISSUE_TEMPLATE/bug_report.yml`.

**Related PR:** #11812 (`fix(server): let gateway routes own bearer authentication`)
is open and addresses the same seam with a broader route-owned-auth allowlist. It
has had no commit since 2026-08-20 and is 427 commits behind `master`, so it would
need a substantial rebase. Thank you to its author — the diagnosis there is correct
and I reached the same conclusion independently. I am proposing this smaller change
because it adds one regex to the check `master` already has, and it can land now. If
you would rather land #11812, this PR should be closed in its favour; the two must
not both land, because they would exempt the same path twice.

**What happened?**

`POST /api/tool-gateway/gateways/{gatewayId}/mcp` answers
`401 {"error":"Agent token did not verify; obtain fresh credentials and retry"}`
when the caller sends the `pcgw_` bearer that the tool gateway minted for it. The
MCP handshake never reaches the handler that can verify the token.

The path is not dead code. `GET /api/tool-gateway/gateways/{gatewayId}/mcp`
advertises it as the endpoint to call: `server/src/routes/tool-gateway.ts:446`
returns `endpoint: "/api/tool-gateway/gateways/{id}/mcp"`. The `POST` handler is
mounted at `server/src/routes/tool-gateway.ts:451`. A client that reads the `GET`
response and calls the path it names receives a 401 it cannot act on.

`master` is not fully exposed to this today, because its own `heartbeat.ts` emits
the newer public path — `grep -c "api/tool-gateway/gateways" server/src/services/heartbeat.ts`
returns 0. Any other client that trusts the advertised endpoint still hits it.

**Expected behavior**

The legacy protocol path accepts the gateway's own bearer and lets the route
verify it, the same way the public path `/mcp/gateways/gw_…` already does
(`server/src/middleware/auth.ts:214`, `:242`).

**Steps to reproduce**

1. Create a named MCP gateway and mint a client token for it. The token has the
   form `pcgw_<tokenId>.<secret>`.
2. `GET /api/tool-gateway/gateways/{gatewayId}/mcp`. Note the `endpoint` field in
   the response. It names the `/api` path.
3. `POST` a JSON-RPC `initialize` to that exact endpoint with
   `Authorization: Bearer pcgw_…`.
4. Observe `401 {"error":"Agent token did not verify; obtain fresh credentials and retry"}`.
   The gateway service is never called.
5. Repeat step 3 against `/mcp/gateways/gw_…` with the same token. It returns 200.

The added test reproduces this without a database or a live gateway.

**Paperclip version or commit**

`master` at `a7ed22e3dd7e2ca6bdd7b02c7393376ab46e534e`.

**Deployment mode**

Reproduced in `authenticated`. `local_trusted` is also affected: there
`actorMiddleware` seeds an implicit board actor, so the failure mode differs, which
is why the added negative-control test pins the sibling token mint route
explicitly. See Risks.

**Agent adapter(s) involved**

Not adapter-specific. The defect is at the middleware and route seam, above any
adapter.

**Relevant logs or output**

```
POST /api/tool-gateway/gateways/<uuid>/mcp
Authorization: Bearer pcgw_<tokenId>.<secret>

401 {"error":"Agent token did not verify; obtain fresh credentials and retry"}
```

## What Changed

- `server/src/middleware/auth.ts`: adds `legacyMcpGatewayProtocolPath`, a second
  regex, and consults it in the exemption branch that already tests
  `publicMcpGatewayProtocolPath`. The regex matches the gateway id as a UUID and
  requires `/mcp` as the final segment.
- `server/src/__tests__/mcp-gateway-legacy-path-bearer.test.ts`: a new test with
  four cases. It mounts `actorMiddleware` in front of the real routers, in the
  order `app.ts` uses. Three cases assert that a `pcgw_` bearer reaches its
  handler. The fourth asserts that an unverifiable bearer on the sibling token
  mint route is still rejected.

Production code changes by 15 added lines and 2 changed lines, in one file.

## Verification

Run the added test:

```
cd server && pnpm vitest run src/__tests__/mcp-gateway-legacy-path-bearer.test.ts
```

**Result on unmodified `master`: 2 failed, 2 passed.** The two legacy-path cases
fail with `expected 401 to be 200`. The public-path case passes, because `master`
already exempts that path. The negative control passes. A test that failed on
every case would prove nothing; these two specific failures are the defect.

**Result with this change: 4 passed.**

**Mutation testing.** The test must fail if the regex is wrong in either
direction. Each mutant was applied to `auth.ts` and the test re-run:

| mutant | result |
|---|---|
| Remove the legacy regex — that is exactly `master` today | KILLED — 2 failed |
| Widen the legacy regex to `/^\/api\/.*$/i` | KILLED — the negative control fails |
| Drop the trailing `/mcp` anchor, so the pattern ends at the gateway id | KILLED — the negative control fails |

The third mutant is why the negative control probes
`POST /api/tool-gateway/gateways/{id}/tokens` rather than an unrelated route.
That mint route is the nearest neighbour under the same prefix. An earlier draft
of this test probed a distant `/api` path instead, and I measured that the third
mutant **survived** it — the suite stayed 4/4 green while the exemption swallowed
the token mint route. Pointing the control at the sibling route kills it.

**Neighbouring suites.** `mcp-gateway-legacy-path-bearer`, `agent-auth-middleware`,
`express5-auth-wildcard`, `adapter-routes-authz`, `authz-company-access`:
**53 passed, 53 total.**

**Typecheck.** `tsc --noEmit` in `server/` reports 209 errors both with and
without this change, and the two sorted outputs are byte-identical under `diff`.
All 209 come from an unbuilt `@paperclipai/plugin-sdk` in my environment, because
`cargo` is absent and the `build:binary` prerequisite cannot run. **Zero errors
in either file this PR touches.** I could not get a clean typecheck baseline
locally. CI must confirm it.

## Risks

Low, but stated precisely.

The exemption skips actor resolution. It does not grant access. The protocol
routes read no `req.actor`, and an invalid gateway bearer is still rejected by the
handler that owns that check. Every other route, `/api` included, keeps the normal
actor authentication path.

The specific risk to weigh is scope. If the pattern matched more than it should,
it would downgrade a rejected bearer to an unauthenticated actor on the extra
routes. In `authenticated` mode that fails closed. In `local_trusted` mode —
which is the default — `actorMiddleware` seeds an implicit board actor with
`isInstanceAdmin: true`, so an over-broad pattern would be an authentication
bypass, and on the sibling `/tokens` route specifically it would become a token
mint. That is the reason for the UUID-shaped id, the required trailing `/mcp`
segment, and the mutation test that pins both.

A gateway id that is not UUID-shaped falls through to the existing 401 rather than
being wrongly exempted. The failure direction is closed, not open. Every gateway
this codebase mints has a UUID id: `toolMcpGateways.id` is
`uuid("id").primaryKey().defaultRandom()` in `packages/db/src/schema/tool_access.ts:453`.

**Not verified.** I did not run the full server suite; it needs an embedded
Postgres per file and CI is better placed to run it. I did not run a live
end-to-end handshake against a running gateway. The proof here is at the
middleware and route seam, which is where the defect is; the handler behaviour
below that seam is unchanged by this PR.

## Model Used

Anthropic Claude Opus 5 (`claude-opus-5`), used with extended thinking and tool
use — file reads, shell commands, and test execution. The model wrote the change,
the test, and this description. A human authorised the work and reviewed it before
submission.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no documentation describes this path's authentication, so there is nothing to update
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — CI has not run; this is stated in Verification
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — no review has run yet
- [x] I will address all Greptile and reviewer comments before requesting merge