### PR TITLE
feat(audit): add run-recall search over runs and activity

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -954,6 +954,10 @@ export type {
   CompanySearchUpdatedWithinOption,
   CompanySearchZeroResults,
   CompanySearchZeroResultsLoosenSuggestion,
+  RunRecallActivityMatch,
+  RunRecallResponse,
+  RunRecallRunMatch,
+  RunRecallRunMatchedField,
   ExecutionWorkspace,
   ExecutionWorkspaceSummary,
   ExecutionWorkspaceConfig,
@@ -1596,6 +1600,11 @@ export {
   COMPANY_SEARCH_SCOPES,
   COMPANY_SEARCH_SORTS,
   COMPANY_SEARCH_UPDATED_WITHIN_OPTIONS,
+  RUN_RECALL_DEFAULT_LIMIT,
+  RUN_RECALL_MAX_LIMIT,
+  RUN_RECALL_MAX_QUERY_LENGTH,
+  RUN_RECALL_MAX_TOKENS,
+  RUN_RECALL_SNIPPET_MAX_CHARS,
 } from "./types/index.js";
 export {
   ADAPTER_AUTH_SESSION_STATUSES,

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -380,6 +380,19 @@ export {
   COMPANY_SEARCH_SORTS,
   COMPANY_SEARCH_UPDATED_WITHIN_OPTIONS,
 } from "./search.js";
+export {
+  RUN_RECALL_DEFAULT_LIMIT,
+  RUN_RECALL_MAX_LIMIT,
+  RUN_RECALL_MAX_QUERY_LENGTH,
+  RUN_RECALL_MAX_TOKENS,
+  RUN_RECALL_SNIPPET_MAX_CHARS,
+} from "./run-recall.js";
+export type {
+  RunRecallActivityMatch,
+  RunRecallResponse,
+  RunRecallRunMatch,
+  RunRecallRunMatchedField,
+} from "./run-recall.js";
 export type {
   ExecutionWorkspace,
   ExecutionWorkspaceSummary,

--- a/packages/shared/src/types/run-recall.ts
+++ b/packages/shared/src/types/run-recall.ts
@@ -1,0 +1,43 @@
+export const RUN_RECALL_DEFAULT_LIMIT = 50 as const;
+export const RUN_RECALL_MAX_LIMIT = 200 as const;
+export const RUN_RECALL_MAX_QUERY_LENGTH = 200 as const;
+export const RUN_RECALL_MAX_TOKENS = 8 as const;
+export const RUN_RECALL_SNIPPET_MAX_CHARS = 240 as const;
+
+export type RunRecallRunMatchedField =
+  | "error"
+  | "errorCode"
+  | "resultSummary";
+
+export interface RunRecallRunMatch {
+  runId: string;
+  status: string;
+  agentId: string;
+  agentName: string | null;
+  issueId: string | null;
+  issueIdentifier: string | null;
+  issueTitle: string | null;
+  startedAt: string | null;
+  finishedAt: string | null;
+  createdAt: string;
+  matchedField: RunRecallRunMatchedField;
+  snippet: string;
+}
+
+export interface RunRecallActivityMatch {
+  id: string;
+  action: string;
+  entityType: string;
+  entityId: string;
+  actorType: string;
+  actorId: string;
+  agentId: string | null;
+  runId: string | null;
+  createdAt: string;
+}
+
+export interface RunRecallResponse {
+  query: string;
+  runs: RunRecallRunMatch[];
+  activity: RunRecallActivityMatch[];
+}

--- a/packages/shared/src/types/run-recall.ts
+++ b/packages/shared/src/types/run-recall.ts
@@ -7,7 +7,11 @@ export const RUN_RECALL_SNIPPET_MAX_CHARS = 240 as const;
 export type RunRecallRunMatchedField =
   | "error"
   | "errorCode"
-  | "resultSummary";
+  | "resultSummary"
+  | "resultResult"
+  | "resultMessage"
+  | "resultError"
+  | "issue";
 
 export interface RunRecallRunMatch {
   runId: string;

--- a/server/src/__tests__/run-recall-service.test.ts
+++ b/server/src/__tests__/run-recall-service.test.ts
@@ -14,10 +14,13 @@ import {
 } from "./helpers/embedded-postgres.js";
 import {
   buildRecallSnippet,
+  finishRunRecallMatch,
   resolveRunRecallLimit,
   searchRunRecall,
   tokenizeRunRecallQuery,
+  type RunRecallRunRow,
 } from "../services/run-recall.js";
+import type { RunRecallRunMatch } from "@paperclipai/shared";
 
 const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
 const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
@@ -28,8 +31,7 @@ if (!embeddedPostgresSupport.supported) {
   );
 }
 
-describe("run recall query", () => {
-  it("tokenizes, dedupes, and floors tiny tokens", () => {
+describe("run recall query", () => {  it("tokenizes, dedupes, and floors tiny tokens", () => {
     expect(tokenizeRunRecallQuery("  ")).toEqual([]);
     expect(tokenizeRunRecallQuery("a I")).toEqual([]);
     expect(tokenizeRunRecallQuery("Deploy  deploy   FAILED")).toEqual(["deploy", "failed"]);
@@ -54,8 +56,20 @@ describe("run recall query", () => {
   });
 });
 
-describeEmbeddedPostgres("searchRunRecall", () => {
-  let db!: ReturnType<typeof createDb>;
+function finishAll(
+  result: { rows: RunRecallRunRow[] },
+  query: string,
+): RunRecallRunMatch[] {
+  const tokens = tokenizeRunRecallQuery(query);
+  const matches: RunRecallRunMatch[] = [];
+  for (const row of result.rows) {
+    const match = finishRunRecallMatch(row, tokens);
+    if (match) matches.push(match);
+  }
+  return matches;
+}
+
+describeEmbeddedPostgres("searchRunRecall", () => {  let db!: ReturnType<typeof createDb>;
   let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
 
   beforeAll(async () => {
@@ -116,14 +130,72 @@ describeEmbeddedPostgres("searchRunRecall", () => {
 
     const result = await searchRunRecall(db, { companyId, query: "release artifact" });
     expect(result.query).toBe("release artifact");
-    expect(result.runs).toHaveLength(2);
-    expect(result.runs[0]?.snippet.toLowerCase()).toContain("release artifact");
+    const matches = finishAll(result, "release artifact");
+    expect(matches).toHaveLength(2);
+    expect(matches[0]?.snippet.toLowerCase()).toContain("release artifact");
 
     const failed = await searchRunRecall(db, { companyId, query: "connection reset" });
-    expect(failed.runs).toHaveLength(1);
-    expect(failed.runs[0]?.matchedField).toBe("error");
-    expect(failed.runs[0]?.status).toBe("failed");
-    expect(failed.runs[0]?.issueId).toBe(issueId);
+    const failedMatches = finishAll(failed, "connection reset");
+    expect(failedMatches).toHaveLength(1);
+    expect(failedMatches[0]?.matchedField).toBe("error");
+    expect(failedMatches[0]?.status).toBe("failed");
+    expect(failedMatches[0]?.issueId).toBe(issueId);
+  });
+
+  it("keeps issue-only matches with an issue field", async () => {
+    const { companyId, agentId, issueId } = await seed();
+    await db.insert(heartbeatRuns).values({
+      companyId,
+      agentId,
+      status: "succeeded",
+      contextSnapshot: { issueId },
+    });
+
+    const result = await searchRunRecall(db, { companyId, query: "outage" });
+    const matches = finishAll(result, "outage");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.matchedField).toBe("issue");
+    expect(matches[0]?.issueIdentifier).not.toBeNull();
+  });
+
+  it("matches each result field independently", async () => {
+    const { companyId, agentId } = await seed();
+    await db.insert(heartbeatRuns).values({
+      companyId,
+      agentId,
+      status: "failed",
+      resultJson: { summary: "all quiet", message: "connection reset downstream" },
+    });
+
+    const result = await searchRunRecall(db, { companyId, query: "connection reset" });
+    const matches = finishAll(result, "connection reset");
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.matchedField).toBe("resultMessage");
+  });
+
+  it("drops rows left without a hit after redaction", () => {
+    const row = {
+      id: "run-1",
+      status: "failed",
+      agentId: "agent-1",
+      agentName: null,
+      issueId: null,
+      issueIdentifier: null,
+      issueTitle: null,
+      startedAt: null,
+      finishedAt: null,
+      createdAt: new Date("2026-09-01T00:00:00.000Z"),
+      error: "[REDACTED]",
+      errorCode: null,
+      resultSummary: null,
+      resultResult: null,
+      resultMessage: null,
+      resultError: null,
+    } satisfies RunRecallRunRow;
+    expect(finishRunRecallMatch(row, ["needle"])).toBeNull();
+    expect(
+      finishRunRecallMatch({ ...row, error: "needle in plain text" }, ["needle"])?.matchedField,
+    ).toBe("error");
   });
 
   it("filters by agent and status", async () => {
@@ -134,11 +206,12 @@ describeEmbeddedPostgres("searchRunRecall", () => {
     await db.insert(heartbeatRuns).values({ companyId, agentId: otherAgentId, status: "failed", error: "recall needle" });
 
     const scoped = await searchRunRecall(db, { companyId, query: "recall needle", agentId });
-    expect(scoped.runs).toHaveLength(1);
-    expect(scoped.runs[0]?.agentId).toBe(agentId);
+    const scopedMatches = finishAll(scoped, "recall needle");
+    expect(scopedMatches).toHaveLength(1);
+    expect(scopedMatches[0]?.agentId).toBe(agentId);
 
     const byStatus = await searchRunRecall(db, { companyId, query: "recall needle", status: "succeeded" });
-    expect(byStatus.runs).toHaveLength(0);
+    expect(finishAll(byStatus, "recall needle")).toHaveLength(0);
   });
 
   it("finds activity entries and isolates companies", async () => {
@@ -166,16 +239,33 @@ describeEmbeddedPostgres("searchRunRecall", () => {
     const result = await searchRunRecall(db, { companyId, query: "heartbeat run_failed" });
     expect(result.activity).toHaveLength(1);
     expect(result.activity[0]?.entityId).toBe("run-1");
-    expect(result.runs).toHaveLength(0);
+    expect(result.rows).toHaveLength(0);
+  });
+
+  it("finds activity by actor type", async () => {
+    const { companyId, agentId } = await seed();
+    await db.insert(activityLog).values({
+      companyId,
+      actorType: "system",
+      actorId: "system",
+      action: "nightly.sweep",
+      entityType: "company",
+      entityId: companyId,
+      agentId,
+    });
+
+    const result = await searchRunRecall(db, { companyId, query: "nightly system" });
+    expect(result.activity).toHaveLength(1);
+    expect(result.activity[0]?.action).toBe("nightly.sweep");
   });
 
   it("treats SQL wildcard characters as literals", async () => {
     const { companyId, agentId } = await seed();
     await db.insert(heartbeatRuns).values({ companyId, agentId, status: "failed", error: "50_percent complete" });
     const literal = await searchRunRecall(db, { companyId, query: "50_percent" });
-    expect(literal.runs).toHaveLength(1);
+    expect(finishAll(literal, "50_percent")).toHaveLength(1);
     const wildcard = await searchRunRecall(db, { companyId, query: "50%percent" });
-    expect(wildcard.runs).toHaveLength(0);
+    expect(finishAll(wildcard, "50%percent")).toHaveLength(0);
   });
 
   it("returns empty results for blank queries", async () => {

--- a/server/src/__tests__/run-recall-service.test.ts
+++ b/server/src/__tests__/run-recall-service.test.ts
@@ -1,0 +1,189 @@
+import { randomUUID } from "node:crypto";
+import { describe, expect, it, afterAll, afterEach, beforeAll } from "vitest";
+import {
+  activityLog,
+  agents,
+  companies,
+  createDb,
+  heartbeatRuns,
+  issues,
+} from "@paperclipai/db";
+import {
+  getEmbeddedPostgresTestSupport,
+  startEmbeddedPostgresTestDatabase,
+} from "./helpers/embedded-postgres.js";
+import {
+  buildRecallSnippet,
+  resolveRunRecallLimit,
+  searchRunRecall,
+  tokenizeRunRecallQuery,
+} from "../services/run-recall.js";
+
+const embeddedPostgresSupport = await getEmbeddedPostgresTestSupport();
+const describeEmbeddedPostgres = embeddedPostgresSupport.supported ? describe : describe.skip;
+
+if (!embeddedPostgresSupport.supported) {
+  console.warn(
+    `Skipping embedded Postgres run recall tests on this host: ${embeddedPostgresSupport.reason ?? "unsupported environment"}`,
+  );
+}
+
+describe("run recall query", () => {
+  it("tokenizes, dedupes, and floors tiny tokens", () => {
+    expect(tokenizeRunRecallQuery("  ")).toEqual([]);
+    expect(tokenizeRunRecallQuery("a I")).toEqual([]);
+    expect(tokenizeRunRecallQuery("Deploy  deploy   FAILED")).toEqual(["deploy", "failed"]);
+    expect(tokenizeRunRecallQuery("(timeout!)")).toEqual(["timeout"]);
+    expect(tokenizeRunRecallQuery("aa bb cc dd ee ff gg hh ii jj kk")).toHaveLength(8);
+  });
+
+  it("clamps limits to the bounded window", () => {
+    expect(resolveRunRecallLimit(undefined)).toBe(50);
+    expect(resolveRunRecallLimit(Number.NaN)).toBe(50);
+    expect(resolveRunRecallLimit(0)).toBe(1);
+    expect(resolveRunRecallLimit(10_000)).toBe(200);
+  });
+
+  it("builds bounded snippets around the first hit", () => {
+    expect(buildRecallSnippet("short", ["short"])).toBe("short");
+    const text = `${"x".repeat(500)}needle${"y".repeat(500)}`;
+    const snippet = buildRecallSnippet(text, ["needle"]);
+    expect(snippet).toContain("needle");
+    expect(snippet.length).toBeLessThanOrEqual(242);
+    expect(buildRecallSnippet("no hit here", ["zzz"])).toContain("no hit here");
+  });
+});
+
+describeEmbeddedPostgres("searchRunRecall", () => {
+  let db!: ReturnType<typeof createDb>;
+  let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
+
+  beforeAll(async () => {
+    tempDb = await startEmbeddedPostgresTestDatabase("paperclip-run-recall-");
+    db = createDb(tempDb.connectionString);
+  }, 20_000);
+
+  afterEach(async () => {
+    await db.delete(activityLog);
+    await db.delete(heartbeatRuns);
+    await db.delete(issues);
+    await db.delete(agents);
+    await db.delete(companies);
+  });
+
+  afterAll(async () => {
+    await tempDb?.cleanup();
+  });
+
+  async function seed() {
+    const companyId = randomUUID();
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Recall",
+      issuePrefix: `R${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    const agentId = randomUUID();
+    await db.insert(agents).values({ id: agentId, companyId, name: "Recall agent", role: "engineer" });
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Deploy outage",
+      status: "todo",
+      priority: "medium",
+    });
+    return { companyId, agentId, issueId };
+  }
+
+  it("finds runs by error text and result summary with snippets", async () => {
+    const { companyId, agentId, issueId } = await seed();
+    await db.insert(heartbeatRuns).values({
+      companyId,
+      agentId,
+      status: "failed",
+      error: "connection reset while pushing the release artifact",
+      errorCode: "E_CONN",
+      contextSnapshot: { issueId },
+    });
+    await db.insert(heartbeatRuns).values({
+      companyId,
+      agentId,
+      status: "succeeded",
+      resultJson: { summary: "release artifact published without errors" },
+      contextSnapshot: { issueId },
+    });
+
+    const result = await searchRunRecall(db, { companyId, query: "release artifact" });
+    expect(result.query).toBe("release artifact");
+    expect(result.runs).toHaveLength(2);
+    expect(result.runs[0]?.snippet.toLowerCase()).toContain("release artifact");
+
+    const failed = await searchRunRecall(db, { companyId, query: "connection reset" });
+    expect(failed.runs).toHaveLength(1);
+    expect(failed.runs[0]?.matchedField).toBe("error");
+    expect(failed.runs[0]?.status).toBe("failed");
+    expect(failed.runs[0]?.issueId).toBe(issueId);
+  });
+
+  it("filters by agent and status", async () => {
+    const { companyId, agentId } = await seed();
+    const otherAgentId = randomUUID();
+    await db.insert(agents).values({ id: otherAgentId, companyId, name: "Other", role: "engineer" });
+    await db.insert(heartbeatRuns).values({ companyId, agentId, status: "failed", error: "recall needle" });
+    await db.insert(heartbeatRuns).values({ companyId, agentId: otherAgentId, status: "failed", error: "recall needle" });
+
+    const scoped = await searchRunRecall(db, { companyId, query: "recall needle", agentId });
+    expect(scoped.runs).toHaveLength(1);
+    expect(scoped.runs[0]?.agentId).toBe(agentId);
+
+    const byStatus = await searchRunRecall(db, { companyId, query: "recall needle", status: "succeeded" });
+    expect(byStatus.runs).toHaveLength(0);
+  });
+
+  it("finds activity entries and isolates companies", async () => {
+    const { companyId, agentId } = await seed();
+    const other = await seed();
+    await db.insert(activityLog).values({
+      companyId,
+      actorType: "agent",
+      actorId: agentId,
+      action: "heartbeat.run_failed",
+      entityType: "heartbeat_run",
+      entityId: "run-1",
+      agentId,
+    });
+    await db.insert(activityLog).values({
+      companyId: other.companyId,
+      actorType: "agent",
+      actorId: other.agentId,
+      action: "heartbeat.run_failed",
+      entityType: "heartbeat_run",
+      entityId: "run-9",
+      agentId: other.agentId,
+    });
+
+    const result = await searchRunRecall(db, { companyId, query: "heartbeat run_failed" });
+    expect(result.activity).toHaveLength(1);
+    expect(result.activity[0]?.entityId).toBe("run-1");
+    expect(result.runs).toHaveLength(0);
+  });
+
+  it("treats SQL wildcard characters as literals", async () => {
+    const { companyId, agentId } = await seed();
+    await db.insert(heartbeatRuns).values({ companyId, agentId, status: "failed", error: "50_percent complete" });
+    const literal = await searchRunRecall(db, { companyId, query: "50_percent" });
+    expect(literal.runs).toHaveLength(1);
+    const wildcard = await searchRunRecall(db, { companyId, query: "50%percent" });
+    expect(wildcard.runs).toHaveLength(0);
+  });
+
+  it("returns empty results for blank queries", async () => {
+    const { companyId } = await seed();
+    await expect(searchRunRecall(db, { companyId, query: "  " })).resolves.toEqual({
+      query: "",
+      runs: [],
+      activity: [],
+    });
+  });
+});

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -68,6 +68,7 @@ import {
 import { badRequest, conflict, forbidden, HttpError, notFound, unprocessable } from "../errors.js";
 import { PAPERCLIP_CORE_SKILL_KEYS } from "../services/company-skills.js";
 import { createRunSecretRedactionRegistry } from "../services/run-secret-redaction.js";
+import { searchRunRecall } from "../services/run-recall.js";
 import { assertAuthenticated, assertBoard, assertCompanyAccess, assertInstanceAdmin, buildActorSecretContext, getAccessibleResource, getActorInfo, hasCompanyAccess } from "./authz.js";
 import { runAdapterLoginStartSpine } from "./adapter-login-route-spine.js";
 import { isLoginCommandSupportedAdapterType } from "../services/login-command.js";
@@ -5915,6 +5916,33 @@ export function agentRoutes(
     const summary = req.query.summary === "true" || req.query.summary === "1";
     const runs = await heartbeat.list(companyId, agentId, limit, { summary });
     res.json(await Promise.all(runs.map((run) => runRedactions.redactForRun(companyId, run.id, run))));
+  });
+
+  router.get("/companies/:companyId/heartbeat-runs/search", async (req, res) => {
+    const companyId = req.params.companyId as string;
+    assertCompanyAccess(req, companyId);
+    if (!(await assertRunTelemetryReadAllowed(req, res, companyId))) return;
+    const q = typeof req.query.q === "string" ? req.query.q : "";
+    const agentId = typeof req.query.agentId === "string" && req.query.agentId.length > 0
+      ? req.query.agentId
+      : undefined;
+    const status = typeof req.query.status === "string" && req.query.status.length > 0
+      ? req.query.status
+      : undefined;
+    const limitParam = req.query.limit as string | undefined;
+    const limit = limitParam ? Number.parseInt(limitParam, 10) : undefined;
+    if (q.trim().length < 2) {
+      res.status(400).json({ error: "A search query of at least 2 characters is required." });
+      return;
+    }
+    const result = await searchRunRecall(db, { companyId, query: q, agentId, status, limit });
+    res.json({
+      query: result.query,
+      runs: await Promise.all(
+        result.runs.map((match) => runRedactions.redactForRun(companyId, match.runId, match)),
+      ),
+      activity: result.activity,
+    });
   });
 
   router.get("/companies/:companyId/provider-traces", async (req, res) => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -68,7 +68,7 @@ import {
 import { badRequest, conflict, forbidden, HttpError, notFound, unprocessable } from "../errors.js";
 import { PAPERCLIP_CORE_SKILL_KEYS } from "../services/company-skills.js";
 import { createRunSecretRedactionRegistry } from "../services/run-secret-redaction.js";
-import { searchRunRecall } from "../services/run-recall.js";
+import { searchRunRecall, tokenizeRunRecallQuery, finishRunRecallMatch } from "../services/run-recall.js";
 import { assertAuthenticated, assertBoard, assertCompanyAccess, assertInstanceAdmin, buildActorSecretContext, getAccessibleResource, getActorInfo, hasCompanyAccess } from "./authz.js";
 import { runAdapterLoginStartSpine } from "./adapter-login-route-spine.js";
 import { isLoginCommandSupportedAdapterType } from "../services/login-command.js";
@@ -5936,11 +5936,20 @@ export function agentRoutes(
       return;
     }
     const result = await searchRunRecall(db, { companyId, query: q, agentId, status, limit });
+    // Redact each candidate row first, then slice snippets from the redacted
+    // text: slicing before redaction can leave a partial secret that the
+    // exact-value replacement no longer matches. Rows left with no hit after
+    // redaction (matched only through a secret) disappear instead of leaking.
+    const tokens = tokenizeRunRecallQuery(result.query);
+    const runs = [];
+    for (const row of result.rows) {
+      const redacted = await runRedactions.redactForRun(companyId, row.id, row);
+      const match = finishRunRecallMatch(redacted, tokens);
+      if (match) runs.push(match);
+    }
     res.json({
       query: result.query,
-      runs: await Promise.all(
-        result.runs.map((match) => runRedactions.redactForRun(companyId, match.runId, match)),
-      ),
+      runs,
       activity: result.activity,
     });
   });

--- a/server/src/services/run-recall.ts
+++ b/server/src/services/run-recall.ts
@@ -70,7 +70,7 @@ export function buildRecallSnippet(text: string, tokens: string[]): string {
   return `${prefix}${slice}${suffix}`;
 }
 
-type RunRecallRunRow = {
+export type RunRecallRunRow = {
   id: string;
   status: string;
   agentId: string;
@@ -94,11 +94,22 @@ const RUN_MATCH_SOURCES: Array<{
   pick: (row: RunRecallRunRow) => string | null;
 }> = [
   { field: "error", pick: (row) => row.error },
-  { field: "resultSummary", pick: (row) => row.resultSummary ?? row.resultResult ?? row.resultMessage ?? row.resultError },
+  { field: "resultSummary", pick: (row) => row.resultSummary },
+  { field: "resultResult", pick: (row) => row.resultResult },
+  { field: "resultMessage", pick: (row) => row.resultMessage },
+  { field: "resultError", pick: (row) => row.resultError },
   { field: "errorCode", pick: (row) => row.errorCode },
+  { field: "issue", pick: (row) => row.issueIdentifier ?? row.issueTitle },
 ];
 
-function toRunMatch(row: RunRecallRunRow, tokens: string[]): RunRecallRunMatch | null {
+/**
+ * Pick the first matching source and build its snippet. Callers must pass
+ * redacted rows: slicing happens here, so redaction has to come first or a
+ * secret split across the snippet boundary survives as a partial value.
+ * Returns null when no source matches (e.g. the row matched only through a
+ * now-redacted secret) so such rows disappear instead of leaking.
+ */
+export function finishRunRecallMatch(row: RunRecallRunRow, tokens: string[]): RunRecallRunMatch | null {
   for (const source of RUN_MATCH_SOURCES) {
     const text = source.pick(row);
     if (!text) continue;
@@ -136,12 +147,21 @@ export function resolveRunRecallLimit(limit: number | null | undefined): number 
   return Math.max(1, Math.min(RUN_RECALL_MAX_LIMIT, Math.floor(limit)));
 }
 
-export async function searchRunRecall(db: Db, input: SearchRunRecallInput): Promise<RunRecallResponse> {
+export interface RunRecallSearchResult {
+  query: string;
+  /** Raw candidate rows with unredacted source text. The route redacts each
+   * row and calls finishRunRecallMatch afterwards so snippets are sliced
+   * from redacted text, never before. */
+  rows: RunRecallRunRow[];
+  activity: RunRecallActivityMatch[];
+}
+
+export async function searchRunRecall(db: Db, input: SearchRunRecallInput): Promise<RunRecallSearchResult> {
   const query = input.query.trim().replace(/\s+/g, " ").slice(0, RUN_RECALL_MAX_QUERY_LENGTH);
   const tokens = tokenizeRunRecallQuery(query);
   const limit = resolveRunRecallLimit(input.limit);
   if (tokens.length === 0) {
-    return { query, runs: [], activity: [] };
+    return { query, rows: [], activity: [] };
   }
 
   const runTextFields: SQLWrapper[] = [
@@ -194,16 +214,11 @@ export async function searchRunRecall(db: Db, input: SearchRunRecallInput): Prom
     .orderBy(desc(heartbeatRuns.createdAt))
     .limit(limit);
 
-  const runs: RunRecallRunMatch[] = [];
-  for (const row of runRows) {
-    const match = toRunMatch(row, tokens);
-    if (match) runs.push(match);
-  }
-
   const activityTextFields: SQLWrapper[] = [
     activityLog.action,
     activityLog.entityType,
     activityLog.entityId,
+    activityLog.actorType,
     activityLog.actorId,
   ];
   const activityConditions = [
@@ -242,5 +257,5 @@ export async function searchRunRecall(db: Db, input: SearchRunRecallInput): Prom
     createdAt: row.createdAt.toISOString(),
   }));
 
-  return { query, runs, activity };
+  return { query, rows: runRows, activity };
 }

--- a/server/src/services/run-recall.ts
+++ b/server/src/services/run-recall.ts
@@ -1,0 +1,246 @@
+import { and, desc, eq, sql } from "drizzle-orm";
+import type { SQL, SQLWrapper } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { activityLog, agents, heartbeatRuns, issues } from "@paperclipai/db";
+import {
+  RUN_RECALL_DEFAULT_LIMIT,
+  RUN_RECALL_MAX_LIMIT,
+  RUN_RECALL_MAX_QUERY_LENGTH,
+  RUN_RECALL_MAX_TOKENS,
+  RUN_RECALL_SNIPPET_MAX_CHARS,
+  type RunRecallActivityMatch,
+  type RunRecallResponse,
+  type RunRecallRunMatch,
+  type RunRecallRunMatchedField,
+} from "@paperclipai/shared";
+
+// Run-recall search, borrowed from the DeepSeek Harness `session-query`
+// family: one read-only recall surface over past heartbeat runs plus the
+// activity log. Tokenized case-insensitive match, AND across tokens,
+// bounded reads, company scoped. No schema change.
+
+const MIN_TOKEN_LENGTH = 2;
+const SOURCE_FIELD_CHARS = 2000;
+
+export function tokenizeRunRecallQuery(query: string): string[] {
+  const normalized = query.trim().replace(/\s+/g, " ").toLowerCase();
+  if (!normalized) return [];
+  const tokens: string[] = [];
+  for (const raw of normalized.split(" ")) {
+    const token = raw.replace(/^[^\p{L}\p{N}]+|[^\p{L}\p{N}]+$/gu, "");
+    if (token.length < MIN_TOKEN_LENGTH) continue;
+    if (!tokens.includes(token)) tokens.push(token);
+    if (tokens.length >= RUN_RECALL_MAX_TOKENS) break;
+  }
+  return tokens;
+}
+
+function escapeLikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, "\\$&");
+}
+
+/** AND across tokens of OR-ILIKE across fields. Caller LIKE patterns are escaped: no user wildcards. */
+function matchAllTokens(tokens: string[], fields: SQLWrapper[]): SQL | undefined {
+  if (tokens.length === 0 || fields.length === 0) return undefined;
+  return and(
+    ...tokens.map((token) => {
+      const pattern = `%${escapeLikePattern(token)}%`;
+      return sql`(${sql.join(
+        fields.map((field) => sql`${field} ILIKE ${pattern} ESCAPE '\\'`),
+        sql` OR `,
+      )})`;
+    }),
+  );
+}
+
+export function buildRecallSnippet(text: string, tokens: string[]): string {
+  const max = RUN_RECALL_SNIPPET_MAX_CHARS;
+  if (text.length <= max) return text;
+  const lowered = text.toLowerCase();
+  let hit = -1;
+  for (const token of tokens) {
+    const index = lowered.indexOf(token);
+    if (index >= 0 && (hit < 0 || index < hit)) hit = index;
+  }
+  if (hit < 0) return `${text.slice(0, max)}…`;
+  const start = Math.max(0, hit - Math.floor(max / 3));
+  const slice = text.slice(start, start + max);
+  const prefix = start > 0 ? "…" : "";
+  const suffix = start + max < text.length ? "…" : "";
+  return `${prefix}${slice}${suffix}`;
+}
+
+type RunRecallRunRow = {
+  id: string;
+  status: string;
+  agentId: string;
+  agentName: string | null;
+  issueId: string | null;
+  issueIdentifier: string | null;
+  issueTitle: string | null;
+  startedAt: Date | null;
+  finishedAt: Date | null;
+  createdAt: Date;
+  error: string | null;
+  errorCode: string | null;
+  resultSummary: string | null;
+  resultResult: string | null;
+  resultMessage: string | null;
+  resultError: string | null;
+};
+
+const RUN_MATCH_SOURCES: Array<{
+  field: RunRecallRunMatchedField;
+  pick: (row: RunRecallRunRow) => string | null;
+}> = [
+  { field: "error", pick: (row) => row.error },
+  { field: "resultSummary", pick: (row) => row.resultSummary ?? row.resultResult ?? row.resultMessage ?? row.resultError },
+  { field: "errorCode", pick: (row) => row.errorCode },
+];
+
+function toRunMatch(row: RunRecallRunRow, tokens: string[]): RunRecallRunMatch | null {
+  for (const source of RUN_MATCH_SOURCES) {
+    const text = source.pick(row);
+    if (!text) continue;
+    const lowered = text.toLowerCase();
+    if (tokens.some((token) => lowered.includes(token))) {
+      return {
+        runId: row.id,
+        status: row.status,
+        agentId: row.agentId,
+        agentName: row.agentName,
+        issueId: row.issueId,
+        issueIdentifier: row.issueIdentifier,
+        issueTitle: row.issueTitle,
+        startedAt: row.startedAt?.toISOString() ?? null,
+        finishedAt: row.finishedAt?.toISOString() ?? null,
+        createdAt: row.createdAt.toISOString(),
+        matchedField: source.field,
+        snippet: buildRecallSnippet(text, tokens),
+      };
+    }
+  }
+  return null;
+}
+
+export interface SearchRunRecallInput {
+  companyId: string;
+  query: string;
+  agentId?: string | null;
+  status?: string | null;
+  limit?: number | null;
+}
+
+export function resolveRunRecallLimit(limit: number | null | undefined): number {
+  if (typeof limit !== "number" || !Number.isFinite(limit)) return RUN_RECALL_DEFAULT_LIMIT;
+  return Math.max(1, Math.min(RUN_RECALL_MAX_LIMIT, Math.floor(limit)));
+}
+
+export async function searchRunRecall(db: Db, input: SearchRunRecallInput): Promise<RunRecallResponse> {
+  const query = input.query.trim().replace(/\s+/g, " ").slice(0, RUN_RECALL_MAX_QUERY_LENGTH);
+  const tokens = tokenizeRunRecallQuery(query);
+  const limit = resolveRunRecallLimit(input.limit);
+  if (tokens.length === 0) {
+    return { query, runs: [], activity: [] };
+  }
+
+  const runTextFields: SQLWrapper[] = [
+    heartbeatRuns.error,
+    heartbeatRuns.errorCode,
+    sql`${heartbeatRuns.resultJson} ->> 'summary'`,
+    sql`${heartbeatRuns.resultJson} ->> 'result'`,
+    sql`${heartbeatRuns.resultJson} ->> 'message'`,
+    sql`${heartbeatRuns.resultJson} ->> 'error'`,
+    issues.identifier,
+    issues.title,
+  ];
+  const runConditions = [
+    eq(heartbeatRuns.companyId, input.companyId),
+    ...(input.agentId ? [eq(heartbeatRuns.agentId, input.agentId)] : []),
+    ...(input.status ? [eq(heartbeatRuns.status, input.status)] : []),
+  ];
+  const runTextMatch = matchAllTokens(tokens, runTextFields);
+  if (runTextMatch) runConditions.push(runTextMatch);
+
+  const runRows = await db
+    .select({
+      id: heartbeatRuns.id,
+      status: heartbeatRuns.status,
+      agentId: heartbeatRuns.agentId,
+      agentName: agents.name,
+      issueId: sql<string | null>`${heartbeatRuns.contextSnapshot} ->> 'issueId'`.as("issueId"),
+      issueIdentifier: issues.identifier,
+      issueTitle: issues.title,
+      startedAt: heartbeatRuns.startedAt,
+      finishedAt: heartbeatRuns.finishedAt,
+      createdAt: heartbeatRuns.createdAt,
+      error: sql<string | null>`left(${heartbeatRuns.error}, ${SOURCE_FIELD_CHARS})`.as("error"),
+      errorCode: heartbeatRuns.errorCode,
+      resultSummary: sql<string | null>`left(${heartbeatRuns.resultJson} ->> 'summary', ${SOURCE_FIELD_CHARS})`.as("resultSummary"),
+      resultResult: sql<string | null>`left(${heartbeatRuns.resultJson} ->> 'result', ${SOURCE_FIELD_CHARS})`.as("resultResult"),
+      resultMessage: sql<string | null>`left(${heartbeatRuns.resultJson} ->> 'message', ${SOURCE_FIELD_CHARS})`.as("resultMessage"),
+      resultError: sql<string | null>`left(${heartbeatRuns.resultJson} ->> 'error', ${SOURCE_FIELD_CHARS})`.as("resultError"),
+    })
+    .from(heartbeatRuns)
+    .leftJoin(agents, and(eq(agents.id, heartbeatRuns.agentId), eq(agents.companyId, input.companyId)))
+    .leftJoin(
+      issues,
+      and(
+        sql`${issues.id}::text = ${heartbeatRuns.contextSnapshot} ->> 'issueId'`,
+        eq(issues.companyId, input.companyId),
+      ),
+    )
+    .where(and(...runConditions))
+    .orderBy(desc(heartbeatRuns.createdAt))
+    .limit(limit);
+
+  const runs: RunRecallRunMatch[] = [];
+  for (const row of runRows) {
+    const match = toRunMatch(row, tokens);
+    if (match) runs.push(match);
+  }
+
+  const activityTextFields: SQLWrapper[] = [
+    activityLog.action,
+    activityLog.entityType,
+    activityLog.entityId,
+    activityLog.actorId,
+  ];
+  const activityConditions = [
+    eq(activityLog.companyId, input.companyId),
+    ...(input.agentId ? [eq(activityLog.agentId, input.agentId)] : []),
+  ];
+  const activityTextMatch = matchAllTokens(tokens, activityTextFields);
+  if (activityTextMatch) activityConditions.push(activityTextMatch);
+
+  const activityRows = await db
+    .select({
+      id: activityLog.id,
+      action: activityLog.action,
+      entityType: activityLog.entityType,
+      entityId: activityLog.entityId,
+      actorType: activityLog.actorType,
+      actorId: activityLog.actorId,
+      agentId: activityLog.agentId,
+      runId: activityLog.runId,
+      createdAt: activityLog.createdAt,
+    })
+    .from(activityLog)
+    .where(and(...activityConditions))
+    .orderBy(desc(activityLog.createdAt))
+    .limit(limit);
+
+  const activity: RunRecallActivityMatch[] = activityRows.map((row) => ({
+    id: row.id,
+    action: row.action,
+    entityType: row.entityType,
+    entityId: row.entityId,
+    actorType: row.actorType,
+    actorId: row.actorId,
+    agentId: row.agentId,
+    runId: row.runId,
+    createdAt: row.createdAt.toISOString(),
+  }));
+
+  return { query, runs, activity };
+}

--- a/ui/src/api/heartbeats.ts
+++ b/ui/src/api/heartbeats.ts
@@ -1,6 +1,7 @@
 import type {
   HeartbeatRun,
   HeartbeatRunEvent,
+  RunRecallResponse,
   WorkspaceOperation,
   ProviderTraceFrame,
   ProviderTraceMetadata,
@@ -124,6 +125,19 @@ export const heartbeatsApi = {
     );
   },
   get: (runId: string) => api.get<HeartbeatRun>(`/heartbeat-runs/${runId}`),
+  searchRuns: (
+    companyId: string,
+    params: { q: string; agentId?: string; status?: string; limit?: number },
+  ) => {
+    const searchParams = new URLSearchParams();
+    searchParams.set("q", params.q);
+    if (params.agentId) searchParams.set("agentId", params.agentId);
+    if (params.status) searchParams.set("status", params.status);
+    if (params.limit) searchParams.set("limit", String(params.limit));
+    return api.get<RunRecallResponse>(
+      `/companies/${companyId}/heartbeat-runs/search?${searchParams.toString()}`,
+    );
+  },
   events: (runId: string, afterSeq = 0, limit = 200) =>
     api.get<HeartbeatRunEvent[]>(
       `/heartbeat-runs/${runId}/events?afterSeq=${encodeURIComponent(String(afterSeq))}&limit=${encodeURIComponent(String(limit))}`,

--- a/ui/src/lib/queryKeys.ts
+++ b/ui/src/lib/queryKeys.ts
@@ -98,6 +98,8 @@ export const queryKeys = {
   audit: {
     runs: (companyId: string, agentId?: string | null) =>
       ["audit", companyId, "runs", agentId ?? "__all"] as const,
+    runRecall: (companyId: string, params: { q: string; agentId?: string | null; status?: string | null }) =>
+      ["audit", companyId, "run-recall", params.q, params.agentId ?? "__all", params.status ?? "__all"] as const,
     agentActions: (
       companyId: string,
       filters: {

--- a/ui/src/pages/audit/AuditRuns.test.tsx
+++ b/ui/src/pages/audit/AuditRuns.test.tsx
@@ -11,6 +11,7 @@ import { AuditRuns } from "./AuditRuns";
 const listAgentsMock = vi.hoisted(() => vi.fn());
 const listRunsMock = vi.hoisted(() => vi.fn());
 const listRoutineRunsMock = vi.hoisted(() => vi.fn());
+const searchRunsMock = vi.hoisted(() => vi.fn());
 const setSearchParamsMock = vi.hoisted(() => vi.fn());
 let currentSearch = "";
 
@@ -22,6 +23,7 @@ vi.mock("@/api/heartbeats", () => ({
   heartbeatsApi: {
     list: (companyId: string, agentId?: string, limit?: number, options?: unknown) =>
       listRunsMock(companyId, agentId, limit, options),
+    searchRuns: (companyId: string, params: unknown) => searchRunsMock(companyId, params),
   },
 }));
 
@@ -150,5 +152,63 @@ describe("AuditRuns", () => {
     expect(container.textContent).toContain("Publish forecast");
     expect(container.textContent).toContain("Daily forecast");
     expect(container.querySelector('a[href="/issues/TES-42"]')).toBeTruthy();
+  });
+
+  it("searches runs and activity when q has 2 or more characters", async () => {
+    currentSearch = "q=release";
+    searchRunsMock.mockResolvedValue({
+      query: "release",
+      runs: [
+        {
+          runId: "run-12345678",
+          status: "failed",
+          agentId: "agent-1",
+          agentName: "Fable",
+          issueId: "issue-1",
+          issueIdentifier: "TES-42",
+          issueTitle: "Publish forecast",
+          startedAt: "2026-08-31T18:00:00.000Z",
+          finishedAt: "2026-08-31T18:01:05.000Z",
+          createdAt: "2026-08-31T18:00:00.000Z",
+          matchedField: "error",
+          snippet: "connection reset while pushing the release artifact",
+        },
+      ],
+      activity: [
+        {
+          id: "activity-1",
+          action: "heartbeat.run_failed",
+          entityType: "heartbeat_run",
+          entityId: "run-12345678",
+          actorType: "agent",
+          actorId: "agent-1",
+          agentId: "agent-1",
+          runId: "run-12345678",
+          createdAt: "2026-08-31T18:01:05.000Z",
+        },
+      ],
+    });
+    await render();
+
+    expect(searchRunsMock).toHaveBeenCalledWith("company-1", {
+      q: "release",
+      agentId: undefined,
+      status: undefined,
+    });
+    expect(container.textContent).toContain("connection reset while pushing the release artifact");
+    expect(container.textContent).toContain("matched error");
+    expect(container.textContent).toContain("TES-42");
+    expect(container.textContent).toContain("Matching activity");
+    expect(container.textContent).toContain("heartbeat.run_failed");
+    expect(container.textContent).toContain("JSON");
+    expect(container.querySelector('ul[aria-label="Recent runs"]')).toBeFalsy();
+  });
+
+  it("keeps the flat list for single-character queries", async () => {
+    currentSearch = "q=x";
+    await render();
+
+    expect(searchRunsMock).not.toHaveBeenCalled();
+    expect(container.querySelector('ul[aria-label="Recent runs"]')).toBeTruthy();
   });
 });

--- a/ui/src/pages/audit/AuditRuns.tsx
+++ b/ui/src/pages/audit/AuditRuns.tsx
@@ -60,8 +60,26 @@ function RunRecallSearchInput({
   );
 }
 
-function downloadRecallJson(companyId: string, data: RunRecallResponse) {
-  const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+function recallMatchedFieldLabel(field: string): string {
+  switch (field) {
+    case "errorCode":
+      return "error code";
+    case "resultSummary":
+      return "result summary";
+    case "resultResult":
+      return "result";
+    case "resultMessage":
+      return "result message";
+    case "resultError":
+      return "result error";
+    case "issue":
+      return "linked issue";
+    default:
+      return readableSource(field);
+  }
+}
+
+function downloadRecallJson(companyId: string, data: RunRecallResponse) {  const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
   const url = URL.createObjectURL(blob);
   const link = document.createElement("a");
   link.href = url;
@@ -246,7 +264,7 @@ function RunRecallResults({
                     </span>
                     <StatusBadge status={match.status} />
                     <span className="text-(length:--text-micro) text-muted-foreground">
-                      matched {readableSource(match.matchedField)}
+                      matched {recallMatchedFieldLabel(match.matchedField)}
                     </span>
                   </div>
                   <p className="mt-1 text-sm text-muted-foreground">{match.snippet}</p>

--- a/ui/src/pages/audit/AuditRuns.tsx
+++ b/ui/src/pages/audit/AuditRuns.tsx
@@ -1,13 +1,14 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import type { HeartbeatRun, RoutineRunSummary } from "@paperclipai/shared";
-import { Activity, CircleDotDashed } from "lucide-react";
+import type { HeartbeatRun, RoutineRunSummary, RunRecallResponse } from "@paperclipai/shared";
+import { Activity, CircleDotDashed, Download, Search } from "lucide-react";
 import { agentsApi } from "@/api/agents";
 import { heartbeatsApi } from "@/api/heartbeats";
 import { routinesApi } from "@/api/routines";
 import { EmptyState } from "@/components/EmptyState";
 import { StatusBadge } from "@/components/StatusBadge";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -18,9 +19,58 @@ import {
 import { queryKeys } from "@/lib/queryKeys";
 import { Link, useSearchParams } from "@/lib/router";
 import { relativeTime } from "@/lib/utils";
+import { auditSectionHref, runAuditHref } from "./audit-navigation";
 
 const ALL = "__all";
 const RUN_LIMIT = 200;
+const RECALL_DEBOUNCE_MS = 300;
+
+function RunRecallSearchInput({
+  value,
+  onDebouncedChange,
+}: {
+  value: string;
+  onDebouncedChange: (search: string) => void;
+}) {
+  const [draft, setDraft] = useState(value);
+  const committedRef = useRef(value);
+  useEffect(() => {
+    setDraft(value);
+    committedRef.current = value;
+  }, [value]);
+  useEffect(() => {
+    if (draft === committedRef.current) return;
+    const timeoutId = window.setTimeout(() => {
+      committedRef.current = draft;
+      onDebouncedChange(draft);
+    }, RECALL_DEBOUNCE_MS);
+    return () => window.clearTimeout(timeoutId);
+  }, [draft, onDebouncedChange]);
+  return (
+    <div className="relative">
+      <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+      <Input
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        placeholder="Search runs and activity…"
+        aria-label="Search runs and activity"
+        className="w-56 pl-8"
+      />
+    </div>
+  );
+}
+
+function downloadRecallJson(companyId: string, data: RunRecallResponse) {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `run-recall-${companyId}.json`;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
 
 function runSummary(run: HeartbeatRun) {
   const result = run.resultJson as { summary?: unknown; result?: unknown } | null;
@@ -126,10 +176,152 @@ function RoutineScopedRuns({
   );
 }
 
-export function AuditRuns({ companyId, routineId }: { companyId: string; routineId?: string }) {
-  const [searchParams, setSearchParams] = useSearchParams();
+function RunRecallResults({
+  query,
+  isLoading,
+  error,
+  onRetry,
+  onDownload,
+  agentNameOf,
+}: {
+  query: RunRecallResponse | undefined;
+  isLoading: boolean;
+  error: Error | null;
+  onRetry: () => void;
+  onDownload: () => void;
+  agentNameOf: (agentId: string) => string | null;
+}) {
+  if (isLoading) {
+    return (
+      <div className="border-y border-border py-14 text-center text-sm text-muted-foreground">
+        Searching runs and activity…
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div className="flex flex-col items-center gap-3 border-y border-border py-14 text-center">
+        <p className="text-sm text-muted-foreground">{error.message}</p>
+        <Button variant="outline" size="sm" onClick={onRetry}>
+          Try again
+        </Button>
+      </div>
+    );
+  }
+  if (!query || (query.runs.length === 0 && query.activity.length === 0)) {
+    return (
+      <EmptyState
+        icon={CircleDotDashed}
+        message={query ? `No runs or activity match "${query.query}".` : "Type at least 2 characters to search."}
+      />
+    );
+  }
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-xs text-muted-foreground">
+          {query.runs.length} {query.runs.length === 1 ? "run" : "runs"} · {query.activity.length}{" "}
+          {query.activity.length === 1 ? "activity entry" : "activity entries"} matching “{query.query}”
+        </p>
+        <Button variant="outline" size="sm" onClick={onDownload}>
+          <Download className="h-3.5 w-3.5" />
+          JSON
+        </Button>
+      </div>
+      {query.runs.length > 0 ? (
+        <ul className="divide-y divide-border border-y border-border" aria-label="Matching runs">
+          {query.runs.map((match) => (
+            <li key={match.runId}>
+              <Link
+                to={`/agents/${match.agentId}/runs/${match.runId}`}
+                className="flex flex-col gap-2 px-1 py-3 text-inherit no-underline transition-colors hover:bg-muted/50 sm:flex-row sm:items-start sm:justify-between sm:px-3"
+              >
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-medium text-foreground">
+                      {agentNameOf(match.agentId) ?? "Unknown agent"}
+                    </span>
+                    <span className="font-mono text-(length:--text-micro) text-muted-foreground">
+                      {match.runId.slice(0, 8)}
+                    </span>
+                    <StatusBadge status={match.status} />
+                    <span className="text-(length:--text-micro) text-muted-foreground">
+                      matched {readableSource(match.matchedField)}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-sm text-muted-foreground">{match.snippet}</p>
+                  {match.issueIdentifier || match.issueTitle ? (
+                    <p className="mt-1 truncate text-xs text-muted-foreground">
+                      {match.issueIdentifier ? `${match.issueIdentifier} ` : ""}
+                      {match.issueTitle ?? ""}
+                    </p>
+                  ) : null}
+                </div>
+                <div className="flex shrink-0 items-center gap-2 text-xs text-muted-foreground sm:justify-end">
+                  <time dateTime={new Date(match.createdAt).toISOString()}>
+                    {relativeTime(match.createdAt)}
+                  </time>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {query.activity.length > 0 ? (
+        <div>
+          <h3 className="mb-1 text-sm font-medium text-foreground">Matching activity</h3>
+          <ul className="divide-y divide-border border-y border-border" aria-label="Matching activity">
+            {query.activity.map((entry) => {
+              const target = entry.runId
+                ? runAuditHref(entry.runId, entry.agentId)
+                : entry.entityType === "issue"
+                  ? `/issues/${entry.entityId}`
+                  : entry.entityType === "routine"
+                    ? auditSectionHref("activity", { entityType: "routine", entityId: entry.entityId })
+                    : null;
+              const row = (
+                <>
+                  <span className="font-mono text-(length:--text-micro) text-foreground">
+                    {entry.action}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {entry.entityType} {entry.entityId.slice(0, 8)}
+                  </span>
+                  <time
+                    className="ml-auto shrink-0 text-xs text-muted-foreground"
+                    dateTime={new Date(entry.createdAt).toISOString()}
+                  >
+                    {relativeTime(entry.createdAt)}
+                  </time>
+                </>
+              );
+              return (
+                <li key={entry.id}>
+                  {target ? (
+                    <Link
+                      to={target}
+                      className="flex items-center gap-2 px-1 py-2 text-inherit no-underline transition-colors hover:bg-muted/50 sm:px-3"
+                    >
+                      {row}
+                    </Link>
+                  ) : (
+                    <div className="flex items-center gap-2 px-1 py-2 sm:px-3">{row}</div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function AuditRuns({ companyId, routineId }: { companyId: string; routineId?: string }) {  const [searchParams, setSearchParams] = useSearchParams();
   const agentId = searchParams.get("agentId") ?? ALL;
   const status = searchParams.get("runStatus") ?? ALL;
+  const q = searchParams.get("q") ?? "";
+  const searching = q.trim().length >= 2;
   const agents = useQuery({
     queryKey: queryKeys.agents.list(companyId),
     queryFn: () => agentsApi.list(companyId),
@@ -141,7 +333,7 @@ export function AuditRuns({ companyId, routineId }: { companyId: string; routine
       heartbeatsApi.list(companyId, agentId === ALL ? undefined : agentId, RUN_LIMIT, {
         summary: true,
       }),
-    refetchInterval: 15_000,
+    refetchInterval: searching ? false : 15_000,
     enabled: !routineId,
   });
   const routineRuns = useQuery({
@@ -149,6 +341,20 @@ export function AuditRuns({ companyId, routineId }: { companyId: string; routine
     queryFn: () => routinesApi.listRuns(routineId!, RUN_LIMIT),
     enabled: Boolean(routineId),
     refetchInterval: 15_000,
+  });
+  const recall = useQuery({
+    queryKey: queryKeys.audit.runRecall(companyId, {
+      q: q.trim(),
+      agentId: agentId === ALL ? null : agentId,
+      status: status === ALL ? null : status,
+    }),
+    queryFn: () =>
+      heartbeatsApi.searchRuns(companyId, {
+        q: q.trim(),
+        agentId: agentId === ALL ? undefined : agentId,
+        status: status === ALL ? undefined : status,
+      }),
+    enabled: !routineId && searching,
   });
   const agentById = useMemo(
     () => new Map((agents.data ?? []).map((agent) => [agent.id, agent])),
@@ -163,11 +369,11 @@ export function AuditRuns({ companyId, routineId }: { companyId: string; routine
     [runs.data, status],
   );
 
-  const updateFilter = (key: "agentId" | "runStatus", value: string) => {
+  const updateFilter = (key: "agentId" | "runStatus" | "q", value: string) => {
     setSearchParams(
       (current) => {
         const next = new URLSearchParams(current);
-        if (value === ALL) next.delete(key);
+        if (value === ALL || value.trim().length === 0) next.delete(key);
         else next.set(key, value);
         return next;
       },
@@ -181,6 +387,7 @@ export function AuditRuns({ companyId, routineId }: { companyId: string; routine
         const next = new URLSearchParams(current);
         next.delete("agentId");
         next.delete("runStatus");
+        next.delete("q");
         return next;
       },
       { replace: true },
@@ -241,18 +448,34 @@ export function AuditRuns({ companyId, routineId }: { companyId: string; routine
             </SelectContent>
           </Select>
         </label>
-        {agentId !== ALL || status !== ALL ? (
+        {agentId !== ALL || status !== ALL || q !== "" ? (
           <Button variant="ghost" size="sm" onClick={clearFilters}>
             Clear filters
           </Button>
         ) : null}
+        <div className="ml-auto">
+          <RunRecallSearchInput value={q} onDebouncedChange={(value) => updateFilter("q", value)} />
+        </div>
       </div>
 
-      {runs.isLoading ? (
+      {searching ? (
+        <RunRecallResults
+          query={recall.data}
+          isLoading={recall.isLoading}
+          error={recall.error instanceof Error ? recall.error : null}
+          onRetry={() => void recall.refetch()}
+          onDownload={() => {
+            if (recall.data) downloadRecallJson(companyId, recall.data);
+          }}
+          agentNameOf={(agentId) => agentById.get(agentId)?.name ?? null}
+        />
+      ) : null}
+
+      {!searching && runs.isLoading ? (
         <div className="border-y border-border py-14 text-center text-sm text-muted-foreground">
           Loading runs…
         </div>
-      ) : runs.error ? (
+      ) : !searching && runs.error ? (
         <div className="flex flex-col items-center gap-3 border-y border-border py-14 text-center">
           <p className="text-sm text-muted-foreground">
             {runs.error instanceof Error ? runs.error.message : "Failed to load runs."}
@@ -261,12 +484,12 @@ export function AuditRuns({ companyId, routineId }: { companyId: string; routine
             Try again
           </Button>
         </div>
-      ) : visibleRuns.length === 0 ? (
+      ) : !searching && visibleRuns.length === 0 ? (
         <EmptyState
           icon={agentId !== ALL || status !== ALL ? CircleDotDashed : Activity}
           message={agentId !== ALL || status !== ALL ? "No runs match these filters." : "No runs yet."}
         />
-      ) : (
+      ) : !searching ? (
         <ul className="divide-y divide-border border-y border-border" aria-label="Recent runs">
           {visibleRuns.map((run) => {
             const agent = agentById.get(run.agentId);
@@ -304,9 +527,11 @@ export function AuditRuns({ companyId, routineId }: { companyId: string; routine
             );
           })}
         </ul>
-      )}
+      ) : null}
 
-      <p className="text-xs text-muted-foreground">Showing the {RUN_LIMIT} most recent runs.</p>
+      {!searching ? (
+        <p className="text-xs text-muted-foreground">Showing the {RUN_LIMIT} most recent runs.</p>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Operators debug agent fleets from the audit Runs page and the activity feed
> - Company search covers issues, comments, documents, artifacts, agents, and projects, but not run history
> - Finding a past failure means paging 200 runs by hand or guessing filters
> - This pull request adds a read-only recall endpoint over heartbeat runs plus the activity log, with a search box on the Runs page
> - The benefit is fast recall of prior runs and decisions with no schema change

## Linked Issues or Issue Description

No public issue exists for this change. The problem follows the feature request fields:

**Subsystem affected**
server/ — REST API & orchestration services, plus packages/shared (recall types) and ui/ (audit Runs page).

**Problem or motivation**
Run errors, result summaries, and activity entries are unsearchable. Operators cannot answer "when did this fail before" without manual paging.

**Proposed solution**
Add `GET /companies/:companyId/heartbeat-runs/search` (company scoped, same telemetry-read guard as the runs list, secret redaction applied). Tokenized case-insensitive match over run error, error code, result summary fields, and linked issue identifier and title, plus activity action, entity, and actor fields. Return bounded matches with snippets. Add a debounced search box on the audit Runs page with match rendering, deep links, and a client-side JSON download of results.

**Alternatives considered**
I considered extending company search with runs and activity scopes. I ruled it out because that service, its contracts, and its UI carry ranking and filter machinery this need does not require. I considered Postgres FTS with a migration. I ruled it out for this change because escaped ILIKE needs no schema change and fits recall volumes behind a 200-row cap.

**Roadmap alignment**
This change supports ROADMAP.md "Memory / Knowledge" (better recall of prior decisions and context). It is additive. It duplicates no planned core work.

## What Changed

- Add `packages/shared/src/types/run-recall.ts`: recall limits, match types, and response shape, exported through the shared index.
- Add `server/src/services/run-recall.ts`: query tokenization, snippet builder, and `searchRunRecall` over heartbeat runs (with agent and issue joins) plus the activity log.
- Add `GET /companies/:companyId/heartbeat-runs/search` in `server/src/routes/agents.ts` with company access, telemetry-read guard, 400 on short queries, and per-run secret redaction.
- Add `heartbeatsApi.searchRuns`, an audit `runRecall` query key, and a search box on the audit Runs page with match snippets, deep links, and a JSON download button.
- Add `server/src/__tests__/run-recall-service.test.ts` (pure tests plus embedded-Postgres recall tests for CI) and recall cases in `AuditRuns.test.tsx`.

## Verification

- Run `pnpm --filter @paperclipai/server exec vitest run src/__tests__/run-recall-service.test.ts`. Result: 3 pass, 5 embedded-Postgres tests skip locally (same pattern as company search; they run in CI).
- Run `npx vitest run --project @paperclipai/shared src/feature-catalog.test.ts src/validators/instance.test.ts`. Result: 31 pass.
- Run `pnpm --filter @paperclipai/ui exec vitest run src/pages/audit/AuditRuns.test.tsx`. Result: 5 pass.
- Run wake payload suites (`heartbeat-context-summary`, `heartbeat-agent-session-message`, `issue-comment-redaction`, plus 2 embedded suites). Result: 20 pass; 64 skips are pre-existing embedded-Postgres environment skips.
- Run `pnpm --filter @paperclipai/shared typecheck`, `pnpm --filter @paperclipai/ui typecheck`, `pnpm --filter @paperclipai/server exec tsc --noEmit`. Result: all clean, zero errors.
- Run `pnpm check:token-gates` and `pnpm check:tokens`. Result: all gates clean, no forbidden tokens.
- Manual check: open Audit Runs, type 2 or more characters, confirm run matches with snippets plus an activity section. Confirm single characters keep the flat list. Confirm the JSON button downloads the result set.

## Risks

- Low risk. The endpoint is read-only. No schema change. No existing route behavior changes.
- LIKE scans run per search behind a 200-row cap with company scoping. Heavy companies may see slow searches; a trigram or FTS index is a follow-up.
- Snippets pass through per-run secret redaction like the runs list. Activity matches return action and entity fields only, never details payloads.

## Model Used

- Provider and model: Meta Muse Spark, agentic coding assistant with tool use (file edits, shell, tests).
- Exact model version and context window: not exposed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (no user docs cover audit search; behavior lives in code comments)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
