### PR TITLE
fix(claude-local): read OAuth credentials from the macOS keychain

### DIFF
--- a/packages/adapters/claude-local/src/server/quota.test.ts
+++ b/packages/adapters/claude-local/src/server/quota.test.ts
@@ -1,0 +1,115 @@
+import * as fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// The keychain read runs `security`, so the child-process call is mocked. The
+// handle lets each test control the result.
+const { execFile } = vi.hoisted(() => ({ execFile: vi.fn() }));
+
+vi.mock("node:child_process", async () => {
+  const actual = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  return { ...actual, execFile };
+});
+
+import { readClaudeToken } from "./quota.js";
+
+// promisify(execFile) calls the mock with a callback. This helper answers that
+// callback with stdout, or with an error.
+function keychainReturns(stdout: string): void {
+  execFile.mockImplementation((_cmd, _args, _opts, cb) => {
+    cb(null, { stdout, stderr: "" });
+    return undefined;
+  });
+}
+
+function keychainFails(message: string): void {
+  execFile.mockImplementation((_cmd, _args, _opts, cb) => {
+    cb(new Error(message), { stdout: "", stderr: "" });
+    return undefined;
+  });
+}
+
+const CREDENTIALS = JSON.stringify({
+  claudeAiOauth: { accessToken: "keychain-token", subscriptionType: "max" },
+});
+
+describe("readClaudeToken", () => {
+  const cleanupDirs: string[] = [];
+  const originalPlatform = process.platform;
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
+  function setPlatform(value: NodeJS.Platform): void {
+    Object.defineProperty(process, "platform", { value, configurable: true });
+  }
+
+  async function emptyConfigDir(): Promise<string> {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "claude-quota-"));
+    cleanupDirs.push(dir);
+    process.env.CLAUDE_CONFIG_DIR = dir;
+    return dir;
+  }
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    execFile.mockReset();
+    setPlatform(originalPlatform);
+    if (originalConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+    while (cleanupDirs.length > 0) {
+      const dir = cleanupDirs.pop();
+      if (!dir) continue;
+      await fs.rm(dir, { recursive: true, force: true }).catch(() => undefined);
+    }
+  });
+
+  it("prefers the credentials file over the keychain", async () => {
+    const dir = await emptyConfigDir();
+    await fs.writeFile(
+      path.join(dir, ".credentials.json"),
+      JSON.stringify({ claudeAiOauth: { accessToken: "file-token" } }),
+      "utf8",
+    );
+    setPlatform("darwin");
+    keychainReturns(CREDENTIALS);
+
+    await expect(readClaudeToken()).resolves.toBe("file-token");
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it("reads the keychain on macOS when no credentials file exists", async () => {
+    await emptyConfigDir();
+    setPlatform("darwin");
+    keychainReturns(CREDENTIALS);
+
+    await expect(readClaudeToken()).resolves.toBe("keychain-token");
+    const [command, args] = execFile.mock.calls[0] ?? [];
+    expect(command).toBe("security");
+    expect(args).toEqual(["find-generic-password", "-s", "Claude Code-credentials", "-w"]);
+  });
+
+  it("does not read the keychain on other platforms", async () => {
+    await emptyConfigDir();
+    setPlatform("linux");
+    keychainReturns(CREDENTIALS);
+
+    await expect(readClaudeToken()).resolves.toBeNull();
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the keychain item is absent", async () => {
+    await emptyConfigDir();
+    setPlatform("darwin");
+    keychainFails("The specified item could not be found in the keychain.");
+
+    await expect(readClaudeToken()).resolves.toBeNull();
+  });
+
+  it("returns null when the keychain item is not the expected JSON", async () => {
+    await emptyConfigDir();
+    setPlatform("darwin");
+    keychainReturns("not json");
+
+    await expect(readClaudeToken()).resolves.toBeNull();
+  });
+});

--- a/packages/adapters/claude-local/src/server/quota.ts
+++ b/packages/adapters/claude-local/src/server/quota.ts
@@ -10,6 +10,9 @@ const execFileAsync = promisify(execFile);
 const CLAUDE_USAGE_SOURCE_OAUTH = "anthropic-oauth";
 const CLAUDE_USAGE_SOURCE_CLI = "claude-cli";
 
