### PR TITLE
docs: propose summarize-and-continue session compaction

### DIFF
--- a/doc/plans/2026-09-08-session-compaction.md
+++ b/doc/plans/2026-09-08-session-compaction.md
@@ -21,8 +21,12 @@ summarize-and-continue half to Paperclip's rotation model.
   keyed by company, agent, adapter type, and task key, plus adapter-native
   session stores referenced by `heartbeat_runs.session_id_before/after`.
   Read path: `getTaskSession` in `server/src/services/heartbeat.ts`.
-- Twelve adapters (`packages/adapters/*`) each own their session format
-  behind per-adapter codecs (`sessionCodec` serialize/deserialize).
+- Twelve adapters (`packages/adapters/*`) each own their session format,
+  mostly behind per-adapter codecs (`sessionCodec` serialize/deserialize).
+  OpenClaw Gateway is the exception: it has no `sessionCodec` and derives
+  a session key from its configured strategy (`sessionKeyStrategy`:
+  issue, fixed, or run), so any history-read or rewrite seam needs an
+  explicit OpenClaw path, not just codec coverage.
 - Rotation already exists and is policy-driven:
   `packages/adapter-utils/src/session-compaction.ts` resolves a per-adapter
   policy (run count, raw input tokens, session age; defaults 200 runs, 2M
@@ -91,8 +95,11 @@ visibility into per-session pressure before rotation fires.
 ### Phase 1: pressure visibility (Path-1 sized, no prompt changes)
 
 - Derive per-task-session pressure from existing rows: run count and error
-  streak from `heartbeat_runs`, summed tokens from `usage_json`, session age,
-  each against the resolved rotation policy for that adapter.
+  streak from `heartbeat_runs`, token usage from `usage_json`, session age,
+  each against the resolved rotation policy for that adapter. Token math
+  must respect reporting shape: per-run usage is summed, while adapters
+  that report cumulative session usage on each run contribute only deltas,
+  or pressure reads inflated past the threshold.
 - Surface it where operators already look: the run/session UI and wake
   metadata (numbers only, never content).
 - No summarization, no rewrites, no new prompts. Pure observability that the
@@ -106,7 +113,12 @@ visibility into per-session pressure before rotation fires.
 - Execution, mirroring the harness commit protocol and reusing the
   rotation decision point:
   1. Select a span: the session history minus a verbatim tail (propose the
-     reference default of 0.16 measured context).
+     reference default of 0.16 measured context). Prerequisite: a history
+     read API. The shared codec handles opaque resume metadata only, and
+     the rotation path reads run summaries, not adapter conversation
+     history — span selection with version checking needs a shared or
+     per-adapter history seam first, without which the non-goal of leaving
+     adapter contracts unchanged cannot hold.
   2. Summarize the span with an auxiliary model call using a fixed
      checkpoint schema (adopt the reference sections: intent, concepts,
      files, errors, pending, current work, next step, critical context).
@@ -130,8 +142,10 @@ visibility into per-session pressure before rotation fires.
 ### Phase 3: automatic checkpoint-on-rotation (later, needs phase 2 data)
 
 - Where rotation currently attaches the deterministic handoff, attach a
-  checkpoint instead, gated per adapter. Operator-visible, reversible via
-  fresh-session reset, logged.
+  checkpoint instead, gated per adapter. Operator-visible, logged, with
+  fresh-session reset kept as the escape hatch (reset discards the active
+  session and starts clean; it does not restore pre-compaction state, so
+  true rollback would need a snapshot mechanism defined separately).
 
 ## Open Questions for Maintainers
 
@@ -146,6 +160,9 @@ visibility into per-session pressure before rotation fires.
    for native-context-management adapters?
 6. Should phase 1 pressure numbers feed existing budgets/watchdogs, or stay
    advisory until phase 2?
+7. What provides the history-read seam for span selection: a shared
+   adapter-history API, per-adapter implementations, or reuse of an
+   existing transcript surface?
 
 ## Risks
 

