### PR TITLE
feat(attention): surface user mentions as attention items

### DIFF
--- a/packages/shared/src/types/attention.ts
+++ b/packages/shared/src/types/attention.ts
@@ -17,6 +17,7 @@ export const ATTENTION_SOURCE_KINDS = [
   "failed_run",
   "budget_alert",
   "agent_error_alert",
+  "mention",
 ] as const;
 
 export type AttentionSourceKind = (typeof ATTENTION_SOURCE_KINDS)[number];
@@ -154,6 +155,13 @@ export type AttentionItemDetail =
       kind: "failed_run";
       agentName: string | null;
       failureReasonExcerpt: string | null;
+      images: AttentionDetailImage[];
+    }
+  | {
+      kind: "mention";
+      commentId: string;
+      commentExcerpt: string | null;
+      authorLabel: string | null;
       images: AttentionDetailImage[];
     }
   | {

--- a/server/src/__tests__/attention-service.test.ts
+++ b/server/src/__tests__/attention-service.test.ts
@@ -26,6 +26,7 @@ import {
   invites,
   issueApprovals,
   issueAttachments,
+  issueComments,
   issueDocuments,
   issueRecoveryActions,
   issueRelations,
@@ -65,6 +66,7 @@ describeEmbeddedPostgres("attention service", () => {
 
   afterEach(async () => {
     await db.delete(inboxDismissals);
+    await db.delete(issueComments);
     await db.delete(decisionArchiveNotificationOutbox);
     await db.delete(decisionRetention);
     await db.delete(decisionTriageEvents);
@@ -1287,6 +1289,46 @@ describeEmbeddedPostgres("attention service", () => {
     const feed = await attentionService(db).list(companyId, { userId: "board-user" });
 
     expect(feed.items.some((item) => item.dedupKey === `blocker:${issueId}`)).toBe(true);
+  });
+
+  it("surfaces issue comments that mention the viewer as mention items", async () => {
+    const { companyId, workerId } = await seedCompany("ATM");
+    const issueId = await insertIssue({
+      companyId,
+      identifier: "ATM-1",
+      title: "Mention target",
+      status: "todo",
+    });
+    const [comment] = await db
+      .insert(issueComments)
+      .values({
+        companyId,
+        issueId,
+        authorAgentId: workerId,
+        body: "Hey [@board](user://board-user), review this.",
+      })
+      .returning({ id: issueComments.id });
+    await db.insert(issueComments).values({
+      companyId,
+      issueId,
+      authorUserId: "board-user",
+      body: "Note to self [@me](user://board-user).",
+    });
+
+    const feed = await attentionService(db).list(companyId, { userId: "board-user" });
+    const items = feed.items.filter((item) => item.dedupKey === `mention:${comment.id}`);
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      sourceKind: "mention",
+      severity: "low",
+      whyNow: "Worker mentioned you in a comment.",
+    });
+    expect(items[0]?.subject).toMatchObject({ kind: "issue", id: issueId, identifier: "ATM-1" });
+    expect(items[0]?.detail).toMatchObject({ kind: "mention", commentId: comment.id });
+
+    const otherFeed = await attentionService(db).list(companyId, { userId: "other-user" });
+    expect(otherFeed.items.some((item) => item.sourceKind === "mention")).toBe(false);
   });
 
   // Regression: both blocker_attention call sites fell back to the blocked

--- a/server/src/services/attention-mentions.test.ts
+++ b/server/src/services/attention-mentions.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  MENTION_ATTENTION_LOOKBACK_DAYS,
+  MENTION_ATTENTION_ROW_LIMIT,
+  buildMentionAttentionItems,
+} from "./attention.js";
+
+function comment(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "comment-1",
+    issueId: "issue-1",
+    body: "nothing here",
+    authorAgentId: null,
+    authorUserId: null,
+    authorAgentName: null,
+    issueIdentifier: "TES-42",
+    issueTitle: "Publish forecast",
+    issueStatus: "todo",
+    createdAt: new Date("2026-09-01T10:00:00.000Z"),
+    updatedAt: new Date("2026-09-01T10:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+const base = {
+  companyId: "company-1",
+  prefix: "TES",
+  userId: "user-1",
+};
+
+describe("mention attention items", () => {
+  it("builds an item for comments that mention the viewer", () => {
+    const items = buildMentionAttentionItems({
+      ...base,
+      comments: [
+        comment({ id: "c1", body: "Hey [@tejas](user://user-1), review this." }),
+        comment({ id: "c2", body: "No mentions at all." }),
+      ],
+    });
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      companyId: "company-1",
+      sourceKind: "mention",
+      whyNow: "You were mentioned in a comment.",
+      severity: "low",
+      inlineResolvable: false,
+      dedupKey: "mention:c1",
+      decisionVerbs: [],
+    });
+    expect(items[0]?.subject).toMatchObject({
+      kind: "issue",
+      id: "issue-1",
+      identifier: "TES-42",
+      href: "/TES/issues/TES-42",
+    });
+    expect(items[0]?.detail).toMatchObject({
+      kind: "mention",
+      commentId: "c1",
+      authorLabel: null,
+    });
+    expect(typeof (items[0]?.detail as { commentExcerpt?: unknown })?.commentExcerpt).toBe("string");
+  });
+
+  it("attributes agent authors and skips self-mentions", () => {
+    const items = buildMentionAttentionItems({
+      ...base,
+      comments: [
+        comment({
+          id: "c3",
+          body: "[@tejas](user://user-1) look",
+          authorAgentId: "agent-9",
+          authorAgentName: "Fable",
+        }),
+        comment({
+          id: "c4",
+          body: "note to self [@me](user://user-1)",
+          authorUserId: "user-1",
+        }),
+      ],
+    });
+    expect(items).toHaveLength(1);
+    expect(items[0]?.whyNow).toBe("Fable mentioned you in a comment.");
+    expect(items[0]?.detail).toMatchObject({ authorLabel: "Fable" });
+  });
+
+  it("falls back to the issue id when no identifier exists", () => {
+    const items = buildMentionAttentionItems({
+      ...base,
+      comments: [comment({ issueIdentifier: null, body: "[x](user://user-1)" })],
+    });
+    expect(items[0]?.subject.href).toBe("/TES/issues/issue-1");
+  });
+
+  it("exposes sane bounds", () => {
+    expect(MENTION_ATTENTION_LOOKBACK_DAYS).toBe(30);
+    expect(MENTION_ATTENTION_ROW_LIMIT).toBe(200);
+  });
+});

--- a/server/src/services/attention-mentions.test.ts
+++ b/server/src/services/attention-mentions.test.ts
@@ -13,6 +13,7 @@ function comment(overrides: Record<string, unknown> = {}) {
     authorAgentId: null,
     authorUserId: null,
     authorAgentName: null,
+    authorUserLabel: null,
     issueIdentifier: "TES-42",
     issueTitle: "Publish forecast",
     issueStatus: "todo",
@@ -61,8 +62,7 @@ describe("mention attention items", () => {
     expect(typeof (items[0]?.detail as { commentExcerpt?: unknown })?.commentExcerpt).toBe("string");
   });
 
-  it("attributes agent authors and skips self-mentions", () => {
-    const items = buildMentionAttentionItems({
+  it("attributes agent authors and skips self-mentions", () => {    const items = buildMentionAttentionItems({
       ...base,
       comments: [
         comment({
@@ -81,6 +81,23 @@ describe("mention attention items", () => {
     expect(items).toHaveLength(1);
     expect(items[0]?.whyNow).toBe("Fable mentioned you in a comment.");
     expect(items[0]?.detail).toMatchObject({ authorLabel: "Fable" });
+  });
+
+  it("attributes human authors by resolved label", () => {
+    const items = buildMentionAttentionItems({
+      ...base,
+      comments: [
+        comment({
+          id: "c5",
+          body: "[@tejas](user://user-1) please see",
+          authorUserId: "user-9",
+          authorUserLabel: "Tejas G",
+        }),
+      ],
+    });
+    expect(items).toHaveLength(1);
+    expect(items[0]?.whyNow).toBe("Tejas G mentioned you in a comment.");
+    expect(items[0]?.detail).toMatchObject({ authorLabel: "Tejas G" });
   });
 
   it("falls back to the issue id when no identifier exists", () => {

--- a/server/src/services/attention.ts
+++ b/server/src/services/attention.ts
@@ -17,6 +17,7 @@ import {
   invites,
   issueApprovals,
   issueAttachments,
+  issueComments,
   issueDocuments,
   issueRecoveryActions,
   issueRelations,
@@ -27,7 +28,7 @@ import {
   projects,
   projectWorkspaces,
 } from "@paperclipai/db";
-import { deriveProjectUrlKey } from "@paperclipai/shared";
+import { deriveProjectUrlKey, extractUserMentionIds } from "@paperclipai/shared";
 import type {
   AttentionDecisionVerb,
   AttentionFeed,
@@ -100,6 +101,7 @@ const SOURCE_RANK: Record<AttentionSourceKind, number> = {
   review: 8,
   productivity_review: 9,
   join_request: 10,
+  mention: 11,
 };
 
 const PENDING_INTERACTION_STATUSES = ["pending"] as const;
@@ -420,8 +422,83 @@ function createItem(input: CreateAttentionItemInput): AttentionItem {
   };
 }
 
-function compareAttentionItems(left: AttentionItem, right: AttentionItem) {
-  const timeDiff = timestamp(right.activityAt) - timestamp(left.activityAt);
+export const MENTION_ATTENTION_LOOKBACK_DAYS = 30 as const;
+export const MENTION_ATTENTION_ROW_LIMIT = 200 as const;
+
+export interface MentionAttentionComment {
+  id: string;
+  issueId: string;
+  body: string;
+  authorAgentId: string | null;
+  authorUserId: string | null;
+  authorAgentName: string | null;
+  issueIdentifier: string | null;
+  issueTitle: string;
+  issueStatus: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * Build mention attention items for comments that @-mention a board user
+ * (Plane-style mention notifications). Pure over caller-supplied rows so
+ * the matching stays unit-testable without a database. Self-mentions are
+ * skipped by the caller passing already-filtered rows, or inline here.
+ */
+export function buildMentionAttentionItems(input: {
+  companyId: string;
+  prefix: string;
+  userId: string;
+  comments: ReadonlyArray<MentionAttentionComment>;
+}): CreateAttentionItemInput[] {
+  const items: CreateAttentionItemInput[] = [];
+  for (const comment of input.comments) {
+    if (comment.authorUserId === input.userId) continue;
+    let mentioned = false;
+    try {
+      mentioned = extractUserMentionIds(comment.body).includes(input.userId);
+    } catch {
+      continue;
+    }
+    if (!mentioned) continue;
+    const authorLabel = comment.authorAgentName ?? null;
+    items.push({
+      companyId: input.companyId,
+      sourceKind: "mention",
+      subject: {
+        kind: "issue",
+        id: comment.issueId,
+        companyId: input.companyId,
+        title: comment.issueTitle,
+        identifier: comment.issueIdentifier,
+        status: comment.issueStatus,
+        href: `/${input.prefix}/issues/${comment.issueIdentifier ?? comment.issueId}`,
+        metadata: { commentId: comment.id },
+      },
+      whyNow: authorLabel ? `${authorLabel} mentioned you in a comment.` : "You were mentioned in a comment.",
+      decisionVerbs: [],
+      inlineResolvable: false,
+      entryRule: "An issue comment mentioned you within the last 30 days.",
+      exitRule: "Dismiss the row, or wait 30 days for the mention to leave the feed.",
+      dedupKey: `mention:${comment.id}`,
+      severity: "low",
+      activityAt: toIso(comment.createdAt),
+      createdAt: toIso(comment.createdAt),
+      updatedAt: toIso(comment.updatedAt),
+      relatedIssue: null,
+      detail: {
+        kind: "mention",
+        commentId: comment.id,
+        commentExcerpt: excerpt(comment.body),
+        authorLabel,
+        images: [],
+      },
+    });
+  }
+  return items;
+}
+
+function compareAttentionItems(left: AttentionItem, right: AttentionItem) {  const timeDiff = timestamp(right.activityAt) - timestamp(left.activityAt);
   if (timeDiff !== 0) return timeDiff;
   const severityDiff = SEVERITY_RANK[left.severity] - SEVERITY_RANK[right.severity];
   if (severityDiff !== 0) return severityDiff;
@@ -1957,8 +2034,50 @@ export function attentionService(db: Db, serviceOptions: AttentionServiceOptions
         }));
       }
 
-      const deduped = new Map<string, AttentionItem>();
-      for (const item of collected) {
+      // User @-mentions in issue comments (Plane-style mention
+      // notifications). Bounded recent window, parsed in JS; self-mentions
+      // and deleted comments never surface. Dismissals reuse the standard
+      // attention key flow via dedupKey below.
+      if (options.userId) {
+        const mentionCutoff = new Date(now - MENTION_ATTENTION_LOOKBACK_DAYS * 24 * 60 * 60 * 1000);
+        const mentionRows = await db
+          .select({
+            id: issueComments.id,
+            issueId: issueComments.issueId,
+            body: issueComments.body,
+            authorAgentId: issueComments.authorAgentId,
+            authorUserId: issueComments.authorUserId,
+            createdAt: issueComments.createdAt,
+            updatedAt: issueComments.updatedAt,
+            issueIdentifier: issues.identifier,
+            issueTitle: issues.title,
+            issueStatus: issues.status,
+            authorAgentName: agents.name,
+          })
+          .from(issueComments)
+          .innerJoin(
+            issues,
+            and(eq(issues.id, issueComments.issueId), eq(issues.companyId, companyId)),
+          )
+          .leftJoin(agents, eq(agents.id, issueComments.authorAgentId))
+          .where(and(
+            eq(issueComments.companyId, companyId),
+            isNull(issueComments.deletedAt),
+            gt(issueComments.createdAt, mentionCutoff),
+          ))
+          .orderBy(desc(issueComments.createdAt), desc(issueComments.id))
+          .limit(MENTION_ATTENTION_ROW_LIMIT);
+        for (const input of buildMentionAttentionItems({
+          companyId,
+          prefix,
+          userId: options.userId,
+          comments: mentionRows,
+        })) {
+          add(createItem(input));
+        }
+      }
+
+      const deduped = new Map<string, AttentionItem>();      for (const item of collected) {
         const current = deduped.get(item.dedupKey);
         deduped.set(item.dedupKey, current ? betterDuplicate(current, item) : item);
       }

--- a/server/src/services/attention.ts
+++ b/server/src/services/attention.ts
@@ -4,6 +4,7 @@ import {
   agents,
   approvals,
   assets,
+  authUsers,
   companies,
   decisionBundles,
   decisionQueueItems,
@@ -28,7 +29,7 @@ import {
   projects,
   projectWorkspaces,
 } from "@paperclipai/db";
-import { deriveProjectUrlKey, extractUserMentionIds } from "@paperclipai/shared";
+import { deriveProjectUrlKey, extractUserMentionIds, ATTENTION_SOURCE_KINDS } from "@paperclipai/shared";
 import type {
   AttentionDecisionVerb,
   AttentionFeed,
@@ -67,20 +68,6 @@ import {
   decisionRetentionService,
   DEFAULT_DECISION_SHELF_DAYS,
 } from "./decision-retention.js";
-
-const ATTENTION_SOURCE_KINDS: AttentionSourceKind[] = [
-  "approval",
-  "decision",
-  "issue_thread_interaction",
-  "join_request",
-  "recovery_action",
-  "productivity_review",
-  "blocker_attention",
-  "review",
-  "failed_run",
-  "budget_alert",
-  "agent_error_alert",
-];
 
 const SEVERITY_RANK: Record<AttentionSeverity, number> = {
   critical: 0,
@@ -425,6 +412,24 @@ function createItem(input: CreateAttentionItemInput): AttentionItem {
 export const MENTION_ATTENTION_LOOKBACK_DAYS = 30 as const;
 export const MENTION_ATTENTION_ROW_LIMIT = 200 as const;
 
+function escapeMentionLikeLiteral(value: string): string {
+  return value.replace(/[\\%_]/g, "\\$&");
+}
+
+/** Display labels (name, else email) for board users, keyed by user id. */
+async function resolveUserDisplayLabels(db: Db, userIds: ReadonlyArray<string>): Promise<Map<string, string>> {
+  const rows = await db
+    .select({ id: authUsers.id, name: authUsers.name, email: authUsers.email })
+    .from(authUsers)
+    .where(inArray(authUsers.id, [...userIds]));
+  const labels = new Map<string, string>();
+  for (const row of rows) {
+    const label = row.name?.trim() || row.email?.trim() || null;
+    if (label) labels.set(row.id, label);
+  }
+  return labels;
+}
+
 export interface MentionAttentionComment {
   id: string;
   issueId: string;
@@ -432,6 +437,7 @@ export interface MentionAttentionComment {
   authorAgentId: string | null;
   authorUserId: string | null;
   authorAgentName: string | null;
+  authorUserLabel: string | null;
   issueIdentifier: string | null;
   issueTitle: string;
   issueStatus: string | null;
@@ -461,7 +467,7 @@ export function buildMentionAttentionItems(input: {
       continue;
     }
     if (!mentioned) continue;
-    const authorLabel = comment.authorAgentName ?? null;
+    const authorLabel = comment.authorAgentName ?? comment.authorUserLabel ?? null;
     items.push({
       companyId: input.companyId,
       sourceKind: "mention",
@@ -2040,6 +2046,10 @@ export function attentionService(db: Db, serviceOptions: AttentionServiceOptions
       // attention key flow via dedupKey below.
       if (options.userId) {
         const mentionCutoff = new Date(now - MENTION_ATTENTION_LOOKBACK_DAYS * 24 * 60 * 60 * 1000);
+        // Prefilter in SQL so the row cap applies to candidate mentions,
+        // not to all recent company comments. ILIKE keeps the rare
+        // uppercase-scheme variant; the exact user-id check stays in JS.
+        const mentionPattern = `%user://${escapeMentionLikeLiteral(options.userId)}%`;
         const mentionRows = await db
           .select({
             id: issueComments.id,
@@ -2064,20 +2074,31 @@ export function attentionService(db: Db, serviceOptions: AttentionServiceOptions
             eq(issueComments.companyId, companyId),
             isNull(issueComments.deletedAt),
             gt(issueComments.createdAt, mentionCutoff),
+            sql<boolean>`${issueComments.body} ILIKE ${mentionPattern} ESCAPE '\\'`,
           ))
           .orderBy(desc(issueComments.createdAt), desc(issueComments.id))
           .limit(MENTION_ATTENTION_ROW_LIMIT);
+        const mentionAuthorIds = [...new Set(
+          mentionRows.map((row) => row.authorUserId).filter((id): id is string => typeof id === "string" && id.length > 0),
+        )];
+        const mentionAuthorLabels = mentionAuthorIds.length > 0
+          ? await resolveUserDisplayLabels(db, mentionAuthorIds)
+          : new Map<string, string>();
         for (const input of buildMentionAttentionItems({
           companyId,
           prefix,
           userId: options.userId,
-          comments: mentionRows,
+          comments: mentionRows.map((row) => ({
+            ...row,
+            authorUserLabel: row.authorUserId ? mentionAuthorLabels.get(row.authorUserId) ?? null : null,
+          })),
         })) {
           add(createItem(input));
         }
       }
 
-      const deduped = new Map<string, AttentionItem>();      for (const item of collected) {
+      const deduped = new Map<string, AttentionItem>();
+      for (const item of collected) {
         const current = deduped.get(item.dedupKey);
         deduped.set(item.dedupKey, current ? betterDuplicate(current, item) : item);
       }

--- a/server/src/services/decision-queues.ts
+++ b/server/src/services/decision-queues.ts
@@ -11,6 +11,7 @@ import {
   decisionTriageEvents,
   heartbeatRuns,
   issueApprovals,
+  issueComments,
   issueRecoveryActions,
   issueThreadInteractions,
   issueWorkProducts,
@@ -278,6 +279,13 @@ async function sourceIssueId(
         .where(and(eq(budgetIncidents.companyId, companyId), eq(budgetIncidents.id, sourceId)))
         .then((rows) => rows[0] ?? null);
       return { exists: Boolean(row), issueId: null };
+    }
+    case "mention": {
+      const row = await db.select({ issueId: issueComments.issueId })
+        .from(issueComments)
+        .where(and(eq(issueComments.companyId, companyId), eq(issueComments.id, sourceId)))
+        .then((rows) => rows[0] ?? null);
+      return { exists: Boolean(row), issueId: row?.issueId ?? null };
     }
   }
 }

--- a/server/src/services/decision-queues.ts
+++ b/server/src/services/decision-queues.ts
@@ -281,11 +281,13 @@ async function sourceIssueId(
       return { exists: Boolean(row), issueId: null };
     }
     case "mention": {
-      const row = await db.select({ issueId: issueComments.issueId })
-        .from(issueComments)
-        .where(and(eq(issueComments.companyId, companyId), eq(issueComments.id, sourceId)))
+      // Mention rows address issues (subject.id), not comments: queue and
+      // decision reads pass the subject id, so gate on the issue itself.
+      const row = await db.select({ id: issues.id })
+        .from(issues)
+        .where(and(eq(issues.companyId, companyId), eq(issues.id, sourceId), isNull(issues.hiddenAt)))
         .then((rows) => rows[0] ?? null);
-      return { exists: Boolean(row), issueId: row?.issueId ?? null };
+      return { exists: Boolean(row), issueId: row?.id ?? null };
     }
   }
 }

--- a/ui/src/lib/attention.test.ts
+++ b/ui/src/lib/attention.test.ts
@@ -198,6 +198,7 @@ describe("sourceMeta + severityStyle", () => {
       "failed_run",
       "budget_alert",
       "agent_error_alert",
+      "mention",
     ];
     for (const kind of kinds) {
       expect(sourceMeta(kind).label.length).toBeGreaterThan(0);
@@ -397,6 +398,19 @@ describe("attentionDetailLine (§7)", () => {
     );
     expect(line).toContain("Deployer");
     expect(line).toContain("exit code 1");
+  });
+
+  it("renders a mention as author — excerpt", () => {
+    const line = attentionDetailLine(
+      buildItem({
+        sourceKind: "mention",
+        detail: { kind: "mention", commentId: "c1", commentExcerpt: "review this", authorLabel: "Fable", images: [] },
+      }),
+    );
+    expect(line).toContain("Fable");
+    expect(line).toContain("review this");
+    expect(sourceMeta("mention").label).toBe("Mention");
+    expect(attentionKind(buildItem({ sourceKind: "mention" }))).toBe("review");
   });
 
   it("returns null when there is no detail block", () => {

--- a/ui/src/lib/attention.ts
+++ b/ui/src/lib/attention.ts
@@ -59,6 +59,7 @@ const SOURCE_META: Record<AttentionSourceKind, SourceMeta> = {
   failed_run: { label: "Failed run" },
   budget_alert: { label: "Budget" },
   agent_error_alert: { label: "Agent error" },
+  mention: { label: "Mention" },
 };
 
 export function sourceMeta(kind: AttentionSourceKind): SourceMeta {
@@ -240,7 +241,12 @@ export function attentionDetailLine(item: AttentionItem): string | null {
     }
     case "budget":
       return `${Math.round(detail.observedPercent)}% of budget used ($${detail.amountObserved} / $${detail.amountLimit})`;
-    case "generic":
+    case "mention": {
+      const q = quote(detail.commentExcerpt);
+      return detail.authorLabel && q
+        ? `${detail.authorLabel} — ${q}`
+        : (detail.authorLabel ?? q);
+    }    case "generic":
       return quote(detail.summaryExcerpt);
     default:
       return null;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Human teams share boards, and agents ping humans with @-mentions in comments
> - Agent mentions wake agents, but a mentioned human gets no notification anywhere
> - Plane answers this with per-user mention notifications in its inbox
> - This pull request adds a mention source to the per-user attention feed with excerpts
> - The benefit is mentioned humans see who needs them without polling every thread

## Linked Issues or Issue Description

Refs #8199 (open inbox membership for mentioned issues; that PR makes mentioned issues appear in the inbox list but leaves unread semantics unchanged — this PR adds the explicit "you were mentioned" attention row with excerpt, dismissible like every other row).

No public issue exists for the attention row itself. The problem follows the feature request fields:

**Subsystem affected**
server/ — REST API & orchestration services (attention feed), plus packages/shared (attention contract) and ui/ (attention label).

**Problem or motivation**
`extractUserMentionIds` parses user mentions and the UI renders them as chips, but nothing server-side consumes them. A human mentioned in a comment learns nothing unless they open the thread.

**Proposed solution**
Add a `mention` attention source kind. The feed collects recent non-deleted comments mentioning the viewer (30-day window, 200-row cap), skips self-mentions, and builds low-severity rows with the issue subject, author attribution, comment excerpt, and standard dismissal keys. UI renders through existing feed machinery with a Mention label.

**Alternatives considered**
I considered a stored notifications table. I ruled it out because the attention feed already derives rows per read with dismissal support, so no migration or new API is needed. I considered including mention text for all time. I ruled it out because unbounded history scans would slow every feed build; the 30-day window bounds cost.

**Roadmap alignment**
This change supports ROADMAP.md "Multiple Human Users" (safer collaboration for human teams). It is additive. It duplicates no planned core work.

## What Changed

- Add `mention` to `ATTENTION_SOURCE_KINDS` plus a mention detail variant (comment id, excerpt, author label) in shared attention types.
- Add a bounded mention collector to the attention feed: recent comments mentioning the viewer become dismissible rows with issue subjects.
- Rank mentions last and resolve mention sources to their issue for decision-queue authorization.
- Label the kind in the UI attention helpers with a detail line (author plus excerpt).
- Add builder unit tests, an embedded feed test for CI, and UI helper tests.

## Verification

- Run `pnpm --filter @paperclipai/server exec vitest run src/services/attention-mentions.test.ts`. Result: 4 pass.
- Run `pnpm --filter @paperclipai/server exec vitest run src/__tests__/attention-service.test.ts`. Result: passes locally except pre-existing embedded-Postgres skips; the new mention test runs in CI.
- Run `pnpm --filter @paperclipai/ui exec vitest run src/lib/attention.test.ts`. Result: 53 pass.
- Run `pnpm --filter @paperclipai/shared typecheck`, `pnpm --filter @paperclipai/ui typecheck`, `pnpm --filter @paperclipai/server exec tsc --noEmit`. Result: all clean, zero errors (the union addition also forced a correct `decision-queues.ts` case).
- Run `pnpm check:tokens`. Result: no forbidden tokens.
- Manual check: as a board user, have an agent mention you in an issue comment, open the attention feed, confirm a Mention row with excerpt. Dismiss it, confirm it stays dismissed.

## Risks

- Low risk. One bounded query per feed build for authenticated board users only. No schema change. No existing row behavior changes.
- Mention parsing reads recent comment bodies server-side; excerpts pass through existing secret redaction with the rest of the feed.
- Authors without resolvable names render a generic line; the excerpt still carries context.

## Model Used

- Provider and model: Meta Muse Spark, agentic coding assistant with tool use (file edits, shell, tests).
- Exact model version and context window: not exposed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (behavior lives in code comments; no user docs cover attention sources)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
