### PR TITLE
feat(server): add advisory heartbeat loop guard to wake prompts

### DIFF
--- a/packages/adapter-utils/src/server-utils.test.ts
+++ b/packages/adapter-utils/src/server-utils.test.ts
@@ -2767,6 +2767,54 @@ describe("renderPaperclipWakePrompt - task watchdog", () => {
   });
 });
 
+describe("renderPaperclipWakePrompt - loop guard", () => {
+  const baseLoopGuardPayload = {
+    reason: "issue_assigned",
+    issue: {
+      id: "loop-issue-1",
+      identifier: "PAP-9101",
+      title: "Flaky deploy step",
+      status: "in_progress",
+      workMode: "standard",
+    },
+    commentWindow: { requestedCount: 0, includedCount: 0, missingCount: 0 },
+    comments: [],
+    fallbackFetchNeeded: false,
+  };
+
+  it("renders the loop guard notice when present and omits the section when absent", () => {
+    const notice =
+      "Loop guard: repeated runs are not making progress. 5 consecutive runs ended with status \"failed\".";
+    const prompt = renderPaperclipWakePrompt({
+      ...baseLoopGuardPayload,
+      loopGuardNotice: notice,
+    });
+    expect(prompt).toContain("Loop guard notice:");
+    expect(prompt).toContain(notice);
+
+    const without = renderPaperclipWakePrompt(baseLoopGuardPayload);
+    expect(without).not.toContain("Loop guard notice:");
+
+    const parsed = JSON.parse(
+      stringifyPaperclipWakePayload({
+        ...baseLoopGuardPayload,
+        loopGuardNotice: notice,
+      }) ?? "{}",
+    );
+    expect(parsed.loopGuardNotice).toBe(notice);
+  });
+
+  it("drops a blank loop guard notice during normalization", () => {
+    const parsed = JSON.parse(
+      stringifyPaperclipWakePayload({
+        ...baseLoopGuardPayload,
+        loopGuardNotice: "   ",
+      }) ?? "{}",
+    );
+    expect(parsed.loopGuardNotice).toBeNull();
+  });
+});
+
 describe("applyPaperclipWorkspaceEnv", () => {
   it("adds shared workspace env vars including AGENT_HOME", () => {
     const env = applyPaperclipWorkspaceEnv(

--- a/packages/adapter-utils/src/server-utils.ts
+++ b/packages/adapter-utils/src/server-utils.ts
@@ -730,6 +730,9 @@ type PaperclipWakePayload = {
   planReviewContext: PaperclipWakePlanReviewContext | null;
   documentReviewContext: PaperclipWakeDocumentReviewContext | null;
   livenessContinuation: PaperclipWakeLivenessContinuation | null;
+  // Advisory repeat-run notice from the heartbeat loop guard. Null when
+  // recent runs show no repeat streak. Advisory only, never a block.
+  loopGuardNotice: string | null;
   taskWatchdog: PaperclipWakeTaskWatchdogContext | null;
   interactionKind: string | null;
   interactionStatus: string | null;
@@ -1378,6 +1381,7 @@ export function normalizePaperclipWakePayload(value: unknown): PaperclipWakePayl
         .filter((entry): entry is PaperclipWakeAnnotationDelta => Boolean(entry))
     : [];
   const livenessContinuation = normalizePaperclipWakeLivenessContinuation(payload.livenessContinuation);
+  const loopGuardNotice = asString(payload.loopGuardNotice, "").trim() || null;
   const taskWatchdog = normalizePaperclipWakeTaskWatchdog(payload.taskWatchdog);
   const recovery = normalizePaperclipWakeRecovery(payload.recovery);
   const childIssueSummaries = Array.isArray(payload.childIssueSummaries)
@@ -1413,7 +1417,7 @@ export function normalizePaperclipWakePayload(value: unknown): PaperclipWakePayl
     : null;
   const executionWorkspace = normalizePaperclipWakeExecutionWorkspace(payload.executionWorkspace);
   const agentMessage = normalizePaperclipWakeAgentMessage(payload.agentMessage);
-  if (comments.length === 0 && commentIds.length === 0 && annotationDeltas.length === 0 && childIssueSummaries.length === 0 && unresolvedBlockerIssueIds.length === 0 && unresolvedBlockerSummaries.length === 0 && !activeTreeHold && !executionStage && !continuationSummary && !planReviewContext && !documentReviewContext && !livenessContinuation && !taskWatchdog && !checkboxSelection && !questionResponse && !executionWorkspace && !agentMessage && !recovery && !normalizePaperclipWakeIssue(payload.issue)) {
+  if (comments.length === 0 && commentIds.length === 0 && annotationDeltas.length === 0 && childIssueSummaries.length === 0 && unresolvedBlockerIssueIds.length === 0 && unresolvedBlockerSummaries.length === 0 && !activeTreeHold && !executionStage && !continuationSummary && !planReviewContext && !documentReviewContext && !livenessContinuation && !loopGuardNotice && !taskWatchdog && !checkboxSelection && !questionResponse && !executionWorkspace && !agentMessage && !recovery && !normalizePaperclipWakeIssue(payload.issue)) {
     return null;
   }
 
@@ -1434,6 +1438,7 @@ export function normalizePaperclipWakePayload(value: unknown): PaperclipWakePayl
     documentReviewContext,
     annotationDeltas,
     livenessContinuation,
+    loopGuardNotice,
     taskWatchdog,
     interactionKind: asString(payload.interactionKind, "").trim() || null,
     interactionStatus: asString(payload.interactionStatus, "").trim() || null,
@@ -2046,6 +2051,10 @@ export function renderPaperclipWakePrompt(
     if (continuation.instruction) {
       lines.push(`- instruction: ${continuation.instruction}`);
     }
+  }
+
+  if (normalized.loopGuardNotice) {
+    lines.push("", "Loop guard notice:", normalized.loopGuardNotice);
   }
 
   if (normalized.childIssueSummaries.length > 0) {

--- a/server/src/services/heartbeat-loop-guard.test.ts
+++ b/server/src/services/heartbeat-loop-guard.test.ts
@@ -66,6 +66,23 @@ describe("heartbeat loop guard", () => {
     ).toBeNull();
   });
 
+  it("never counts cancelled or interrupted runs as streak outcomes", () => {
+    const cancelled = { status: "cancelled", errorCode: null };
+    const interrupted = { status: "interrupted", errorCode: null };
+    expect(detectRepeatHeartbeatLoop([cancelled, cancelled, cancelled])).toBeNull();
+    expect(detectRepeatHeartbeatLoop([interrupted, interrupted, interrupted])).toBeNull();
+    const failed = { status: "failed", errorCode: null };
+    // Older streaks behind a boundary stay buried: only the two recent
+    // failures count.
+    expect(
+      detectRepeatHeartbeatLoop([failed, failed, cancelled, failed, failed, failed]),
+    ).toBeNull();
+    // A boundary older than a fresh streak changes nothing.
+    expect(
+      detectRepeatHeartbeatLoop([failed, failed, failed, cancelled]),
+    ).toEqual({ repeatCount: 3, status: "failed", errorCode: null });
+  });
+
   it("escalates the notice from gentle to detailed", () => {
     const gentle = buildLoopGuardNotice({ repeatCount: 3, status: "failed", errorCode: "E_CONN" });
     expect(gentle).toContain("Loop guard");

--- a/server/src/services/heartbeat-loop-guard.test.ts
+++ b/server/src/services/heartbeat-loop-guard.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLoopGuardNotice,
+  detectRepeatHeartbeatLoop,
+  fingerprintHeartbeatRunForLoopGuard,
+} from "./heartbeat-loop-guard.js";
+
+describe("heartbeat loop guard", () => {
+  it("fingerprints runs by status and normalized error code", () => {
+    expect(
+      fingerprintHeartbeatRunForLoopGuard({ status: "failed", errorCode: "E_CONN" }),
+    ).toBe(
+      fingerprintHeartbeatRunForLoopGuard({ status: "failed", errorCode: "  E_CONN " }),
+    );
+    expect(
+      fingerprintHeartbeatRunForLoopGuard({ status: "failed", errorCode: "E_CONN" }),
+    ).not.toBe(
+      fingerprintHeartbeatRunForLoopGuard({ status: "failed", errorCode: "E_OTHER" }),
+    );
+    expect(
+      fingerprintHeartbeatRunForLoopGuard({ status: "failed", errorCode: null }),
+    ).not.toBe(
+      fingerprintHeartbeatRunForLoopGuard({ status: "timed_out", errorCode: null }),
+    );
+  });
+
+  it("detects a streak only at configured thresholds", () => {
+    const failed = { status: "failed", errorCode: "E_CONN" };
+    expect(detectRepeatHeartbeatLoop([failed, failed])).toBeNull();
+    expect(detectRepeatHeartbeatLoop([failed, failed, failed])).toEqual({
+      repeatCount: 3,
+      status: "failed",
+      errorCode: "E_CONN",
+    });
+    expect(detectRepeatHeartbeatLoop([failed, failed, failed, failed])).toBeNull();
+    const five = [failed, failed, failed, failed, failed];
+    expect(detectRepeatHeartbeatLoop(five)?.repeatCount).toBe(5);
+  });
+
+  it("breaks the streak on a different outcome and skips scheduler rows", () => {
+    const failed = { status: "failed", errorCode: "E_CONN" };
+    const ok = { status: "succeeded", errorCode: null };
+    // Newest-first: a different newest outcome breaks the streak after 2.
+    expect(
+      detectRepeatHeartbeatLoop([failed, failed, ok, failed, failed, failed]),
+    ).toBeNull();
+    // An older success does not erase a fresh 3-run streak.
+    expect(
+      detectRepeatHeartbeatLoop([failed, failed, failed, ok, failed, failed]),
+    ).toEqual({ repeatCount: 3, status: "failed", errorCode: "E_CONN" });
+    expect(
+      detectRepeatHeartbeatLoop([
+        failed,
+        { status: "running", errorCode: null },
+        { status: "queued", errorCode: null },
+        failed,
+        failed,
+      ]),
+    ).toEqual({ repeatCount: 3, status: "failed", errorCode: "E_CONN" });
+  });
+
+  it("treats an operator cancel as a fresh instruction that breaks the streak", () => {
+    const failed = { status: "failed", errorCode: null };
+    expect(
+      detectRepeatHeartbeatLoop([failed, failed, { status: "cancelled", errorCode: null }, failed]),
+    ).toBeNull();
+  });
+
+  it("escalates the notice from gentle to detailed", () => {
+    const gentle = buildLoopGuardNotice({ repeatCount: 3, status: "failed", errorCode: "E_CONN" });
+    expect(gentle).toContain("Loop guard");
+    expect(gentle).toContain("3 consecutive runs");
+    expect(gentle).toContain("E_CONN");
+    const firm = buildLoopGuardNotice({ repeatCount: 5, status: "timed_out", errorCode: null });
+    expect(firm).toContain("not making progress");
+    expect(firm).toContain("5 consecutive runs");
+  });
+});

--- a/server/src/services/heartbeat-loop-guard.ts
+++ b/server/src/services/heartbeat-loop-guard.ts
@@ -1,0 +1,127 @@
+import { and, desc, eq, inArray, ne, sql } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { heartbeatRuns } from "@paperclipai/db";
+
+// Advisory repeat-run guard for heartbeat dispatch, borrowed from the
+// DeepSeek Harness `repeat-tool-reminder` / `timeout-policy` guards
+// (packages/guard/*): notice identical consecutive terminal runs and nudge
+// the next run to change approach. The notice advises; it never blocks.
+// Timeout enforcement already exists here (the `timed_out` run outcome and
+// monitor timeouts), so this module covers only the repeat half.
+
+export const HEARTBEAT_LOOP_GUARD_THRESHOLDS = [3, 5] as const;
+export const HEARTBEAT_LOOP_GUARD_LOOKBACK = 8 as const;
+
+// Non-terminal rows never count toward a streak and never break one: they
+// are scheduler artifacts, not agent outcomes. A run the operator cancelled
+// or interrupted breaks the streak like a fresh instruction.
+const LOOP_GUARD_COUNTED_STATUSES = [
+  "succeeded",
+  "failed",
+  "timed_out",
+  "interrupted",
+  "cancelled",
+] as const;
+
+export interface LoopGuardRunOutcome {
+  status: string;
+  errorCode: string | null;
+}
+
+export interface LoopGuardDetection {
+  repeatCount: number;
+  status: string;
+  errorCode: string | null;
+}
+
+function normalizeErrorCode(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function fingerprintHeartbeatRunForLoopGuard(
+  run: LoopGuardRunOutcome,
+): string {
+  return JSON.stringify([run.status, normalizeErrorCode(run.errorCode)]);
+}
+
+function isCountedStatus(status: string): boolean {
+  return (LOOP_GUARD_COUNTED_STATUSES as readonly string[]).includes(status);
+}
+
+export function detectRepeatHeartbeatLoop(
+  newestFirst: ReadonlyArray<LoopGuardRunOutcome>,
+  thresholds: ReadonlyArray<number> = HEARTBEAT_LOOP_GUARD_THRESHOLDS,
+): LoopGuardDetection | null {
+  let fingerprint: string | null = null;
+  let repeatCount = 0;
+  let status = "";
+  let errorCode: string | null = null;
+  for (const run of newestFirst) {
+    if (!isCountedStatus(run.status)) continue;
+    const current = fingerprintHeartbeatRunForLoopGuard(run);
+    if (fingerprint === null) {
+      fingerprint = current;
+      status = run.status;
+      errorCode = normalizeErrorCode(run.errorCode);
+      repeatCount = 1;
+      continue;
+    }
+    if (current !== fingerprint) break;
+    repeatCount += 1;
+  }
+  if (repeatCount < 2 || !thresholds.includes(repeatCount)) return null;
+  return { repeatCount, status, errorCode };
+}
+
+const LOOP_GUARD_GENTLE_NOTICE =
+  "Loop guard: the last runs on this issue ended the same way. "
+  + "Analyze the last result before you act. If the same approach already "
+  + "failed, change the approach or stop and report.";
+
+function describeLoopGuardOutcome(detection: LoopGuardDetection): string {
+  const error = detection.errorCode ? ` (error ${detection.errorCode})` : "";
+  return `${detection.repeatCount} consecutive runs ended with status "${detection.status}"${error}`;
+}
+
+export function buildLoopGuardNotice(detection: LoopGuardDetection): string {
+  if (detection.repeatCount === HEARTBEAT_LOOP_GUARD_THRESHOLDS[0]) {
+    return `${LOOP_GUARD_GENTLE_NOTICE} (${describeLoopGuardOutcome(detection)}.)`;
+  }
+  return (
+    "Loop guard: repeated runs are not making progress. "
+    + `${describeLoopGuardOutcome(detection)}. `
+    + "Do not repeat the same actions again. Inspect the latest result and "
+    + "choose a different action, or finish the task if you gathered enough "
+    + "evidence. If the issue cannot advance, report the blocker and stop."
+  );
+}
+
+export async function loadLoopGuardNotice(input: {
+  db: Db;
+  companyId: string;
+  issueId: string;
+  agentId: string;
+  excludeRunId: string;
+}): Promise<string | null> {
+  const rows = await input.db
+    .select({
+      status: heartbeatRuns.status,
+      errorCode: heartbeatRuns.errorCode,
+    })
+    .from(heartbeatRuns)
+    .where(
+      and(
+        eq(heartbeatRuns.companyId, input.companyId),
+        eq(heartbeatRuns.agentId, input.agentId),
+        sql`${heartbeatRuns.contextSnapshot} ->> 'issueId' = ${input.issueId}`,
+        ne(heartbeatRuns.id, input.excludeRunId),
+        inArray(heartbeatRuns.status, [...LOOP_GUARD_COUNTED_STATUSES]),
+      ),
+    )
+    .orderBy(desc(heartbeatRuns.createdAt))
+    .limit(HEARTBEAT_LOOP_GUARD_LOOKBACK);
+  const detection = detectRepeatHeartbeatLoop(rows);
+  return detection ? buildLoopGuardNotice(detection) : null;
+}

--- a/server/src/services/heartbeat-loop-guard.ts
+++ b/server/src/services/heartbeat-loop-guard.ts
@@ -12,15 +12,21 @@ import { heartbeatRuns } from "@paperclipai/db";
 export const HEARTBEAT_LOOP_GUARD_THRESHOLDS = [3, 5] as const;
 export const HEARTBEAT_LOOP_GUARD_LOOKBACK = 8 as const;
 
-// Non-terminal rows never count toward a streak and never break one: they
-// are scheduler artifacts, not agent outcomes. A run the operator cancelled
-// or interrupted breaks the streak like a fresh instruction.
+// Only terminal agent outcomes count toward a streak. Scheduler rows
+// (queued, running, retries) are transparent: they neither count nor break.
+// Operator-cancelled and interrupted runs are fresh-instruction boundaries:
+// they stop the scan, so only runs newer than the latest boundary count.
+// Without this, three consecutive cancellations would warn the next agent
+// that its approach failed when the loop was the operator's, not its own.
 const LOOP_GUARD_COUNTED_STATUSES = [
   "succeeded",
   "failed",
   "timed_out",
-  "interrupted",
+] as const;
+
+const LOOP_GUARD_BOUNDARY_STATUSES = [
   "cancelled",
+  "interrupted",
 ] as const;
 
 export interface LoopGuardRunOutcome {
@@ -50,6 +56,10 @@ function isCountedStatus(status: string): boolean {
   return (LOOP_GUARD_COUNTED_STATUSES as readonly string[]).includes(status);
 }
 
+function isBoundaryStatus(status: string): boolean {
+  return (LOOP_GUARD_BOUNDARY_STATUSES as readonly string[]).includes(status);
+}
+
 export function detectRepeatHeartbeatLoop(
   newestFirst: ReadonlyArray<LoopGuardRunOutcome>,
   thresholds: ReadonlyArray<number> = HEARTBEAT_LOOP_GUARD_THRESHOLDS,
@@ -59,7 +69,11 @@ export function detectRepeatHeartbeatLoop(
   let status = "";
   let errorCode: string | null = null;
   for (const run of newestFirst) {
-    if (!isCountedStatus(run.status)) continue;
+    if (!isCountedStatus(run.status)) {
+      // A boundary ends the scannable streak; scheduler rows pass through.
+      if (isBoundaryStatus(run.status)) break;
+      continue;
+    }
     const current = fingerprintHeartbeatRunForLoopGuard(run);
     if (fingerprint === null) {
       fingerprint = current;

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -387,6 +387,7 @@ import {
   type AgentOrgRow,
 } from "./agent-invokability.js";
 import { isHeartbeatWakeOnDemandEnabled } from "./heartbeat-policy.js";
+import { loadLoopGuardNotice } from "./heartbeat-loop-guard.js";
 import {
   redactQuarantinedBodyForHigherTrust,
   sanitizeQuarantinedCommentForHigherTrust,
@@ -6877,6 +6878,10 @@ export async function buildPaperclipWakePayload(input: {
     executionPolicy?: unknown;
   } | null;
   exposeLowTrustRaw?: boolean;
+  // Advisory repeat-run notice from the heartbeat loop guard (borrowed from
+  // the DeepSeek Harness repeat-tool-reminder guard). Null when recent runs
+  // show no repeat streak.
+  loopGuardNotice?: string | null;
   // Experimental: agents write user-interaction content in ASD-STE100
   // Simplified Technical English (rendered as a prompt directive downstream).
   simplifiedEnglishInteractions?: boolean;
@@ -7264,6 +7269,7 @@ export async function buildPaperclipWakePayload(input: {
       Object.keys(executionStage).length > 0 ? executionStage : null,
     taskWatchdog: (input.contextSnapshot.taskWatchdog ?? null) as unknown,
     skillTest: (input.contextSnapshot.paperclipSkillTest ?? null) as unknown,
+    loopGuardNotice: readNonEmptyString(input.loopGuardNotice) ?? null,
     continuationSummary: safeContinuationSummary
       ? {
           key: safeContinuationSummary.key,
@@ -18504,6 +18510,18 @@ export function heartbeatService(
       } else {
         delete context.paperclipSkillTest;
       }
+      // Advisory nudge when this issue+agent pair keeps ending runs the
+      // same way (DeepSeek Harness repeat-tool-reminder port). Null when
+      // there is no repeat streak. Never blocks dispatch.
+      const loopGuardNotice = issueRef
+        ? await loadLoopGuardNotice({
+            db,
+            companyId: agent.companyId,
+            issueId: issueRef.id,
+            agentId: agent.id,
+            excludeRunId: run.id,
+          })
+        : null;
       const paperclipWakePayload = await buildPaperclipWakePayload({
         db,
         companyId: agent.companyId,
@@ -18523,6 +18541,7 @@ export function heartbeatService(
             }
           : null,
         exposeLowTrustRaw,
+        loopGuardNotice,
         simplifiedEnglishInteractions:
           experimentalInstanceSettings.enableSimplifiedEnglishInteractions ===
           true,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -18512,16 +18512,25 @@ export function heartbeatService(
       }
       // Advisory nudge when this issue+agent pair keeps ending runs the
       // same way (DeepSeek Harness repeat-tool-reminder port). Null when
-      // there is no repeat streak. Never blocks dispatch.
-      const loopGuardNotice = issueRef
-        ? await loadLoopGuardNotice({
+      // there is no repeat streak. Fail-open by design: a lookup failure
+      // must never block wake/dispatch, so it logs and continues silent.
+      let loopGuardNotice: string | null = null;
+      if (issueRef) {
+        try {
+          loopGuardNotice = await loadLoopGuardNotice({
             db,
             companyId: agent.companyId,
             issueId: issueRef.id,
             agentId: agent.id,
             excludeRunId: run.id,
-          })
-        : null;
+          });
+        } catch (err) {
+          logger.warn(
+            { err, issueId: issueRef.id, agentId: agent.id, runId: run.id },
+            "loop guard lookup failed; continuing dispatch without a notice",
+          );
+        }
+      }
       const paperclipWakePayload = await buildPaperclipWakePayload({
         db,
         companyId: agent.companyId,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Heartbeat runs dispatch agents against issues again and again
> - An agent can end several consecutive runs the same way without progress
> - Budgets and watchdogs limit the damage, but the agent gets no nudge to change approach
> - This pull request adds an advisory loop guard notice to the wake prompt when recent runs form a repeat streak
> - The benefit is fewer wasted runs and faster blocker reports with no behavior block

## Linked Issues or Issue Description

Refs #4725 (open recovery-loop protection rollup; that PR enforces caps and rate limits, this PR adds the complementary advisory prompt nudge).
Refs #4709 (closed unmerged continuation loop guard attempt; different mechanism, noted for context).

No public issue exists for the advisory notice itself. The problem follows the feature request fields:

**Subsystem affected**
server/ — REST API & orchestration services, plus packages/adapter-utils (wake prompt renderer).

**Problem or motivation**
Agents repeat the same failing approach across heartbeats. Each run costs budget. Nothing in the wake prompt tells the agent its last runs ended identically.

**Proposed solution**
Detect identical consecutive terminal runs per issue and agent (thresholds 3 gentle, 5 firm). Inject a short advisory notice into the wake payload and render it in the wake prompt. The notice advises only. It never blocks dispatch.

**Alternatives considered**
I considered blocking dispatch after N repeats. I ruled it out because recovery paths and operator cancels already govern retries, and a block risks stalling productive work. I considered a run-log event. I deferred it to keep this change prompt-only with no contract change.

**Roadmap alignment**
This change supports ROADMAP.md "Enforced Outcomes (watchdogs, recovery actions, review gates)". It is additive. It duplicates no planned core work.

## What Changed

- Add `server/src/services/heartbeat-loop-guard.ts`: run fingerprinting, streak detection over the last 8 terminal runs, gentle and firm notice text, and a company and agent scoped loader that excludes the current run.
- Wire the loader into `executeRun` in `server/src/services/heartbeat.ts`. Pass the notice into `buildPaperclipWakePayload` as an optional field.
- Add `loopGuardNotice` to the wake payload type, normalizer, and prompt renderer in `packages/adapter-utils/src/server-utils.ts`.
- Add `server/src/services/heartbeat-loop-guard.test.ts` (5 tests) and loop guard renderer cases in `server-utils.test.ts` (2 tests).

## Verification

- Run `pnpm --filter @paperclipai/server exec vitest run src/services/heartbeat-loop-guard.test.ts`. Result: 5 tests pass.
- Run `npx vitest run --project @paperclipai/adapter-utils src/server-utils.test.ts`. Result: 103 tests pass.
- Run related wake payload suites (`heartbeat-context-summary`, `heartbeat-agent-session-message`, `issue-comment-redaction`). Result: 19 pass, 4 skipped (pre-existing skips in untouched files).
- Run `pnpm --filter @paperclipai/adapter-utils typecheck`. Result: clean.
- Run `pnpm --filter @paperclipai/server exec tsc --noEmit` (after building `@paperclipai/plugin-sdk`, which this environment leaves unbuilt). Result: clean, zero errors.
- Manual check: force 3 identical failed runs for one issue and agent, trigger a wake, confirm the prompt contains the "Loop guard notice" section. Confirm dispatch still proceeds.

## Risks

- Low risk. The notice is advisory text in the wake prompt. Dispatch, retries, budgets, and approvals are untouched.
- One extra indexed select per dispatch (`company_id`, `agent_id`, `contextSnapshot issueId`, limit 8). Negligible cost.
- A false positive notice (streak by coincidence) only adds prompt text. The agent can ignore it.

## Model Used

- Provider and model: Meta Muse Spark, agentic coding assistant with tool use (file edits, shell, tests).
- Exact model version and context window: not exposed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (no user docs cover wake prompt internals; behavior lives in code comments)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