--- a/doc/plans/2026-09-08-session-compaction.md
+++ b/doc/plans/2026-09-08-session-compaction.md
@@ -1,0 +1,147 @@
+# Session Compaction Proposal
+
+Status: proposal. No code changes. Seeks maintainer direction before any
+Path-2 implementation work.
+
+## Context
+
+Long-lived agent sessions degrade. Context fills with tool output, old
+decisions go stale, and adapters slow down or fail past model limits.
+Operators today have two levers, both blunt: let the session keep growing,
+or reset to a fresh session and lose all working context.
+
+DeepSeek Harness solves this with a compaction seam (`packages/compaction/*`
+plus `packages/guard/*` spill policy): pressure-triggered and operator-invoked
+(`/compact`) summarization that replaces old history with a structured
+checkpoint while keeping a verbatim tail. This proposal ports that idea to
+Paperclip's heartbeat and adapter model.
+
+## What We Know Today
+
+- Session resume state lives in `agent_task_sessions.session_params_json`,
+  keyed by company, agent, adapter type, and task key, plus adapter-native
+  session stores referenced by `heartbeat_runs.session_id_before/after`.
+  Read path: `getTaskSession` in `server/src/services/heartbeat.ts`.
+- Twelve adapters (`packages/adapters/*`: Claude, Codex, Cursor, Gemini,
+  Grok, Kimi, OpenClaw, OpenCode, Pi, Hermes, and cloud variants) each own
+  their session format behind per-adapter codecs (`sessionCodec`
+  serialize/deserialize in `heartbeat.ts`).
+- A fresh-session reset already exists end to end
+  (`forceFreshSession` from UI/API through `heartbeat.ts` into dispatch).
+  Reset drops context; there is no middle ground.
+- Continuation summaries (`server/src/services/issue-continuation-summary.ts`)
+  are deterministic metadata rollups (run status, errors, excerpts; 8,000
+  char cap), not conversation summaries. They preserve outcomes, not reasoning.
+- Per-run token usage is recorded (`heartbeat_runs.usage_json`), but no
+  pressure signal is derived from it. Nothing measures session size, age, or
+  cost-to-continue per task session.
+- Wake-prompt pressure valves exist piecemeal (comment truncation in
+  `buildPaperclipWakePayload`, spill-behind-flag work in progress), but they
+  bound single wakes, not session growth across runs.
+- Prior art in DeepSeek Harness, studied for this proposal:
+  - `compaction-basic`: threshold ratio 0.8 of model context, 0.16 verbatim
+    tail retention, per-model policy overrides, auxiliary-LLM summarization
+    with a fixed checkpoint schema (intent, concepts, files, errors, pending,
+    current work, next step, critical context), prefix-cache-aligned replay.
+  - `region`: token-metered span selection, tool-pairing balance, transactional
+    commit with stability guarantees across async summarization.
+  - `command-compact`: argument-free operator command with a closed failure
+    taxonomy (busy, cancelled, changed, summary, commit, persistence).
+  - `compaction-tool-result-pruner` and `spill-policy`: oversized tool
+    results are pruned/spilled before they enter history.
+
+## Goals
+
+1. Give operators visibility into session pressure (size, age, run count,
+   estimated tokens) per task session before quality degrades.
+2. Provide an operator-invoked compact action that summarizes a session and
+   resumes it, without losing pending work or auditability.
+3. Add automatic pressure-triggered compaction only after manual compaction
+   proves safe per adapter.
+4. Charge summarization cost to explicit budgets and log every compaction in
+   the activity trail.
+
+## Non-Goals
+
+- Changing adapter session formats or the resume codec contract.
+- Silent automatic rewrites in phase 1 and 2. Every rewrite is operator
+  visible and reversible (fresh-session reset remains the escape hatch).
+- Cross-issue or cross-agent memory. Compaction stays within one task
+  session. Durable knowledge is the Memory/Knowledge roadmap item, separate.
+- Replacing continuation summaries. They remain the deterministic outcome
+  record; compaction checkpoints cover reasoning and working context.
+
+## Proposed Model
+
+### Phase 1: pressure visibility (Path-1 sized, no prompt changes)
+
+- Derive per-task-session pressure from existing rows: byte size of
+  `session_params_json`, run count and error streak from `heartbeat_runs`,
+  summed tokens from `usage_json`.
+- Surface it where operators already look: the run/session UI and the wake
+  payload metadata (numbers only, never content).
+- No summarization, no rewrites, no new prompts. Pure observability that the
+  later phases read.
+
+### Phase 2: operator compact action (Path-2, this proposal's core)
+
+- New operator action on a task session: `compactSession`.
+- Execution, mirroring the harness commit protocol:
+  1. Select a span: everything except a verbatim tail (propose 0.16 of
+     measured context, same default as the reference).
+  2. Summarize the span with an auxiliary model call using a fixed
+     checkpoint schema (adopt the reference sections: intent, concepts,
+     files, errors, pending, current work, next step, critical context).
+  3. Commit transactionally: verify the span is unchanged since selection
+     (`changed` failure otherwise), write the checkpoint, rewrite
+     `session_params_json` through the adapter's own codec, record the
+     attempt and outcome in `heartbeat_run_events` and the activity log.
+  4. Closed failure taxonomy like the reference: busy, cancelled, changed,
+     summary, commit, persistence. Any failure leaves the session runnable.
+- Per-adapter rewrite seams: each adapter implements
+  `rewriteSessionForCheckpoint(codecParams, checkpoint)` or opts out
+  (opt-out adapters fall back to fresh-session reset with the checkpoint
+  attached as context, never silently).
+- Summarizer model and budget: explicit per-company configuration, default
+  off; summarization spend recorded as its own cost event, never folded
+  into the agent's task budget silently.
+
+### Phase 3: automatic pressure compaction (later, needs phase 2 data)
+
+- Threshold-triggered compaction (propose 0.8 pressure ratio default) after
+  per-adapter safety is demonstrated. Operator-visible, reversible, logged.
+
+## Open Questions for Maintainers
+
+1. Who pays for the summarizer call: the agent's budget, a company-level
+   compaction budget, or instance config? Who chooses the model?
+2. Should the checkpoint schema be shared across adapters or per-adapter?
+3. Where should checkpoints live: inside `session_params_json`, as issue
+   documents (like continuation summaries), or a new table?
+4. Does the wake prompt need a "compacted context" marker so agents trust
+   but verify checkpoints (low-trust implications)?
+5. Which adapter goes first for the rewrite seam pilot?
+6. Should phase 1 pressure numbers feed existing budgets/watchdogs, or stay
+   advisory until phase 2?
+
+## Risks
+
+- A bad summary loses working context mid-task. Mitigation: verbatim tail,
+  transactional commit, failure taxonomy, fresh-session escape hatch.
+- Twelve adapters means twelve rewrite behaviors to verify. Mitigation:
+  opt-out fallback, one pilot adapter first.
+- Summarization adds model spend. Mitigation: explicit config default off,
+  separate cost events.
+
+## Alternatives Considered
+
+- Fresh-session reset only (status quo). Rejected: loses all working
+  context; operators already avoid it for long tasks.
+- Extending deterministic continuation summaries. Rejected: metadata
+  rollups cannot preserve reasoning, file context, or pending-job nuance.
+- Per-adapter native compaction (e.g. relying on each provider's own
+  compaction). Rejected as the primary path: inconsistent across twelve
+  adapters and invisible to Paperclip governance; acceptable as a fallback
+  under the control-plane seam.
+- Doing nothing. Rejected: session growth is the primary quality cliff for
+  24/7 autonomous operation (MAXIMIZER MODE direction).

