### PR TITLE
fix(server): ignore task watchdog child completions

### DIFF
--- a/doc/task-watchdog-child-completion-graft-runbook.md
+++ b/doc/task-watchdog-child-completion-graft-runbook.md
@@ -1,0 +1,59 @@
+# Task-watchdog child-completion graft runbook
+
+This runbook hands the reviewed source fix to a release owner without replacing
+newer routing overlays with build output from the validation base. The private
+delivery manifest identifies the approved source commit, exact active preimage,
+and replay-bundle attachment; those environment-specific values do not belong in
+the public repository.
+
+## Source acceptance
+
+1. Confirm that the production source diff contains exactly three line-neutral
+   replacements: two terminal caller guards and one filtered child query.
+2. Run the focused route/service tests and
+   `scripts/smoke/task-watchdog-child-completion.sh`.
+3. Run server typecheck, server and CLI builds, the repository test suites, and
+   the release smoke required by `doc/DEVELOPING.md`. Record every exit code;
+   classify skips or baseline failures explicitly rather than calling them pass.
+4. Confirm that the native runtime path is either covered by its adjacent tests
+   or recorded as absent in the private applicability manifest. Do not copy a
+   native subsystem from another branch into an older validation base.
+
+## Fail-closed candidate construction
+
+1. Build the clean validation base and approved source commit with the same
+   lockfile, Node version, package-manager version, and build command in separate
+   isolated checkouts.
+2. Verify the build delta with the approved private replay bundle. Both target
+   JavaScript files must change, no generated line may be added or removed, and
+   the changed-path set must remain within the two target JavaScript files and
+   their source maps.
+3. Run the bundle's line-delta, tree-delta, and source-map graft checks. Any
+   preimage drift, ambiguous replacement, mapping reflow on an unchanged
+   generated line, or non-target hash drift is a hard stop. Do not relax a gate.
+4. Graft only the reviewed changed lines and their aligned mappings onto the
+   byte-exact active preimage. Never copy complete route or service build output
+   from the validation base over the active release.
+5. Create a new immutable copy-on-write release. Record full pre/post manifests,
+   target hashes, the source commit, bundle checksum, toolchain, service command,
+   approvals, and rollback target before activation.
+
+## Staged verification and rollback
+
+1. Run package-integrity and JavaScript syntax checks on the staged release.
+2. Run `scripts/smoke/task-watchdog-child-completion.sh` for the behavioral
+   contract. Optionally pass an explicit test/staging health endpoint and the
+   continuity report:
+
+   ```sh
+   scripts/smoke/task-watchdog-child-completion.sh \
+     --health-url http://127.0.0.1:3100/api/health \
+     --continuity-json /path/to/continuity.json
+   ```
+
+3. Verify that the service command resolves to the new immutable release and
+   that the continuity report has `lostRunIds=[]`. Use a dedicated test area;
+   never use a live business issue as a probe.
+4. Activation and rollback require the designated root approver. Rollback removes
+   only the new activation layer and restores the recorded immutable predecessor;
+   rerun health, continuity, and the smoke after rollback.

