### PR TITLE
fix(server): preserve runtime MCP profile restrictions

### DIFF
--- a/doc/MCP-RUNTIME-OPERATIONS.md
+++ b/doc/MCP-RUNTIME-OPERATIONS.md
@@ -13,6 +13,23 @@ Tool action approvals require `PAPERCLIP_TOOL_ACTION_SIGNING_SECRET` to be set i
 | `remote_http` | Supported | Supported | Preferred production path. Paperclip proxies calls through the gateway with policy, audit, timeout, and redaction controls. |
 | `local_stdio` | Supported through approved templates and supervised runtime slots | Supported only when an explicitly trusted MCP runtime worker/host is configured | Set `PAPERCLIP_TRUSTED_MCP_RUNTIME_HOST` or `PAPERCLIP_TOOL_RUNTIME_TRUSTED_HOST` only for a worker that is allowed to supervise local processes. Do not enable arbitrary agent-supplied commands. |
 
+## Runtime Assignment Profiles
+
+Paperclip gives each runtime assignment a separate gateway profile. Exact tool
+selections and connection grants with exclusions use the permitted catalogue
+entries. An explicit connection grant from a profile with no exclusions can
+still expose the whole connection before its catalogue is populated.
+
+The generated profile and gateway use a versioned projection identity. New runs
+do not reuse older, broader projections. Cache reuse checks the stored profile,
+gateway and gateway bindings before issuing a token. This does not revoke tokens
+already issued to running tasks; their existing expiry and run lifecycle apply.
+
+Conditional profile entries cannot yet be preserved by this projection. When an
+effective source entry has nonempty conditions, Paperclip omits this optional MCP
+delivery and logs the reason. It does not convert the condition into an
+unconditional grant. The native runtime assignment digest remains unchanged.
+
 ## Metrics
 
 The board runtime health API summarizes one-hour event windows plus current durable slot state:

--- a/server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts
+++ b/server/src/__tests__/heartbeat-runtime-mcp-servers.test.ts
@@ -1,5 +1,8 @@
-import { randomUUID } from "node:crypto";
-import { eq } from "drizzle-orm";
+import { createHash, randomUUID } from "node:crypto";
+import { createServer } from "node:http";
+import express from "express";
+import { and, eq } from "drizzle-orm";
+import request from "supertest";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
   agents,
