### PR TITLE
fix(adapter-utils): discover gh.exe/git.exe in Windows GitHub launchers

### DIFF
--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -3,7 +3,7 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { randomBytes, randomUUID } from "node:crypto";
-import { githubLauncherSource } from "./github-launcher.js";
+import { githubLauncherCommandSource, githubLauncherSource } from "./github-launcher.js";
 import type { SshRemoteExecutionSpec } from "./ssh.js";
 import {
   prepareCommandManagedRuntime,
@@ -1502,6 +1502,15 @@ export function runtimeAssetDir(
   return prepared.assetDirs[key] ?? path.posix.join(fallbackRemoteCwd, ".paperclip-runtime", key);
 }
 
+/** Git Bash maps `C:\dir` to `/c/dir`, so POSIX profiles staged on Windows use that form. */
+function gitBashPathList(value: string): string {
+  return value.split(";").map((entry) => {
+    if (/^[A-Za-z]:[\\/]/.test(entry)) return `/${entry[0].toLowerCase()}${entry.slice(2).replace(/\\/g, "/")}`;
+    if (entry.startsWith("\\\\")) return `//${entry.slice(2).replace(/\\/g, "/")}`;
+    return entry.replace(/\\/g, "/");
+  }).join(":");
+}
+
 type GitHubLauncherLocation = {
   runId: string; target: AdapterExecutionTarget | null | undefined;
 };
@@ -1561,14 +1570,23 @@ export async function prepareGitHubOperationLaunchers(input: {
   const directory = githubOperationLauncherDirectory(input);
   const configDirectory = path.posix.join(directory, "gh-config");
   const basePath = await githubOperationLauncherBasePath(remote, input.env);
-  const managedPath = basePath ? `${directory}:${basePath}` : directory;
+  // Native Windows processes require ';' between PATH entries; remote and POSIX
+  // locals keep the POSIX ':' join.
+  const managedDelimiter = remote ? ":" : path.delimiter;
+  const managedPath = basePath ? [directory, basePath].join(managedDelimiter) : directory;
   // Login shells may reorder PATH through /etc/profile or path_helper. Restore
   // the managed launchers after startup without loading a host user's profile.
-  const profile = `export PATH=${shellQuote(managedPath)}\n`;
+  const profilePath = !remote && process.platform === "win32" ? gitBashPathList(managedPath) : managedPath;
+  const profile = `export PATH=${shellQuote(profilePath)}\n`;
   const files: Record<string, string> = Object.fromEntries([
     ...["git", "gh"].map((name) => [name, githubLauncherSource()] as const),
     ...[".zshenv", ".zprofile", ".zshrc", ".bash_profile", ".bashrc", ".profile"].map((name) => [name, profile] as const),
   ]);
+  if (!remote && process.platform === "win32") {
+    // cmd.exe and PowerShell resolve commands through PATHEXT, so the
+    // extension-less shebang shims need callable .cmd peers.
+    for (const name of ["git", "gh"]) files[`${name}.cmd`] = githubLauncherCommandSource(process.execPath, name);
+  }
   if (remote) {
     const runner = adapterExecutionTargetCommandRunner(remote);
     for (const [program, body] of Object.entries(files)) {

--- a/packages/adapter-utils/src/github-launcher.test.ts
+++ b/packages/adapter-utils/src/github-launcher.test.ts
@@ -1,16 +1,16 @@
 import { execFile } from "node:child_process";
 import { createServer } from "node:http";
-import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { copyFile, mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
-import { githubBrokerEnvironment, githubLauncherSource } from "./github-launcher.js";
+import { githubBrokerEnvironment, githubLauncherCommandSource, githubLauncherSource } from "./github-launcher.js";
 const exec = promisify(execFile);
 const cleanups: Array<() => Promise<unknown>> = [];
 afterEach(async () => { for (const cleanup of cleanups.splice(0).reverse()) await cleanup(); });
 
-describe("managed GitHub launchers", () => {
+describe.skipIf(process.platform === "win32")("managed GitHub launchers", () => {
   it("explains unavailable access while allowing local work without credentials", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "paperclip-github-diagnostic-"));
     cleanups.push(() => rm(root, {recursive:true,force:true}));
@@ -91,5 +91,58 @@ process.stdout.write(JSON.stringify({identity, token:process.env.GH_TOKEN ?? nul
     expect(await git("status", "--porcelain")).toBe(""); // unrelated public/local Git still works
     expect(env.GH_TOKEN).toBe("");
     expect(env.GIT_AUTHOR_NAME).toBe("");
+  });
+});
+
+describe.runIf(process.platform === "win32")("managed GitHub launchers on Windows", () => {
+  const stage = async (prefix: string) => {
+    const root = await mkdtemp(path.join(os.tmpdir(), prefix));
+    cleanups.push(() => rm(root, { recursive: true, force: true }));
+    const bin = path.join(root, "managed"), realBin = path.join(root, "real");
+    await mkdir(bin); await mkdir(realBin);
+    await writeFile(path.join(bin, "gh"), githubLauncherSource(), { mode: 0o700 });
+    // A real gh.exe stand-in: Windows discovery requires an executable image.
+    await copyFile(process.execPath, path.join(realBin, "gh.exe"));
+    return { root, bin, realBin };
+  };
+  const broker = async (token: string) => {
+    const server = createServer((_req, res) => {
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ status: "available", env: { GH_TOKEN: token } }));
+    });
+    await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+    cleanups.push(() => new Promise<void>((resolve, reject) => server.close(error => error ? reject(error) : resolve())));
+    return server.address() as { port: number };
+  };
+  it("discovers gh.exe via PATHEXT on a semicolon-joined PATH", async () => {
+    const { bin, realBin } = await stage("paperclip-github-win-");
+    const { port } = await broker("credential-windows");
+    const env = { ...process.env, ...githubBrokerEnvironment({ GH_TOKEN: "host-token" }, { url: `http://127.0.0.1:${port}`, token: "run-capability" }),
+      PAPERCLIP_API_URL: "", PATH: [bin, realBin, process.env.PATH].join(";") };
+    const result = await exec(process.execPath, [path.join(bin, "gh"), "-e", "process.stdout.write(JSON.stringify({token:process.env.GH_TOKEN??null}))"], { env });
+    expect(JSON.parse(result.stdout)).toEqual({ token: "credential-windows" });
+  });
+  it("resolves a colon-joined POSIX-style PATH handed over by Git Bash", async () => {
+    const { root, bin, realBin } = await stage("paperclip-github-win-posix-");
+    const { port } = await broker("credential-posix-path");
+    const env = { ...process.env, ...githubBrokerEnvironment({}, { url: `http://127.0.0.1:${port}`, token: "run-capability" }),
+      PAPERCLIP_API_URL: "", PATH: ["managed", "real"].join(":") };
+    const result = await exec(process.execPath, [path.join(bin, "gh"), "-e", "process.stdout.write(process.env.GH_TOKEN)"], { cwd: root, env });
+    expect(result.stdout).toBe("credential-posix-path");
+  });
+  it("runs the staged .cmd wrapper from cmd.exe", async () => {
+    const { bin, realBin } = await stage("paperclip-github-win-cmd-");
+    await writeFile(path.join(bin, "gh.cmd"), githubLauncherCommandSource(process.execPath, "gh"));
+    const { port } = await broker("credential-cmd");
+    const env = { ...process.env, ...githubBrokerEnvironment({}, { url: `http://127.0.0.1:${port}`, token: "run-capability" }),
+      PAPERCLIP_API_URL: "", PATH: [bin, realBin, process.env.PATH].join(";") };
+    const result = await exec("cmd.exe", ["/d", "/c", path.join(bin, "gh.cmd"), "-e", "process.stdout.write(process.env.GH_TOKEN)"], { env });
+    expect(result.stdout).toBe("credential-cmd");
+  });
+  it("still exits 127 when no real GitHub binary is installed", async () => {
+    const { bin } = await stage("paperclip-github-win-missing-");
+    const env = { ...process.env, PATH: bin };
+    await expect(exec(process.execPath, [path.join(bin, "gh")], { env }))
+      .rejects.toMatchObject({ code: 127, stderr: expect.stringContaining("not installed") });
   });
 });

--- a/packages/adapter-utils/src/github-launcher.ts
+++ b/packages/adapter-utils/src/github-launcher.ts
@@ -5,12 +5,25 @@ const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
 const { spawn } = require('node:child_process');
+const windows = process.platform === 'win32';
 const directory = path.dirname(fs.realpathSync(process.argv[1]));
-const program = path.basename(process.argv[1]);
-const originalPath = (process.env.PATH || '').split(path.delimiter).filter(p => {
-  try { return fs.realpathSync(p) !== directory; } catch { return true; }
+const program = path.basename(process.argv[1]).replace(/\.(com|exe|bat|cmd)$/i, '');
+// Git Bash and MSYS shells hand native Node a POSIX colon-joined PATH, while
+// plain Windows processes use semicolons. Split with the delimiter this value
+// actually uses, and restore the same shape for child processes.
+const rawPath = process.env.PATH || '';
+const pathDelimiter = windows && !rawPath.includes(';') && rawPath.includes(':') ? ':' : path.delimiter;
+const sameDirectory = (a, b) => windows ? a.toLowerCase() === b.toLowerCase() : a === b;
+const originalPath = rawPath.split(pathDelimiter).filter(Boolean).filter(p => {
+  try { return !sameDirectory(fs.realpathSync(p), directory); } catch { return true; }
 });
-const executable = originalPath.map(p => path.join(p, program)).find(p => {
+// Windows installs ship gh.exe/git.exe, so resolve PATHEXT candidates before
+// the bare name; POSIX keeps the single bare candidate.
+const pathExtensions = (process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD').split(';')
+  .map(e => e.trim().toLowerCase()).filter(e => e.startsWith('.'));
+pathExtensions.push('');
+const candidates = windows ? pathExtensions.map(e => program + e) : [program];
+const executable = originalPath.flatMap(p => candidates.map(c => path.join(p, c))).find(p => {
   try { fs.accessSync(p, fs.constants.X_OK); return fs.statSync(p).isFile(); } catch { return false; }
 });
 if (!['git', 'gh'].includes(program) || !executable) {
@@ -71,7 +84,7 @@ async function main() {
   }
   // Only this invocation and its children inherit the captured credential.
   // Its Git children use the real binary, so steering cannot split a gh operation.
-  env.PATH = originalPath.join(path.delimiter);
+  env.PATH = originalPath.join(pathDelimiter);
   // Nested shell aliases must not reload the parent launcher profile and
   // recapture a newer identity. All ordinary descendants stay in this operation.
   env.ZDOTDIR = configDirectory;
@@ -84,6 +97,14 @@ async function main() {
 }
 main().catch(() => { process.stderr.write('Paperclip: GitHub credential context unavailable; retry this operation.\n'); process.exitCode = 1; });
 `;
+}
+
+/**
+ * cmd.exe and PowerShell cannot execute the shebang shim directly. Stage a
+ * PATHEXT-discoverable wrapper that runs it with the controller's Node.
+ */
+export function githubLauncherCommandSource(nodePath: string, name: string): string {
+  return `@"${nodePath}" "%~dp0${name}" %*\r\n`;
 }
 
 /** Override inherited credentials even when adapters merge the host environment later. */


### PR DESCRIPTION
## Problem

On Windows, the per-run GitHub runtime wrapper (`%TEMP%/paperclip-github-runtime/<runId>/gh`) could not discover the real binary and every invocation exited 127 ("Paperclip: requested GitHub command is not installed"). Additionally, Git Bash sessions inherited a single Windows-style semicolon-joined PATH string, so `curl`/`node`/`grep` were all "command not found" until the agent manually re-exported a POSIX PATH.

## Root causes

- The shim resolved the real binary with `path.join(p, program)` using the bare program name only, but Windows installs ship `gh.exe`/`git.exe` only.
- The shim split `PATH` on `path.delimiter` alone, so a colon-joined POSIX PATH handed over by Git Bash never resolved.
- `prepareGitHubOperationLaunchers` joined the managed PATH with a literal `:` even on local Windows runs, producing `C:\...\runId;...`-style hybrid strings that broke both native PATH splitting and POSIX shell profiles.
- The staged shell profiles re-exported that raw Windows string, clobbering Git Bash's converted PATH at startup.

## Fix

- Shim discovery now tries PATHEXT-style candidates (`.com/.exe/.bat/.cmd`, honoring `PATHEXT` order) before the bare name, splits inherited PATH with the delimiter the value actually uses, compares the launcher directory case-insensitively on Windows, and restores the same PATH shape for child processes.
- Local Windows staging joins the managed PATH with `path.delimiter` (`;`), stages Git Bash-style POSIX profiles (`/c/...` entries), and stages `gh.cmd`/`git.cmd` peers so cmd.exe and PowerShell can also invoke the brokered shims.
- Remote/sandbox targets keep the POSIX `:` join and are unchanged.

## Testing

- New win32-scoped integration tests in `github-launcher.test.ts`: PATHEXT discovery of `gh.exe` end-to-end through the credential broker, colon-joined POSIX-style PATH resolution, `cmd.exe → gh.cmd → shim → gh.exe` chain, and the preserved 127 diagnostic.
- Existing POSIX tests unchanged (now skipped on win32 where extension-less shebang exec never worked); `github-launcher-environment.test.ts` remote-path behavior unchanged.
- Verified locally: 4/4 new Windows tests pass; `tsc --noEmit` clean for `@paperclipai/adapter-utils`.