+const CLAUDE_KEYCHAIN_SERVICE = "Claude Code-credentials";
+const KEYCHAIN_TIMEOUT_MS = 5_000;
+
 export function claudeConfigDir(): string {
   const fromEnv = process.env.CLAUDE_CONFIG_DIR;
   if (typeof fromEnv === "string" && fromEnv.trim().length > 0) return fromEnv.trim();
@@ -85,13 +88,7 @@ function trimToLatestUsagePanel(text: string): string | null {
   return tail;
 }
 
-async function readClaudeTokenFromFile(credPath: string): Promise<string | null> {
-  let raw: string;
-  try {
-    raw = await fs.readFile(credPath, "utf8");
-  } catch {
-    return null;
-  }
+function parseClaudeOauthAccessToken(raw: string): string | null {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
@@ -104,6 +101,38 @@ async function readClaudeTokenFromFile(credPath: string): Promise<string | null>
   if (typeof oauth !== "object" || oauth === null) return null;
   const token = (oauth as Record<string, unknown>)["accessToken"];
   return typeof token === "string" && token.length > 0 ? token : null;
+}
+
+async function readClaudeTokenFromFile(credPath: string): Promise<string | null> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(credPath, "utf8");
+  } catch {
+    return null;
+  }
+  return parseClaudeOauthAccessToken(raw);
+}
+
+/**
+ * macOS stores the Claude Code credentials in the login keychain instead of a
+ * file in the config directory. Read them with the `security` tool.
+ *
+ * The function returns null on other platforms. It also returns null if the
+ * keychain item is absent, the keychain is locked, or the item is not the
+ * expected JSON. The caller then continues to the CLI probe.
+ */
+async function readClaudeTokenFromKeychain(): Promise<string | null> {
+  if (process.platform !== "darwin") return null;
+  try {
+    const { stdout } = await execFileAsync(
+      "security",
+      ["find-generic-password", "-s", CLAUDE_KEYCHAIN_SERVICE, "-w"],
+      { timeout: KEYCHAIN_TIMEOUT_MS, maxBuffer: 1024 * 1024 },
+    );
+    return parseClaudeOauthAccessToken(stdout.trim());
+  } catch {
+    return null;
+  }
 }
 
 interface ClaudeAuthStatus {
@@ -143,7 +172,7 @@ export async function readClaudeToken(): Promise<string | null> {
     const token = await readClaudeTokenFromFile(path.join(configDir, filename));
     if (token) return token;
   }
-  return null;
+  return readClaudeTokenFromKeychain();
 }
 
 interface AnthropicUsageWindow {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The claude-local adapter reports Claude subscription headroom through `cost quota-windows`.
> - `readClaudeToken()` looks for the OAuth token only in `~/.claude/.credentials.json`.
> - macOS Claude Code keeps that token in the login keychain, so the file is absent.
> - The adapter then falls back to a probe of the interactive `/usage` TUI, and that probe fails.
> - Anthropic quota is therefore unavailable on every macOS host, while the openai provider works.
> - This pull request reads the keychain item after the file lookups miss.
> - The benefit is that macOS operators can see Claude subscription limits before agents exhaust them.

## Linked Issues or Issue Description

Refs #12005 — the same fallback path. That issue reports a leaked `script`/`sh`/`claude` process tree from the `/usage` probe. On Linux the fallback runs only at token expiry. On macOS it runs on every poll, so this change also reduces that leak.

No issue covers the macOS credential source. The problem, in bug-report form:

**What happened?**
`cost quota-windows` returns `ok: false` for the anthropic provider on macOS. The error is `Claude is logged in via claude.ai (max), but quota polling failed (Claude CLI /usage: Command failed: sh -c (sleep 2; printf '/usage\r'; ...) | script -q /dev/null claude --tools "")`. The openai provider returns its windows correctly.

**Expected behavior**
The adapter reports the Anthropic usage windows when the user is logged in with a Claude subscription.

**Steps to reproduce**
1. Use macOS. Log in to Claude Code with a claude.ai subscription.
2. Confirm `~/.claude/.credentials.json` does not exist.
3. Run `paperclipai cost quota-windows --company-id <id>`.
4. The anthropic provider returns `ok: false`.

**Agent adapter(s) involved**
`claude_local`

**Operating system**
macOS 25.6 (darwin, arm64). Claude Code 2.1.263. Node 24.12.0. Paperclip 2026.831.1.

**Relevant logs or output**
Before: `provider=anthropic ok=False`.
After: `provider=anthropic ok=True source=anthropic-oauth`, with `Current session 6%` and `Current week (all models) 19%`.

## What Changed

- Moved the credential JSON parsing into `parseClaudeOauthAccessToken()`, so the file path and the keychain path share one parser.
- Added `readClaudeTokenFromKeychain()`. It runs `security find-generic-password -s "Claude Code-credentials" -w` on darwin only.
- `readClaudeToken()` now returns the keychain result after the file lookups miss.
- Added `quota.test.ts` with 5 tests for the new behaviour.

## Verification

```
pnpm --filter @paperclipai/adapter-claude-local exec vitest run src/server/quota.test.ts   # 5 passed
pnpm --filter @paperclipai/adapter-claude-local exec vitest run                            # 270 passed, 1 skipped
pnpm --filter @paperclipai/adapter-claude-local typecheck                                  # clean
```

Manual check on a macOS host with a Claude Max subscription: `cost quota-windows` changed from `ok: false` to `ok: true` with `source: anthropic-oauth`, and returned the session and weekly windows. The keychain item holds the same `claudeAiOauth` object shape as the file.

## Risks

Low risk. The file remains the first source, so `CLAUDE_CONFIG_DIR` and non-macOS hosts do not change behaviour. The keychain read is darwin only. Any failure — absent item, locked keychain, missing `security` tool, or malformed JSON — returns null, and the CLI fallback runs exactly as before. The read has a 5 second timeout.

One note: `security find-generic-password` can prompt for keychain access when the item is not already unlocked. In that case the call fails on the timeout and the previous behaviour applies.

## Model Used

Claude Opus 5 (`claude-opus-5`, 1M context), extended thinking, with tool use and code execution. The root cause, the patch, and the tests were produced in a Claude Code session and verified locally against a live macOS install.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes — no documented behaviour changes; `docs/adapters/claude-local.md` does not describe the credential source
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green — not yet run on this branch
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — not yet reviewed
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)