--- a/doc/plans/2026-09-08-session-compaction.md
+++ b/doc/plans/2026-09-08-session-compaction.md
@@ -7,14 +7,13 @@ Path-2 implementation work.
 
 Long-lived agent sessions degrade. Context fills with tool output, old
 decisions go stale, and adapters slow down or fail past model limits.
-Operators today have two levers, both blunt: let the session keep growing,
-or reset to a fresh session and lose all working context.
-
-DeepSeek Harness solves this with a compaction seam (`packages/compaction/*`
-plus `packages/guard/*` spill policy): pressure-triggered and operator-invoked
-(`/compact`) summarization that replaces old history with a structured
-checkpoint while keeping a verbatim tail. This proposal ports that idea to
-Paperclip's heartbeat and adapter model.
+Paperclip already rotates overgrown sessions, but rotation drops working
+context: the replacement session restarts from a thin handoff. DeepSeek
+Harness closes the same gap with a compaction seam (`packages/compaction/*`
+plus `packages/guard/*` spill policy): pressure-triggered and
+operator-invoked (`/compact`) summarization that replaces old history with a
+structured checkpoint while keeping a verbatim tail. This proposal ports the
+summarize-and-continue half to Paperclip's rotation model.
 
 ## What We Know Today
 
@@ -22,94 +21,117 @@ Paperclip's heartbeat and adapter model.
   keyed by company, agent, adapter type, and task key, plus adapter-native
   session stores referenced by `heartbeat_runs.session_id_before/after`.
   Read path: `getTaskSession` in `server/src/services/heartbeat.ts`.