--- a/scripts/smoke/task-watchdog-child-completion.sh
+++ b/scripts/smoke/task-watchdog-child-completion.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/smoke/task-watchdog-child-completion.sh [options]
+
+Runs the watchdog child-completion contract through real Express routes and an
+isolated embedded PostgreSQL instance. It never launches agent workers.
+
+Options:
+  --health-url URL          Also require an explicit test/staging /api/health endpoint to report status=ok.
+  --continuity-json FILE    Also require a release continuity report whose lostRunIds array is empty.
+  -h, --help                Show this help.
+
+Do not point --health-url at a live business environment. The behavioral smoke
+creates its own test company only inside the embedded test database.
+EOF
+}
+
+health_url=""
+continuity_json=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --health-url)
+      [[ $# -ge 2 ]] || { echo "--health-url requires a value" >&2; exit 2; }
+      health_url="$2"
+      shift 2
+      ;;
+    --continuity-json)
+      [[ $# -ge 2 ]] || { echo "--continuity-json requires a value" >&2; exit 2; }
+      continuity_json="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -n "${DATABASE_URL:-}" ]]; then
+  echo "Refusing to run with DATABASE_URL set; this smoke owns an isolated embedded PostgreSQL instance." >&2
+  exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+cd "$repo_root"
+
+pnpm exec vitest run \
+  server/src/__tests__/task-watchdog-child-completion-e2e.test.ts \
+  --reporter=verbose
+
+if [[ -n "$health_url" ]]; then
+  [[ "$health_url" == */api/health ]] || {
+    echo "--health-url must end in /api/health" >&2
+    exit 2
+  }
+  health_payload="$(curl --fail --silent --show-error --max-time 10 "$health_url")"
+  node -e '
+    const payload = JSON.parse(process.argv[1]);
+    if (payload.status !== "ok") {
+      throw new Error(`Expected health status=ok, received ${JSON.stringify(payload)}`);
+    }
+  ' "$health_payload"
+fi
+
+if [[ -n "$continuity_json" ]]; then
+  [[ -f "$continuity_json" ]] || {
+    echo "Continuity report not found: $continuity_json" >&2
+    exit 2
+  }
+  node -e '
+    const fs = require("node:fs");
+    const payload = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    if (!Array.isArray(payload.lostRunIds) || payload.lostRunIds.length !== 0) {
+      throw new Error(`Expected lostRunIds=[], received ${JSON.stringify(payload.lostRunIds)}`);
+    }
+  ' "$continuity_json"
+fi
+
+echo "task-watchdog child-completion smoke: PASS"

--- a/scripts/smoke/task-watchdog-child-completion.sh
+++ b/scripts/smoke/task-watchdog-child-completion.sh
@@ -53,9 +53,36 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/../.." && pwd)"
 cd "$repo_root"
 
+scratch_root="${PAPERCLIP_RUN_SCRATCH_DIR:-${PAPERCLIP_SCRATCH_DIR:-${TMPDIR:-/tmp}}}"
+[[ -d "$scratch_root" ]] || {
+  echo "Smoke scratch directory not found: $scratch_root" >&2
+  exit 2
+}
+smoke_tmp_dir="$(mktemp -d "$scratch_root/task-watchdog-child-completion.XXXXXX")"
+trap 'rm -rf "$smoke_tmp_dir"' EXIT
+vitest_report="$smoke_tmp_dir/vitest-report.json"
+
 pnpm exec vitest run \
   server/src/__tests__/task-watchdog-child-completion-e2e.test.ts \
-  --reporter=verbose
+  --reporter=verbose \
+  --reporter=json \
+  --outputFile.json="$vitest_report"
+
+node -e '
+  const fs = require("node:fs");
+  const report = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+  const total = report.numTotalTests;
+  const passed = report.numPassedTests;
+  const failed = report.numFailedTests;
+  const pending = report.numPendingTests;
+  if (![total, passed, failed, pending].every(Number.isInteger)
+      || total < 1
+      || passed !== total
+      || failed !== 0
+      || pending !== 0) {
+    throw new Error(`Watchdog smoke did not execute every test: ${JSON.stringify({ total, passed, failed, pending })}`);
+  }
+' "$vitest_report"
 
 if [[ -n "$health_url" ]]; then
   [[ "$health_url" == */api/health ]] || {

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -2551,6 +2551,84 @@ describe.sequential("issue comment reopen routes", () => {
     );
   });
 
+  it("does not evaluate or wake the parent when a task_watchdog completes through an approval comment", async () => {
+    const reviewerAgentId = "33333333-3333-4333-8333-333333333333";
+    const policy = await normalizePolicy({
+      stages: [
+        {
+          id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          type: "review",
+          participants: [{ type: "agent", agentId: reviewerAgentId }],
+        },
+      ],
+    })!;
+    const issue = {
+      ...makeIssue("todo"),
+      status: "in_review",
+      parentId: "parent-1",
+      originKind: "task_watchdog",
+      assigneeAgentId: reviewerAgentId,
+      executionPolicy: policy,
+      executionState: {
+        status: "pending",
+        currentStageId: policy.stages[0].id,
+        currentStageIndex: 0,
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: reviewerAgentId },
+        returnAssignee: { type: "agent", agentId: "22222222-2222-4222-8222-222222222222" },
+        completedStageIds: [],
+        lastDecisionId: null,
+        lastDecisionOutcome: null,
+      },
+    };
+    const reviewBody = "## Review: PAP-580 - APPROVED\n\nLooks good.";
+    mockIssueService.getById.mockResolvedValue(issue);
+    mockIssueService.addComment.mockResolvedValue({
+      id: "comment-review-watchdog",
+      issueId: issue.id,
+      companyId: issue.companyId,
+      body: reviewBody,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      authorAgentId: reviewerAgentId,
+      authorUserId: null,
+    });
+    mockIssueService.update.mockImplementation(async (_id: string, update: Record<string, unknown>, tx?: unknown) => ({
+      ...issue,
+      ...update,
+      status: "done",
+      completedAt: new Date(),
+      updatedAt: new Date(),
+      _tx: tx,
+    }));
+    mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue({
+      id: "parent-1",
+      assigneeAgentId: "agent-9",
+      childIssueIds: [issue.id],
+      childIssueSummaries: [],
+      childIssueSummaryTruncated: false,
+    });
+
+    const res = await request(
+      await installActor(createApp(), {
+        type: "agent",
+        agentId: reviewerAgentId,
+        companyId: "company-1",
+        source: "agent_key",
+        runId: "run-review-watchdog",
+      }),
+    )
+      .post(`/api/issues/${issue.id}/comments`)
+      .send({ body: reviewBody });
+
+    expect(res.status).toBe(201);
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mockIssueService.getWakeableParentAfterChildCompletion).not.toHaveBeenCalled();
+    expect(
+      mockHeartbeatService.wakeup.mock.calls.some(([, wakeup]) => wakeup.reason === "issue_children_completed"),
+    ).toBe(false);
+  });
+
   it("auto-approves a reviewer comment with structured review metadata", async () => {
     const reviewerAgentId = "33333333-3333-4333-8333-333333333333";
     const policy = await normalizePolicy({

--- a/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
+++ b/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
@@ -62,6 +62,9 @@ vi.mock("../services/index.js", () => ({
   heartbeatService: () => ({
     wakeup: mockWakeup,
     reportRunActivity: vi.fn(async () => undefined),
+    getRun: vi.fn(async () => null),
+    getActiveRunForAgent: vi.fn(async () => null),
+    cancelRun: vi.fn(async () => null),
   }),
   getIssueContinuationSummaryDocument: vi.fn(async () => null),
   instanceSettingsService: () => ({
@@ -326,6 +329,7 @@ describe("issue dependency wakeups in issue routes", () => {
       status: "in_progress",
       priority: "medium",
       parentId: "parent-1",
+      originKind: "task_watchdog_product_bug",
       assigneeAgentId: "agent-1",
       assigneeUserId: null,
       createdByAgentId: null,
@@ -343,6 +347,7 @@ describe("issue dependency wakeups in issue routes", () => {
       status: "done",
       priority: "medium",
       parentId: "parent-1",
+      originKind: "task_watchdog_product_bug",
       assigneeAgentId: "agent-1",
       assigneeUserId: null,
       createdByAgentId: null,
@@ -681,4 +686,45 @@ describe("issue dependency wakeups in issue routes", () => {
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(mockWakeup).not.toHaveBeenCalled();
   });
+  it.each(["done", "cancelled"] as const)(
+    "does not evaluate or wake the parent when an exact task_watchdog child becomes %s",
+    async (status) => {
+      const watchdog = {
+        id: "watchdog-1",
+        companyId: "company-1",
+        identifier: "PAP-102",
+        title: "Synthetic watchdog",
+        description: null,
+        status: "in_progress",
+        priority: "medium",
+        parentId: "parent-1",
+        originKind: "task_watchdog",
+        assigneeAgentId: "agent-1",
+        assigneeUserId: null,
+        createdByAgentId: null,
+        createdByUserId: null,
+        executionWorkspaceId: null,
+        labels: [],
+        labelIds: [],
+      };
+      mockIssueService.getById.mockResolvedValue(watchdog);
+      mockIssueService.update.mockResolvedValue({ ...watchdog, status });
+      mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue({
+        id: "parent-1",
+        assigneeAgentId: "agent-9",
+        childIssueIds: [watchdog.id],
+        childIssueSummaries: [],
+        childIssueSummaryTruncated: false,
+      });
+
+      const res = await request(await createApp())
+        .patch(`/api/issues/${watchdog.id}`)
+        .send({ status });
+
+      expect(res.status).toBe(200);
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(mockIssueService.getWakeableParentAfterChildCompletion).not.toHaveBeenCalled();
+      expect(mockWakeup.mock.calls.some(([, wakeup]) => wakeup.reason === "issue_children_completed")).toBe(false);
+    },
+  );
 });

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -4807,6 +4807,126 @@ describeEmbeddedPostgres("issueService blockers and dependency wake readiness", 
       childIssueSummaryTruncated: false,
     });
   });
+
+  it("excludes only exact task_watchdog children before readiness, ids, summaries, and truncation", async () => {
+    const companyId = randomUUID();
+    const assigneeAgentId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: assigneeAgentId,
+      companyId,
+      name: "CodexCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+
+    // Keep the explicit IS NULL compatibility branch covered even though current
+    // installations create origin_kind as NOT NULL. Older restored databases may
+    // still contain nulls, and the child-completion contract keeps them as work.
+    await db.execute(sql.raw('ALTER TABLE "issues" ALTER COLUMN "origin_kind" DROP NOT NULL'));
+
+    const parentId = randomUUID();
+    const watchdogOnlyParentId = randomUUID();
+    const normalChildIds = Array.from({ length: 20 }, () => randomUUID());
+    const watchdogChildIds = Array.from({ length: 5 }, () => randomUUID());
+    await db.insert(issues).values([
+      {
+        id: parentId,
+        companyId,
+        issueNumber: 1,
+        title: "Parent with real work",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId,
+      },
+      {
+        id: watchdogOnlyParentId,
+        companyId,
+        issueNumber: 2,
+        title: "Watchdog-only parent",
+        status: "todo",
+        priority: "medium",
+        assigneeAgentId,
+      },
+      ...normalChildIds.map((id, index) => ({
+        id,
+        companyId,
+        parentId,
+        issueNumber: 10 + index,
+        title: `Work child ${index + 1}`,
+        status: index === normalChildIds.length - 1 ? "todo" : "done",
+        priority: "medium",
+        originKind:
+          index === 0
+            ? (null as unknown as string)
+            : index === 1
+              ? "task_watchdog_product_bug"
+              : index === 2
+                ? "custom_automation"
+                : "manual",
+      })),
+      ...watchdogChildIds.map((id, index) => ({
+        id,
+        companyId,
+        parentId,
+        issueNumber: 100 + index,
+        title: `Synthetic watchdog ${index + 1}`,
+        status: index % 2 === 0 ? "todo" : "in_progress",
+        priority: "medium",
+        originKind: "task_watchdog",
+      })),
+      {
+        id: randomUUID(),
+        companyId,
+        parentId: watchdogOnlyParentId,
+        issueNumber: 200,
+        title: "Only synthetic child",
+        status: "done",
+        priority: "medium",
+        originKind: "task_watchdog",
+      },
+    ]);
+
+    expect(await svc.getWakeableParentAfterChildCompletion(parentId)).toBeNull();
+    expect(await svc.getWakeableParentAfterChildCompletion(watchdogOnlyParentId)).toBeNull();
+
+    await svc.update(normalChildIds.at(-1)!, { status: "done" });
+    const ready = await svc.getWakeableParentAfterChildCompletion(parentId);
+    expect(ready).toMatchObject({
+      id: parentId,
+      assigneeAgentId,
+      childIssueSummaryTruncated: false,
+    });
+    expect(ready?.childIssueIds).toEqual(normalChildIds);
+    expect(ready?.childIssueSummaries).toHaveLength(20);
+    expect(ready?.childIssueSummaries.map((child) => child.id)).toEqual(normalChildIds);
+    expect(ready?.childIssueIds.some((id) => watchdogChildIds.includes(id))).toBe(false);
+
+    const twentyFirstWorkChildId = randomUUID();
+    await db.insert(issues).values({
+      id: twentyFirstWorkChildId,
+      companyId,
+      parentId,
+      issueNumber: 30,
+      title: "Twenty-first work child",
+      status: "cancelled",
+      priority: "medium",
+      originKind: "manual",
+    });
+    const truncated = await svc.getWakeableParentAfterChildCompletion(parentId);
+    expect(truncated?.childIssueIds).toEqual([...normalChildIds, twentyFirstWorkChildId]);
+    expect(truncated?.childIssueSummaries).toHaveLength(20);
+    expect(truncated?.childIssueSummaryTruncated).toBe(true);
+  });
 });
 
 describeEmbeddedPostgres("issueService.create workspace inheritance", () => {

--- a/server/src/__tests__/task-watchdog-child-completion-e2e.test.ts
+++ b/server/src/__tests__/task-watchdog-child-completion-e2e.test.ts
@@ -1,0 +1,645 @@
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import express from "express";
+import request from "supertest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  activityLog,
+  agentWakeupRequests,
+  agents,
+  companies,
+  companyMemberships,
+  createDb,
+  heartbeatRuns,
+  issueComments,
+  issueExecutionDecisions,
+  issueRelations,
+  issueThreadInteractions,
+  issueWatchdogs,
+  issues,
+  principalPermissionGrants,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+
+const heartbeatDouble = vi.hoisted(() => ({
+  wakeup: vi.fn(),
+  reportRunActivity: vi.fn(async () => undefined),
+  getRun: vi.fn(async () => null),
+  getActiveRunForAgent: vi.fn(async () => null),
+  cancelRun: vi.fn(async () => null),
+}));
+
+vi.mock("../services/heartbeat.js", async () => {
+  const actual = await vi.importActual<typeof import("../services/heartbeat.js")>("../services/heartbeat.js");
+  return {
+    ...actual,
+    heartbeatService: () => heartbeatDouble,
+  };
+});
+
+import { errorHandler } from "../middleware/index.js";
+import { issueRoutes } from "../routes/issues.js";
+import { normalizeIssueExecutionPolicy } from "../services/issue-execution-policy.js";
+import { ensureHumanRoleDefaultGrants } from "../services/principal-access-compatibility.js";
+import { taskWatchdogService } from "../services/task-watchdogs.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe.sequential : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping task-watchdog child-completion API/PostgreSQL tests: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describeEmbeddedPostgres("task-watchdog child-completion API/PostgreSQL boundary", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-watchdog-child-completion-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    heartbeatDouble.reportRunActivity.mockResolvedValue(undefined);
+    heartbeatDouble.getRun.mockResolvedValue(null);
+    heartbeatDouble.getActiveRunForAgent.mockResolvedValue(null);
+    heartbeatDouble.cancelRun.mockResolvedValue(null);
+    heartbeatDouble.wakeup.mockImplementation(async (agentId: string, options: Record<string, any> = {}) => {
+      const agent = await db
+        .select({ companyId: agents.companyId })
+        .from(agents)
+        .where(eq(agents.id, agentId))
+        .then((rows) => rows[0] ?? null);
+      if (!agent) throw new Error(`Missing queued-wake agent ${agentId}`);
+
+      if (typeof options.idempotencyKey === "string") {
+        const existing = await db
+          .select({ runId: agentWakeupRequests.runId })
+          .from(agentWakeupRequests)
+          .where(and(
+            eq(agentWakeupRequests.companyId, agent.companyId),
+            eq(agentWakeupRequests.agentId, agentId),
+            eq(agentWakeupRequests.idempotencyKey, options.idempotencyKey),
+          ))
+          .then((rows) => rows[0] ?? null);
+        if (existing?.runId) return { id: existing.runId };
+      }
+
+      const wakeupRequestId = randomUUID();
+      const runId = randomUUID();
+      await db.transaction(async (tx) => {
+        await tx.insert(agentWakeupRequests).values({
+          id: wakeupRequestId,
+          companyId: agent.companyId,
+          agentId,
+          source: options.source ?? "automation",
+          triggerDetail: options.triggerDetail ?? null,
+          reason: options.reason ?? null,
+          payload: options.payload ?? null,
+          status: "queued",
+          requestedByActorType: options.requestedByActorType ?? null,
+          requestedByActorId: options.requestedByActorId ?? null,
+          idempotencyKey: options.idempotencyKey ?? null,
+        });
+        await tx.insert(heartbeatRuns).values({
+          id: runId,
+          companyId: agent.companyId,
+          agentId,
+          invocationSource: options.source ?? "automation",
+          triggerDetail: options.triggerDetail ?? null,
+          status: "queued",
+          wakeupRequestId,
+          contextSnapshot: options.contextSnapshot ?? options.payload ?? null,
+        });
+        await tx
+          .update(agentWakeupRequests)
+          .set({ runId, updatedAt: new Date() })
+          .where(eq(agentWakeupRequests.id, wakeupRequestId));
+      });
+      return { id: runId };
+    });
+  });
+
+  afterEach(async () => {
+    await settleWakeups();
+    await db.delete(activityLog);
+    await db.delete(issueExecutionDecisions);
+    await db.delete(issueThreadInteractions);
+    await db.delete(issueComments);
+    await db.delete(issueRelations);
+    await db.delete(issueWatchdogs);
+    await db.delete(issues);
+    await db.delete(heartbeatRuns);
+    await db.delete(agentWakeupRequests);
+    await db.delete(agents);
+    await db.delete(principalPermissionGrants);
+    await db.delete(companyMemberships);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  function createApp(companyId: string) {
+    const app = express();
+    app.use(express.json());
+    app.use((req, _res, next) => {
+      req.actor = {
+        type: "board",
+        userId: "cloud-user-1",
+        companyIds: [companyId],
+        memberships: [{ companyId, membershipRole: "owner", status: "active" }],
+        source: "cloud_tenant",
+        isInstanceAdmin: false,
+      };
+      next();
+    });
+    app.use("/api", issueRoutes(db, {} as any, { taskWatchdogEnqueueWakeup: null }));
+    app.use(errorHandler);
+    return app;
+  }
+
+  async function settleWakeups() {
+    let previousCallCount = -1;
+    let stablePasses = 0;
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      const wakeupPromises = heartbeatDouble.wakeup.mock.results
+        .map((result) => result.value)
+        .filter((value): value is Promise<unknown> => value instanceof Promise);
+      await Promise.allSettled(wakeupPromises);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      const callCount = heartbeatDouble.wakeup.mock.calls.length;
+      stablePasses = callCount === previousCallCount ? stablePasses + 1 : 0;
+      if (stablePasses >= 3) return;
+      previousCallCount = callCount;
+    }
+    throw new Error("Deferred issue wakeups did not settle");
+  }
+
+  async function seedCompany() {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Watchdog child-completion e2e",
+      issuePrefix: `W${randomUUID().replace(/-/g, "").slice(0, 5).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(companyMemberships).values({
+      companyId,
+      principalType: "user",
+      principalId: "cloud-user-1",
+      status: "active",
+      membershipRole: "owner",
+      updatedAt: new Date(),
+    });
+    await ensureHumanRoleDefaultGrants(db, {
+      companyId,
+      principalId: "cloud-user-1",
+      membershipRole: "owner",
+      grantedByUserId: null,
+    });
+    return companyId;
+  }
+
+  async function seedAgent(companyId: string, name: string) {
+    const id = randomUUID();
+    await db.insert(agents).values({
+      id,
+      companyId,
+      name,
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    return id;
+  }
+
+  async function seedIssue(companyId: string, overrides: Partial<typeof issues.$inferInsert> = {}) {
+    const id = overrides.id ?? randomUUID();
+    await db.insert(issues).values({
+      id,
+      companyId,
+      title: overrides.title ?? "Issue",
+      status: overrides.status ?? "todo",
+      priority: overrides.priority ?? "medium",
+      createdAt: overrides.createdAt ?? new Date(Date.now() - 60 * 60 * 1000),
+      ...overrides,
+    });
+    return id;
+  }
+
+  async function patchStatus(app: express.Express, issueId: string, body: Record<string, unknown>) {
+    const response = await request(app).patch(`/api/issues/${issueId}`).send(body);
+    expect(response.status, JSON.stringify(response.body)).toBe(200);
+    await settleWakeups();
+    return response;
+  }
+
+  async function addApprovalComment(app: express.Express, issueId: string) {
+    const response = await request(app)
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "## Review: APPROVED\n\nWatchdog disposition accepted." });
+    expect(response.status, JSON.stringify(response.body)).toBe(201);
+    await settleWakeups();
+    return response;
+  }
+
+  async function wakeRows(companyId: string, issueId: string, reason: string) {
+    const rows = await db
+      .select({
+        id: agentWakeupRequests.id,
+        reason: agentWakeupRequests.reason,
+        payload: agentWakeupRequests.payload,
+        runId: agentWakeupRequests.runId,
+        idempotencyKey: agentWakeupRequests.idempotencyKey,
+      })
+      .from(agentWakeupRequests)
+      .where(eq(agentWakeupRequests.companyId, companyId));
+    return rows.filter((row) => row.reason === reason && row.payload?.issueId === issueId);
+  }
+
+  async function sourceRunIds(companyId: string, agentId: string, issueId: string) {
+    const rows = await db
+      .select({ id: heartbeatRuns.id, contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(and(eq(heartbeatRuns.companyId, companyId), eq(heartbeatRuns.agentId, agentId)));
+    return rows
+      .filter((row) => row.contextSnapshot?.issueId === issueId || row.contextSnapshot?.taskId === issueId)
+      .map((row) => row.id)
+      .sort();
+  }
+
+  async function sourceSnapshot(input: {
+    companyId: string;
+    sourceIssueId: string;
+    sourceAgentId: string;
+    interactionId?: string;
+  }) {
+    const source = await db
+      .select({ status: issues.status, updatedAt: issues.updatedAt })
+      .from(issues)
+      .where(eq(issues.id, input.sourceIssueId))
+      .then((rows) => rows[0]!);
+    const watchdog = await db
+      .select({ lastObservedFingerprint: issueWatchdogs.lastObservedFingerprint })
+      .from(issueWatchdogs)
+      .where(and(
+        eq(issueWatchdogs.companyId, input.companyId),
+        eq(issueWatchdogs.issueId, input.sourceIssueId),
+      ))
+      .then((rows) => rows[0]!);
+    const interaction = input.interactionId
+      ? await db
+        .select({ status: issueThreadInteractions.status, result: issueThreadInteractions.result })
+        .from(issueThreadInteractions)
+        .where(eq(issueThreadInteractions.id, input.interactionId))
+        .then((rows) => rows[0] ?? null)
+      : null;
+    return {
+      status: source.status,
+      updatedAt: source.updatedAt.toISOString(),
+      interaction,
+      lastObservedFingerprint: watchdog.lastObservedFingerprint,
+      sourceRunIds: await sourceRunIds(input.companyId, input.sourceAgentId, input.sourceIssueId),
+    };
+  }
+
+  it("keeps blocked/review waits, pending interaction, source runs, and stop fingerprints stable across watchdog lifecycles", async () => {
+    const companyId = await seedCompany();
+    const reviewSourceAgentId = await seedAgent(companyId, "Review source agent");
+    const blockedSourceAgentId = await seedAgent(companyId, "Blocked source agent");
+    const watchdogAgentId = await seedAgent(companyId, "Watchdog agent");
+    const humanBlockerId = await seedIssue(companyId, {
+      title: "Human decision",
+      status: "todo",
+      assigneeUserId: "cloud-user-1",
+      issueNumber: 1,
+    });
+    const reviewSourceId = await seedIssue(companyId, {
+      title: "Source waiting in review",
+      status: "in_review",
+      assigneeAgentId: reviewSourceAgentId,
+      issueNumber: 2,
+      updatedAt: new Date("2026-08-01T10:00:00.000Z"),
+    });
+    const blockedSourceId = await seedIssue(companyId, {
+      title: "Source waiting on a human blocker",
+      status: "blocked",
+      assigneeAgentId: blockedSourceAgentId,
+      issueNumber: 3,
+      updatedAt: new Date("2026-08-01T11:00:00.000Z"),
+    });
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: humanBlockerId,
+      relatedIssueId: blockedSourceId,
+      type: "blocks",
+      createdByUserId: "cloud-user-1",
+    });
+    const interactionId = randomUUID();
+    await db.insert(issueThreadInteractions).values({
+      id: interactionId,
+      companyId,
+      issueId: reviewSourceId,
+      kind: "request_confirmation",
+      status: "pending",
+      continuationPolicy: "wake_assignee",
+      payload: {
+        version: 1,
+        prompt: "Approve the current source result?",
+        supersedeOnUserComment: false,
+      },
+      createdByUserId: "cloud-user-1",
+    });
+
+    const reviewPolicy = normalizeIssueExecutionPolicy({
+      stages: [{
+        id: randomUUID(),
+        type: "review",
+        approvalsNeeded: 1,
+        participants: [{ type: "user", userId: "cloud-user-1" }],
+      }],
+    })!;
+    const reviewWatchdogId = await seedIssue(companyId, {
+      title: "Review-source watchdog",
+      status: "todo",
+      parentId: reviewSourceId,
+      assigneeAgentId: watchdogAgentId,
+      issueNumber: 4,
+      originKind: "task_watchdog",
+      originId: reviewSourceId,
+      originFingerprint: "bootstrap",
+      executionPolicy: reviewPolicy,
+    });
+    const blockedWatchdogId = await seedIssue(companyId, {
+      title: "Blocked-source watchdog",
+      status: "in_progress",
+      parentId: blockedSourceId,
+      assigneeAgentId: watchdogAgentId,
+      issueNumber: 5,
+      originKind: "task_watchdog",
+      originId: blockedSourceId,
+      originFingerprint: "bootstrap",
+    });
+    await db.insert(issueWatchdogs).values([
+      {
+        companyId,
+        issueId: reviewSourceId,
+        watchdogAgentId,
+        watchdogIssueId: reviewWatchdogId,
+        status: "active",
+      },
+      {
+        companyId,
+        issueId: blockedSourceId,
+        watchdogAgentId,
+        watchdogIssueId: blockedWatchdogId,
+        status: "active",
+      },
+    ]);
+    await db.insert(heartbeatRuns).values([
+      {
+        companyId,
+        agentId: reviewSourceAgentId,
+        status: "succeeded",
+        contextSnapshot: { issueId: reviewSourceId },
+      },
+      {
+        companyId,
+        agentId: blockedSourceAgentId,
+        status: "succeeded",
+        contextSnapshot: { issueId: blockedSourceId },
+      },
+    ]);
+
+    await taskWatchdogService(db).reconcileTaskWatchdogs({ companyId });
+    const reviewBefore = await sourceSnapshot({
+      companyId,
+      sourceIssueId: reviewSourceId,
+      sourceAgentId: reviewSourceAgentId,
+      interactionId,
+    });
+    const blockedBefore = await sourceSnapshot({
+      companyId,
+      sourceIssueId: blockedSourceId,
+      sourceAgentId: blockedSourceAgentId,
+    });
+    expect(reviewBefore.lastObservedFingerprint).toMatch(/^task_watchdog_stop:/);
+    expect(blockedBefore.lastObservedFingerprint).toMatch(/^task_watchdog_stop:/);
+
+    const app = createApp(companyId);
+    await patchStatus(app, blockedWatchdogId, { status: "cancelled" });
+    await patchStatus(app, blockedWatchdogId, { status: "cancelled" });
+
+    for (let cycle = 0; cycle < 3; cycle += 1) {
+      await patchStatus(app, reviewWatchdogId, { status: "in_review" });
+      await addApprovalComment(app, reviewWatchdogId);
+      if (cycle < 2) {
+        await patchStatus(app, reviewWatchdogId, {
+          status: "todo",
+          assigneeAgentId: watchdogAgentId,
+          assigneeUserId: null,
+        });
+      }
+    }
+
+    expect(await sourceSnapshot({
+      companyId,
+      sourceIssueId: reviewSourceId,
+      sourceAgentId: reviewSourceAgentId,
+      interactionId,
+    })).toEqual(reviewBefore);
+    expect(await sourceSnapshot({
+      companyId,
+      sourceIssueId: blockedSourceId,
+      sourceAgentId: blockedSourceAgentId,
+    })).toEqual(blockedBefore);
+    expect(await wakeRows(companyId, reviewSourceId, "issue_children_completed")).toHaveLength(0);
+    expect(await wakeRows(companyId, blockedSourceId, "issue_children_completed")).toHaveLength(0);
+
+    const finalInteraction = await db
+      .select({ status: issueThreadInteractions.status, result: issueThreadInteractions.result })
+      .from(issueThreadInteractions)
+      .where(eq(issueThreadInteractions.id, interactionId))
+      .then((rows) => rows[0]);
+    expect(finalInteraction).toEqual({ status: "pending", result: null });
+  });
+
+  it("wakes actionable parents exactly once for the last normal child in either completion order and filters watchdog payload data", async () => {
+    const companyId = await seedCompany();
+    const parentAgentId = await seedAgent(companyId, "Parent agent");
+    const app = createApp(companyId);
+
+    for (const [caseIndex, completionOrder] of [[0, [0, 1]], [1, [1, 0]]] as const) {
+      const parentId = await seedIssue(companyId, {
+        title: `Mixed parent ${caseIndex}`,
+        status: caseIndex === 0 ? "todo" : "in_progress",
+        assigneeAgentId: parentAgentId,
+        issueNumber: 10 + caseIndex * 10,
+      });
+      const normalChildIds = [randomUUID(), randomUUID()];
+      await db.insert(issues).values([
+        {
+          id: normalChildIds[0],
+          companyId,
+          parentId,
+          title: "Near-collision normal child",
+          status: "todo",
+          priority: "medium",
+          issueNumber: 11 + caseIndex * 10,
+          originKind: "task_watchdog_product_bug",
+          createdAt: new Date(Date.now() - 60 * 60 * 1000),
+        },
+        {
+          id: normalChildIds[1],
+          companyId,
+          parentId,
+          title: "Arbitrary-origin normal child",
+          status: "todo",
+          priority: "medium",
+          issueNumber: 12 + caseIndex * 10,
+          originKind: "custom_automation",
+          createdAt: new Date(Date.now() - 60 * 60 * 1000),
+        },
+        {
+          companyId,
+          parentId,
+          title: "Synthetic watchdog sibling",
+          status: caseIndex === 0 ? "in_progress" : "done",
+          priority: "medium",
+          issueNumber: 13 + caseIndex * 10,
+          originKind: "task_watchdog",
+          originId: parentId,
+          createdAt: new Date(Date.now() - 60 * 60 * 1000),
+        },
+      ]);
+
+      const firstId = normalChildIds[completionOrder[0]];
+      const lastId = normalChildIds[completionOrder[1]];
+      await patchStatus(app, firstId, { status: "done" });
+      expect(await wakeRows(companyId, parentId, "issue_children_completed")).toHaveLength(0);
+
+      await patchStatus(app, lastId, { status: caseIndex === 0 ? "cancelled" : "done" });
+      const rows = await wakeRows(companyId, parentId, "issue_children_completed");
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.payload).toMatchObject({
+        issueId: parentId,
+        completedChildIssueId: lastId,
+        childIssueIds: normalChildIds,
+        childIssueSummaries: [
+          expect.objectContaining({ id: normalChildIds[0], title: "Near-collision normal child" }),
+          expect.objectContaining({ id: normalChildIds[1], title: "Arbitrary-origin normal child" }),
+        ],
+        childIssueSummaryTruncated: false,
+      });
+      expect(JSON.stringify(rows[0]?.payload)).not.toContain("Synthetic watchdog sibling");
+
+      await patchStatus(app, lastId, { status: "done" });
+      expect(await wakeRows(companyId, parentId, "issue_children_completed")).toHaveLength(1);
+    }
+
+    const normalOnlyParentId = await seedIssue(companyId, {
+      title: "Normal-only parent",
+      status: "todo",
+      assigneeAgentId: parentAgentId,
+      issueNumber: 40,
+    });
+    const normalOnlyChildId = await seedIssue(companyId, {
+      title: "Only normal child",
+      status: "in_progress",
+      parentId: normalOnlyParentId,
+      issueNumber: 41,
+      originKind: "manual",
+    });
+    await patchStatus(app, normalOnlyChildId, { status: "done" });
+    expect(await wakeRows(companyId, normalOnlyParentId, "issue_children_completed")).toHaveLength(1);
+
+    for (const [offset, parentStatus] of [[50, "backlog"], [60, "done"]] as const) {
+      const parentId = await seedIssue(companyId, {
+        title: `${parentStatus} parent`,
+        status: parentStatus,
+        assigneeAgentId: parentAgentId,
+        issueNumber: offset,
+      });
+      const childId = await seedIssue(companyId, {
+        title: `Child of ${parentStatus} parent`,
+        status: "todo",
+        parentId,
+        issueNumber: offset + 1,
+      });
+      await patchStatus(app, childId, { status: "done" });
+      expect(await wakeRows(companyId, parentId, "issue_children_completed")).toHaveLength(0);
+    }
+  });
+
+  it("preserves explicit issue_blockers_resolved while suppressing child completion and duplicate queue rows", async () => {
+    const companyId = await seedCompany();
+    const sourceAgentId = await seedAgent(companyId, "Blocked source agent");
+    const watchdogAgentId = await seedAgent(companyId, "Watchdog agent");
+    const sourceId = await seedIssue(companyId, {
+      title: "Source explicitly blocked by watchdog",
+      status: "blocked",
+      assigneeAgentId: sourceAgentId,
+      issueNumber: 70,
+      updatedAt: new Date("2026-08-02T10:00:00.000Z"),
+    });
+    const watchdogId = await seedIssue(companyId, {
+      title: "Explicit blocker watchdog",
+      status: "in_progress",
+      assigneeAgentId: watchdogAgentId,
+      parentId: sourceId,
+      issueNumber: 71,
+      originKind: "task_watchdog",
+      originId: sourceId,
+    });
+    await db.insert(issueRelations).values({
+      companyId,
+      issueId: watchdogId,
+      relatedIssueId: sourceId,
+      type: "blocks",
+      createdByUserId: "cloud-user-1",
+    });
+    const sourceBefore = await db
+      .select({ status: issues.status, updatedAt: issues.updatedAt })
+      .from(issues)
+      .where(eq(issues.id, sourceId))
+      .then((rows) => rows[0]!);
+
+    const app = createApp(companyId);
+    await patchStatus(app, watchdogId, { status: "done" });
+    expect(await wakeRows(companyId, sourceId, "issue_blockers_resolved")).toHaveLength(1);
+    expect(await wakeRows(companyId, sourceId, "issue_children_completed")).toHaveLength(0);
+    expect(await sourceRunIds(companyId, sourceAgentId, sourceId)).toHaveLength(1);
+
+    await patchStatus(app, watchdogId, { status: "done" });
+    await patchStatus(app, watchdogId, {
+      status: "todo",
+      assigneeAgentId: watchdogAgentId,
+      assigneeUserId: null,
+    });
+    await patchStatus(app, watchdogId, { status: "done" });
+    const dependencyRows = await wakeRows(companyId, sourceId, "issue_blockers_resolved");
+    expect(dependencyRows).toHaveLength(1);
+    expect(dependencyRows[0]?.idempotencyKey).toMatch(/^issue_blockers_resolved:/);
+    expect(await wakeRows(companyId, sourceId, "issue_children_completed")).toHaveLength(0);
+    expect(await sourceRunIds(companyId, sourceAgentId, sourceId)).toHaveLength(1);
+
+    const sourceAfter = await db
+      .select({ status: issues.status, updatedAt: issues.updatedAt })
+      .from(issues)
+      .where(eq(issues.id, sourceId))
+      .then((rows) => rows[0]!);
+    expect(sourceAfter.status).toBe(sourceBefore.status);
+    expect(sourceAfter.updatedAt.toISOString()).toBe(sourceBefore.updatedAt.toISOString());
+  });
+});

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -11465,7 +11465,7 @@ export function issueRoutes(
         });
         await destroyReusableSandboxLeasesForTerminalIssue(issue);
       }
-      if (becameTerminal && issue.parentId) {
+      if (becameTerminal && issue.parentId && issue.originKind !== TASK_WATCHDOG_ORIGIN_KIND) {
         const parent = await svc.getWakeableParentAfterChildCompletion(issue.parentId);
         if (parent) {
           addWakeup(parent.assigneeAgentId, {
@@ -13975,7 +13975,7 @@ export function issueRoutes(
         });
         await destroyReusableSandboxLeasesForTerminalIssue(currentIssue);
       }
-      if (becameTerminal && currentIssue.parentId) {
+      if (becameTerminal && currentIssue.parentId && currentIssue.originKind !== TASK_WATCHDOG_ORIGIN_KIND) {
         const parent = await svc.getWakeableParentAfterChildCompletion(currentIssue.parentId);
         if (parent) {
           addWakeup(parent.assigneeAgentId, {

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -6723,7 +6723,7 @@ export function issueService(db: Db) {
           updatedAt: issues.updatedAt,
         })
         .from(issues)
-        .where(and(eq(issues.companyId, parent.companyId), eq(issues.parentId, parentIssueId)))
+        .where(and(eq(issues.companyId, parent.companyId), eq(issues.parentId, parentIssueId), or(isNull(issues.originKind), ne(issues.originKind, "task_watchdog"))))
         .orderBy(asc(issues.issueNumber), asc(issues.createdAt));
       if (children.length === 0) return null;
       if (!children.every((child) => child.status === "done" || child.status === "cancelled")) {

--- a/server/src/services/native-runtime/status-decision-committer-child-wake.test.ts
+++ b/server/src/services/native-runtime/status-decision-committer-child-wake.test.ts
@@ -1,0 +1,249 @@
+import { randomUUID } from "node:crypto";
+import { and, eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  agentWakeupRequests,
+  agents,
+  companies,
+  completionContracts,
+  createDb,
+  heartbeatRuns,
+  issueRelations,
+  issues,
+  nativeRunFinalizations,
+  nativeRunResults,
+  workAssessments,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "../../__tests__/helpers/embedded-postgres.js";
+import { NATIVE_STATUS_ARBITER_POLICY_VERSION, type NativeStatusDecision } from "./status-arbiter.js";
+import { commitNativeStatusDecision } from "./status-decision-committer.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping native status child-wake tests on this host: ${
+      embeddedPostgresSupport.reason ?? "unsupported environment"
+    }`,
+  );
+}
+
+describeEmbeddedPostgres("native status decision child-completion wake routing", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-native-child-wake-");
+    db = createDb(tempDb.connectionString);
+  }, 30_000);
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seedNativeCompletionCase(input: {
+    originKind: string;
+    parentStatus?: "todo" | "blocked";
+    parentBlockedByChild?: boolean;
+  }) {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const parentId = randomUUID();
+    const childId = randomUUID();
+    const siblingId = randomUUID();
+    const runId = randomUUID();
+    const contractId = randomUUID();
+    const resultId = randomUUID();
+    const assessmentId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: `Native child wake ${input.originKind}`,
+      issuePrefix: `N${companyId.replace(/-/g, "").slice(0, 5).toUpperCase()}`,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "Native child wake agent",
+      adapterType: "codex_local",
+      status: "running",
+    });
+    await db.insert(issues).values([
+      {
+        id: parentId,
+        companyId,
+        issueNumber: 1,
+        title: "Parent issue",
+        status: input.parentStatus ?? "todo",
+        assigneeAgentId: agentId,
+      },
+      {
+        id: siblingId,
+        companyId,
+        parentId,
+        issueNumber: 2,
+        title: "Completed normal sibling",
+        status: "done",
+        originKind: "manual",
+      },
+      {
+        id: childId,
+        companyId,
+        parentId,
+        issueNumber: 3,
+        title: "Native terminal child",
+        status: "in_progress",
+        assigneeAgentId: agentId,
+        originKind: input.originKind,
+      },
+    ]);
+    if (input.parentBlockedByChild) {
+      await db.insert(issueRelations).values({
+        companyId,
+        issueId: childId,
+        relatedIssueId: parentId,
+        type: "blocks",
+      });
+    }
+    await db.insert(completionContracts).values({
+      id: contractId,
+      companyId,
+      issueId: childId,
+      revision: 1,
+      schemaVersion: "paperclip.completion-contract.v1",
+      policyVersion: NATIVE_STATUS_ARBITER_POLICY_VERSION,
+      risk: "standard",
+      completionAuthority: "server_arbiter",
+      incompleteCriteriaPolicy: "preserve_non_terminal",
+      contractJson: { revision: 1, criteria: [] },
+      canonicalSha256: `contract:${contractId}`,
+      createdByActorType: "system",
+      createdByActorId: "native-child-wake-test",
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      runtimeMode: "native",
+      runtimeModeResolvedAt: new Date(),
+      nativeIssueId: childId,
+      completionContractId: contractId,
+      completionContractSha256: `contract:${contractId}`,
+      contextSnapshot: { issueId: childId },
+    });
+    await db.insert(nativeRunResults).values({
+      id: resultId,
+      companyId,
+      issueId: childId,
+      runId,
+      completionContractId: contractId,
+      serverFingerprint: `fingerprint:${resultId}`,
+      schemaStatus: "accepted",
+      resultJson: { result: { summary: "Native child completed" } },
+      canonicalSha256: `result:${resultId}`,
+    });
+    await db.insert(workAssessments).values({
+      id: assessmentId,
+      companyId,
+      issueId: childId,
+      runId,
+      contractId,
+      resultId,
+      triggerKind: "native_result",
+      triggerActorCompanyId: companyId,
+      priorIssueStatus: "in_progress",
+      priorStatusVersion: 0,
+      policyVersion: NATIVE_STATUS_ARBITER_POLICY_VERSION,
+      assessmentJson: { source: "native-child-wake-test" },
+      inputDigest: `assessment:${assessmentId}`,
+    });
+    await db.insert(nativeRunFinalizations).values({
+      runId,
+      companyId,
+      issueId: childId,
+      phase: "arbitrating",
+      attempt: 0,
+      resultId,
+      assessmentId,
+    });
+
+    return { companyId, parentId, childId, siblingId, runId, assessmentId };
+  }
+
+  async function commitDone(
+    fixture: Awaited<ReturnType<typeof seedNativeCompletionCase>>,
+  ) {
+    const decision: NativeStatusDecision = {
+      policyVersion: NATIVE_STATUS_ARBITER_POLICY_VERSION,
+      statusAction: "done",
+      toStatus: "done",
+      reasonCode: "native_child_wake_test_complete",
+      unblockDescriptor: null,
+      effects: [],
+    };
+    return commitNativeStatusDecision({
+      db,
+      companyId: fixture.companyId,
+      issueId: fixture.childId,
+      runId: fixture.runId,
+      assessmentId: fixture.assessmentId,
+      priorStatus: "in_progress",
+      priorStatusVersion: 0,
+      priorDecisionId: null,
+      decision,
+    });
+  }
+
+  async function wakeRows(companyId: string, reason: string) {
+    return db
+      .select({ reason: agentWakeupRequests.reason, payload: agentWakeupRequests.payload })
+      .from(agentWakeupRequests)
+      .where(and(
+        eq(agentWakeupRequests.companyId, companyId),
+        eq(agentWakeupRequests.reason, reason),
+      ));
+  }
+
+  it("does not emit child completion when a native exact watchdog finishes beside terminal normal work", async () => {
+    const exactWatchdog = await seedNativeCompletionCase({ originKind: "task_watchdog" });
+    await commitDone(exactWatchdog);
+
+    expect(await wakeRows(exactWatchdog.companyId, "issue_children_completed")).toHaveLength(0);
+
+    const nearMatch = await seedNativeCompletionCase({ originKind: "task_watchdog_product_bug" });
+    await commitDone(nearMatch);
+
+    const nearMatchRows = await wakeRows(nearMatch.companyId, "issue_children_completed");
+    expect(nearMatchRows).toHaveLength(1);
+    expect(nearMatchRows[0]?.payload).toMatchObject({
+      issueId: nearMatch.parentId,
+      completedChildIssueId: nearMatch.childId,
+      childIssueIds: expect.arrayContaining([nearMatch.siblingId, nearMatch.childId]),
+    });
+  });
+
+  it("keeps an exact watchdog dependency wake as blockers-resolved without a child-completion wake", async () => {
+    const fixture = await seedNativeCompletionCase({
+      originKind: "task_watchdog",
+      parentStatus: "blocked",
+      parentBlockedByChild: true,
+    });
+
+    await commitDone(fixture);
+    await commitDone(fixture);
+
+    const dependencyRows = await wakeRows(fixture.companyId, "issue_blockers_resolved");
+    expect(dependencyRows).toHaveLength(1);
+    expect(dependencyRows[0]?.payload).toMatchObject({
+      issueId: fixture.parentId,
+      resolvedBlockerIssueId: fixture.childId,
+      blockerIssueIds: [fixture.childId],
+    });
+    expect(await wakeRows(fixture.companyId, "issue_children_completed")).toHaveLength(0);
+  });
+});

--- a/server/src/services/native-runtime/status-decision-committer.ts
+++ b/server/src/services/native-runtime/status-decision-committer.ts
@@ -28,6 +28,7 @@ import { issueService } from "../issues.js";
 import { issueThreadInteractionService } from "../issue-thread-interactions.js";
 import { issueRecoveryActionService } from "../issue-recovery-actions.js";
 import { buildIssueBlockersResolvedWakeIdempotencyKey } from "../issue-dependency-wakeups.js";
+import { TASK_WATCHDOG_ORIGIN_KIND } from "../task-watchdog-scope.js";
 import { persistActivity, publishActivity, type ActivityPublication } from "../activity-log.js";
 import { emitAgentTaskRun } from "../agent-task-run-telemetry.js";
 
@@ -1187,7 +1188,7 @@ export async function commitNativeStatusDecision(input: {
           const summary = record(record(rows[0]?.resultJson).result).summary;
           return typeof summary === "string" && summary.trim().length > 0 ? summary.trim() : null;
         });
-      const parent = issue.parentId
+      const parent = issue.parentId && issue.originKind !== TASK_WATCHDOG_ORIGIN_KIND
         ? await issueSvc.getWakeableParentAfterChildCompletion(issue.parentId, {
             issueId: input.issueId,
             summary: completedResultSummary,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The issue completion subsystem wakes a parent when child work reaches a terminal state.
> - Task watchdog children are reusable control-plane records. They must not create generic child-completion wakes.
> - Legacy API routes and native status decisions can both complete an issue.
> - Normal children and explicit dependency wakeups must keep their current behavior in both paths.
> - This pull request applies one exact-origin rule to all terminal paths.
> - The benefit is one useful parent wake for real work, without watchdog noise or lost dependency events.

## Linked Issues or Issue Description

Fixes: #12089

Refs: #4942

## What Changed

- Skip generic parent completion signals for an exact `task_watchdog` child in both legacy terminal issue update paths.
- Skip the generic parent lookup for an exact `task_watchdog` child in the native status-decision path.
- Keep native dependency lookup and `issue_blockers_resolved` routing active for exact watchdog blockers.
- Remove exact `task_watchdog` children before parent readiness, child IDs, summaries, and truncation are calculated.
- Keep null origins, other origins, and near-match origin names eligible.
- Add route, service, native status, and embedded PostgreSQL regression coverage.
- Add a three-case smoke command and a fail-closed graft runbook.

## Verification

- Focused server and native test files: 246 tests passed.
- The native status test uses isolated embedded PostgreSQL. It proves zero child-completion wakes for an exact watchdog beside terminal normal work.
- The native status test proves one blockers-resolved wake and zero child-completion wakes for an exact watchdog dependency.
- The native status test keeps `task_watchdog_product_bug` as a negative control.
- `bash scripts/smoke/task-watchdog-child-completion.sh`: 3 tests passed on the exact validation base.
- Server TypeScript compile: passed with `tsc --noEmit`.
- Paperclip runner TypeScript build: passed on the prior pull request head.
- CLI build: passed on the prior pull request head.
- Full Playwright run on the prior pull request head: 44 passed, 2 skipped, 2 failed, and 1 did not run. The failures were unrelated Apps navigation and Smoke Lab fixture flakes.
- Isolated rerun of both failed Playwright tests on the prior pull request head: 2 tests passed.
- The latest local native regression ran on Node 22.22.2 and printed the repository Node 24.11 engine warning. GitHub CI on Node 24.11 is authoritative for the new head.

- Canonical GitHub CI on final head `90966f2197cd91853d0655f16a2a01b81807a1fe`: 31 checks passed, with no failed or pending checks; Storybook visual regression was skipped by workflow policy.
- The initial run completed all 22 tests on e2e shard 3, then hit an intermediary 403 while finalizing its Playwright artifact. A tree-identical no-op head triggered full replacement run `34255707525`, which passed.
- Greptile reviewed the final head at 5/5 with no new actionable issue; the prior smoke-test finding is resolved.

## Risks

- Low runtime risk. The legacy production path still uses three exact-match conditions.
- The native path adds one exact-match condition before the generic parent lookup.
- There is no schema or API contract change.
- The change suppresses only generic child-completion behavior for exact `task_watchdog` children. Explicit dependency behavior remains active.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

OpenAI Codex with GPT-5, reasoning, tool use, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge