### PR TITLE
fix(agents): validate pi_local adapterConfig.model at create/update time

### DIFF
--- a/packages/adapters/pi-local/src/index.ts
+++ b/packages/adapters/pi-local/src/index.ts
@@ -5,6 +5,17 @@ export const SANDBOX_INSTALL_COMMAND = "npm install -g @earendil-works/pi-coding
 
 export const models: Array<{ id: string; label: string }> = [];
 
+// Pi model ids use provider/model form (e.g. "anthropic/claude-sonnet-5" or
+// "ai-gw-anthropic-200k/anthropic/claude-sonnet-5"). Mirrors the OpenCode
+// adapter's isValidOpenCodeModelId shape check: require a non-empty string
+// with a "/" that is neither the first nor the last character.
+export function isValidPiModelId(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const trimmed = value.trim();
+  const slashIndex = trimmed.indexOf("/");
+  return Boolean(trimmed) && slashIndex > 0 && slashIndex !== trimmed.length - 1;
+}
+
 export const agentConfigurationDoc = `# pi_local agent configuration
 
 Adapter: pi_local

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -1598,6 +1598,90 @@ describe.sequential("agent permission routes", () => {
     });
   }
 
+  it("rejects creating a pi_local agent with an empty adapterConfig (STU-27 regression)", async () => {
+    mockAccessService.canUser.mockResolvedValue(true);
+
+    const app = await createApp({
+      type: "board",
+      userId: "agent-admin-user",
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agents`)
+      .send({
+        name: "Broken Pi Hire",
+        role: "engineer",
+        adapterType: "pi_local",
+        adapterConfig: {},
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.error).toContain("pi_local");
+    expect(res.body.error).toContain("adapterConfig.model");
+    expect(mockAgentService.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects creating a pi_local agent with a malformed (non provider/model) model string", async () => {
+    mockAccessService.canUser.mockResolvedValue(true);
+
+    const app = await createApp({
+      type: "board",
+      userId: "agent-admin-user",
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agents`)
+      .send({
+        name: "Broken Pi Hire 2",
+        role: "engineer",
+        adapterType: "pi_local",
+        adapterConfig: { model: "claude-sonnet-5" },
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.error).toContain("pi_local");
+    expect(mockAgentService.create).not.toHaveBeenCalled();
+  });
+
+  it("allows creating a pi_local agent with a valid provider/model string", async () => {
+    mockAccessService.canUser.mockResolvedValue(true);
+
+    const app = await createApp({
+      type: "board",
+      userId: "agent-admin-user",
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+    mockAgentService.create.mockResolvedValue({
+      ...baseAgent,
+      name: "Working Pi Hire",
+      adapterType: "pi_local",
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agents`)
+      .send({
+        name: "Working Pi Hire",
+        role: "engineer",
+        adapterType: "pi_local",
+        adapterConfig: { model: "ai-gw-anthropic-200k/anthropic/claude-sonnet-5" },
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockAgentService.create).toHaveBeenCalledWith(
+      companyId,
+      expect.objectContaining({ adapterType: "pi_local" }),
+      { claudeLogin: { storedSessionId: null, ownerUserId: "agent-admin-user", applyExistingWithoutClaim: false } },
+    );
+  });
+
   it("rejects updating an agent with an unsupported default environment driver", async () => {
     const environmentId = "33333333-3333-4333-8333-333333333333";
     mockEnvironmentService.getById.mockResolvedValue({

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -205,6 +205,7 @@ import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import { DEFAULT_KIMI_LOCAL_MODEL } from "@paperclipai/adapter-kimi-local";
 import { DEFAULT_OPENCODE_LOCAL_MODEL } from "@paperclipai/adapter-opencode-local";
 import { requireOpenCodeModelId } from "@paperclipai/adapter-opencode-local/server";
+import { isValidPiModelId } from "@paperclipai/adapter-pi-local";
 import {
   loadDefaultAgentInstructionsBundle,
   resolveDefaultAgentInstructionsBundleRole,
@@ -2400,12 +2401,27 @@ export function agentRoutes(
       await assertFreshPaperclipRunnerProvider(companyId, adapterType, adapterConfig);
       return;
     }
-    if (adapterType !== "opencode_local") return;
-    try {
-      requireOpenCodeModelId(adapterConfig.model);
-    } catch (err) {
-      const reason = err instanceof Error ? err.message : String(err);
-      throw unprocessable(`Invalid opencode_local adapterConfig: ${reason}`);
+    if (adapterType === "opencode_local") {
+      try {
+        requireOpenCodeModelId(adapterConfig.model);
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        throw unprocessable(`Invalid opencode_local adapterConfig: ${reason}`);
+      }
+      return;
+    }
+    if (adapterType === "pi_local") {
+      // pi_local has no viable default model (routing is gateway/provider-specific
+      // per company), so we cannot silently default it like gemini/kimi/opencode.
+      // Instead, fail fast at creation time with the same shape check the pi_local
+      // adapter itself enforces at heartbeat bootstrap, so a broken hire never
+      // reaches `status: error` silently (STU-27 root cause).
+      if (!isValidPiModelId(adapterConfig.model)) {
+        throw unprocessable(
+          "Invalid pi_local adapterConfig: `adapterConfig.model` is required in provider/model format (e.g. \"anthropic/claude-sonnet-5\").",
+        );
+      }
+      return;
     }
   }
 


### PR DESCRIPTION
## Problem

`assertAdapterConfigConstraints` in `server/src/routes/agents.ts` validates/defaults `adapterConfig.model` at agent create/update time for `opencode_local`, `gemini_local`, `kimi_local`, and `cursor` — but never covered `pi_local`.

A `pi_local` agent hired with an empty (or malformed) `adapterConfig` currently passes creation successfully and only fails much later, at first heartbeat, deep in adapter bootstrap. That is exactly what happened to a real hire in our company (an AI/ML Engineer agent that silently ended up `status: error` and required a manual `adapterConfig` patch to fix).

## Fix

- Export `isValidPiModelId` from `@paperclipai/adapter-pi-local`: a shape check requiring a non-empty `provider/model` string. This mirrors the existing `isValidOpenCodeModelId` approach. Note `pi_local` has no single viable default model to fall back to (routing is gateway/provider-specific per company), so unlike `opencode_local`/`gemini_local`/`kimi_local` we reject rather than default.
- Wire the check into `assertAdapterConfigConstraints` so a `pi_local` agent create/update with a missing or malformed `adapterConfig.model` fails fast with a `422` and an actionable message, instead of silently reaching `status: error` on first heartbeat.
- Add 3 regression tests to `server/src/__tests__/agent-permissions-routes.test.ts`:
  1. empty `adapterConfig` on a `pi_local` create → rejected (422)
  2. malformed (non `provider/model`) model string → rejected (422)
  3. valid `provider/model` string → accepted (201)

## Testing

- `server` test suite: 66/66 passing (`agent-permissions-routes.test.ts`, includes the 3 new tests)
- `packages/adapters/pi-local` test suite: 35/35 passing (all 4 existing test files unaffected)
- `tsc --noEmit` clean on the touched packages

## Notes

No behavior change for `opencode_local`/`gemini_local`/`kimi_local`/`cursor`. This is purely additive validation for the previously-uncovered `pi_local` case.
