### PR TITLE
fix(claude-local): do not treat a background-task notification as a finished turn

### DIFF
--- a/packages/adapters/claude-local/src/server/execute.ts
+++ b/packages/adapters/claude-local/src/server/execute.ts
@@ -62,6 +62,7 @@ import {
 import {
   claudeModelUsageTotals,
   parseClaudeStreamJson,
+  hasClaudeTurnResult,
   describeClaudeFailure,
   detectClaudeLoginRequired,
   extractClaudeRetryNotBefore,
@@ -972,7 +973,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       settleRunDisposition: paperclipBridge?.settleRunDisposition,
       terminalResultCleanup: {
         graceMs: terminalResultCleanupGraceMs,
-        hasTerminalResult: ({ stdout }) => parseClaudeStreamJson(stdout).resultJson !== null,
+        hasTerminalResult: ({ stdout }) => hasClaudeTurnResult(stdout),
       },
       localProcessSandbox,
     });

--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   claudeModelUsageTotals,
   parseClaudeStreamJson,
+  hasClaudeTurnResult,
+  isClaudeTaskNotificationResult,
   detectClaudeLoginRequired,
   extractClaudeRetryNotBefore,
   isClaudeProviderQuotaError,
@@ -565,5 +567,52 @@ describe("parseClaudeStreamJson usage extraction", () => {
       cachedInputTokens: 20,
     });
     expect(parsed.usageBasis).toBe("per_run");
+  });
+});
+
+describe("hasClaudeTurnResult", () => {
+  const notificationResult = JSON.stringify({
+    type: "result",
+    subtype: "success",
+    is_error: false,
+    num_turns: 0,
+    result: "",
+    origin: { kind: "task-notification" },
+  });
+  const turnResult = JSON.stringify({
+    type: "result",
+    subtype: "success",
+    is_error: false,
+    num_turns: 14,
+    result: "done",
+  });
+  const init = JSON.stringify({ type: "system", subtype: "init", session_id: "s1" });
+
+  it("does not treat a background-task notification drain as a finished turn", () => {
+    // A resumed session emits this before the requested turn even starts.
+    // Treating it as terminal makes terminalResultCleanup SIGTERM the process
+    // mid-turn, killing work the run had not yet reported.
+    expect(hasClaudeTurnResult([notificationResult, init].join("\n"))).toBe(false);
+  });
+
+  it("treats a real turn result as a finished turn", () => {
+    expect(hasClaudeTurnResult([init, turnResult].join("\n"))).toBe(true);
+  });
+
+  it("still sees the turn result when a notification lands after it", () => {
+    expect(hasClaudeTurnResult([init, turnResult, notificationResult].join("\n"))).toBe(true);
+  });
+
+  it("ignores non-result events and unparsable lines", () => {
+    expect(hasClaudeTurnResult([init, "not json", ""].join("\n"))).toBe(false);
+    expect(hasClaudeTurnResult("")).toBe(false);
+  });
+});
+
+describe("isClaudeTaskNotificationResult", () => {
+  it("recognizes the notification origin and nothing else", () => {
+    expect(isClaudeTaskNotificationResult({ origin: { kind: "task-notification" } })).toBe(true);
+    expect(isClaudeTaskNotificationResult({ origin: { kind: "cli" } })).toBe(false);
+    expect(isClaudeTaskNotificationResult({})).toBe(false);
   });
 });

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -54,6 +54,40 @@ export function claudeModelUsageTotals(modelUsage: unknown): UsageSummary | null
   return { inputTokens, outputTokens, cachedInputTokens };
 }
 
