### PR TITLE
feat: bind an agent to a Codex login whose account differs from the company default

### DIFF
--- a/packages/adapters/codex-local/src/server/codex-auth-cache.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-cache.test.ts
@@ -9,6 +9,7 @@ import {
   clearCodexAuthCacheEntry,
   ensureCodexAuthCacheEntryDir,
   isCodexAuthCacheEnabled,
+  isCodexAuthCachePath,
   resolveCodexAuthCacheDir,
   resolveCodexAuthCacheEntryPath,
   selectVendCredential,
@@ -83,6 +84,25 @@ describe("codex auth cache store", () => {
       expect(cacheDir).toBe(
         path.resolve(home, "instances", "default", "companies", "company-a", "codex-auth-cache"),
       );
+    });
+
+    it("isCodexAuthCachePath recognizes store entries for any company and rejects everything else", async () => {
+      const home = await makeInstanceRoot();
+      const env = envFor(home);
+      const cacheDir = resolveCodexAuthCacheDir(env, "company-a");
+      expect(isCodexAuthCachePath(env, cacheDir)).toBe(true);
+      expect(isCodexAuthCachePath(env, path.join(cacheDir, "acct-1"))).toBe(true);
+      expect(isCodexAuthCachePath(env, resolveCodexAuthCacheDir(env, "company-b"))).toBe(true);
+      // The company Codex home and a per-agent home are managed homes, not
+      // store entries — the seeding pass owns them.
+      expect(isCodexAuthCachePath(env, path.join(home, "instances", "default", "companies", "company-a", "codex-home"))).toBe(false);
+      expect(
+        isCodexAuthCachePath(env, path.join(home, "instances", "default", "companies", "company-a", "agents", "agent-1", "codex-home")),
+      ).toBe(false);
+      // A sibling directory whose name merely STARTS with the store name
+      // stays out, as does anything outside the instance tree.
+      expect(isCodexAuthCachePath(env, path.join(home, "instances", "default", "companies", "company-a", "codex-auth-cache-extra"))).toBe(false);
+      expect(isCodexAuthCachePath(env, "/tmp/codex-auth-cache/acct-1")).toBe(false);
     });
 
     it("resolveCodexAuthCacheEntryPath keys the entry by a sanitized account_id and ends with auth.json", async () => {

--- a/packages/adapters/codex-local/src/server/codex-auth-cache.ts
+++ b/packages/adapters/codex-local/src/server/codex-auth-cache.ts
@@ -113,6 +113,33 @@ export function resolveCodexAuthCacheDir(
 }
 
 /**
+ * True when `homePath` sits inside the per-identity credential store of ANY
+ * company: `<instanceRoot>/companies/<id>/codex-auth-cache/…` (or is a store
+ * root itself). These directories are identity-anchored slots owned by the
+ * device-login promotion, the vend, and the copy-back, each under its own
+ * lock. The managed-home seeding pass consults this to refuse to symlink,
+ * heal, or overwrite an entry's `auth.json`: an agent may bind `CODEX_HOME`
+ * to an entry (through the login's account-home secret), and seeding it like
+ * an ordinary managed home would silently swap the bound account's durable
+ * credential for the host login.
+ */
+export function isCodexAuthCachePath(
+  env: NodeJS.ProcessEnv,
+  homePath: string,
+): boolean {
+  const instanceRoot = resolvePaperclipInstanceRootForAdapter({
+    homeDir: nonEmpty(env.PAPERCLIP_HOME) ?? undefined,
+    instanceId: nonEmpty(env.PAPERCLIP_INSTANCE_ID) ?? undefined,
+    env,
+  });
+  const companiesRoot = path.resolve(instanceRoot, "companies");
+  const resolved = path.resolve(homePath);
+  if (!resolved.startsWith(companiesRoot + path.sep)) return false;
+  const segments = resolved.slice(companiesRoot.length + 1).split(path.sep);
+  return segments.length >= 2 && segments[1] === CACHE_DIR_NAME;
+}
+
+/**
  * Resolves the entry path for one identity: `<cacheRoot>/<safeAccountId>/auth.json`.
  * The `account_id` is validated first by {@link toAccountHandle} (a strict
  * allowlist), the entry point of this function, then sanitized again by

--- a/packages/adapters/codex-local/src/server/codex-home.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.test.ts
@@ -587,6 +587,77 @@ describe("seedManagedCodexHome", () => {
     }
   });
 
+  it("never symlinks or heals a credential-store entry's auth.json, even for a fresher same-identity source", async () => {
+    // An agent can bind CODEX_HOME to a per-identity store entry through the
+    // login's account-home secret, and this seeding pass runs before every
+    // probe and execute. The entry's auth.json is the durable login the
+    // promotion/vend/copy-back own — a strictly-fresher same-identity shared
+    // source must NOT trigger the #5028 heal here, or the bound account is
+    // silently swapped for the host login.
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-seed-store-"));
+    try {
+      const sharedCodexHome = path.join(root, "shared-codex-home");
+      const entryHome = path.join(
+        root, "paperclip-home", "instances", "default", "companies", "company-1", "codex-auth-cache", "acct-bound",
+      );
+      const env = {
+        CODEX_HOME: sharedCodexHome,
+        PAPERCLIP_HOME: path.join(root, "paperclip-home"),
+        PAPERCLIP_INSTANCE_ID: "default",
+      };
+      const stored = subscriptionAuth("acct-same", "stored", "2026-07-09T01:00:00Z");
+      await fs.mkdir(sharedCodexHome, { recursive: true });
+      await fs.writeFile(
+        path.join(sharedCodexHome, "auth.json"),
+        subscriptionAuth("acct-same", "host", "2026-07-09T02:00:00Z"),
+        "utf8",
+      );
+      await fs.writeFile(path.join(sharedCodexHome, "config.toml"), 'model = "gpt-5"\n', "utf8");
+      await fs.mkdir(entryHome, { recursive: true });
+      await fs.writeFile(path.join(entryHome, "auth.json"), stored, "utf8");
+
+      await seedManagedCodexHome(entryHome, env, async () => {});
+
+      const kept = path.join(entryHome, "auth.json");
+      expect((await fs.lstat(kept)).isSymbolicLink()).toBe(false);
+      expect(await fs.readFile(kept, "utf8")).toBe(stored);
+      // The static shared config still copies in, so a bound run gets the
+      // same config a per-agent home gets.
+      expect(await fs.readFile(path.join(entryHome, "config.toml"), "utf8")).toBe('model = "gpt-5"\n');
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses an API-key rewrite of a credential-store entry's auth.json", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-seed-store-apikey-"));
+    try {
+      const sharedCodexHome = path.join(root, "shared-codex-home");
+      const entryHome = path.join(
+        root, "paperclip-home", "instances", "default", "companies", "company-1", "codex-auth-cache", "acct-bound",
+      );
+      const env = {
+        CODEX_HOME: sharedCodexHome,
+        PAPERCLIP_HOME: path.join(root, "paperclip-home"),
+        PAPERCLIP_INSTANCE_ID: "default",
+      };
+      const stored = subscriptionAuth("acct-bound-id", "stored", "2026-07-09T01:00:00Z");
+      await fs.mkdir(sharedCodexHome, { recursive: true });
+      await fs.mkdir(entryHome, { recursive: true });
+      await fs.writeFile(path.join(entryHome, "auth.json"), stored, "utf8");
+      const logs: string[] = [];
+
+      await seedManagedCodexHome(entryHome, env, async (_stream, line) => {
+        logs.push(line);
+      }, { apiKey: "sk-configured" });
+
+      expect(await fs.readFile(path.join(entryHome, "auth.json"), "utf8")).toBe(stored);
+      expect(logs.join("\n")).toContain("Refusing to write an API-key auth.json into credential-store entry");
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("still removes an apikey-mode auth.json so the chatgpt-mode symlink is restored", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-seed-apikey-residue-"));
     try {

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import type { AdapterExecutionContext } from "@paperclipai/adapter-utils";
 import { resolvePaperclipInstanceRootForAdapter } from "@paperclipai/adapter-utils/server-utils";
-import { readSubscriptionAccountId } from "./codex-auth-cache.js";
+import { isCodexAuthCachePath, readSubscriptionAccountId } from "./codex-auth-cache.js";
 
 const TRUTHY_ENV_RE = /^(1|true|yes|on)$/i;
 const COPIED_SHARED_FILES = ["config.json", "config.toml", "instructions.md"] as const;
@@ -614,6 +614,17 @@ export async function seedManagedCodexHome(
   const sourceHome = resolveSharedCodexHomeDir(env);
   const seedFromShared = path.resolve(sourceHome) !== path.resolve(targetHome);
 
+  // A per-identity credential-store entry is not a seedable home: its
+  // auth.json is the durable, identity-anchored result of a device login,
+  // maintained by the promotion, the vend, and the copy-back under their own
+  // locks. An agent can bind `CODEX_HOME` to an entry through the login's
+  // account-home secret, and this pass runs before every probe and execute —
+  // symlinking the entry to the shared source would silently swap the bound
+  // account for the host login, and an API-key rewrite would destroy the
+  // stored credential outright. The static shared config files still copy
+  // in below, so a bound run gets the same config a per-agent home gets.
+  const credentialStoreEntry = isCodexAuthCachePath(env, targetHome);
+
   await fs.mkdir(targetHome, { recursive: true });
 
   // A regular-file auth.json in the target home is one of two very different
@@ -645,7 +656,7 @@ export async function seedManagedCodexHome(
   // deleting it would silently sign the company out right after a successful
   // device login.
   let keepPromotedAuth = false;
-  if (!apiKey && seedFromShared) {
+  if (!apiKey && seedFromShared && !credentialStoreEntry) {
     const authPath = path.join(targetHome, "auth.json");
     const existing = await fs.lstat(authPath).catch(() => null);
     if (existing && !existing.isSymbolicLink()) {
@@ -713,8 +724,9 @@ export async function seedManagedCodexHome(
   if (seedFromShared) {
     for (const name of SYMLINKED_SHARED_FILES) {
       // The kept promoted credential is authoritative for this home; the shared
-      // symlink would silently swap the account back to the host login.
-      if (name === "auth.json" && keepPromotedAuth) continue;
+      // symlink would silently swap the account back to the host login. A
+      // credential-store entry's auth.json is authoritative unconditionally.
+      if (name === "auth.json" && (keepPromotedAuth || credentialStoreEntry)) continue;
       const source = path.join(sourceHome, name);
       if (!(await pathExists(source))) continue;
       await ensureSymlink(path.join(targetHome, name), source);
@@ -733,11 +745,22 @@ export async function seedManagedCodexHome(
   }
 
   if (apiKey) {
-    await writeApiKeyAuthJson(targetHome, apiKey);
-    await onLog(
-      "stdout",
-      `[paperclip] Wrote API-key auth.json into Codex home "${targetHome}" from configured OPENAI_API_KEY.\n`,
-    );
+    if (credentialStoreEntry) {
+      // Refuse, loudly: overwriting a store entry's subscription credential
+      // with an API-key file would destroy the durable login the entry
+      // exists to hold. The operator combined an account binding with a
+      // configured OPENAI_API_KEY; the binding wins for this home.
+      await onLog(
+        "stdout",
+        `[paperclip] Refusing to write an API-key auth.json into credential-store entry "${targetHome}"; the bound account's stored login stays authoritative.\n`,
+      );
+    } else {
+      await writeApiKeyAuthJson(targetHome, apiKey);
+      await onLog(
+        "stdout",
+        `[paperclip] Wrote API-key auth.json into Codex home "${targetHome}" from configured OPENAI_API_KEY.\n`,
+      );
+    }
   }
 }
 

--- a/packages/adapters/codex-local/src/server/index.ts
+++ b/packages/adapters/codex-local/src/server/index.ts
@@ -13,6 +13,7 @@ export { getConfigSchema } from "./config-schema.js";
 export {
   reconcileManagedCodexHome,
   isManagedCodexHomePath,
+  resolveManagedCodexHomeDir,
   evaluateCodexCredentialReadiness,
   type ReconcileManagedCodexHomeInput,
   type ReconcileManagedCodexHomeResult,
@@ -47,6 +48,8 @@ export {
   withAccountHomeSecretMutationLock,
   assertAccountHomeCacheDirStillValid,
   resolveCodexAuthCacheDir,
+  isCodexAuthCachePath,
+  readSubscriptionAccountId,
 } from "./codex-auth-cache.js";
 export { parseCodexJsonl, isCodexHarnessCrash, isCodexProviderQuotaError, isCodexTransientUpstreamError, isCodexUnknownSessionError } from "./parse.js";
 export {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -936,6 +936,7 @@ export type {
   AdapterAuthSessionResponse,
   AdapterAuthSessionPrompt,
   AdapterAuthSessionOwnerResponse,
+  CodexAccountBindingClaim,
   StartAdapterAuthSessionRequest,
   AdapterAuthPanelMode,
   ClaudeSetupTokenSessionPrompt,

--- a/packages/shared/src/types/agent.ts
+++ b/packages/shared/src/types/agent.ts
@@ -181,10 +181,24 @@ export interface AdapterAuthSessionPrompt {
   code: string;
 }
 
+// The account-binding claim of a finished Codex login. `secretId` is the
+// opaque company secret that names the signed-in account's own Codex home.
+// `companyIdentityDiffers` is true when the company default home stayed on a
+// DIFFERENT account — the promotion never displaces another account's claim —
+// which is exactly when binding an agent to this secret is the only way the
+// login can take effect for it. The claim carries no account identifier and
+// no credential byte, and the server returns it only through an owner read of
+// an `authenticated` session.
+export interface CodexAccountBindingClaim {
+  secretId: string;
+  companyIdentityDiffers: boolean;
+}
+
 // The owner read of a login session. It adds the one-time prompt to the public
 // response. Only the owner principal that started the session reads this shape.
 export interface AdapterAuthSessionOwnerResponse extends AdapterAuthSessionResponse {
   prompt: AdapterAuthSessionPrompt | null;
+  codexAccountBinding?: CodexAccountBindingClaim | null;
 }
 
 // The request that starts a login session for one adapter in one environment.

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -299,6 +299,7 @@ export type {
   AdapterAuthSessionResponse,
   AdapterAuthSessionPrompt,
   AdapterAuthSessionOwnerResponse,
+  CodexAccountBindingClaim,
   StartAdapterAuthSessionRequest,
   AdapterAuthPanelMode,
   ClaudeSetupTokenSessionPrompt,

--- a/server/src/__tests__/agent-device-login-routes.test.ts
+++ b/server/src/__tests__/agent-device-login-routes.test.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import request from "supertest";
-import { lstat, mkdtemp, rm } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -908,6 +908,82 @@ describe("adapter device-login routes", () => {
       const status = await request(app).get(`${loginPath(COMPANY_1)}/${first.body.sessionId}`);
       expect(status.body.status).toBe("authenticated");
     });
+  });
+
+  it("an authenticated login's owner read carries the account-binding claim with the identity verdict", async () => {
+    // The claim is non-secret — the opaque company secret id plus whether the
+    // company default home stayed on a DIFFERENT account. The client offers
+    // binding the agent's CODEX_HOME only when the identities differ, which
+    // is the one case where the login cannot take effect through the shared
+    // company home.
+    const instanceRoot = await mkdtemp(path.join(os.tmpdir(), "paperclip-login-binding-"));
+    try {
+      vi.stubEnv("PAPERCLIP_HOME", instanceRoot);
+      vi.stubEnv("PAPERCLIP_INSTANCE_ID", "default");
+      const companyHome = path.join(instanceRoot, "instances", "default", "companies", COMPANY_1, "codex-home");
+      await mkdir(companyHome, { recursive: true });
+      await writeFile(
+        path.join(companyHome, "auth.json"),
+        JSON.stringify({
+          tokens: { id_token: "t", access_token: "t", refresh_token: "t", account_id: "acct-other" },
+        }),
+      );
+      mockSecretService.resolveSecretValueForDeviceLoginCheck.mockResolvedValue(
+        "/tmp/paperclip-codex-account-home/acct-default",
+      );
+      const app = await createApp();
+      const started = await request(app).post(loginPath(COMPANY_1)).send({ environmentId: SANDBOX_ENV_1 });
+      expect(started.status, JSON.stringify(started.body)).toBe(201);
+      harness.releaseGate();
+      await vi.waitFor(async () => {
+        const status = await request(app).get(`${loginPath(COMPANY_1)}/${started.body.sessionId}`);
+        expect(status.body.status).toBe("authenticated");
+        expect(status.body.codexAccountBinding).toEqual({
+          secretId: "secret-1",
+          companyIdentityDiffers: true,
+        });
+      });
+    } finally {
+      vi.unstubAllEnvs();
+      await rm(instanceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("a login for the account the company home already holds reports no identity mismatch", async () => {
+    // Same-account logins take effect through the company-home refresh; the
+    // claim still rides along with `companyIdentityDiffers: false`, and the
+    // client deliberately binds nothing.
+    const instanceRoot = await mkdtemp(path.join(os.tmpdir(), "paperclip-login-binding-same-"));
+    try {
+      vi.stubEnv("PAPERCLIP_HOME", instanceRoot);
+      vi.stubEnv("PAPERCLIP_INSTANCE_ID", "default");
+      const companyHome = path.join(instanceRoot, "instances", "default", "companies", COMPANY_1, "codex-home");
+      await mkdir(companyHome, { recursive: true });
+      await writeFile(
+        path.join(companyHome, "auth.json"),
+        JSON.stringify({
+          tokens: { id_token: "t", access_token: "t", refresh_token: "t", account_id: "acct-default" },
+        }),
+      );
+      mockSecretService.resolveSecretValueForDeviceLoginCheck.mockResolvedValue(
+        "/tmp/paperclip-codex-account-home/acct-default",
+      );
+      const app = await createApp();
+      const started = await request(app).post(loginPath(COMPANY_1)).send({ environmentId: SANDBOX_ENV_1 });
+      expect(started.status, JSON.stringify(started.body)).toBe(201);
+      harness.releaseGate();
+      await vi.waitFor(async () => {
+        const status = await request(app).get(`${loginPath(COMPANY_1)}/${started.body.sessionId}`);
+        expect(status.body.status).toBe("authenticated");
+        expect(status.body.codexAccountBinding).toEqual({
+          secretId: "secret-1",
+          companyIdentityDiffers: false,
+        });
+      });
+    } finally {
+      vi.unstubAllEnvs();
+      await rm(instanceRoot, { recursive: true, force: true });
+    }
   });
 
   it("fails closed when promotion loses the sole-owner claim", async () => {

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -1,6 +1,6 @@
 import { Router, type NextFunction, type Request, type Response } from "express";
 import { generateKeyPairSync, randomUUID } from "node:crypto";
-import { rm } from "node:fs/promises";
+import { readFile, rm } from "node:fs/promises";
 import path from "node:path";
 import type { Db } from "@paperclipai/db";
 import { agents as agentsTable, companies, heartbeatRuns, issues as issuesTable, projects as projectsTable } from "@paperclipai/db";
@@ -86,7 +86,7 @@ import type {
   AdapterEnvironmentTestResult,
 } from "@paperclipai/adapter-utils";
 import { evaluateCodexCredentialReadiness } from "@paperclipai/adapter-codex-local/server";
-import type { AdapterAuthSignal, AdapterAuthSignalResponse } from "@paperclipai/shared";
+import type { AdapterAuthSignal, AdapterAuthSignalResponse, CodexAccountBindingClaim } from "@paperclipai/shared";
 import { getDisabledAdapterTypes } from "../services/adapter-plugin-store.js";
 import { skillVersionSelectionMap } from "../services/runtime-skill-selections.js";
 import { secretService } from "../services/secrets.js";
@@ -182,6 +182,8 @@ import {
 import {
   checkStagedCredentialReadiness,
   promoteDeviceLoginCredential,
+  readSubscriptionAccountId,
+  resolveManagedCodexHomeDir,
   withAccountHomeSecretMutationLock,
   withCodexAccountHomePromotionLock,
 } from "@paperclipai/adapter-codex-local/server";
@@ -699,8 +701,25 @@ export function agentRoutes(
   // nothing outlives one login attempt.
   const pendingAccountHomeSecretCommits = new Map<
     string,
-    { secretId: string; secretName: string; accountHomeDir: string }
+    { secretId: string; secretName: string; accountHomeDir: string; companyIdentityDiffers: boolean }
   >();
+
+  // Non-secret binding claims for AUTHENTICATED Codex logins, keyed by the
+  // internal session id and served on the owner status read. In-memory like
+  // the one-time login prompt: a restart loses the claim and the panel shows
+  // plain success with no binding offer — graceful degradation, never a
+  // wrong bind. Bounded with insertion-order eviction so reaped sessions
+  // cannot grow it forever.
+  const committedCodexAccountBindings = new Map<string, CodexAccountBindingClaim>();
+  const MAX_COMMITTED_CODEX_ACCOUNT_BINDINGS = 200;
+  function rememberCodexAccountBinding(sessionId: string, claim: CodexAccountBindingClaim): void {
+    committedCodexAccountBindings.set(sessionId, claim);
+    while (committedCodexAccountBindings.size > MAX_COMMITTED_CODEX_ACCOUNT_BINDINGS) {
+      const oldest = committedCodexAccountBindings.keys().next().value;
+      if (oldest === undefined) break;
+      committedCodexAccountBindings.delete(oldest);
+    }
+  }
 
   const adapterLoginService = createDeviceLoginService({
     store: adapterLoginStore,
@@ -806,6 +825,26 @@ export function agentRoutes(
             }
             const secretName = `CODEX_HOME_${handle}`;
             const accountHomeDir = result.accountHomeDir;
+            // Whether the company default home ended on a DIFFERENT account
+            // than this login. The promotion's own company-home write already
+            // ran (a seed or same-identity refresh landed this login there; a
+            // different account's claim was kept), so this read observes the
+            // post-promotion state. The flag rides to the owner status read,
+            // where the client offers binding the agent to this account — the
+            // only way the login can take effect while another account holds
+            // the company slot. Any read failure degrades to `false`: the
+            // client then simply offers nothing, never a wrong bind.
+            const companyIdentityDiffers = await (async () => {
+              try {
+                const companyAuthBytes = await readFile(
+                  path.join(resolveManagedCodexHomeDir(process.env, context.companyId), "auth.json"),
+                );
+                const companyIdentity = readSubscriptionAccountId(companyAuthBytes);
+                return companyIdentity !== null && companyIdentity !== result.accountId;
+              } catch {
+                return false;
+              }
+            })();
             const existingSecret = await secretsSvc.getByName(context.companyId, secretName);
             if (existingSecret) {
               // A same-name secret already exists. Confirm it still names this
@@ -827,6 +866,7 @@ export function agentRoutes(
                 secretId: existingSecret.id,
                 secretName,
                 accountHomeDir,
+                companyIdentityDiffers,
               });
               return;
             }
@@ -850,6 +890,7 @@ export function agentRoutes(
                 secretId: createdSecret.id,
                 secretName,
                 accountHomeDir,
+                companyIdentityDiffers,
               });
             } catch (err) {
               if (err instanceof HttpError && err.status === 409) {
@@ -874,6 +915,7 @@ export function agentRoutes(
                   secretId: winningSecret.id,
                   secretName,
                   accountHomeDir,
+                  companyIdentityDiffers,
                 });
                 return;
               }
@@ -935,7 +977,7 @@ export function agentRoutes(
             // the service ever reaches this call). Nothing to reconfirm.
             return commit();
           }
-          return withAccountHomeSecretMutationLock(undefined, context.companyId, async () => {
+          const committed = await withAccountHomeSecretMutationLock(undefined, context.companyId, async () => {
             // Resolve by the secret's id, not its name: a rotate changes the
             // value under the same id, so re-resolving this id picks up a
             // rotation the same way the very first check would have, with no
@@ -953,6 +995,14 @@ export function agentRoutes(
             );
             return commit();
           });
+          // Only after the terminal write is durable: an owner status read
+          // must never see a binding claim for a session that failed to
+          // authenticate.
+          rememberCodexAccountBinding(context.sessionId, {
+            secretId: pending.secretId,
+            companyIdentityDiffers: pending.companyIdentityDiffers,
+          });
+          return committed;
         },
       },
       grok_local: {
@@ -1816,7 +1866,16 @@ export function agentRoutes(
     if (!row || row.adapterType !== adapterType || row.startedByUserId !== requestingUserId) {
       return null;
     }
-    return adapterLoginService.readOwnerSession(publicSessionId, companyId, requestingUserId);
+    const session = await adapterLoginService.readOwnerSession(publicSessionId, companyId, requestingUserId);
+    if (!session) return session;
+    // Merge the non-secret account-binding claim onto an authenticated Codex
+    // owner read. The claim lives beside the terminal commit that produced it
+    // (see rememberCodexAccountBinding); a process restart simply drops it.
+    if (row.adapterType === "codex_local" && session.status === "authenticated") {
+      const claim = committedCodexAccountBindings.get(row.id);
+      if (claim) return { ...session, codexAccountBinding: claim };
+    }
+    return session;
   }
 
   async function assertCanReadConfigurations(req: Request, companyId: string) {

--- a/ui/src/components/AgentConfigForm.render.test.tsx
+++ b/ui/src/components/AgentConfigForm.render.test.tsx
@@ -1746,6 +1746,62 @@ describe("AgentConfigForm environment selector", () => {
     expect(findButton(container, "Cancel")).toBeFalsy();
     expect(mockAgentsApi.cancelAdapterAuthLogin).not.toHaveBeenCalled();
   });
+  it("reports the account-binding claim upward exactly once when the session authenticates", async () => {
+    // The authenticated owner read can carry the non-secret Codex
+    // account-binding claim. The panel hands it to the caller once; the
+    // caller (the edit-mode form) decides whether a bind is warranted.
+    mockAgentsApi.startAdapterAuthLogin.mockResolvedValue({
+      sessionId: "bind-session-1",
+      environmentId: "sandbox-1",
+      status: "waiting_for_user",
+      expiresAt: null,
+      failure: null,
+      prompt: { url: "https://auth.example.test/bind", code: "BIND-1" },
+    });
+    mockAgentsApi.getAdapterAuthLoginStatus.mockResolvedValue({
+      sessionId: "bind-session-1",
+      environmentId: "sandbox-1",
+      status: "authenticated",
+      expiresAt: null,
+      failure: null,
+      prompt: null,
+      codexAccountBinding: { secretId: "secret-bind-1", companyIdentityDiffers: true },
+    });
+    const onAccountBinding = vi.fn();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    roots.push(root);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    await act(async () => {
+      root.render(
+        <QueryClientProvider client={queryClient}>
+          <ToastProvider>
+            <TooltipProvider>
+              <AdapterLoginPanel
+                companyId="company-1"
+                adapterType="codex_local"
+                environmentId="sandbox-1"
+                autoStart
+                onAccountBinding={onAccountBinding}
+              />
+            </TooltipProvider>
+          </ToastProvider>
+        </QueryClientProvider>,
+      );
+    });
+    await flushUntil(() => onAccountBinding.mock.calls.length > 0);
+
+    expect(onAccountBinding).toHaveBeenCalledTimes(1);
+    expect(onAccountBinding).toHaveBeenCalledWith({
+      secretId: "secret-bind-1",
+      companyIdentityDiffers: true,
+    });
+  });
+
   it("resumes an active login session on mount, adopting its session id and prompt", async () => {
     // A page reload loses every piece of local state, so the panel must read
     // the caller's active session and adopt it instead of starting a new one.

--- a/ui/src/components/AgentConfigForm.tsx
+++ b/ui/src/components/AgentConfigForm.tsx
@@ -6,6 +6,7 @@ import type {
   Agent,
   AdapterAuthSessionPrompt,
   AdapterAuthSessionStatus,
+  CodexAccountBindingClaim,
   AdapterEnvironmentTestResult,
   CompanySecret,
   EnvBinding,
@@ -597,6 +598,35 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
       ...buildAgentUpdatePatch(props.agent, nextOverlay),
       applyStoredClaudeLogin: true,
     });
+    invalidateUserSecretDefinitions();
+  };
+
+  // Edit mode: a Codex login that signed in to a DIFFERENT account than the
+  // company default cannot take effect through the shared company home — the
+  // promotion never displaces another account's claim there. Bind this
+  // agent's CODEX_HOME to the login's account-home secret and persist at
+  // once, the same one-step shape as the Claude stored-login bind above.
+  // Same-account logins skip the bind on purpose: the company-home refresh
+  // already carried them, and an unbound agent keeps following the company
+  // default across later credential rotations. No claim flag is needed —
+  // the secret already exists company-scoped, so this is an ordinary
+  // secret-reference binding through the normal agent-update patch.
+  const handleCodexAccountBindingEdit = async (claim: CodexAccountBindingClaim) => {
+    if (isCreate || !claim.companyIdentityDiffers) return;
+    const flushedEnv = flushEnvironmentDraft();
+    const baseEnv =
+      flushedEnv ??
+      (eff("adapterConfig", "env", (config.env ?? EMPTY_ENV) as Record<string, EnvBinding>));
+    const nextEnv: Record<string, EnvBinding> = {
+      ...baseEnv,
+      CODEX_HOME: { type: "secret_ref", secretId: claim.secretId, version: "latest" },
+    };
+    const nextOverlay: AgentConfigOverlay = {
+      ...overlay,
+      adapterConfig: { ...overlay.adapterConfig, env: nextEnv },
+    };
+    setOverlay(nextOverlay);
+    await props.onSave(buildAgentUpdatePatch(props.agent, nextOverlay));
     invalidateUserSecretDefinitions();
   };
 
@@ -1548,6 +1578,7 @@ export function AgentConfigForm(props: AgentConfigFormProps) {
               onApplyStored={
                 isCreate ? handleApplyStoredClaudeLogin : handleApplyStoredClaudeLoginEdit
               }
+              onAccountBinding={isCreate ? undefined : handleCodexAccountBindingEdit}
             />
           )}
 
@@ -2101,6 +2132,14 @@ export type AdapterLoginDescriptor = {
 export type AdapterLoginPanelProps = AdapterLoginDescriptor & {
   onStored?: (storedSessionId: string) => void;
   onApplyStored?: () => void;
+  // Reports the non-secret Codex account-binding claim from an authenticated
+  // owner read: the company secret that names the signed-in account's own
+  // home, and whether the company default home stayed on a DIFFERENT account.
+  // The edit-mode form binds the agent's CODEX_HOME to the secret when the
+  // identities differ — the only case where the login cannot take effect
+  // through the shared company home. The callback never carries a token byte
+  // or an account identifier.
+  onAccountBinding?: (claim: CodexAccountBindingClaim) => void;
   // Start the login on mount instead of waiting for a press. The connect step's
   // footer button is the press — by the time the panel is rendered there, the
   // customer has already asked for this.
@@ -2162,6 +2201,7 @@ function DisplayedCodeLoginPanel({
   environmentId,
   autoStart,
   onConnected,
+  onAccountBinding,
   chrome = "panel",
   onPromptReady,
 }: AdapterLoginPanelProps) {
@@ -2355,6 +2395,20 @@ function DisplayedCodeLoginPanel({
     connectedRef.current = true;
     onConnectedRef.current?.();
   }, [status]);
+
+  // Report the account-binding claim upward once. The claim arrives on the
+  // same owner read that reports `authenticated` (or a later poll before the
+  // poll stops); it is non-secret — a company secret id plus a flag — and the
+  // caller decides whether a bind is warranted.
+  const accountBindingReportedRef = useRef(false);
+  const onAccountBindingRef = useRef(onAccountBinding);
+  onAccountBindingRef.current = onAccountBinding;
+  const accountBinding = statusQuery.data?.codexAccountBinding ?? null;
+  useEffect(() => {
+    if (status !== "authenticated" || !accountBinding || accountBindingReportedRef.current) return;
+    accountBindingReportedRef.current = true;
+    onAccountBindingRef.current?.(accountBinding);
+  }, [status, accountBinding]);
 
   // Report the prompt's URL upward, the way the submitted-browser-code panel
   // does. The caller's loading beat ends when this arrives, so without it the


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The `codex_local` adapter signs agents in to OpenAI, and a company keeps one default Codex identity in its shared company home
> - A login with a DIFFERENT account than the company default is deliberately kept out of the shared home — one agent's sign-in must not switch every unbound agent's credentials — but that left the cross-account login inert: nothing connected the agent the operator was configuring to the credential the login stored
> - The stored credential and its company secret already exist; only the last mile — an agent actually using them — was missing
> - This pull request reports a non-secret binding claim on the authenticated login and lets the agent page bind that one agent's `CODEX_HOME` to the account's secret, exactly and only when the identities differ
> - The benefit is that multi-account Codex becomes one click on the agent that needs it, with company-wide identity untouched

## Linked Issues or Issue Description

**What happened?**

On an agent's detail page, "Sign in with Codex" using a different OpenAI account than the company default succeeds but changes nothing for that agent. The credential lands in the per-identity store and a company secret names it, but the agent keeps using the company default. The Test keeps reporting that authentication is needed, and no repeat login helps.

**Expected behavior**

When the operator deliberately signs an agent's page in with a different account, that agent starts using that account. Agents that were not part of the action keep the company default. A same-account login keeps working through the shared company home with no per-agent pinning.

**Steps to reproduce**

1. Configure a company whose Codex home holds account A.
2. Open a `codex_local` agent's detail page with a sandbox environment and complete "Sign in with Codex" using account B.
3. Press Test. Before this change the agent still resolves account A and the authentication-needed check returns.

## What Changed

- `packages/adapters/codex-local` — the prerequisite shield: `isCodexAuthCachePath` recognizes per-identity credential-store entries, and `seedManagedCodexHome` refuses to symlink, heal, or API-key-overwrite an entry's `auth.json`. The seeding pass runs before every probe and execute; without the shield, an agent bound to an entry would have its stored login silently swapped for the host credential. Static shared config files still copy in. Rotation already survives binding: the sandbox copy-back writes rotated credentials into the identity-keyed store slot.
- `server` — the promotion records whether the company default home ended on a different account than the login (any read failure degrades to `false`, so the client can never be told to bind wrongly). After the terminal commit, the routes layer remembers a non-secret claim — the opaque account-home secret id plus that verdict — in a bounded in-memory map, and merges it into the owner read of an `authenticated` `codex_local` session. A restart drops the claim; the panel then shows plain success.
- `packages/shared` — `CodexAccountBindingClaim` on the owner session response. It carries no account identifier and no credential byte.
- `ui` — the login panel reports the claim upward once. The edit-mode form binds the agent's `CODEX_HOME` to the secret and saves in one step, only when `companyIdentityDiffers` is true. Same-account logins bind nothing on purpose: the company-home refresh already carried them, and an unbound agent keeps following the company default across rotations. Create mode is unchanged.

## Verification

- Adapter suite: 381 passed, 1 skipped (includes the new store-entry shield tests and the path-predicate cases).
- Server suites (8 files): 130 passed, 15 skipped — including two new route tests that drive a login to `authenticated` and assert the claim with both identity verdicts.
- UI render suite: 85 passed — including a panel test that the claim is reported upward exactly once.
- `tsc --noEmit` clean in `packages/shared`, the adapter package, and `ui`; `server` clean for the touched file.

## Risks

- The bind changes one agent's configuration through the normal agent-update patch, initiated by the operator's own login on that agent's page. The failure direction of every fallback is "offer nothing": a missing claim, a restart, or an unreadable company home all degrade to no bind.
- The seed shield narrows what the seeding pass may touch; homes outside the credential store behave exactly as before, covered by the existing seed tests.
- Builds on the sign-in credential-resolution fix (#13064); this branch stacks on it and the diff here contains only the binding feature once that merges.

## Model Used

Claude (Anthropic) — Claude Fable 5 (`claude-fable-5`), extended thinking, agentic tool use in Claude Code (terminal).

**Related PRs (searched; no duplicates found):** #12740, #12082, and #9621 touch adjacent Codex credential sync paths; #8495 is the standing hardening effort for probe auth seeding.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (no standalone docs cover this flow; the behavioral contracts are documented in-line at each changed site)
- [x] I have considered and documented any risks above