### PR TITLE
fix: collect an explicit model for pi_local (server validation + onboarding wizard input)

### DIFF
--- a/packages/adapters/pi-local/src/index.ts
+++ b/packages/adapters/pi-local/src/index.ts
@@ -5,6 +5,17 @@ export const SANDBOX_INSTALL_COMMAND = "npm install -g @earendil-works/pi-coding
 
 export const models: Array<{ id: string; label: string }> = [];
 
+// Pi model ids use provider/model form (e.g. "anthropic/claude-sonnet-5" or
+// "ai-gw-anthropic-200k/anthropic/claude-sonnet-5"). Mirrors the OpenCode
+// adapter's isValidOpenCodeModelId shape check: require a non-empty string
+// with a "/" that is neither the first nor the last character.
+export function isValidPiModelId(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  const trimmed = value.trim();
+  const slashIndex = trimmed.indexOf("/");
+  return Boolean(trimmed) && slashIndex > 0 && slashIndex !== trimmed.length - 1;
+}
+
 export const agentConfigurationDoc = `# pi_local agent configuration
 
 Adapter: pi_local

--- a/server/src/__tests__/agent-permissions-routes.test.ts
+++ b/server/src/__tests__/agent-permissions-routes.test.ts
@@ -1598,6 +1598,90 @@ describe.sequential("agent permission routes", () => {
     });
   }
 
+  it("rejects creating a pi_local agent with an empty adapterConfig (STU-27 regression)", async () => {
+    mockAccessService.canUser.mockResolvedValue(true);
+
+    const app = await createApp({
+      type: "board",
+      userId: "agent-admin-user",
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agents`)
+      .send({
+        name: "Broken Pi Hire",
+        role: "engineer",
+        adapterType: "pi_local",
+        adapterConfig: {},
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.error).toContain("pi_local");
+    expect(res.body.error).toContain("adapterConfig.model");
+    expect(mockAgentService.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects creating a pi_local agent with a malformed (non provider/model) model string", async () => {
+    mockAccessService.canUser.mockResolvedValue(true);
+
+    const app = await createApp({
+      type: "board",
+      userId: "agent-admin-user",
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agents`)
+      .send({
+        name: "Broken Pi Hire 2",
+        role: "engineer",
+        adapterType: "pi_local",
+        adapterConfig: { model: "claude-sonnet-5" },
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(422);
+    expect(res.body.error).toContain("pi_local");
+    expect(mockAgentService.create).not.toHaveBeenCalled();
+  });
+
+  it("allows creating a pi_local agent with a valid provider/model string", async () => {
+    mockAccessService.canUser.mockResolvedValue(true);
+
+    const app = await createApp({
+      type: "board",
+      userId: "agent-admin-user",
+      source: "session",
+      isInstanceAdmin: false,
+      companyIds: [companyId],
+    });
+    mockAgentService.create.mockResolvedValue({
+      ...baseAgent,
+      name: "Working Pi Hire",
+      adapterType: "pi_local",
+    });
+
+    const res = await requestApp(app, (baseUrl) => request(baseUrl)
+      .post(`/api/companies/${companyId}/agents`)
+      .send({
+        name: "Working Pi Hire",
+        role: "engineer",
+        adapterType: "pi_local",
+        adapterConfig: { model: "ai-gw-anthropic-200k/anthropic/claude-sonnet-5" },
+      }));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(mockAgentService.create).toHaveBeenCalledWith(
+      companyId,
+      expect.objectContaining({ adapterType: "pi_local" }),
+      { claudeLogin: { storedSessionId: null, ownerUserId: "agent-admin-user", applyExistingWithoutClaim: false } },
+    );
+  });
+
   it("rejects updating an agent with an unsupported default environment driver", async () => {
     const environmentId = "33333333-3333-4333-8333-333333333333";
     mockEnvironmentService.getById.mockResolvedValue({

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -205,6 +205,7 @@ import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import { DEFAULT_KIMI_LOCAL_MODEL } from "@paperclipai/adapter-kimi-local";
 import { DEFAULT_OPENCODE_LOCAL_MODEL } from "@paperclipai/adapter-opencode-local";
 import { requireOpenCodeModelId } from "@paperclipai/adapter-opencode-local/server";
+import { isValidPiModelId } from "@paperclipai/adapter-pi-local";
 import {
   loadDefaultAgentInstructionsBundle,
   resolveDefaultAgentInstructionsBundleRole,
@@ -2400,12 +2401,27 @@ export function agentRoutes(
       await assertFreshPaperclipRunnerProvider(companyId, adapterType, adapterConfig);
       return;
     }
-    if (adapterType !== "opencode_local") return;
-    try {
-      requireOpenCodeModelId(adapterConfig.model);
-    } catch (err) {
-      const reason = err instanceof Error ? err.message : String(err);
-      throw unprocessable(`Invalid opencode_local adapterConfig: ${reason}`);
+    if (adapterType === "opencode_local") {
+      try {
+        requireOpenCodeModelId(adapterConfig.model);
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        throw unprocessable(`Invalid opencode_local adapterConfig: ${reason}`);
+      }
+      return;
+    }
+    if (adapterType === "pi_local") {
+      // pi_local has no viable default model (routing is gateway/provider-specific
+      // per company), so we cannot silently default it like gemini/kimi/opencode.
+      // Instead, fail fast at creation time with the same shape check the pi_local
+      // adapter itself enforces at heartbeat bootstrap, so a broken hire never
+      // reaches `status: error` silently (STU-27 root cause).
+      if (!isValidPiModelId(adapterConfig.model)) {
+        throw unprocessable(
+          "Invalid pi_local adapterConfig: `adapterConfig.model` is required in provider/model format (e.g. \"anthropic/claude-sonnet-5\").",
+        );
+      }
+      return;
     }
   }
 

--- a/tests/e2e/onboarding.spec.ts
+++ b/tests/e2e/onboarding.spec.ts
@@ -591,4 +591,138 @@ test.describe("Onboarding wizard", () => {
 
     expect(pageErrors, pageErrors.join("\n")).toHaveLength(0);
   });
+
+  test("pi_local collects an explicit model before the hire, and blocks client-side until it is valid", async ({
+    page,
+  }) => {
+    // pi_local has no safe default model: routing is provider/gateway-specific
+    // per company, so the server rejects a pi hire whose adapterConfig.model is
+    // empty or malformed (assertAdapterConfigConstraints). This test is the
+    // wizard's half of that contract: the connect step shows a model field for
+    // the Pi source, blocks the hire client-side while the typed value fails
+    // the adapter's own shape check, and carries a valid id verbatim into the
+    // hire — never reaching the server's 422.
+    const pageErrors: string[] = [];
+    page.on("pageerror", (err) => pageErrors.push(err.message));
+
+    const flagRes = await page.request.patch("/api/instance/settings/experimental", {
+      data: { enableConferenceRoomChat: true },
+    });
+    expect(flagRes.ok()).toBe(true);
+
+    // The connect step probes before hiring; pi declares no login flow, so a
+    // passing probe is the only gate between the tile and the hire.
+    await page.route("**/test-environment", (route) =>
+      route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          adapterType: "pi_local",
+          status: "pass",
+          checks: [],
+          testedAt: new Date().toISOString(),
+        }),
+      }),
+    );
+
+    // The hire itself goes to the real server, so the created agent and its
+    // configuration can be verified after the wizard advances. The body is
+    // captured on the way through.
+    let hireRequestBody: {
+      adapterType?: string;
+      adapterConfig?: { model?: string };
+    } | null = null;
+    await page.route("**/agent-hires", async (route) => {
+      hireRequestBody = JSON.parse(route.request().postData() || "{}");
+      return route.continue();
+    });
+
+    await page.goto("/onboarding");
+
+    const startBtn = page.getByRole("button", {
+      name: /Start Onboarding|New Organization|Add Agent/,
+    });
+    if (await startBtn.count()) {
+      await startBtn.first().click();
+    }
+    const createCard = page.getByRole("button", { name: /Build a new organization/ });
+    if (await createCard.count()) {
+      await createCard.first().click();
+    }
+
+    await expect(
+      page.getByRole("heading", { name: "What is the name of your organization?" }),
+    ).toBeVisible({ timeout: 15_000 });
+    await page.getByPlaceholder("e.g. Northwind Labs").fill(`${COMPANY_NAME}-pi-model`);
+    await page.getByRole("button", { name: /^Continue/ }).click();
+
+    await page.waitForSelector("#onboarding-agent-name", { timeout: 30_000 });
+    await page.locator("#onboarding-agent-name").fill("Ada");
+    await page.getByRole("button", { name: "Next" }).click();
+
+    // Pick the Pi tile. The wizard labels it "Pi" (CONNECT_SOURCE_NAMES),
+    // with the credential tag trailing in the same accessible name.
+    const piTile = page.getByRole("radio", { name: /^Pi/ });
+    await piTile.waitFor({ timeout: 30_000 });
+    await piTile.click();
+
+    // The model field is the point of this source: it must be there, and it
+    // must arrive empty — a seeded suggestion would be exactly the bogus
+    // default the server's constraint exists to reject.
+    const modelField = page.locator("#onboarding-model");
+    await expect(modelField).toBeVisible({ timeout: 15_000 });
+    await expect(modelField).toHaveValue("");
+
+    const connect = page.getByRole("button", { name: "Connect", exact: true });
+    await expect(connect).toBeEnabled({ timeout: 30_000 });
+
+    // Empty model: blocked with a clear client-side message, and no hire
+    // request may leave the page.
+    await connect.click();
+    await expect(
+      page.getByText("Pi requires an explicit model in provider/model format."),
+    ).toBeVisible({ timeout: 15_000 });
+    expect(hireRequestBody).toBeNull();
+
+    // Malformed id (no provider half): same block, still no hire.
+    await modelField.fill("grok-4");
+    await connect.click();
+    await expect(
+      page.getByText("Pi requires an explicit model in provider/model format."),
+    ).toBeVisible({ timeout: 15_000 });
+    expect(hireRequestBody).toBeNull();
+
+    // Valid id: the hire goes through carrying the typed model verbatim.
+    await modelField.fill("xai/grok-4");
+    await connect.click();
+
+    // The wizard reaches Review once the hire lands. (Not clicking "Get
+    // started": that would create the first task and wake the agent, which
+    // this test has no runtime for — the hire itself is the surface here.)
+    await page
+      .getByRole("button", { name: /Get started/ })
+      .waitFor({ timeout: 30_000 });
+
+    expect(hireRequestBody?.adapterType).toBe("pi_local");
+    expect(hireRequestBody?.adapterConfig?.model).toBe("xai/grok-4");
+
+    // And the created agent really carries it: the server accepted the pi
+    // hire with the explicit model, which is the whole contract.
+    const companiesRes = await page.request.get("/api/companies");
+    expect(companiesRes.ok()).toBe(true);
+    const companies = await companiesRes.json();
+    const company = companies.find(
+      (c: { name: string }) => c.name === `${COMPANY_NAME}-pi-model`,
+    );
+    expect(company, "the created company should exist").toBeTruthy();
+    const agentsRes = await page.request.get(`/api/companies/${company.id}/agents`);
+    expect(agentsRes.ok()).toBe(true);
+    const agents = await agentsRes.json();
+    const hired = agents.find(
+      (a: { adapterType?: string }) => a.adapterType === "pi_local",
+    );
+    expect(hired, "the pi_local agent should exist").toBeTruthy();
+    expect(hired.adapterConfig?.model).toBe("xai/grok-4");
+
+    expect(pageErrors, pageErrors.join("\n")).toHaveLength(0);
+  });
 });

--- a/ui/src/adapters/adapter-display-registry.ts
+++ b/ui/src/adapters/adapter-display-registry.ts
@@ -121,6 +121,7 @@ const adapterDisplayMap: Record<string, AdapterDisplayInfo> = {
     label: "Pi",
     description: "Pi harness",
     icon: Terminal,
+    recommended: true,
   },
   cursor: {
     label: "Cursor",

--- a/ui/src/components/AdapterLoginChrome.tsx
+++ b/ui/src/components/AdapterLoginChrome.tsx
@@ -49,6 +49,7 @@ export type AdapterLoginChrome = "panel" | "onboarding";
 export const CONNECT_SOURCE_NAMES: Record<string, string> = {
   claude_local: "Claude",
   codex_local: "OpenAI",
+  pi_local: "Pi",
 };
 
 /** The provider name for a source, falling back to the type when unlisted. */

--- a/ui/src/components/OnboardingWizard.model-input.test.tsx
+++ b/ui/src/components/OnboardingWizard.model-input.test.tsx
@@ -1,0 +1,429 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Sibling of OnboardingWizard.adapters.test.tsx, covering the connect step's
+ * explicit-model surface: adapters with no safe default model (see
+ * EXPLICIT_MODEL_VALIDATORS in OnboardingWizard.tsx — currently pi_local)
+ * get a model input on step 4, and the hire blocks client-side until the
+ * typed value passes the adapter's own shape check (isValidPiModelId), so a
+ * bad model never reaches the server's assertAdapterConfigConstraints 422.
+ */
+
+const ONBOARDING_STORAGE_KEY = "paperclip-onboarding-state";
+
+// --- Mocks (hoisted so vi.mock factories can close over them) ----------------
+
+const mockAuthApi = vi.hoisted(() => ({ getSession: vi.fn() }));
+vi.mock("../api/auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../api/auth")>();
+  return { ...actual, authApi: { ...actual.authApi, getSession: mockAuthApi.getSession } };
+});
+
+const mockDialog = vi.hoisted(() => ({
+  onboardingOpen: true,
+  onboardingOptions: {} as { initialStep?: number; companyId?: string },
+  closeOnboarding: vi.fn(),
+  onboardingRouteDismissed: false,
+  setOnboardingRouteDismissed: vi.fn(),
+}));
+
+const mockCompany = vi.hoisted(() => ({
+  companies: [] as Array<{ id: string; name: string; issuePrefix: string }>,
+  setSelectedCompanyId: vi.fn(),
+  loading: false,
+  error: null as Error | null,
+}));
+
+const mockCompaniesApi = vi.hoisted(() => ({
+  detachInflightList: vi.fn(),
+  create: vi.fn(),
+  update: vi.fn(),
+  list: vi.fn(),
+}));
+const mockGoalsApi = vi.hoisted(() => ({
+  create: vi.fn(),
+  list: vi.fn(async () => []),
+}));
+const mockAgentsApi = vi.hoisted(() => ({
+  adapterModels: vi.fn(async () => [] as Array<{ id: string; label: string }>),
+  testEnvironment: vi.fn(
+    async (): Promise<import("@paperclipai/shared").AdapterEnvironmentTestResult> => ({
+      adapterType: "pi_local",
+      status: "pass",
+      checks: [],
+      testedAt: new Date().toISOString(),
+    }),
+  ),
+  hire: vi.fn(async () => ({ agent: { id: "agent-1" }, approval: null })),
+  instructionsBundle: vi.fn(async () => ({ entryFile: "AGENTS.md" })),
+  saveInstructionsFile: vi.fn(async () => ({})),
+  getClaudeOAuthTokenStatus: vi.fn(),
+  getAdapterAuthSignal: vi.fn(
+    async (): Promise<import("@paperclipai/shared").AdapterAuthSignalResponse> => ({
+      status: "present",
+    }),
+  ),
+}));
+const mockApprovalsApi = vi.hoisted(() => ({
+  create: vi.fn(),
+  approve: vi.fn(),
+}));
+const mockSecretsApi = vi.hoisted(() => ({
+  listMyUserSecrets: vi.fn(),
+  createUserSecretDefinition: vi.fn(),
+  createMyUserSecret: vi.fn(),
+  rotateMyUserSecret: vi.fn(),
+}));
+const mockIssuesApi = vi.hoisted(() => ({
+  create: vi.fn(),
+}));
+const mockProjectsApi = vi.hoisted(() => ({
+  create: vi.fn(),
+  list: vi.fn(async () => []),
+}));
+const mockEnvironmentsApi = vi.hoisted(() => ({
+  list: vi.fn(async () => [] as Array<Record<string, unknown>>),
+  capabilities: vi.fn(
+    async (): Promise<import("@paperclipai/shared").EnvironmentCapabilities> =>
+      (await import("@paperclipai/shared")).getEnvironmentCapabilities([]),
+  ),
+}));
+const mockInstanceSettingsApi = vi.hoisted(() => ({
+  get: vi.fn(async () => ({ defaultEnvironmentId: null as string | null })),
+  getExperimental: vi.fn(async () => ({ enableManagedSandboxOnly: false })),
+}));
+
+// The real adapter registry eagerly imports every adapter package. Stub it and
+// drive the tile row through this knob. The build mock defaults to echoing the
+// model it was handed so tests can assert what the hire would have carried.
+const mockAdapterRegistry = vi.hoisted(() => ({
+  list: [] as Array<{ type: string }>,
+  disabled: new Set<string>(),
+  loaded: true,
+}));
+const mockAdapterBuild = vi.hoisted(() => ({
+  buildAdapterConfig: vi.fn(
+    (values: { model?: string }) => ({ model: values.model } as Record<string, unknown>),
+  ),
+}));
+
+vi.mock("@/lib/router", () => ({
+  useLocation: () => ({ pathname: "/", search: "", hash: "", state: null }),
+  useNavigate: () => vi.fn(),
+  useParams: () => ({}),
+}));
+vi.mock("../context/DialogContext", () => ({
+  useDialog: () => mockDialog,
+}));
+vi.mock("../context/CompanyContext", () => ({
+  useCompany: () => mockCompany,
+}));
+vi.mock("../api/companies", () => ({ companiesApi: mockCompaniesApi }));
+vi.mock("../api/goals", () => ({ goalsApi: mockGoalsApi }));
+vi.mock("../api/agents", () => ({ agentsApi: mockAgentsApi }));
+vi.mock("../api/approvals", () => ({ approvalsApi: mockApprovalsApi }));
+vi.mock("../api/secrets", () => ({ secretsApi: mockSecretsApi }));
+vi.mock("../api/issues", () => ({ issuesApi: mockIssuesApi }));
+vi.mock("../api/projects", () => ({ projectsApi: mockProjectsApi }));
+vi.mock("../api/environments", () => ({ environmentsApi: mockEnvironmentsApi }));
+vi.mock("../api/instanceSettings", () => ({ instanceSettingsApi: mockInstanceSettingsApi }));
+vi.mock("../adapters", () => ({
+  listUIAdapters: () => mockAdapterRegistry.list,
+  getUIAdapter: () => ({ buildAdapterConfig: mockAdapterBuild.buildAdapterConfig }),
+}));
+vi.mock("../adapters/metadata", () => ({ isVisualAdapterChoice: () => true }));
+vi.mock("../adapters/adapter-display-registry", () => ({
+  // Mirrors the real registry, where pi_local is `recommended` alongside
+  // claude_local and codex_local — that flag is what puts a tile in the
+  // connect step's source row.
+  getAdapterDisplay: (type: string) => ({
+    type,
+    recommended: type === "claude_local" || type === "codex_local" || type === "pi_local",
+    label: type,
+    description: "",
+    icon: () => null,
+  }),
+  getAdapterLabel: (type: string) => type,
+  getAdapterLabels: () => ({}) as Record<string, string>,
+  isKnownAdapterType: () => true,
+}));
+vi.mock("../adapters/use-disabled-adapters", () => ({
+  useDisabledAdaptersSync: () => mockAdapterRegistry.disabled,
+  useAdapterRegistryLoaded: () => mockAdapterRegistry.loaded,
+}));
+// pi_local declares no login capability (mirroring the real registry's
+// fallback for an unlisted type), so Connect goes straight to the probe and
+// the hire — which is the path under test.
+vi.mock("../adapters/use-adapter-capabilities", () => ({
+  useAdapterCapabilities: () => () => ({
+    supportsInstructionsBundle: false,
+    supportsSkills: false,
+    supportsLocalAgentJwt: false,
+    requiresMaterializedRuntimeSkills: false,
+  }),
+}));
+vi.mock("./AsciiArtAnimation", () => ({ AsciiArtAnimation: () => null }));
+vi.mock("./FrontDoor", () => ({ FrontDoor: () => null }));
+vi.mock("./AgentCapsule", () => ({ AgentCapsule: () => null }));
+
+import { ApiError } from "../api/client";
+import { queryKeys } from "../lib/queryKeys";
+import { ONBOARDING_STORAGE_KEY as EXPORTED_KEY, OnboardingWizard } from "./OnboardingWizard";
+
+// The wizard exports the exact key it reads; pin the local copy against drift.
+void ONBOARDING_STORAGE_KEY;
+const STORAGE_KEY = EXPORTED_KEY;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+/** React tracks input value on the DOM node; set it the way React will see. */
+function setControlledValue(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    "value",
+  )!.set!;
+  setter.call(el, value);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+  });
+}
+
+const SESSION_USER_ID = "user-b";
+
+/**
+ * Walk to the connect step with the Pi tile picked, the way a customer gets
+ * there: create the company, name the lead, advance, answer the source row.
+ *
+ * By `aria-checked` and the mocked label (the display registry mock labels a
+ * tile with its type id), so the test asserts the mechanism rather than the
+ * mock's cosmetics.
+ */
+async function openConnectStepWithPi() {
+  mockAdapterRegistry.list = [
+    { type: "claude_local" },
+    { type: "codex_local" },
+    { type: "pi_local" },
+  ];
+  mockCompaniesApi.create.mockResolvedValue({ id: "company-new", issuePrefix: "INI" });
+  window.localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ step: 1, onboardingPath: "create", companyName: "Initech" }),
+  );
+  mockDialog.onboardingOptions = {};
+  mockCompany.companies = [];
+  mockCompany.loading = false;
+  mockCompaniesApi.list.mockResolvedValue([]);
+
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  queryClient.setQueryData(queryKeys.auth.session, {
+    session: { id: "session-b", userId: SESSION_USER_ID },
+    user: { id: SESSION_USER_ID, name: "B", email: "b@example.com", image: null },
+  });
+  await act(async () => {
+    root.render(
+      <QueryClientProvider client={queryClient}>
+        <OnboardingWizard />
+      </QueryClientProvider>,
+    );
+  });
+  await flushReact();
+
+  const clickByText = async (match: (text: string) => boolean) => {
+    const el = [...document.body.querySelectorAll("button")].find((b) =>
+      match(b.textContent?.trim() ?? ""),
+    )!;
+    await act(async () => {
+      el.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    await flushReact();
+  };
+
+  await clickByText((t) => t.startsWith("Continue"));
+  const agentField = document.body.querySelector(
+    "#onboarding-agent-name",
+  ) as HTMLInputElement;
+  await act(async () => {
+    setControlledValue(agentField, "Ada");
+  });
+  await flushReact();
+  await clickByText((t) => t.startsWith("Next"));
+  expect(document.body.textContent).toContain("Connect a model");
+
+  // Pick the Pi tile from the source row. The tile is labelled by
+  // CONNECT_SOURCE_NAMES ("Pi"), not by the type id, and the credential tag
+  // trails it in the same text node — match on the leading label.
+  const piTile = [...document.body.querySelectorAll("button[aria-checked]")].find(
+    (b) => b.textContent?.startsWith("Pi"),
+  )!;
+  await act(async () => {
+    piTile.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+  await flushReact();
+
+  return { root, clickByText };
+}
+
+/** The arc footer's primary button, whatever this step calls it. */
+function isArcPrimary(text: string): boolean {
+  return text.startsWith("Next") || text.startsWith("Connect");
+}
+
+describe("OnboardingWizard explicit model input (pi_local)", () => {
+  beforeEach(() => {
+    mockAuthApi.getSession.mockResolvedValue({
+      session: { id: "session-b", userId: SESSION_USER_ID },
+      user: { id: SESSION_USER_ID, name: "B", email: "b@example.com", image: null },
+    });
+    window.localStorage.clear();
+    mockDialog.onboardingOpen = true;
+    mockDialog.onboardingOptions = {};
+    mockDialog.onboardingRouteDismissed = false;
+    mockCompany.companies = [];
+    mockCompany.loading = false;
+    mockCompany.error = null;
+    mockCompaniesApi.list.mockResolvedValue([]);
+    mockAdapterRegistry.list = [];
+    mockAdapterRegistry.disabled = new Set<string>();
+    mockAdapterBuild.buildAdapterConfig.mockReset();
+    mockAdapterBuild.buildAdapterConfig.mockImplementation(
+      (values: { model?: string }) => ({ model: values.model } as Record<string, unknown>),
+    );
+    mockAgentsApi.getClaudeOAuthTokenStatus.mockReset();
+    mockAgentsApi.getClaudeOAuthTokenStatus.mockRejectedValue(
+      new ApiError("Not found", 404, null),
+    );
+    mockAgentsApi.testEnvironment.mockReset();
+    mockAgentsApi.testEnvironment.mockResolvedValue({
+      adapterType: "pi_local",
+      status: "pass" as const,
+      checks: [],
+      testedAt: new Date().toISOString(),
+    });
+    mockAgentsApi.hire.mockReset();
+    mockAgentsApi.hire.mockResolvedValue({ agent: { id: "agent-1" }, approval: null });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.clearAllMocks();
+  });
+
+  it("shows a model input when pi_local is the chosen source", async () => {
+    const { root } = await openConnectStepWithPi();
+
+    const modelInput = document.body.querySelector("#onboarding-model") as HTMLInputElement;
+    expect(modelInput).toBeTruthy();
+    // No value is pre-filled: pi has no safe default (see STU-27), and a
+    // seeded suggestion is exactly the bogus default the step must not pick.
+    expect(modelInput.value).toBe("");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("blocks the hire on an empty model with a clear client-side error, before any hire request", async () => {
+    const { root, clickByText } = await openConnectStepWithPi();
+
+    await clickByText((t) => isArcPrimary(t));
+
+    expect(mockAgentsApi.hire).not.toHaveBeenCalled();
+    expect(mockAgentsApi.testEnvironment).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain(
+      "Pi requires an explicit model in provider/model format.",
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("blocks the hire on a malformed model id, not just an empty one", async () => {
+    const { root, clickByText } = await openConnectStepWithPi();
+
+    const modelInput = document.body.querySelector("#onboarding-model") as HTMLInputElement;
+    await act(async () => {
+      // A bare model name with no provider half: the adapter's own shape
+      // check (isValidPiModelId) rejects it, so the step must too.
+      setControlledValue(modelInput, "grok-4");
+    });
+    await flushReact();
+    await clickByText((t) => isArcPrimary(t));
+
+    expect(mockAgentsApi.hire).not.toHaveBeenCalled();
+    expect(document.body.textContent).toContain(
+      "Pi requires an explicit model in provider/model format.",
+    );
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("carries the typed model verbatim into the hire's adapter config", async () => {
+    const { root, clickByText } = await openConnectStepWithPi();
+
+    const modelInput = document.body.querySelector("#onboarding-model") as HTMLInputElement;
+    await act(async () => {
+      setControlledValue(modelInput, "xai/grok-4");
+    });
+    await flushReact();
+    await clickByText((t) => isArcPrimary(t));
+
+    expect(mockAgentsApi.hire).toHaveBeenCalledTimes(1);
+    const hireBody = (mockAgentsApi.hire.mock.calls.at(-1) as unknown[])[1] as {
+      adapterType: string;
+      adapterConfig: { model?: string };
+    };
+    expect(hireBody.adapterType).toBe("pi_local");
+    // Verbatim: whatever was typed is what the built config carries — no
+    // default is substituted on the way through buildAdapterConfig.
+    expect(hireBody.adapterConfig.model).toBe("xai/grok-4");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+
+  it("recovers after the blocked attempt once a valid model is typed", async () => {
+    const { root, clickByText } = await openConnectStepWithPi();
+
+    // First press blocks: empty model.
+    await clickByText((t) => isArcPrimary(t));
+    expect(mockAgentsApi.hire).not.toHaveBeenCalled();
+
+    // Type a valid id and press again: the same press now hires.
+    const modelInput = document.body.querySelector("#onboarding-model") as HTMLInputElement;
+    await act(async () => {
+      setControlledValue(modelInput, "anthropic/claude-sonnet-5");
+    });
+    await flushReact();
+    await clickByText((t) => isArcPrimary(t));
+
+    expect(mockAgentsApi.hire).toHaveBeenCalledTimes(1);
+    const hireBody = (mockAgentsApi.hire.mock.calls.at(-1) as unknown[])[1] as {
+      adapterConfig: { model?: string };
+    };
+    expect(hireBody.adapterConfig.model).toBe("anthropic/claude-sonnet-5");
+
+    await act(async () => {
+      root.unmount();
+    });
+  });
+});

--- a/ui/src/components/OnboardingWizard.tsx
+++ b/ui/src/components/OnboardingWizard.tsx
@@ -101,6 +101,7 @@ import { DEFAULT_CURSOR_LOCAL_MODEL } from "@paperclipai/adapter-cursor-local";
 import { DEFAULT_GEMINI_LOCAL_MODEL } from "@paperclipai/adapter-gemini-local";
 import { DEFAULT_KIMI_LOCAL_MODEL } from "@paperclipai/adapter-kimi-local";
 import { DEFAULT_OPENCODE_LOCAL_MODEL, isValidOpenCodeModelId } from "@paperclipai/adapter-opencode-local";
+import { isValidPiModelId } from "@paperclipai/adapter-pi-local";
 import {
   canGoBackFromOnboardingStep,
   canJumpToOnboardingStep,
@@ -273,6 +274,32 @@ const API_KEY_ENV_KEYS: Record<string, string> = {
 
 function apiKeyEnvKeyFor(adapterType: string): string {
   return API_KEY_ENV_KEYS[adapterType] ?? "API_KEY";
+}
+
+/**
+ * Adapters with no safe default model, keyed by the adapter's own shape check.
+ *
+ * The server's `assertAdapterConfigConstraints` rejects a hire for these
+ * adapters unless `adapterConfig.model` holds an explicit, valid id (pi
+ * routing is gateway/provider-specific per company, so no default can be
+ * right for everyone — see STU-27). This step is where the value comes from,
+ * so it collects the model and validates it with the same check before the
+ * hire, mirroring the `opencode_local` gate in `handleGiveHeartbeat` — the
+ * customer sees a clear field-level error rather than a server 422.
+ *
+ * An entry here composes end-to-end: the connect step renders a model input
+ * for the adapter, `buildAdapterConfig` passes the typed value through
+ * untouched (no default is introduced on either side), and the hire blocks
+ * on the entry's validator. Adding the next explicit-model adapter is adding
+ * one line here.
+ */
+const EXPLICIT_MODEL_VALIDATORS: Record<string, (value: string) => boolean> = {
+  pi_local: isValidPiModelId,
+};
+
+/** True when the adapter requires an explicitly typed model with no default. */
+function requiresExplicitModel(adapterType: string): boolean {
+  return Object.prototype.hasOwnProperty.call(EXPLICIT_MODEL_VALIDATORS, adapterType);
 }
 
 function ModelSourceMark({
@@ -2172,6 +2199,20 @@ function OnboardingWizardInner({
     setLoading(true);
     setError(null);
     try {
+      // Same fail-fast the server applies in `assertAdapterConfigConstraints`,
+      // one hop earlier: an adapter with no safe default model must not reach
+      // the hire with an empty or malformed model. The check is the adapter's
+      // own shape check (see EXPLICIT_MODEL_VALIDATORS), so the customer sees
+      // what this step is missing — not the server's 422 after the probe.
+      if (requiresExplicitModel(adapterType)) {
+        const selectedModelId = model.trim();
+        if (!EXPLICIT_MODEL_VALIDATORS[adapterType]!(selectedModelId)) {
+          setError(
+            `${connectSourceLabel} requires an explicit model in provider/model format.`
+          );
+          return;
+        }
+      }
       if (adapterType === "opencode_local") {
         const selectedModelId = model.trim();
         if (!isValidOpenCodeModelId(selectedModelId)) {
@@ -3221,11 +3262,39 @@ function OnboardingWizardInner({
                   </motion.div>
 
                   {/* Conditional adapter fields */}
-                  {/* No model picker. Every adapter this step offers resolves
-                      its own default (see buildAdapterConfig), so the picker
-                      asked the customer to choose a model before they had any
-                      way to judge one — and the agent's model is changeable
-                      later, where its work gives the choice meaning. */}
+                  {/* No model picker for the sources that resolve their own
+                      default (see buildAdapterConfig): the picker asked the
+                      customer to choose a model before they had any way to
+                      judge one — and the agent's model is changeable later,
+                      where its work gives the choice meaning.
+
+                      The exception is an adapter with no safe default at all
+                      (see EXPLICIT_MODEL_VALIDATORS): there the model is not a
+                      preference but a required field, so this step collects it
+                      and the hire blocks until it holds a valid id. */}
+                  {requiresExplicitModel(adapterType) && (
+                    <div>
+                      <label
+                        htmlFor="onboarding-model"
+                        className="text-xs text-muted-foreground mb-1 block"
+                      >
+                        Model
+                      </label>
+                      <input
+                        id="onboarding-model"
+                        className="w-full rounded-md border border-border bg-transparent px-3 py-2 text-sm font-mono outline-none focus:ring-1 focus:ring-ring placeholder:text-muted-foreground/50"
+                        placeholder="provider/model, e.g. xai/grok-4"
+                        value={model}
+                        onChange={(e) => setModel(e.target.value)}
+                      />
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {connectSourceLabel} has no default model: routing is
+                        provider-specific, so the model id has to be yours. List
+                        what your Pi install offers with{" "}
+                        <span className="font-mono">pi --list-models</span>.
+                      </p>
+                    </div>
+                  )}
 
                   {/* The environment check runs without being shown: Connect
                       probes the adapter before hiring (see handleGiveHeartbeat)


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The onboarding wizard walks a new user from an empty instance to a first hired agent. Its "Connect a model" step offers the local adapter sources.
> - The `pi_local` adapter has no safe default model: Pi model routing is gateway and provider specific per company, so no single model id can be right for every install.
> - The server already knew this and rejected a `pi_local` hire with an empty or malformed `adapterConfig.model` at creation time. But the wizard rendered no model input for any adapter, so a Pi hire from the wizard always failed on that rejection, and the user had no field to fix it.
> - This pull request makes both sides of the contract meet: the server keeps the fail-fast validation, and the wizard collects and validates the model before the hire, with the adapter's own shape check.
> - The benefit is that a new user can hire a Pi agent from the onboarding wizard on the first try, with a clear field-level error instead of a server 422.

## Linked Issues or Issue Description

**What happened?**

- Step 4 of the onboarding wizard ("Connect a model") showed no model input for any adapter.
- Every adapter it offered resolved its own `DEFAULT_*_MODEL` constant in `buildAdapterConfig` when the model state was empty (gemini, kimi, cursor, opencode).
- `pi_local` has no such default by design. The server's `assertAdapterConfigConstraints` (`server/src/routes/agents.ts`) rejects an empty or malformed `pi_local` model at agent-creation time.
- Result: a Pi hire from the wizard sent an empty `adapterConfig.model` and died on the server's 422 (`pi_local adapterConfig.model is required in provider/model format`), with no way to supply the value in the wizard UI.

**Expected behavior**

- The wizard shows a model input for adapters that require an explicit model (currently `pi_local`).
- The hire is blocked client-side with a clear error while the typed value is empty or malformed.
- A valid `provider/model` value reaches the hire verbatim, and the hire succeeds.

**Steps to reproduce**

1. Start a fresh instance and open the onboarding wizard.
2. Create an organization, name the first agent, and advance to "Connect a model".
3. Pick the Pi source and press "Connect" without any way to enter a model.
4. The hire fails with the server's 422 for an empty `adapterConfig.model`.

**Agent adapter(s) involved**

- `pi_local`

(Supersedes #13033, which carried the server-side half of this change. The two halves are one contract — the validation is only correct together with a UI that can satisfy it — so they land together here.)

## What Changed

- `packages/adapters/pi-local/src/index.ts`: export `isValidPiModelId`, a provider/model shape check (non-empty string with a `/` that is neither first nor last character), mirroring the OpenCode adapter's `isValidOpenCodeModelId`.
- `server/src/routes/agents.ts`: `assertAdapterConfigConstraints` validates the `pi_local` `adapterConfig.model` at agent create and update time, so a bad model fails at hire time instead of at first heartbeat.
- `ui/src/components/OnboardingWizard.tsx`: step 4 renders a model input for adapters with no safe default, keyed off `EXPLICIT_MODEL_VALIDATORS` (an adapter-type to shape-check map, currently `pi_local`) instead of hardcoded adapter checks, so the next explicit-model adapter is one added line. "Connect" validates the typed value with the adapter's own shape check and blocks client-side with a field-level error, mirroring the `opencode_local` gate in `handleGiveHeartbeat`. `buildAdapterConfig` still passes the typed model through untouched for `pi_local` — no default is introduced anywhere.
- `ui/src/adapters/adapter-display-registry.ts` and `ui/src/components/AdapterLoginChrome.tsx`: mark `pi_local` as a recommended source with a connect label, so its tile renders on the connect step.
- No `DEFAULT_PI` constant exists anywhere, on purpose: a bogus default model on a hired agent is exactly the failure mode the server validation exists to reject.

## Verification

- `npx vitest run src/components/OnboardingWizard.model-input.test.tsx src/components/OnboardingWizard.adapters.test.tsx` (in `ui/`): 10/10 pass. The new sibling suite covers: the model input appears and starts empty (no seeded suggestion), an empty or malformed model blocks the hire client-side before any request leaves the page, a valid typed model reaches the hire's adapter config verbatim, and a blocked attempt recovers once a valid model is typed.
- `npx vitest run src/__tests__/agent-permissions-routes.test.ts` (in `server/`): 66/66 pass, including the creation-route cases for missing, malformed, and valid `pi_local` model ids.
- `npx playwright test --config tests/e2e/playwright.config.ts -g "pi_local collects an explicit model"`: passes. The e2e case walks a full Pi hire through the wizard end-to-end — empty and malformed models block with the client-side error and no hire request, a valid `xai/grok-4` completes the hire (201), and the created agent's `adapterConfig.model` carries the typed value verbatim.
- `pnpm typecheck` in `ui/` passes.
- The gemini/kimi/cursor/opencode default-model paths are untouched; their existing tests pass unchanged.

## Risks

- Low risk for existing adapters: the change is additive. The only behavioral change on the server is that a `pi_local` hire or update with a missing or malformed model now fails at creation/update time instead of at first heartbeat — which surfaces a pre-existing breakage earlier.
- A saved wizard state that already selected `pi_local` now requires a typed model where none was collected before; the wizard blocks with a clear message until one is provided.

## Model Used

- Claude Sonnet 4.5 (Anthropic), via the `pi_local` adapter — agent-driven implementation and test authoring with file and shell tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs: #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