@@ -11,8 +14,13 @@ import {
   heartbeatRuns,
   toolAccessAuditEvents,
   toolApplications,
+  toolCatalogEntries,
+  toolCallEvents,
   toolConnectionInstalls,
   toolConnections,
+  toolGatewayRateLimitCounters,
+  toolGatewaySessions,
+  toolInvocations,
   toolMcpGateways,
   toolMcpGatewayTokens,
   toolProfileBindings,
@@ -24,6 +32,9 @@ import {
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
 import { buildPaperclipRuntimeMcpServers, createManagedMcpRunConfig } from "../services/heartbeat.js";
+import { mcpGatewayProtocolRoutes } from "../routes/tool-gateway.js";
+import { toolAccessService } from "../services/tool-access.js";
+import { createToolGatewayService } from "../services/tool-gateway.js";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -41,6 +52,10 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
   afterEach(async () => {
     if (originalApiUrl === undefined) delete process.env.PAPERCLIP_API_URL;
     else process.env.PAPERCLIP_API_URL = originalApiUrl;
+    await db.delete(toolCallEvents);
+    await db.delete(toolGatewaySessions);
+    await db.delete(toolGatewayRateLimitCounters);
+    await db.delete(toolInvocations);
     await db.delete(toolMcpGatewayTokens);
     await db.delete(activityLog);
     await db.delete(toolAccessAuditEvents);
@@ -60,6 +75,220 @@ describeEmbeddedPostgres("heartbeat runtime MCP servers", () => {
 
   afterAll(async () => {
     await tempDb?.cleanup();
+  });
+
+  async function seedSelectedTools(url: string, selection: "exact" | "exclusion" = "exact") {
+    process.env.PAPERCLIP_API_URL = "https://paperclip.example.test";
+    const [company] = await db.insert(companies).values({
+      name: `Runtime tool selection ${randomUUID()}`,
+      issuePrefix: `RT${randomUUID().slice(0, 5).toUpperCase()}`,
+    }).returning();
+    const [agent] = await db.insert(agents).values({
+      companyId: company!.id, name: "Selected tools agent", role: "engineer",
+      adapterType: "process", adapterConfig: {},
+    }).returning();
+    const [run] = await db.insert(heartbeatRuns).values({
+      companyId: company!.id, agentId: agent!.id, status: "running", contextSnapshot: {},
+    }).returning();
+    const [application] = await db.insert(toolApplications).values({
+      companyId: company!.id, applicationKey: `selection-${randomUUID().slice(0, 8)}`,
+      name: "Selection fixture", type: "mcp_http", status: "active",
+    }).returning();
+    const [connection] = await db.insert(toolConnections).values({
+      companyId: company!.id, applicationId: application!.id, name: "Three fixture tools",
+      uid: `test/${randomUUID()}`, transport: "mcp_remote", status: "active", enabled: true,
+      healthStatus: "ok", config: { url }, transportConfig: { url },
+      credentialRefs: [], credentialSecretRefs: [],
+    }).returning();
+    await db.insert(connectionGrants).values({
+      companyId: company!.id, connectionId: connection!.id, kind: "organization",
+      status: "active", isDefault: true, credentialSecretRefs: [],
+    });
+    await db.insert(toolConnectionInstalls).values({
+      companyId: company!.id, connectionId: connection!.id, targetType: "agent", targetId: agent!.id,
+    });
+    const catalog = await db.insert(toolCatalogEntries).values(
+      ["read_alpha", "read_beta", "read_gamma"].map((name) => ({
+        companyId: company!.id, applicationId: application!.id, connectionId: connection!.id,
+        entryKind: "tool" as const, name, toolName: name,
+        inputSchema: { type: "object", properties: {}, additionalProperties: false },
+        annotations: { readOnlyHint: true }, riskLevel: "read" as const,
+        isReadOnly: true, isWrite: false, isDestructive: false,
+        status: "active" as const, versionHash: randomUUID(),
+      })),
+    ).returning();
+    const [profile] = await db.insert(toolProfiles).values({
+      companyId: company!.id, profileKey: `selected:${agent!.id}`,
+      name: "Only alpha and beta", status: "active", defaultAction: "deny",
+    }).returning();
+    const entryBase = {
+      companyId: company!.id, profileId: profile!.id,
+      applicationId: application!.id, connectionId: connection!.id, conditions: {},
+    };
+    await db.insert(toolProfileEntries).values(selection === "exact"
+      ? catalog.slice(0, 2).map((tool) => ({
+        ...entryBase, selectorType: "catalog_entry" as const, effect: "include" as const, catalogEntryId: tool.id,
+      }))
+      : [
+        { ...entryBase, selectorType: "connection" as const, effect: "include" as const },
+        { ...entryBase, selectorType: "catalog_entry" as const, effect: "exclude" as const, catalogEntryId: catalog[2]!.id },
+      ]);
+    await db.insert(toolProfileBindings).values({
+      companyId: company!.id, profileId: profile!.id, targetType: "agent", targetId: agent!.id,
+    });
+    return { company: company!, agent: agent!, run: run!, connection: connection!, profile: profile!, catalog };
+  }
+
+  it.each(["fresh exact selection", "legacy broad cache", "connection include with exclusion"])(
+    "enforces selected tools through the issued runtime gateway: %s",
+    async (scenario) => {
+      const providerCalls: string[] = [];
+      const server = createServer(async (req, res) => {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) chunks.push(Buffer.from(chunk));
+        const body = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+        if (body.method === "notifications/initialized") {
+          res.writeHead(202).end();
+          return;
+        }
+        if (body.method === "tools/call") providerCalls.push(body.params.name);
+        res.setHeader("content-type", "application/json");
+        res.end(JSON.stringify({
+          jsonrpc: "2.0", id: body.id,
+          result: body.method === "initialize"
+            ? { protocolVersion: body.params.protocolVersion, capabilities: { tools: {} }, serverInfo: { name: "selection-fixture", version: "1" } }
+            : { content: [{ type: "text", text: `fixture:${body.params.name}` }] },
+        }));
+      });
+      await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+      try {
+        const address = server.address();
+        if (!address || typeof address === "string") throw new Error("Expected loopback fixture address");
+        const fixture = await seedSelectedTools(
+          `http://127.0.0.1:${address.port}/mcp`,
+          scenario === "connection include with exclusion" ? "exclusion" : "exact",
+        );
+        const { company, agent, run, connection, profile, catalog } = fixture;
+        const sourceEntries = await db.select().from(toolProfileEntries).where(eq(toolProfileEntries.profileId, profile.id));
+        const effective = await toolAccessService(db).getEffectiveProfilesForAgent(company.id, agent.id);
+        expect(effective.allowedTools.map((tool) => tool.id).sort()).toEqual(catalog.slice(0, 2).map((tool) => tool.id).sort());
+        const gatewayService = createToolGatewayService(db, {
+          deploymentMode: "local_trusted", deploymentExposure: "private",
+          toolActionSigningSecret: "runtime-selection-fixture",
+        });
+        const summary = await gatewayService.summarizeConnectionAccessForAgent({ companyId: company.id, connectionId: connection.id, agentId: agent.id });
+        const selected = summary.tools.filter((tool) => tool.decision === "allowed");
+        expect(selected.map((tool) => tool.toolName).sort()).toEqual(["read_alpha", "read_beta"]);
+        const excluded = summary.tools.find((tool) => tool.toolName === "read_gamma")!;
+        expect(excluded.decision).toBe("off");
+
+        if (scenario === "legacy broad cache") {
+          // Reproduce the v1 cache's actual key, names and gateway binding before any new build.
+          const digest = createHash("sha256").update(JSON.stringify({
+            version: 1, agentId: agent.id, connections: [connection.id],
+            tools: catalog.slice(0, 2).map((tool) => tool.id).sort(),
+          })).digest("hex");
+          const [legacyProfile] = await db.insert(toolProfiles).values({
+            companyId: company.id, profileKey: `native:${agent.id}:${digest}`,
+            name: `Native ${agent.id.slice(0, 8)} ${digest.slice(0, 12)}`,
+            defaultAction: "deny", metadata: { source: "paperclip_runner", agentId: agent.id, assignmentDigest: digest },
+          }).returning();
+          await db.insert(toolProfileEntries).values({
+            companyId: company.id, profileId: legacyProfile!.id, selectorType: "connection", effect: "include",
+            applicationId: connection.applicationId, connectionId: connection.id,
+          });
+          await gatewayService.createNamedGateway({
+            companyId: company.id,
+            body: {
+              name: `Native ${agent.name} ${digest.slice(0, 8)}`,
+              profileId: legacyProfile!.id, defaultProfileMode: "gateway_only",
+              slug: `native-${agent.id.replaceAll("-", "").slice(0, 12)}-${digest.slice(0, 16)}`,
+              metadata: { nativeRuntimeAssignmentDigest: digest, agentId: agent.id },
+            },
+            actor: { agentId: agent.id },
+          });
+        }
+        const first = await buildPaperclipRuntimeMcpServers({ db, agent, runId: run.id });
+        expect(first).toHaveLength(1);
+        const [runtime] = await buildPaperclipRuntimeMcpServers({ db, agent, runId: run.id });
+        expect(runtime).toBeDefined();
+        expect(runtime!.url).toBe(first[0]!.url);
+        const [realisedGateway] = await db.select().from(toolMcpGateways)
+          .where(eq(toolMcpGateways.gatewayPublicId, new URL(runtime!.url).pathname.split("/").at(-1)!));
+        const realisedEntries = await db.select().from(toolProfileEntries).where(eq(toolProfileEntries.profileId, realisedGateway!.profileId));
+        expect.soft(realisedEntries.map((entry) => ({ selectorType: entry.selectorType, effect: entry.effect, catalogEntryId: entry.catalogEntryId }))
+          .sort((a, b) => String(a.catalogEntryId).localeCompare(String(b.catalogEntryId))))
+          .toEqual(catalog.slice(0, 2).map((tool) => ({ selectorType: "catalog_entry", effect: "include", catalogEntryId: tool.id }))
+            .sort((a, b) => a.catalogEntryId.localeCompare(b.catalogEntryId)));
+
+        const app = express();
+        app.use(express.json());
+        app.use(mcpGatewayProtocolRoutes(gatewayService));
+        const rpc = (method: string, params = {}) => request(app)
+          .post(new URL(runtime!.url).pathname).set("authorization", `Bearer ${runtime!.token}`)
+          .send({ jsonrpc: "2.0", id: randomUUID(), method, params });
+        const listed = await rpc("tools/list");
+        expect(listed.status).toBe(200);
+        expect.soft(listed.body.result.tools.map((tool: { name: string }) => tool.name).sort()).toEqual([
+          ...selected.map((tool) => tool.gatewayToolName), "paperclip_list_resources", "paperclip_read_resource",
+          "paperclip_list_prompts", "paperclip_get_prompt",
+        ].sort());
+        for (const tool of selected) {
+          const called = await rpc("tools/call", { name: tool.gatewayToolName, arguments: {} });
+          expect.soft(called.status).toBe(200);
+          expect.soft(called.body.result).toMatchObject({ content: [{ type: "text", text: `fixture:${tool.toolName}` }], isError: false });
+        }
+        const denied = await rpc("tools/call", { name: excluded.gatewayToolName, arguments: {} });
+        expect.soft(denied.status).toBe(403);
+        expect.soft(denied.body.error?.data.reasonCode).toBe("deny_default");
+        expect.soft(providerCalls.sort()).toEqual(["read_alpha", "read_beta"]);
+        const contextDenied = await rpc("tools/call", { name: "paperclip_list_resources", arguments: {} });
+        expect(contextDenied.status).toBe(403);
+        expect(contextDenied.body.error.data.reasonCode).toBe("gateway_token_action_denied");
+        expect(await db.select().from(toolProfileEntries).where(eq(toolProfileEntries.profileId, profile.id))).toEqual(sourceEntries);
+      } finally {
+        server.closeAllConnections();
+        await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+      }
+    },
+  );
+
+  it.each(["include", "exclude"] as const)("omits optional runtime delivery before creating access when a source %s has conditions", async (effect) => {
+    const { agent, run, profile } = await seedSelectedTools("http://127.0.0.1:9/mcp", effect === "exclude" ? "exclusion" : "exact");
+    await db.update(toolProfileEntries).set({ conditions: { context: { requireProject: true } } })
+      .where(and(eq(toolProfileEntries.profileId, profile.id), eq(toolProfileEntries.effect, effect)));
+    const profilesBefore = await db.select().from(toolProfiles);
+    const entriesBefore = await db.select().from(toolProfileEntries);
+    expect.soft(await buildPaperclipRuntimeMcpServers({ db, agent, runId: run.id })).toEqual([]);
+    expect.soft(await db.select().from(toolProfiles)).toEqual(profilesBefore);
+    expect.soft(await db.select().from(toolProfileEntries)).toEqual(entriesBefore);
+    expect.soft(await db.select().from(toolMcpGateways)).toEqual([]);
+    expect.soft(await db.select().from(toolMcpGatewayTokens)).toEqual([]);
+  });
+
+  it("rejects a cached gateway with an extra binding left by supported profile updates before minting another token", async () => {
+    const { agent, run, company, connection } = await seedSelectedTools("http://127.0.0.1:9/mcp");
+    const [runtime] = await buildPaperclipRuntimeMcpServers({ db, agent, runId: run.id });
+    expect(runtime).toBeDefined();
+    const [gateway] = await db.select().from(toolMcpGateways)
+      .where(eq(toolMcpGateways.gatewayPublicId, new URL(runtime!.url).pathname.split("/").at(-1)!));
+    const [broadProfile] = await db.insert(toolProfiles).values({
+      companyId: company.id, profileKey: `broad:${agent.id}`, name: "Temporary whole connection",
+      status: "active", defaultAction: "deny",
+    }).returning();
+    await db.insert(toolProfileEntries).values({
+      companyId: company.id, profileId: broadProfile!.id, selectorType: "connection", effect: "include",
+      applicationId: connection.applicationId, connectionId: connection.id,
+    });
+    const gatewayService = createToolGatewayService(db);
+    await gatewayService.updateNamedGateway({ companyId: company.id, gatewayId: gateway!.id, body: { profileId: broadProfile!.id } });
+    await gatewayService.updateNamedGateway({ companyId: company.id, gatewayId: gateway!.id, body: { profileId: gateway!.profileId } });
+    const bindings = await db.select().from(toolProfileBindings)
+      .where(and(eq(toolProfileBindings.targetType, "gateway"), eq(toolProfileBindings.targetId, gateway!.id)));
+    expect(bindings.map((binding) => binding.profileId).sort()).toEqual([gateway!.profileId, broadProfile!.id].sort());
+    const tokensBefore = await db.select().from(toolMcpGatewayTokens);
+    await expect(buildPaperclipRuntimeMcpServers({ db, agent, runId: run.id })).rejects.toThrow(/cached runtime MCP gateway/);
+    expect(await db.select().from(toolMcpGatewayTokens)).toEqual(tokensBefore);
   });
 
   it("provisions one aggregate gateway and omits unavailable access without blocking any runtime", async () => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -90,6 +90,7 @@ import {
   toolCatalogEntries,
   toolConnectionInstalls,
   toolConnections,
+  toolProfileBindings,
   toolProfileEntries,
   toolProfiles,
   workspaceOperations,
@@ -4205,6 +4206,14 @@ export async function buildPaperclipRuntimeMcpServers(input: {
     });
     return [];
   }
+  // gateway_only replaces source profiles, so it cannot drop their conditions.
+  if (effective.entries.some((entry) => entry.conditions && Object.keys(entry.conditions).length > 0)) {
+    logger.warn(
+      { companyId: input.agent.companyId, agentId: input.agent.id, runId: input.runId },
+      "runtime MCP delivery omitted because conditional tool profiles cannot be projected",
+    );
+    return [];
+  }
   const assignment = {
     version: 1,
     agentId: input.agent.id,
@@ -4222,7 +4231,49 @@ export async function buildPaperclipRuntimeMcpServers(input: {
   ) {
     return [];
   }
-  const profileKey = `native:${input.agent.id}:${assignmentDigest}`;
+  const fullConnectionIds = new Set(
+    effective.profiles
+      .filter((profile) => profile.entries.every((entry) => entry.effect !== "exclude"))
+      .flatMap((profile) => profile.entries)
+      .filter((entry) => entry.effect === "include" && entry.selectorType === "connection" && entry.connectionId)
+      .map((entry) => entry.connectionId!),
+  );
+  const entries = [
+    ...assignedConnections
+      .filter((connection) => fullConnectionIds.has(connection.id))
+      .map((connection) => ({
+        selectorType: "connection" as const,
+        effect: "include" as const,
+        applicationId: connection.applicationId,
+        connectionId: connection.id,
+      })),
+    ...assignedTools
+      .filter((tool) => !fullConnectionIds.has(tool.connectionId))
+      .map((tool) => ({
+        selectorType: "catalog_entry" as const,
+        effect: "include" as const,
+        applicationId: tool.applicationId,
+        connectionId: tool.connectionId,
+        catalogEntryId: tool.id,
+      })),
+  ].map((entry) => ({
+    catalogEntryId: null,
+    toolName: null,
+    riskLevel: null,
+    conditions: null,
+    ...entry,
+  }));
+  if (entries.length > 250) {
+    throw new Error(
+      "native MCP assignment exceeds the 250-entry gateway profile limit",
+    );
+  }
+  const projectedEntryKeys = entries.map(stableStringifyForFingerprint).sort();
+  // Keep the native snapshot digest stable; cache the realised projection separately.
+  const projectionDigest = createHash("sha256")
+    .update(JSON.stringify({ version: 2, assignmentDigest, entries: projectedEntryKeys }))
+    .digest("hex");
+  const profileKey = `native:${input.agent.id}:${projectionDigest}`;
   let [profile] = await input.db
     .select()
     .from(toolProfiles)
@@ -4235,39 +4286,10 @@ export async function buildPaperclipRuntimeMcpServers(input: {
     .limit(1);
 
   if (!profile) {
-    const fullConnectionIds = new Set(
-      effective.entries
-        .filter((entry) => entry.effect === "include" && entry.selectorType === "connection" && entry.connectionId)
-        .map((entry) => entry.connectionId!),
-    );
-    const entries = [
-      ...assignedConnections
-        .filter((connection) => fullConnectionIds.has(connection.id))
-        .map((connection) => ({
-          selectorType: "connection" as const,
-          effect: "include" as const,
-          applicationId: connection.applicationId,
-          connectionId: connection.id,
-        })),
-      ...assignedTools
-        .filter((tool) => !fullConnectionIds.has(tool.connectionId))
-        .map((tool) => ({
-          selectorType: "catalog_entry" as const,
-          effect: "include" as const,
-          applicationId: tool.applicationId,
-          connectionId: tool.connectionId,
-          catalogEntryId: tool.id,
-        })),
-    ];
-    if (entries.length > 250) {
-      throw new Error(
-        "native MCP assignment exceeds the 250-entry gateway profile limit",
-      );
-    }
     try {
       const created = await access.createProfile(input.agent.companyId, {
         profileKey,
-        name: `Native ${input.agent.id.slice(0, 8)} ${assignmentDigest.slice(0, 12)}`,
+        name: `Native ${input.agent.id.slice(0, 8)} ${projectionDigest.slice(0, 12)}`,
         description: "Immutable Paperclip Runner MCP assignment profile.",
         status: "active",
         defaultAction: "deny",
@@ -4275,6 +4297,7 @@ export async function buildPaperclipRuntimeMcpServers(input: {
           source: "paperclip_runner",
           agentId: input.agent.id,
           assignmentDigest,
+          projectionDigest,
         },
         entries,
       });
@@ -4298,6 +4321,34 @@ export async function buildPaperclipRuntimeMcpServers(input: {
     }
   }
 
+  const cachedEntries = await input.db
+    .select({
+      selectorType: toolProfileEntries.selectorType,
+      effect: toolProfileEntries.effect,
+      applicationId: toolProfileEntries.applicationId,
+      connectionId: toolProfileEntries.connectionId,
+      catalogEntryId: toolProfileEntries.catalogEntryId,
+      toolName: toolProfileEntries.toolName,
+      riskLevel: toolProfileEntries.riskLevel,
+      conditions: toolProfileEntries.conditions,
+    })
+    .from(toolProfileEntries)
+    .where(and(
+      eq(toolProfileEntries.companyId, input.agent.companyId),
+      eq(toolProfileEntries.profileId, profile!.id),
+    ));
+  if (
+    profile!.status !== "active" || profile!.defaultAction !== "deny" ||
+    JSON.stringify(cachedEntries.map(stableStringifyForFingerprint).sort()) !== JSON.stringify(projectedEntryKeys)
+  ) {
+    throw new Error("cached runtime MCP profile does not match the assignment projection");
+  }
+  const matchesProjection = (candidate: typeof toolMcpGateways.$inferSelect) =>
+    candidate.status === "active" && candidate.archivedAt === null &&
+    candidate.profileId === profile!.id && candidate.defaultProfileMode === "gateway_only" &&
+    candidate.metadata?.nativeRuntimeAssignmentDigest === assignmentDigest &&
+    candidate.metadata?.nativeRuntimeProjectionDigest === projectionDigest;
+
   let [gateway] = (
     await input.db
       .select()
@@ -4309,23 +4360,21 @@ export async function buildPaperclipRuntimeMcpServers(input: {
           isNull(toolMcpGateways.archivedAt),
         ),
       )
-  ).filter(
-    (candidate) =>
-      candidate.metadata?.nativeRuntimeAssignmentDigest === assignmentDigest,
-  );
+  ).filter(matchesProjection);
   if (!gateway) {
-    const slug = `native-${input.agent.id.replaceAll("-", "").slice(0, 12)}-${assignmentDigest.slice(0, 16)}`;
+    const slug = `native-${input.agent.id.replaceAll("-", "").slice(0, 12)}-${projectionDigest.slice(0, 16)}`;
     try {
       const created = await service.createNamedGateway({
         companyId: input.agent.companyId,
         body: {
-          name: `Native ${input.agent.name} ${assignmentDigest.slice(0, 8)}`,
+          name: `Native ${input.agent.name} ${projectionDigest.slice(0, 8)}`,
           slug,
           description: "Run-scoped Paperclip Runner MCP gateway.",
           profileId: profile!.id,
           defaultProfileMode: "gateway_only",
           metadata: {
             nativeRuntimeAssignmentDigest: assignmentDigest,
+            nativeRuntimeProjectionDigest: projectionDigest,
             agentId: input.agent.id,
           },
         },
@@ -4351,6 +4400,23 @@ export async function buildPaperclipRuntimeMcpServers(input: {
     }
   }
 
+  if (!gateway || !matchesProjection(gateway)) {
+    throw new Error("cached runtime MCP gateway does not match the assignment projection");
+  }
+  const gatewayBindings = await input.db
+    .select({ profileId: toolProfileBindings.profileId })
+    .from(toolProfileBindings)
+    .where(and(
+      eq(toolProfileBindings.companyId, input.agent.companyId),
+      eq(toolProfileBindings.targetType, "gateway"),
+      eq(toolProfileBindings.targetId, gateway.id),
+    ));
+  if (
+    gatewayBindings.length === 0 ||
+    gatewayBindings.some((binding) => binding.profileId !== profile!.id)
+  ) {
+    throw new Error("cached runtime MCP gateway bindings do not match the assignment projection");
+  }
   const token = await service.createNamedGatewayToken({
     companyId: input.agent.companyId,
     gatewayId: gateway!.id,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Runtime MCP gateways deliver the tools assigned to an agent.
> - Their generated profiles must preserve the effective tool selection.
> - Connection exclusions were lost, and old broad profiles could remain cached.
> - This pull request checks the generated permissions before issuing a new token.
> - The benefit is consistent tool selection across new and reused runtime gateways.

## Linked Issues or Issue Description

**What happened?**

A connection grant with a tool exclusion became a whole-connection runtime grant. Cached profiles could also retain broader access after the projection rules changed.

**Expected behavior**

Runtime profiles must preserve the effective tool selection. A cached profile or gateway with different permissions must not receive another run token.

**Steps to reproduce**

1. Install an MCP connection with three catalogue tools.
2. Include the connection and exclude one tool, or seed a legacy broad runtime profile for an exact selection.
3. Build the runtime gateway.
4. List its tools and call the excluded tool. The old path exposes and executes it.

**Paperclip version or commit**

`297d8741f5f192c66abbec325b1e956cf0e5e667`.

**Deployment mode**

Local development from source, tested with isolated PostgreSQL and a synthetic MCP server.

Refs #13005, which already corrected fresh exact-selector projection. This fix covers cached profiles and remaining exclusions. Refs #11998, which proposes a different connection scope resolver. This change preserves the current resolver.

## What Changed

- Project permitted catalogue entries when a source profile has exclusions. Preserve explicit whole-connection grants from profiles without exclusions.
- Give generated profiles and gateways a separate projection identity. Check stored entries, gateway settings and actual profile bindings before issuing a token.
- Omit optional MCP delivery for nonempty conditional entries instead of dropping their conditions.
- Add database and gateway HTTP regressions. Document cache and conditional-profile limits.

## Verification

- Focused runtime MCP suite: **10 passed, 0 failed, 0 skipped**. It checks allowed calls, excluded-tool denial, no excluded upstream execution, legacy cache names and extra gateway bindings.
- Server typecheck: **passed**.
- Tests used isolated local fixtures. No live harness or subscription tool-delivery claim is made.
- Full workspace typecheck and build: **passed**.
- Standard `pnpm test:run`: **failed in the general-server group** (6,899 passed, 1 failed, 13 skipped); its fail-fast runner did not reach later groups. The failure is `workspace-runtime.test.ts`'s long-readiness reservation case: the service was healthy on the next port instead of the fixture's expected preferred port. An exact-coverage general-group recheck reproduced that failure. The runtime MCP suite passed all ten cases in both group runs.
- The isolated readiness case passed once on unchanged upstream and once on patched source. The complete unchanged-upstream workspace-runtime file also passed all 161 cases with zero skips. The standard runner's remaining 157 invocations completed separately: 11,094 passed, 0 failed, 20 skipped. Across the complete planned membership, the retained result is 17,993 passed, 1 failed, 33 skipped; reruns are not added to that total. These comparisons leave the repeated group failure unresolved; they do not establish a baseline defect or erase the failed runs.

## Risks

- Conditional source profiles omit this optional MCP delivery until their conditions can be preserved.
- Existing profiles and gateways are retained. Already-issued tokens keep their current expiry and run lifecycle; this change does not revoke them.
- Incomplete or changed cached objects fail closed. The existing native assignment digest and 250-entry profile limit remain unchanged.

## Model Used

OpenAI Codex / GPT-6 assisted implementation and review with repository tools and local checks. The exact model variant, reasoning setting and context-window size are not asserted.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
