### PR TITLE
feat(plugins): nudge agents out of repeated identical tool calls

### DIFF
--- a/server/src/__tests__/plugin-tool-repeat-guard.test.ts
+++ b/server/src/__tests__/plugin-tool-repeat-guard.test.ts
@@ -39,9 +39,9 @@ const runContext = { agentId: "agent-1", runId: "run-1", companyId: "company-1",
 describe("repeat tool tracker", () => {
   it("counts consecutive identical calls regardless of argument key order", () => {
     const tracker = createRepeatToolTracker();
-    const first = tracker.observe({ ...runContext, toolName: "t", parameters: { a: 1, b: 2 } });
+    const first = tracker.observe({ ...runContext, toolName: "t", parameters: { a: 1, b: 2 }, result: { content: "r" } });
     expect(first).toEqual({ repeatCount: 1, notice: null });
-    const second = tracker.observe({ ...runContext, toolName: "t", parameters: { b: 2, a: 1 } });
+    const second = tracker.observe({ ...runContext, toolName: "t", parameters: { b: 2, a: 1 }, result: { content: "r" } });
     expect(second.repeatCount).toBe(2);
     expect(second.notice).toBeNull();
   });
@@ -50,20 +50,37 @@ describe("repeat tool tracker", () => {
     const tracker = createRepeatToolTracker();
     const fired: number[] = [];
     for (let index = 0; index < 9; index += 1) {
-      const { repeatCount, notice } = tracker.observe({ ...runContext, toolName: "t", parameters: { q: "x" } });
+      const { repeatCount, notice } = tracker.observe({ ...runContext, toolName: "t", parameters: { q: "x" }, result: { content: "r" } });
       if (notice) fired.push(repeatCount);
     }
     expect(fired).toEqual([3, 5, 8]);
   });
 
-  it("resets on a different call and scopes chains per run", () => {
-    const tracker = createRepeatToolTracker();
-    tracker.observe({ ...runContext, toolName: "t", parameters: { q: "x" } });
-    tracker.observe({ ...runContext, toolName: "t", parameters: { q: "x" } });
-    const changed = tracker.observe({ ...runContext, toolName: "t", parameters: { q: "y" } });
+  it("resets on a different call and scopes chains per run", () => {    const tracker = createRepeatToolTracker();
+    tracker.observe({ ...runContext, toolName: "t", parameters: { q: "x" }, result: { content: "r" } });
+    tracker.observe({ ...runContext, toolName: "t", parameters: { q: "x" }, result: { content: "r" } });
+    const changed = tracker.observe({ ...runContext, toolName: "t", parameters: { q: "y" }, result: { content: "r" } });
     expect(changed).toEqual({ repeatCount: 1, notice: null });
-    const otherRun = tracker.observe({ ...runContext, runId: "run-2", toolName: "t", parameters: { q: "x" } });
+    const otherRun = tracker.observe({ ...runContext, runId: "run-2", toolName: "t", parameters: { q: "x" }, result: { content: "r" } });
     expect(otherRun).toEqual({ repeatCount: 1, notice: null });
+  });
+
+  it("resets when identical calls return different outcomes", () => {
+    const tracker = createRepeatToolTracker();
+    tracker.observe({ ...runContext, toolName: "t", parameters: { q: "x" }, result: { content: "poll 1" } });
+    tracker.observe({ ...runContext, toolName: "t", parameters: { q: "x" }, result: { content: "poll 1" } });
+    const changed = tracker.observe({ ...runContext, toolName: "t", parameters: { q: "x" }, result: { content: "poll 2" } });
+    expect(changed).toEqual({ repeatCount: 1, notice: null });
+  });
+
+  it("never chains oversized or unserializable outcomes", () => {
+    const tracker = createRepeatToolTracker();
+    const big = "z".repeat(5_000);
+    const first = tracker.observe({ ...runContext, toolName: "t", parameters: { q: "x" }, result: { content: big } });
+    const second = tracker.observe({ ...runContext, toolName: "t", parameters: { q: "x" }, result: { content: big } });
+    expect(first.repeatCount).toBe(1);
+    expect(second.repeatCount).toBe(1);
+    expect(second.notice).toBeNull();
   });
 
   it("builds notices only at thresholds", () => {

--- a/server/src/__tests__/plugin-tool-repeat-guard.test.ts
+++ b/server/src/__tests__/plugin-tool-repeat-guard.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  REPEAT_TOOL_REMINDER_THRESHOLDS,
+  buildRepeatToolNotice,
+  createRepeatToolTracker,
+} from "../services/plugin-tool-repeat-guard.js";
+import { validateToolContent } from "../services/tool-content-guards.js";
+import { createPluginToolRegistry } from "../services/plugin-tool-registry.js";
+import type { PluginWorkerManager } from "../services/plugin-worker-manager.js";
+import type { PaperclipPluginManifestV1 } from "@paperclipai/shared";
+
+const PLUGIN_KEY = "acme.repeat";
+const PLUGIN_DB_ID = "00000000-0000-4000-8000-000000000003";
+
+function manifest(): PaperclipPluginManifestV1 {
+  return {
+    id: PLUGIN_KEY,
+    apiVersion: 1,
+    version: "1.0.0",
+    displayName: "Repeat plugin",
+    description: "Repeat fixture",
+    author: "Paperclip",
+    categories: ["automation"],
+    capabilities: ["agent.tools.register"],
+    entrypoints: { worker: "dist/worker.js" },
+    tools: [
+      {
+        name: "lookup",
+        displayName: "Lookup",
+        description: "Looks things up",
+        parametersSchema: { type: "object", properties: {} },
+      },
+    ],
+  } as unknown as PaperclipPluginManifestV1;
+}
+
+const runContext = { agentId: "agent-1", runId: "run-1", companyId: "company-1", projectId: null };
+
+describe("repeat tool tracker", () => {
+  it("counts consecutive identical calls regardless of argument key order", () => {
+    const tracker = createRepeatToolTracker();
+    const first = tracker.observe({ ...runContext, toolName: "t", parameters: { a: 1, b: 2 } });
+    expect(first).toEqual({ repeatCount: 1, notice: null });
+    const second = tracker.observe({ ...runContext, toolName: "t", parameters: { b: 2, a: 1 } });
+    expect(second.repeatCount).toBe(2);
+    expect(second.notice).toBeNull();
+  });
+
+  it("fires gentle then detailed notices at the configured thresholds", () => {
+    const tracker = createRepeatToolTracker();
+    const fired: number[] = [];
+    for (let index = 0; index < 9; index += 1) {
+      const { repeatCount, notice } = tracker.observe({ ...runContext, toolName: "t", parameters: { q: "x" } });
+      if (notice) fired.push(repeatCount);
+    }
+    expect(fired).toEqual([3, 5, 8]);
+  });
+
+  it("resets on a different call and scopes chains per run", () => {
+    const tracker = createRepeatToolTracker();
+    tracker.observe({ ...runContext, toolName: "t", parameters: { q: "x" } });
+    tracker.observe({ ...runContext, toolName: "t", parameters: { q: "x" } });
+    const changed = tracker.observe({ ...runContext, toolName: "t", parameters: { q: "y" } });
+    expect(changed).toEqual({ repeatCount: 1, notice: null });
+    const otherRun = tracker.observe({ ...runContext, runId: "run-2", toolName: "t", parameters: { q: "x" } });
+    expect(otherRun).toEqual({ repeatCount: 1, notice: null });
+  });
+
+  it("builds notices only at thresholds", () => {
+    expect(buildRepeatToolNotice("t", 2, "{}")).toBeNull();
+    expect(buildRepeatToolNotice("t", 4, "{}")).toBeNull();
+    expect(buildRepeatToolNotice("t", 3, "{}")).toContain("Loop guard");
+    expect(REPEAT_TOOL_REMINDER_THRESHOLDS).toEqual([3, 5, 8]);
+  });
+
+  it("produces notices the result content guard never blocks", () => {
+    for (const count of [3, 5, 8]) {
+      const notice = buildRepeatToolNotice("lookup", count, '{"query":"x"}');
+      expect(notice).toBeTruthy();
+      expect(() =>
+        validateToolContent({ value: { content: `found it\n\n${notice}` }, direction: "result" }),
+      ).not.toThrow();
+    }
+  });
+});
+
+describe("registry repeat nudge", () => {
+  function registryWith(content: string) {
+    const call = vi.fn(async () => ({ content }));
+    const manager = {
+      isRunning: () => true,
+      call: call as unknown as PluginWorkerManager["call"],
+    } as unknown as PluginWorkerManager;
+    const registry = createPluginToolRegistry(manager);
+    registry.registerPlugin(PLUGIN_KEY, manifest(), PLUGIN_DB_ID);
+    return { registry, call };
+  }
+
+  it("appends the reminder on the third identical call", async () => {
+    const { registry } = registryWith("found it");
+    const params = { query: "outage" };
+    const first = await registry.executeTool("acme.repeat:lookup", params, runContext);
+    expect(first.result.content).toBe("found it");
+    await registry.executeTool("acme.repeat:lookup", params, runContext);
+    const third = await registry.executeTool("acme.repeat:lookup", params, runContext);
+    expect(third.result.content).toContain("found it");
+    expect(third.result.content).toContain("Loop guard");
+  });
+
+  it("leaves data-only results untouched", async () => {
+    const call = vi.fn(async () => ({ data: { rows: [1] } }));
+    const manager = {
+      isRunning: () => true,
+      call: call as unknown as PluginWorkerManager["call"],
+    } as unknown as PluginWorkerManager;
+    const registry = createPluginToolRegistry(manager);
+    registry.registerPlugin(PLUGIN_KEY, manifest(), PLUGIN_DB_ID);
+    const context = { ...runContext, runId: "run-data-only" };
+    const params = { query: "outage" };
+    await registry.executeTool("acme.repeat:lookup", params, context);
+    await registry.executeTool("acme.repeat:lookup", params, context);
+    const third = await registry.executeTool("acme.repeat:lookup", params, context);
+    expect(third.result).toEqual({ data: { rows: [1] } });
+  });
+});

--- a/server/src/services/plugin-tool-registry.ts
+++ b/server/src/services/plugin-tool-registry.ts
@@ -25,6 +25,7 @@ import type {
 } from "@paperclipai/shared";
 import type { ToolRunContext, ToolResult, ExecuteToolParams } from "@paperclipai/plugin-sdk";
 import type { PluginWorkerManager } from "./plugin-worker-manager.js";
+import { getSharedRepeatToolTracker } from "./plugin-tool-repeat-guard.js";
 import { logger } from "../middleware/logger.js";
 
 // ---------------------------------------------------------------------------
@@ -447,6 +448,19 @@ export function createPluginToolRegistry(
         },
         "tool execution completed",
       );
+
+      // Advisory repeat-call nudge (DeepSeek Harness repeat-tool-reminder
+      // port): identical consecutive calls within one run get a reminder
+      // appended to string content. Never blocks, never rewrites data.
+      const { notice } = getSharedRepeatToolTracker().observe({
+        agentId: runContext.agentId,
+        runId: runContext.runId,
+        toolName: namespacedName,
+        parameters,
+      });
+      if (notice && typeof result.content === "string" && result.content.length > 0) {
+        return { pluginId, toolName, result: { ...result, content: `${result.content}\n\n${notice}` } };
+      }
 
       return { pluginId, toolName, result };
     },

--- a/server/src/services/plugin-tool-registry.ts
+++ b/server/src/services/plugin-tool-registry.ts
@@ -450,13 +450,16 @@ export function createPluginToolRegistry(
       );
 
       // Advisory repeat-call nudge (DeepSeek Harness repeat-tool-reminder
-      // port): identical consecutive calls within one run get a reminder
-      // appended to string content. Never blocks, never rewrites data.
+      // port): consecutive identical plugin calls with identical outcomes
+      // within one run get a reminder appended to string content. Never
+      // blocks, never rewrites data. Adapter-native calls run outside the
+      // host loop and stay invisible to this chain either way.
       const { notice } = getSharedRepeatToolTracker().observe({
         agentId: runContext.agentId,
         runId: runContext.runId,
         toolName: namespacedName,
         parameters,
+        result,
       });
       if (notice && typeof result.content === "string" && result.content.length > 0) {
         return { pluginId, toolName, result: { ...result, content: `${result.content}\n\n${notice}` } };

--- a/server/src/services/plugin-tool-repeat-guard.ts
+++ b/server/src/services/plugin-tool-repeat-guard.ts
@@ -1,0 +1,107 @@
+import { canonicalToolArguments } from "./tool-content-guards.js";
+
+// Advisory repeat-call guard for plugin tool dispatch, borrowed from the
+// DeepSeek Harness `repeat-tool-reminder` guard: notice identical consecutive
+// tool calls and nudge the agent to change approach. The notice advises; it
+// never blocks. Wording stays declarative so the content-guard
+// prompt-injection scanner never flags our own reminder.
+
+export const REPEAT_TOOL_REMINDER_THRESHOLDS = [3, 5, 8] as const;
+
+/** Cap on tracked (agent, run) chains; resets the map instead of growing it. */
+const MAX_TRACKED_CHAINS = 10_000;
+
+interface RepeatChain {
+  key: string;
+  count: number;
+}
+
+function chainScope(agentId: string, runId: string): string {
+  return `${agentId}\n${runId}`;
+}
+
+function callKey(toolName: string, parameters: unknown): string {
+  return JSON.stringify([toolName, canonicalToolArguments(parameters)]);
+}
+
+const REPEAT_TOOL_GENTLE_NOTICE =
+  "Loop guard: this is the same tool call with identical arguments as the " +
+  "previous calls. Review the last result before calling again: when the " +
+  "task is incomplete, a different approach or different arguments usually " +
+  "help more than repeating the call.";
+
+function detailedRepeatToolNotice(toolName: string, count: number, preview: string): string {
+  return (
+    "Loop guard: repeated tool calls are not making progress.\n" +
+    `- tool: ${toolName}\n` +
+    `- consecutive_calls: ${count}\n` +
+    `- arguments: ${preview}\n` +
+    "The repeated calls returned the same outcome. Inspect the latest " +
+    "result and choose a different action, different arguments, or finish " +
+    "the task when enough evidence is gathered."
+  );
+}
+
+function previewArguments(canonical: string, cap = 500): string {
+  if (canonical.length <= cap) return canonical;
+  return `${canonical.slice(0, cap)}… (+${canonical.length - cap} more chars)`;
+}
+
+export function buildRepeatToolNotice(
+  toolName: string,
+  count: number,
+  canonicalArguments: string,
+  thresholds: ReadonlyArray<number> = REPEAT_TOOL_REMINDER_THRESHOLDS,
+): string | null {
+  if (!thresholds.includes(count)) return null;
+  if (count === thresholds[0]) return REPEAT_TOOL_GENTLE_NOTICE;
+  return detailedRepeatToolNotice(toolName, count, previewArguments(canonicalArguments));
+}
+
+/**
+ * Per-process tracker of consecutive identical tool calls, scoped by
+ * (agent, run). A new run starts a fresh chain automatically, like a user
+ * message resets the reference implementation.
+ */
+export function createRepeatToolTracker(
+  thresholds: ReadonlyArray<number> = REPEAT_TOOL_REMINDER_THRESHOLDS,
+) {
+  const chains = new Map<string, RepeatChain>();
+
+  return {
+    observe(input: {
+      agentId: string;
+      runId: string;
+      toolName: string;
+      parameters: unknown;
+    }): { repeatCount: number; notice: string | null } {
+      const scope = chainScope(input.agentId, input.runId);
+      const key = callKey(input.toolName, input.parameters);
+      const previous = chains.get(scope);
+      const count = previous !== undefined && previous.key === key ? previous.count + 1 : 1;
+      if (chains.size >= MAX_TRACKED_CHAINS && !chains.has(scope)) {
+        chains.clear();
+      }
+      chains.set(scope, { key, count });
+      const canonical = canonicalToolArguments(input.parameters);
+      return {
+        repeatCount: count,
+        notice: buildRepeatToolNotice(input.toolName, count, canonical, thresholds),
+      };
+    },
+
+    chainCountForTests(): number {
+      return chains.size;
+    },
+  };
+}
+
+export type RepeatToolTracker = ReturnType<typeof createRepeatToolTracker>;
+
+let sharedTracker: RepeatToolTracker | null = null;
+
+/** Process-wide tracker used by the tool registry dispatch path. */
+export function getSharedRepeatToolTracker(): RepeatToolTracker {
+  if (!sharedTracker) sharedTracker = createRepeatToolTracker();
+  return sharedTracker;
+}

--- a/server/src/services/plugin-tool-repeat-guard.ts
+++ b/server/src/services/plugin-tool-repeat-guard.ts
@@ -1,3 +1,4 @@
+import { createHash, randomUUID } from "node:crypto";
 import { canonicalToolArguments } from "./tool-content-guards.js";
 
 // Advisory repeat-call guard for plugin tool dispatch, borrowed from the
@@ -11,6 +12,12 @@ export const REPEAT_TOOL_REMINDER_THRESHOLDS = [3, 5, 8] as const;
 /** Cap on tracked (agent, run) chains; resets the map instead of growing it. */
 const MAX_TRACKED_CHAINS = 10_000;
 
+/**
+ * Bound on result text fingerprinted per call. Larger results skip chaining:
+ * without a verified identical outcome the guard must not claim a loop.
+ */
+const RESULT_FINGERPRINT_BUDGET_CHARS = 4_096;
+
 interface RepeatChain {
   key: string;
   count: number;
@@ -22,6 +29,32 @@ function chainScope(agentId: string, runId: string): string {
 
 function callKey(toolName: string, parameters: unknown): string {
   return JSON.stringify([toolName, canonicalToolArguments(parameters)]);
+}
+
+/**
+ * Fingerprint the completed outcome so the streak only counts calls that
+ * returned the same outcome. Stateful or time-varying tools (polling,
+ * retries, mutations) reset the chain instead of tripping the guard.
+ * Oversized or unserializable results fingerprint as null, which never
+ * chains, rather than risking a false loop claim.
+ */
+function fingerprintResultOutcome(result: {
+  content?: unknown;
+  data?: unknown;
+  error?: unknown;
+}): string | null {
+  let canonical: string;
+  try {
+    canonical = canonicalToolArguments({
+      content: typeof result.content === "string" ? result.content : null,
+      data: result.data ?? null,
+      error: typeof result.error === "string" ? result.error : null,
+    });
+  } catch {
+    return null;
+  }
+  if (canonical.length > RESULT_FINGERPRINT_BUDGET_CHARS) return null;
+  return createHash("sha256").update(canonical).digest("hex");
 }
 
 const REPEAT_TOOL_GENTLE_NOTICE =
@@ -59,9 +92,12 @@ export function buildRepeatToolNotice(
 }
 
 /**
- * Per-process tracker of consecutive identical tool calls, scoped by
- * (agent, run). A new run starts a fresh chain automatically, like a user
- * message resets the reference implementation.
+ * Per-process tracker of consecutive identical tool calls with identical
+ * outcomes, scoped by (agent, run). A new run starts a fresh chain
+ * automatically, like a user message resets the reference implementation.
+ * Only server-visible plugin dispatches participate: adapter-native calls
+ * execute outside the host loop and can neither count nor reset a chain,
+ * so the notice wording claims consecutive plugin calls, not all calls.
  */
 export function createRepeatToolTracker(
   thresholds: ReadonlyArray<number> = REPEAT_TOOL_REMINDER_THRESHOLDS,
@@ -74,9 +110,15 @@ export function createRepeatToolTracker(
       runId: string;
       toolName: string;
       parameters: unknown;
+      result: { content?: unknown; data?: unknown; error?: unknown };
     }): { repeatCount: number; notice: string | null } {
       const scope = chainScope(input.agentId, input.runId);
-      const key = callKey(input.toolName, input.parameters);
+      const outcome = fingerprintResultOutcome(input.result);
+      // Unverifiable outcomes get a unique key so they reset the streak
+      // instead of ever counting toward a loop claim.
+      const key = outcome === null
+        ? `${callKey(input.toolName, input.parameters)}\n${randomUUID()}`
+        : `${callKey(input.toolName, input.parameters)}\n${outcome}`;
       const previous = chains.get(scope);
       const count = previous !== undefined && previous.key === key ? previous.count + 1 : 1;
       if (chains.size >= MAX_TRACKED_CHAINS && !chains.has(scope)) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents call plugin tools through the host registry during runs
> - A stuck agent repeats the exact same call and burns budget without progress
> - DeepSeek Harness answers this with an advisory repeat-call reminder, never a block
> - This pull request ports that guard to plugin tool dispatch with run-scoped tracking
> - The benefit is fewer wasted tool calls with no behavior block

## Linked Issues or Issue Description

No public issue exists for this change. The problem follows the feature request fields:

**Subsystem affected**
server/ — REST API & orchestration services (plugin tool registry).

**Problem or motivation**
An agent that replays an identical tool call gets an identical result each time. Nothing tells it the repetition is the problem, so loops run until budgets or run timeouts stop them.

**Proposed solution**
Track consecutive identical tool calls per agent and run (canonicalized arguments, key order ignored). At 3, 5, and 8 repeats, append a short advisory notice to string results. Data-only results pass through untouched. New runs start fresh chains automatically. The notice advises only and its wording verifies clean against the result prompt-injection scanner.

**Alternatives considered**
I considered blocking repeated calls. I ruled it out because legitimate retries exist and the reference design deliberately never blocks. I considered a structured flag on results. I ruled it out for this change to keep the result contract untouched; the text nudge reaches every model.

**Roadmap alignment**
This change supports ROADMAP.md "Enforced Outcomes (watchdogs, recovery actions, review gates)" (less wasted execution) and "Better Budgeting" (fewer burned calls). It is additive. It duplicates no planned core work.

## What Changed

- Add `server/src/services/plugin-tool-repeat-guard.ts`: per agent-run streak tracking, threshold notices at 3, 5, and 8, bounded tracker map, shared process instance.
- Wire observation into registry `executeTool` after completed calls. String results gain the notice. Data results, throws, and unknown tools behave exactly as before.
- Add `server/src/__tests__/plugin-tool-repeat-guard.test.ts` (7 tests): key-order canonicalization, threshold firing, cross-call and cross-run reset, registry append and data-only passthrough, and scanner clearance through the real gateway validator.

## Verification

- Run `pnpm --filter @paperclipai/server exec vitest run src/__tests__/plugin-tool-repeat-guard.test.ts`. Result: 7 pass.
- Run dispatcher, tool-access, and plugin-routes suites. Result: 57 pass, 212 embedded-Postgres skips (pre-existing environment pattern).
- Run `pnpm --filter @paperclipai/server exec tsc --noEmit`. Result: clean, zero errors.
- Run `pnpm check:tokens`. Result: no forbidden tokens.
- Manual check: invoke one plugin tool 3 times with identical arguments in a run, confirm the third result carries the Loop guard notice. Confirm differing arguments reset silently.

## Risks

- Low risk. The guard only appends text to string results at exact thresholds. Dispatch, retries, budgets, and approvals are untouched.
- The shared tracker is process memory capped at 10,000 chains with reset. No persistence, no cross-instance state.
- Notice wording avoids all prompt-injection scanner patterns and a test pins that property through the real validator.

## Model Used

- Provider and model: Meta Muse Spark, agentic coding assistant with tool use (file edits, shell, tests).
- Exact model version and context window: not exposed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (behavior lives in code comments; no user docs cover tool dispatch internals)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