+/**
+ * Whether a Claude CLI `result` event closes a turn the adapter asked for.
+ *
+ * When a session resumes, the CLI first drains the background-task
+ * notifications it queued while the previous process was gone, and it emits a
+ * synthetic result event for that drain: `num_turns: 0`, an empty `result`
+ * and `origin.kind: "task-notification"`. It is bookkeeping, not the end of
+ * the run's turn — the real turn has not even started yet.
+ */
+export function isClaudeTaskNotificationResult(event: Record<string, unknown>): boolean {
+  return asString(parseObject(event.origin).kind, "") === "task-notification";
+}
+
+/**
+ * Whether stdout already contains the result event of a real turn.
+ *
+ * `terminalResultCleanup` uses this to decide that the CLI is done and only
+ * an unmanaged background task keeps the process alive. Scanning for any
+ * non-notification result (rather than reading the last result event) keeps a
+ * notification that lands after the turn from hiding the real result.
+ */
+export function hasClaudeTurnResult(stdout: string): boolean {
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const event = parseJson(line);
+    if (!event) continue;
+    if (asString(event.type, "") !== "result") continue;
+    if (isClaudeTaskNotificationResult(event)) continue;
+    return true;
+  }
+  return false;
+}
+
 export function parseClaudeStreamJson(stdout: string) {
   let sessionId: string | null = null;
   let model = "";


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The `claude-local` adapter runs the Claude CLI as a child process and reads its stream-json stdout
> - `terminalResultCleanup` (packages/adapter-utils) SIGTERMs that child once a result event appears, so an unmanaged background task cannot keep the process alive forever
> - A resumed session emits a synthetic result event for the background-task notifications it drains at startup, before the requested turn begins
> - The cleanup reads that drain as the end of the turn and kills the run five seconds after it starts, in the middle of real work
> - This pull request makes the cleanup look for a result event that is not a notification drain
> - The benefit is that resumed sessions with queued background tasks finish their turn instead of dying with exit code 143

## Linked Issues or Issue Description

No public issue exists. Description follows `.github/ISSUE_TEMPLATE/bug_report.yml`.

**What happened?**

An agent whose previous run left a background task behind resumes its session. The Claude CLI drains the queued notifications first and prints a synthetic result event for that drain:

```json
{"type":"result","subtype":"success","is_error":false,"num_turns":0,
 "result":"","origin":{"kind":"task-notification"}}
```

`hasTerminalResult` in `packages/adapters/claude-local/src/server/execute.ts` reports `true` for it, because it only asks whether a result event exists. `terminalResultCleanup` arms its 5 second timer and SIGTERMs the child while the requested turn is still running. The run is recorded as `failed` with `adapter_failed`, the error text `Adapter failed` and exit code 143. Nothing the turn did is reported.

On one instance this cost 23 runs in seven days. The signature is identical to a poisoned session, so an operator cannot tell the two apart from the run record.

**Expected behavior**

The cleanup waits for the result event of the turn the adapter asked for. A notification drain is bookkeeping and must not end the run.

**Steps to reproduce**

1. Let an agent start a background task (`run_in_background`) and end its run while the task is alive.
2. Wake the agent again on the same session, so the CLI drains the notification for that task.
3. Watch the run: it is SIGTERMed about five seconds after start and is recorded as `failed` / `adapter_failed` / exit code 143, mid-turn.

Related PRs, found while searching for duplicates: #12021 and #12899. Both address the other half of this signature — a run that is killed by the cleanup *after* it printed a real result is still recorded as a failure. Neither one changes which result events arm the cleanup, so this change is complementary and does not conflict with either.

## What Changed

- `packages/adapters/claude-local/src/server/parse.ts`: added `isClaudeTaskNotificationResult` and `hasClaudeTurnResult`. The second one scans stdout for a result event that does not come from a notification drain.
- `packages/adapters/claude-local/src/server/execute.ts`: `terminalResultCleanup.hasTerminalResult` now calls `hasClaudeTurnResult` instead of `parseClaudeStreamJson(stdout).resultJson !== null`.
- `packages/adapters/claude-local/src/server/parse.test.ts`: added cases for the notification drain, a real turn result, a notification that lands after the turn, and unparsable input.

## Verification

```
pnpm --filter @paperclipai/adapter-claude-local exec vitest run src/server/parse.test.ts
# Test Files  1 passed (1)
#      Tests  52 passed (52)

pnpm --filter @paperclipai/adapter-claude-local exec tsc --noEmit -p tsconfig.json
# clean
```

## Risks

Low risk. The change only narrows which result events arm the cleanup timer.

- A run that prints no result event other than a notification drain no longer arms the cleanup. It stops on the adapter timeout instead, which is the behavior from before the cleanup existed.
- Scanning for any non-notification result, instead of reading the last result event, keeps a notification that arrives after the turn from hiding the real result.
- `parseClaudeStreamJson` is unchanged, so usage accounting, session ids and summaries keep their current behavior.

## Model Used

Claude Opus 5 (`claude-opus-5`), 1M context, extended thinking, tool use through Claude Code.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