-- Twelve adapters (`packages/adapters/*`: Claude, Codex, Cursor, Gemini,
-  Grok, Kimi, OpenClaw, OpenCode, Pi, Hermes, and cloud variants) each own
-  their session format behind per-adapter codecs (`sessionCodec`
-  serialize/deserialize in `heartbeat.ts`).
-- A fresh-session reset already exists end to end
-  (`forceFreshSession` from UI/API through `heartbeat.ts` into dispatch).
-  Reset drops context; there is no middle ground.
+- Twelve adapters (`packages/adapters/*`) each own their session format
+  behind per-adapter codecs (`sessionCodec` serialize/deserialize).
+- Rotation already exists and is policy-driven:
+  `packages/adapter-utils/src/session-compaction.ts` resolves a per-adapter
+  policy (run count, raw input tokens, session age; defaults 200 runs, 2M
+  tokens, 72h; native-context-management adapters opt out of threshold
+  rotation) with agent overrides and source tracking. The dispatch-side
+  decision (`SessionCompactionDecision` in `heartbeat.ts`) rotates past
+  threshold and attaches a deterministic handoff markdown: previous session
+  id, rotation reason, last-run summary, and a continuation summary excerpt.
+- Related work already open: proactive session rotation costs (#4496),
+  compact-usage status parsing as a pressure signal (#4577), policy
+  resolver coverage (#4920), Codex recovery compaction handoffs (#7838),
+  adapter stdout compaction (#10249). This proposal builds on that line, it
+  does not restart it.
 - Continuation summaries (`server/src/services/issue-continuation-summary.ts`)
-  are deterministic metadata rollups (run status, errors, excerpts; 8,000
-  char cap), not conversation summaries. They preserve outcomes, not reasoning.
-- Per-run token usage is recorded (`heartbeat_runs.usage_json`), but no
-  pressure signal is derived from it. Nothing measures session size, age, or
-  cost-to-continue per task session.
-- Wake-prompt pressure valves exist piecemeal (comment truncation in
-  `buildPaperclipWakePayload`, spill-behind-flag work in progress), but they
-  bound single wakes, not session growth across runs.
-- Prior art in DeepSeek Harness, studied for this proposal:
+  are deterministic metadata rollups (8,000 char cap), not conversation
+  summaries. They preserve outcomes, not reasoning.
+- Per-run token usage is recorded (`heartbeat_runs.usage_json`).
+- A fresh-session reset exists end to end (`forceFreshSession`).
+- Prior art studied in DeepSeek Harness:
   - `compaction-basic`: threshold ratio 0.8 of model context, 0.16 verbatim
     tail retention, per-model policy overrides, auxiliary-LLM summarization
     with a fixed checkpoint schema (intent, concepts, files, errors, pending,
     current work, next step, critical context), prefix-cache-aligned replay.
-  - `region`: token-metered span selection, tool-pairing balance, transactional
-    commit with stability guarantees across async summarization.
+  - `region`: token-metered span selection, tool-pairing balance,
+    transactional commit with stability guarantees across async
+    summarization.
   - `command-compact`: argument-free operator command with a closed failure
     taxonomy (busy, cancelled, changed, summary, commit, persistence).
   - `compaction-tool-result-pruner` and `spill-policy`: oversized tool
     results are pruned/spilled before they enter history.
 
+## The Gap
+
+Rotation answers *when* to restart a session. It does not answer *what to
+carry over*. Today's handoff holds the last run's summary plus a
+continuation excerpt. Everything else — reasoning chains, file context,
+pending-job nuance, corrections — is dropped. Operators also have no
+way to trigger this early on a session they can see going stale, and no
+visibility into per-session pressure before rotation fires.
+
 ## Goals
 
-1. Give operators visibility into session pressure (size, age, run count,
-   estimated tokens) per task session before quality degrades.
-2. Provide an operator-invoked compact action that summarizes a session and
-   resumes it, without losing pending work or auditability.
-3. Add automatic pressure-triggered compaction only after manual compaction
-   proves safe per adapter.
-4. Charge summarization cost to explicit budgets and log every compaction in
-   the activity trail.
+1. Upgrade rotation handoffs from last-run summaries to condensed
+   checkpoints that preserve reasoning and working context.
+2. Provide an operator-invoked compact action for sessions visibly going
+   stale, reusing the rotation commit path.
+3. Give operators per-session pressure visibility (runs, tokens, age vs
+   policy) before rotation fires.
+4. Charge summarization cost explicitly and log every compaction in the
+   activity trail.
 
 ## Non-Goals
 
-- Changing adapter session formats or the resume codec contract.
-- Silent automatic rewrites in phase 1 and 2. Every rewrite is operator
-  visible and reversible (fresh-session reset remains the escape hatch).
+- Changing adapter session formats, the resume codec contract, or the
+  rotation policy resolver. Compaction plugs into the existing decision
+  point.
+- Silent automatic rewrites. Manual compaction first; automatic
+  checkpoint-on-rotation only after per-adapter safety is demonstrated.
 - Cross-issue or cross-agent memory. Compaction stays within one task
   session. Durable knowledge is the Memory/Knowledge roadmap item, separate.
-- Replacing continuation summaries. They remain the deterministic outcome
-  record; compaction checkpoints cover reasoning and working context.
+- Replacing continuation summaries or the deterministic handoff. The
+  checkpoint augments them.
 
 ## Proposed Model
 
 ### Phase 1: pressure visibility (Path-1 sized, no prompt changes)
 
-- Derive per-task-session pressure from existing rows: byte size of
-  `session_params_json`, run count and error streak from `heartbeat_runs`,
-  summed tokens from `usage_json`.
-- Surface it where operators already look: the run/session UI and the wake
-  payload metadata (numbers only, never content).
+- Derive per-task-session pressure from existing rows: run count and error
+  streak from `heartbeat_runs`, summed tokens from `usage_json`, session age,
+  each against the resolved rotation policy for that adapter.
+- Surface it where operators already look: the run/session UI and wake
+  metadata (numbers only, never content).
 - No summarization, no rewrites, no new prompts. Pure observability that the
-  later phases read.
+  later phases read. Complements #4577 (usage parsing as signal).
 
-### Phase 2: operator compact action (Path-2, this proposal's core)
+### Phase 2: summarize-and-continue (Path-2, this proposal's core)
 
-- New operator action on a task session: `compactSession`.
-- Execution, mirroring the harness commit protocol:
-  1. Select a span: everything except a verbatim tail (propose 0.16 of
-     measured context, same default as the reference).
+- New operator action on a task session: `compactSession`. New automatic
+  behavior later: attach a checkpoint where rotation currently attaches
+  only the deterministic handoff.
+- Execution, mirroring the harness commit protocol and reusing the
+  rotation decision point:
+  1. Select a span: the session history minus a verbatim tail (propose the
+     reference default of 0.16 measured context).
   2. Summarize the span with an auxiliary model call using a fixed
      checkpoint schema (adopt the reference sections: intent, concepts,
      files, errors, pending, current work, next step, critical context).
-  3. Commit transactionally: verify the span is unchanged since selection
-     (`changed` failure otherwise), write the checkpoint, rewrite
-     `session_params_json` through the adapter's own codec, record the
-     attempt and outcome in `heartbeat_run_events` and the activity log.
+     Prior checkpoints merge forward (preserve true facts, drop stale
+     ones), never copied verbatim.
+  3. Commit transactionally: verify the span is unchanged since selection,
+     write the checkpoint, rotate through the existing rotation path with
+     the checkpoint as the handoff body, record the attempt and outcome in
+     `heartbeat_run_events` and the activity log.
   4. Closed failure taxonomy like the reference: busy, cancelled, changed,
-     summary, commit, persistence. Any failure leaves the session runnable.
-- Per-adapter rewrite seams: each adapter implements
-  `rewriteSessionForCheckpoint(codecParams, checkpoint)` or opts out
-  (opt-out adapters fall back to fresh-session reset with the checkpoint
-  attached as context, never silently).
+     summary, commit, persistence. Any failure leaves the session runnable
+     on its pre-compaction state.
+- Per-adapter handling: adapters with confirmed native context management
+  (already opted out of threshold rotation) need an explicit decision —
+  drive their native compaction, or run Paperclip checkpoints above it.
+  One pilot adapter first (propose `codex_local`, building on #7838).
 - Summarizer model and budget: explicit per-company configuration, default
   off; summarization spend recorded as its own cost event, never folded
   into the agent's task budget silently.
 
-### Phase 3: automatic pressure compaction (later, needs phase 2 data)
+### Phase 3: automatic checkpoint-on-rotation (later, needs phase 2 data)
 
-- Threshold-triggered compaction (propose 0.8 pressure ratio default) after
-  per-adapter safety is demonstrated. Operator-visible, reversible, logged.
+- Where rotation currently attaches the deterministic handoff, attach a
+  checkpoint instead, gated per adapter. Operator-visible, reversible via
+  fresh-session reset, logged.
 
 ## Open Questions for Maintainers
 
@@ -117,31 +139,33 @@ Paperclip's heartbeat and adapter model.
    compaction budget, or instance config? Who chooses the model?
 2. Should the checkpoint schema be shared across adapters or per-adapter?
 3. Where should checkpoints live: inside `session_params_json`, as issue
-   documents (like continuation summaries), or a new table?
+   documents beside continuation summaries, or a new table?
 4. Does the wake prompt need a "compacted context" marker so agents trust
    but verify checkpoints (low-trust implications)?
-5. Which adapter goes first for the rewrite seam pilot?
+5. Confirm `codex_local` as the rewrite-seam pilot, and the desired behavior
+   for native-context-management adapters?
 6. Should phase 1 pressure numbers feed existing budgets/watchdogs, or stay
    advisory until phase 2?
 
 ## Risks
 
 - A bad summary loses working context mid-task. Mitigation: verbatim tail,
-  transactional commit, failure taxonomy, fresh-session escape hatch.
-- Twelve adapters means twelve rewrite behaviors to verify. Mitigation:
-  opt-out fallback, one pilot adapter first.
-- Summarization adds model spend. Mitigation: explicit config default off,
-  separate cost events.
+  transactional commit, failure taxonomy, fresh-session escape hatch, and
+  the deterministic handoff stays attached regardless.
+- Twelve adapters means twelve behaviors to verify. Mitigation: reuse the
+  existing policy resolver and native-management flags, one pilot first.
+- Summarization adds model spend (the concern behind #4496). Mitigation:
+  explicit config default off, separate cost events.
 
 ## Alternatives Considered
 
-- Fresh-session reset only (status quo). Rejected: loses all working
-  context; operators already avoid it for long tasks.
+- Rotation handoffs as-is (status quo). Rejected: last-run summaries drop
+  reasoning and working context; operators cannot trigger early.
+- Fresh-session reset only. Rejected: loses all working context.
 - Extending deterministic continuation summaries. Rejected: metadata
   rollups cannot preserve reasoning, file context, or pending-job nuance.
-- Per-adapter native compaction (e.g. relying on each provider's own
-  compaction). Rejected as the primary path: inconsistent across twelve
-  adapters and invisible to Paperclip governance; acceptable as a fallback
-  under the control-plane seam.
+- Per-adapter native compaction as the primary path. Rejected: inconsistent
+  across twelve adapters and invisible to Paperclip governance; acceptable
+  as a fallback under the control-plane seam.
 - Doing nothing. Rejected: session growth is the primary quality cliff for
   24/7 autonomous operation (MAXIMIZER MODE direction).


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Long heartbeat sessions degrade past model limits, and rotation restarts them from a thin handoff
> - DeepSeek Harness answers this with summarize-and-continue compaction plus an operator command
> - Porting that touches adapter session handling, so it needs maintainer direction first
> - This pull request adds a proposal doc under doc/plans with prior art, a phased model, and open questions
> - The benefit is a reviewed design the team can approve before anyone writes prompt-adjacent code

## Linked Issues or Issue Description

Related open work, all referenced in the proposal (no duplicates — this PR writes no code):

- Refs #4496 (proactive session rotation costs)
- Refs #4577 (compact usage status parsing as a pressure signal)
- Refs #4920 (session-compaction policy resolver coverage)
- Refs #7838 (Codex recovery compaction handoffs)
- Refs #10249 (pi-local stdout compaction)

No public issue exists for the proposal itself. The problem follows the feature request fields:

**Subsystem affected**
server/ — REST API & orchestration services (heartbeat session handling), plus packages/adapters (per-adapter rewrite seams, future work only).

**Problem or motivation**
Rotation restarts overgrown sessions from a last-run summary. Reasoning chains, file context, and pending-job nuance are dropped. Operators cannot trigger compaction early and see no per-session pressure.

**Proposed solution**
This PR proposes only. Phased model: pressure visibility first (no prompt changes), then an operator compact action plus checkpoint-on-rotation using the existing rotation decision point, with a closed failure taxonomy. Six open questions for maintainers.

**Alternatives considered**
Discussed in the proposal: status quo handoffs, fresh-session reset only, extending deterministic continuation summaries, per-adapter native compaction as primary, doing nothing.

**Roadmap alignment**
This change supports ROADMAP.md "MAXIMIZER MODE" (deeper follow-through with visibility and governance) and "Enforced Outcomes". It is docs only. It duplicates no planned core work.

## What Changed

- Add `doc/plans/2026-09-08-session-compaction.md`: context, current state (rotation policy resolver, handoff markdown, related open PRs), the gap, goals and non-goals, a three-phase model, six open questions, risks, and alternatives.

## Verification

- Confirm all referenced paths exist: `server/src/services/heartbeat.ts` (rotation decision), `packages/adapter-utils/src/session-compaction.ts` (policy resolver), `server/src/services/issue-continuation-summary.ts`, `packages/adapters/*`.
- Run `pnpm check:tokens`. Result: no forbidden tokens.
- Docs only. No typecheck, test, or build surface changes.

## Risks

- Minimal direct risk: one markdown file, no code.
- Design risk sits in the open questions on purpose. Merging the proposal endorses discussion, not the full build. Phase 2 and 3 each need their own review.

## Model Used

- Provider and model: Meta Muse Spark, agentic coding assistant with tool use (file reads, shell).
- Exact model version and context window: not exposed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass (docs only; no code or test surface)
- [ ] I have added or updated tests where applicable (no test surface in a proposal doc)
- [ ] I have updated relevant documentation to reflect my changes (this PR is the documentation)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
