### PR TITLE
fix(plugins): expose complete ReactDOM shim surface

### DIFF
--- a/ui/src/plugins/bridge-init.ts
+++ b/ui/src/plugins/bridge-init.ts
@@ -23,6 +23,7 @@ import {
 } from "./bridge.js";
 import { Component, createElement, useEffect, useMemo, useState, type ComponentType, type ReactNode } from "react";
 import * as ReactJsxRuntimeModule from "react/jsx-runtime";
+import * as ReactDOMClientModule from "react-dom/client";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { User } from "lucide-react";
 import {
@@ -82,6 +83,8 @@ export interface PluginBridgeRegistry {
    */
   reactJsxRuntime: unknown;
   reactDom: unknown;
+  /** The host's real `react-dom/client` module for createRoot/hydrateRoot. */
+  reactDomClient?: unknown;
   sdkUi: Record<string, unknown>;
 }
 
@@ -675,15 +678,18 @@ class PluginSdkErrorBoundary extends Component<{ children: ReactNode; fallback?:
  *
  * @param react - The host's React module
  * @param reactDom - The host's ReactDOM module
+ * @param reactDomClient - The host's ReactDOM client module
  */
 export function initPluginBridge(
   react: typeof import("react"),
   reactDom: typeof import("react-dom"),
+  reactDomClient: typeof import("react-dom/client") = ReactDOMClientModule,
 ): void {
   globalThis.__paperclipPluginBridge__ = {
     react,
     reactJsxRuntime: ReactJsxRuntimeModule,
     reactDom,
+    reactDomClient,
     sdkUi: {
       usePluginData,
       usePluginAction,

--- a/ui/src/plugins/bridge.test.ts
+++ b/ui/src/plugins/bridge.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import * as React from "react";
 import * as ReactDOM from "react-dom";
+import * as ReactDOMClient from "react-dom/client";
 import * as ReactJsxRuntime from "react/jsx-runtime";
 import { flushSync } from "react-dom";
 import { createRoot } from "react-dom/client";
@@ -355,6 +356,20 @@ describe("plugin ReactDOM shim", () => {
     expect(source).toContain("export const createPortal = RD.createPortal;");
     expect(source).toContain("export const flushSync = RD.flushSync;");
     expect(source).toContain("export const unstable_batchedUpdates = RD.unstable_batchedUpdates;");
+  });
+
+  it("keeps the react-dom/client entry point on its own export surface", () => {
+    const source = _createReactDomShimSourceForTests(ReactDOMClient, "reactDomClient");
+
+    for (const name of Object.keys(ReactDOMClient).sort()) {
+      if (name === "default") continue;
+      if (!/^[A-Za-z_$][\w$]*$/.test(name)) continue;
+      expect(source).toContain(`export const ${name} = RD.${name};`);
+    }
+
+    expect(source).toContain("globalThis.__paperclipPluginBridge__?.reactDomClient");
+    expect(source).toContain("export const createRoot = RD.createRoot;");
+    expect(source).toContain("export const hydrateRoot = RD.hydrateRoot;");
   });
 });
 

--- a/ui/src/plugins/bridge.test.ts
+++ b/ui/src/plugins/bridge.test.ts
@@ -351,6 +351,7 @@ describe("plugin ReactDOM shim", () => {
     }
 
     expect(source).toContain("export default RD;");
+    expect(source).toContain('Paperclip plugin ReactDOM runtime is not initialized.');
     expect(source).toContain("export const createPortal = RD.createPortal;");
     expect(source).toContain("export const flushSync = RD.flushSync;");
     expect(source).toContain("export const unstable_batchedUpdates = RD.unstable_batchedUpdates;");

--- a/ui/src/plugins/bridge.test.ts
+++ b/ui/src/plugins/bridge.test.ts
@@ -24,7 +24,10 @@ import {
   type PluginBridgeContextValue,
 } from "./bridge";
 import { initPluginBridge } from "./bridge-init";
-import { _createReactShimSourceForTests } from "./slots";
+import {
+  _createReactDomShimSourceForTests,
+  _createReactShimSourceForTests,
+} from "./slots";
 
 function clickEvent(
   overrides: Partial<ReactMouseEvent<HTMLAnchorElement>> = {},
@@ -334,6 +337,23 @@ describe("plugin React shim", () => {
     expect(source).toContain("export const useId = R.useId;");
     expect(source).toContain("export const useSyncExternalStore = R.useSyncExternalStore;");
     expect(source).toContain("export const startTransition = R.startTransition;");
+  });
+});
+
+describe("plugin ReactDOM shim", () => {
+  it("re-exports every named export from the host ReactDOM module", () => {
+    const source = _createReactDomShimSourceForTests(ReactDOM);
+
+    for (const name of Object.keys(ReactDOM).sort()) {
+      if (name === "default") continue;
+      if (!/^[A-Za-z_$][\w$]*$/.test(name)) continue;
+      expect(source).toContain(`export const ${name} = RD.${name};`);
+    }
+
+    expect(source).toContain("export default RD;");
+    expect(source).toContain("export const createPortal = RD.createPortal;");
+    expect(source).toContain("export const flushSync = RD.flushSync;");
+    expect(source).toContain("export const unstable_batchedUpdates = RD.unstable_batchedUpdates;");
   });
 });
 

--- a/ui/src/plugins/slots.tsx
+++ b/ui/src/plugins/slots.tsx
@@ -30,6 +30,7 @@ import {
   type ComponentType,
 } from "react";
 import * as ReactModule from "react";
+import * as ReactDOMModule from "react-dom";
 import { useQuery } from "@tanstack/react-query";
 import type {
   PluginLauncherDeclaration,
@@ -302,6 +303,24 @@ ${namedExports}
       `;
 }
 
+function createReactDomShimSource(reactDomModule: object): string {
+  const exportNames = Object.keys(reactDomModule)
+    .filter((name) => name !== "default" && /^[A-Za-z_$][\w$]*$/.test(name))
+    .sort();
+  const namedExports = exportNames
+    .map((name) => `        export const ${name} = RD.${name};`)
+    .join("\n");
+
+  return `
+        const RD = globalThis.__paperclipPluginBridge__?.reactDom;
+        if (!RD) {
+          throw new Error("Paperclip plugin ReactDOM runtime is not initialized.");
+        }
+        export default RD;
+${namedExports}
+      `;
+}
+
 function getShimBlobUrl(specifier: "react" | "react-dom" | "react-dom/client" | "react/jsx-runtime" | "sdk-ui"): string {
   if (shimBlobUrls[specifier]) return shimBlobUrls[specifier];
 
@@ -328,12 +347,7 @@ function getShimBlobUrl(specifier: "react" | "react-dom" | "react-dom/client" | 
       break;
     case "react-dom":
     case "react-dom/client":
-      source = `
-        const RD = globalThis.__paperclipPluginBridge__?.reactDom;
-        export default RD;
-        const { createRoot, hydrateRoot, createPortal, flushSync } = RD ?? {};
-        export { createRoot, hydrateRoot, createPortal, flushSync };
-      `;
+      source = createReactDomShimSource(ReactDOMModule);
       break;
     case "sdk-ui":
       source = `
@@ -957,5 +971,6 @@ export function _resetPluginModuleLoader(): void {
 
 export const _applyJsxRuntimeKeyForTests = applyJsxRuntimeKey;
 export const _createReactShimSourceForTests = createReactShimSource;
+export const _createReactDomShimSourceForTests = createReactDomShimSource;
 export const _rewriteBareSpecifiersForTests = rewriteBareSpecifiers;
 export const _collectRegisterableExportNamesForTests = collectRegisterableExportNames;

--- a/ui/src/plugins/slots.tsx
+++ b/ui/src/plugins/slots.tsx
@@ -31,6 +31,7 @@ import {
 } from "react";
 import * as ReactModule from "react";
 import * as ReactDOMModule from "react-dom";
+import * as ReactDOMClientModule from "react-dom/client";
 import { useQuery } from "@tanstack/react-query";
 import type {
   PluginLauncherDeclaration,
@@ -303,7 +304,10 @@ ${namedExports}
       `;
 }
 
-function createReactDomShimSource(reactDomModule: object): string {
+function createReactDomShimSource(
+  reactDomModule: object,
+  bridgeKey: "reactDom" | "reactDomClient" = "reactDom",
+): string {
   const exportNames = Object.keys(reactDomModule)
     .filter((name) => name !== "default" && /^[A-Za-z_$][\w$]*$/.test(name))
     .sort();
@@ -312,7 +316,7 @@ function createReactDomShimSource(reactDomModule: object): string {
     .join("\n");
 
   return `
-        const RD = globalThis.__paperclipPluginBridge__?.reactDom;
+        const RD = globalThis.__paperclipPluginBridge__?.${bridgeKey};
         if (!RD) {
           throw new Error("Paperclip plugin ReactDOM runtime is not initialized.");
         }
@@ -346,8 +350,10 @@ function getShimBlobUrl(specifier: "react" | "react-dom" | "react-dom/client" | 
       `;
       break;
     case "react-dom":
-    case "react-dom/client":
       source = createReactDomShimSource(ReactDOMModule);
+      break;
+    case "react-dom/client":
+      source = createReactDomShimSource(ReactDOMClientModule, "reactDomClient");
       break;
     case "sdk-ui":
       source = `


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Plugin UI bundles reuse the host React and ReactDOM runtimes through a browser bridge
> - The ReactDOM shim exported only four names, so libraries such as dnd-kit that import `unstable_batchedUpdates` fail during module linking
> - The missing export prevents the whole plugin page from loading even though the host runtime provides the API
> - This pull request makes the ReactDOM root and client shims mirror their matching host module named exports and adds regression contracts
> - The benefit is that external plugin libraries can use the supported host ReactDOM runtime without a per-plugin workaround

## Linked Issues or Issue Description

Fixes: #13012

## What Changed

- Generate the root `react-dom` shim's named exports from the host ReactDOM module, including `unstable_batchedUpdates` and future valid named exports.
- Preserve the distinct `react-dom/client` export surface through a dedicated client bridge entry, including `createRoot` and `hydrateRoot`.
- Add regression tests for both shim surfaces and the missing-bridge error.

## Verification

- `pnpm --filter @paperclipai/ui exec vitest run src/plugins/bridge.test.ts` (15 passed)
- `pnpm --filter @paperclipai/ui typecheck` (passed)
- The checkout does not provide a Prettier binary; `git diff --check` passes.
- Paperclip CI and Greptile review are pending on this updated commit.

## Risks

Low risk. The change expands the browser shim's named-export surface while preserving the existing default export and bridge lookup. Root and client entry points now resolve against their matching host modules. Missing bridge initialization reports a clear runtime error for the ReactDOM shims, matching the existing React shim behavior.

## Model Used

OpenAI Codex GPT-5 (current session; exact build identifier is not exposed), with tool use, repository inspection, TypeScript editing, and local test execution. A GPT-5.6-Luna audit worker independently screened adjacent repositories; it did not author this patch.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used with the available model details
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #13012`
- [x] I have not referenced internal/instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal issue id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect this change (no user-facing docs change is needed)
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green (pending)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups (pending)
- [x] I will address all Greptile and reviewer comments before requesting merge
