### PR TITLE
docs: propose intake triage queue for external and recurring inputs

### DIFF
--- a/doc/plans/2026-09-09-intake-triage-queue.md
+++ b/doc/plans/2026-09-09-intake-triage-queue.md
@@ -77,20 +77,32 @@ Jira as on-ramps while Paperclip owns execution).
 
 ### Phase 1: triage state + transitions (schema + service, no UI)
 
-- New `issue_intake` table (company scope): `issueId` (unique, FK cascade),
+- New `issue_intake` table: `companyId` (FK cascade, part of every
+  uniqueness rule and index below), `issueId` (unique, FK cascade),
   `projectId`, triage status (`pending`, `accepted`, `rejected`,
   `snoozed`, `duplicate`), `snoozedTill`, `duplicateOfIssueId` (nullable FK),
   source fields (`source`, `externalSource`, `externalId`, `extra` JSONB),
-  timestamps. New issues created through intake-designated paths start
-  `pending`; all other creates are unaffected.
+  timestamps. Indexes on `(companyId, projectId, status, createdAt)` for
+  the queue read and a partial unique index on `(companyId, externalSource,
+  externalId)` where both are non-null for cross-source identity. New
+  issues created through intake-designated paths start `pending`; all
+  other creates are unaffected.
 - Transitions (`accept`, `decline`, `snooze`, `mark_duplicate`) as service
   operations with actor attribution and activity entries. Accept keeps the
   issue's workflow status flow untouched. Snooze sets `snoozedTill` and
   hides the row until then. Duplicates link, never merge, so no data is
   destroyed.
-- Scheduling guard: heartbeat wakes skip triage-pending issues (one
-  predicate at wakeup selection, mirroring existing status guards), so
-  staged work burns no budget.
+- Scheduling guard: heartbeat wakes skip triage-pending issues, so staged
+  work burns no budget. This needs a mandatory shared guard, not one
+  predicate: assignment, routine, and manual wakes enter `enqueueWakeup`
+  without its optional `issueStateGuard`, and timer wakes use separate
+  status predicates. Every wake path must be enumerated and gated, or
+  pending intake work schedules through the gaps.
+- Reuse before inventing: the decision-desk architecture already specifies
+  company-scoped decision queues with triage events, snoozing, retention,
+  and APIs. Phase 1 must reconcile intake with it — either stage triage
+  rows as a decision-queue kind or justify the separate lifecycle — rather
+  than running a second overlapping queue system.
 - Migration is additive (new table only). No existing column changes.
 
 ### Phase 2: intake queue surface (API + UI)
@@ -125,6 +137,10 @@ Jira as on-ramps while Paperclip owns execution).
 4. Should accept assign an owner, or leave assignment to existing routing?
 5. Do snoozed items need wakeups on expiry, or is queue visibility enough?
 6. Duplicate handling: link-only (proposed) or merge histories?
+7. Should triage staging reuse decision-queue infrastructure (triage
+   events, snoozing, retention, APIs) instead of a standalone table?
+8. Which wake paths does the mandatory pending-issue guard cover, and
+   where does it live so new paths cannot bypass it?
 
 ## Risks
 
@@ -135,8 +151,12 @@ Jira as on-ramps while Paperclip owns execution).
 - Un-triaged buildup if nobody watches a queue. Mitigation: per-project
   counts in existing badge surfaces plus routine-generated triage digests
   as a later step.
-- External duplication across sources. Mitigation: origin fingerprint
-  dedup at create plus explicit duplicate marking.
+- External duplication across sources. Mitigation: phase 1 adds the
+  partial unique index on `(companyId, externalSource, externalId)` plus
+  explicit duplicate marking. Note this is new capability, not existing
+  behavior: `originFingerprint` uniqueness is origin-kind-specific today,
+  and title/idempotency checks do not dedupe arbitrary external
+  fingerprints across sources.
 
 ## Alternatives Considered
 

--- a/doc/plans/2026-09-09-intake-triage-queue.md
+++ b/doc/plans/2026-09-09-intake-triage-queue.md
@@ -1,0 +1,153 @@
+# Intake Triage Queue Proposal
+
+Status: proposal. No code changes. Seeks maintainer direction before any
+Path-2 implementation work.
+
+## Context
+
+Repeatable inputs arrive continuously: support requests, Linear/Jira/Asana
+tickets, emails, form fills, routine findings. Today each such input either
+becomes a live governed issue immediately or has nowhere to go. There is no
+holding pen where inputs wait for a human or agent triage decision. Plane
+answers this with per-project Intake inboxes: external items land as
+triage-state issues (pending, accepted, rejected, snoozed, duplicate) with
+source provenance, and only accepted work enters execution. This proposal
+ports that staging layer to Paperclip's issue model.
+
+## What We Know Today
+
+- Issues already carry provenance: `originKind`, `originId`, and
+  `originFingerprint` on `issues` (`packages/db/src/schema/issues.ts`) with
+  a dedup index, plus create-time duplicate detection
+  (`recent_open_title`, idempotency keys in `server/src/services/issues.ts`).
+  External items can already enter with identity.
+- Scoped ingestion transport is emerging: the intake-receiver API key scope
+  (#10273, open) permits fixed-shape issue creation in one configured
+  project with ownership tagging and replay protection. The connector
+  playbook (`doc/connections/CONNECTOR-PLAYBOOK.md`) governs new
+  integrations.
+- Review surfaces exist but assume live work: the inbox shows assigned and
+  blocked issues, approvals gate governed actions, and routines cover
+  recurring work. None stages un-triaged inputs.
+- Issue statuses (`backlog`, `todo`, `in_progress`, `in_review`, `done`,
+  `blocked`, `cancelled` in `packages/shared/src/constants.ts`) drive
+  orchestration (wakes, locks, monitors). Overloading them with triage
+  states would ripple through heartbeat scheduling and execution guards.
+- Prior art studied in Plane (`apps/api/plane/db/models/intake.py`):
+  - `Intake`: named inbox per project with a default flag.
+  - `IntakeIssue`: triage status (pending, rejected, snoozed, accepted,
+    duplicate), `snoozed_till`, `duplicate_to` link, source tracking
+    (`source`, `source_email`, `external_source`, `external_id`, `extra`).
+  - Triage is a state machine on the intake link, not on the issue's
+    workflow state. Accepted work proceeds; the rest stays staged.
+
+## The Gap
+
+Transport (receivers, provenance) and review (inbox, approvals) both exist,
+but nothing between them stages inputs. Consequences: every external item
+is born as live work that can wake agents and consume budget before anyone
+agrees it matters; deferring means ad-hoc statuses or comments; duplicates
+across sources have no first-class marking. The roadmap asks for exactly
+this layer twice: Work Queues (queue-style streams for support, triage,
+review, backlog intake) and Bring-your-own-ticket-system (Asana, Linear,
+Jira as on-ramps while Paperclip owns execution).
+
+## Goals
+
+1. Give every project an intake holding pen where external and recurring
+   inputs wait as triage-pending issues with source provenance.
+2. Provide accept, decline, snooze, and mark-duplicate transitions with
+   activity attribution, so triage decisions are auditable.
+3. Keep triage state separate from workflow status so heartbeat scheduling,
+   locks, and monitors never see un-triaged work.
+4. Make routines and agents able to file into intake, and let accepted items
+   flow into the existing execution lifecycle unchanged.
+
+## Non-Goals
+
+- Building Linear/Jira/Asana connectors here. On-ramps follow the
+  connector playbook onto the intake API this proposal defines.
+- Email ingestion, web forms, or chatbot front-ends. Those are producers
+  of intake items, not the queue itself.
+- Replacing inbox, approvals, or routines. Intake feeds them.
+- Automatic triage decisions. Human or governed-agent accept/decline only;
+  auto-triage is a later proposal if ever.
+
+## Proposed Model
+
+### Phase 1: triage state + transitions (schema + service, no UI)
+
+- New `issue_intake` table (company scope): `issueId` (unique, FK cascade),
+  `projectId`, triage status (`pending`, `accepted`, `rejected`,
+  `snoozed`, `duplicate`), `snoozedTill`, `duplicateOfIssueId` (nullable FK),
+  source fields (`source`, `externalSource`, `externalId`, `extra` JSONB),
+  timestamps. New issues created through intake-designated paths start
+  `pending`; all other creates are unaffected.
+- Transitions (`accept`, `decline`, `snooze`, `mark_duplicate`) as service
+  operations with actor attribution and activity entries. Accept keeps the
+  issue's workflow status flow untouched. Snooze sets `snoozedTill` and
+  hides the row until then. Duplicates link, never merge, so no data is
+  destroyed.
+- Scheduling guard: heartbeat wakes skip triage-pending issues (one
+  predicate at wakeup selection, mirroring existing status guards), so
+  staged work burns no budget.
+- Migration is additive (new table only). No existing column changes.
+
+### Phase 2: intake queue surface (API + UI)
+
+- Read API: per-project intake queue (pending first, then snoozed-due),
+  reusing inbox filter and pagination idioms.
+- UI: an intake tab reusing inbox row and filter patterns, with
+  accept/decline/snooze/duplicate actions and the standard dismissal
+  affordances. Propose placing it beside the inbox, not inside it, so
+  triage load stays visible separately from owned work.
+- Counts surface where operators already look (sidebar badge, project
+  headers) following the existing badge patterns.
+
+### Phase 3: on-ramps (follow-ups, one per source)
+
+- A scoped intake receiver endpoint creating triage-pending issues with
+  origin provenance, building on #10273's key scope.
+- Routines gain an intake-filing step type so recurring findings (reports,
+  scans, reviews) land as triage items instead of live issues.
+- Linear/Jira/Asana connectors per the connector playbook, each mapping
+  external states onto the triage machine.
+
+## Open Questions for Maintainers
+
+1. Triage as a link table (proposed) versus new workflow statuses: is the
+   scheduling-guard predicate the right seam, or should pending issues be
+   invisible to wakes some other way?
+2. Should every project get a default intake automatically, or only on
+   demand (Plane uses a default flag)?
+3. Who may triage: board operators only, or also governed agents (which
+   policies)?
+4. Should accept assign an owner, or leave assignment to existing routing?
+5. Do snoozed items need wakeups on expiry, or is queue visibility enough?
+6. Duplicate handling: link-only (proposed) or merge histories?
+
+## Risks
+
+- A second issue lifecycle running beside workflow status can confuse
+  operators. Mitigation: triage states never overlap status values, the
+  queue is visually separate, and activity entries narrate every
+  transition.
+- Un-triaged buildup if nobody watches a queue. Mitigation: per-project
+  counts in existing badge surfaces plus routine-generated triage digests
+  as a later step.
+- External duplication across sources. Mitigation: origin fingerprint
+  dedup at create plus explicit duplicate marking.
+
+## Alternatives Considered
+
+- New workflow statuses for triage (e.g. `pending_triage`). Rejected:
+  status drives wakes, locks, and monitors; a parallel machine is safer
+  than threading triage through every status consumer.
+- Labels or a tag for staging. Rejected: labels lack transitions,
+  snooze dates, duplicate links, and auditability.
+- Direct-to-issue ingestion with agent triage afterwards (status quo
+  extended). Rejected: live issues wake agents and spend budget before
+  anyone agrees the work matters.
+- Doing nothing. Rejected: the roadmap names Work Queues and
+  ticket-system on-ramps explicitly, and receivers (#10273) need a
+  governed landing zone.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Repeatable inputs arrive continuously from support, ticket systems, and routines
> - Every input today becomes live work immediately or has nowhere to go
> - Plane stages such inputs in per-project intake inboxes with triage states
> - Adding a triage state machine touches issue lifecycle and scheduling, so it needs maintainer direction first
> - This pull request adds a proposal doc with current-state survey, phased model, and open questions
> - The benefit is a reviewed design the team can approve before schema work starts

## Linked Issues or Issue Description

Related open work, referenced in the proposal:

- Refs #10273 (intake-receiver API key scope; the ingestion transport this staging layer would land)
- Refs #10081 (project and milestone intake in wake payload)

No public issue exists for the proposal itself. The problem follows the feature request fields:

**Subsystem affected**
server/ — REST API & orchestration services (issue lifecycle, wakeup scheduling), plus packages/db (new triage table, future work only).

**Problem or motivation**
External and recurring inputs enter as live governed issues that can wake agents and spend budget before anyone agrees they matter. Deferring means ad-hoc statuses or comments, and cross-source duplicates have no first-class marking.

**Proposed solution**
This PR proposes only. Phased model: triage state plus accept, decline, snooze, and mark-duplicate transitions on a new link table (workflow status untouched, wakes skip pending items), then a queue surface reusing inbox patterns, then scoped on-ramps per the connector playbook. Six open questions for maintainers.

**Alternatives considered**
Discussed in the proposal: new workflow statuses, labels for staging, direct-to-issue ingestion with after-the-fact triage, doing nothing.

**Roadmap alignment**
This change targets ROADMAP.md "Work Queues" and "Bring-your-own-ticket-system" directly. It is docs only. It duplicates no planned core work.

## What Changed

- Add `doc/plans/2026-09-09-intake-triage-queue.md`: context, current state (provenance columns, intake-receiver scope, inbox and approvals, status-driven orchestration), the gap, goals and non-goals, a three-phase model, six open questions, risks, and alternatives.

## Verification

- Confirm all referenced paths exist: `packages/db/src/schema/issues.ts` (provenance), `server/src/services/issues.ts` (creation), `packages/shared/src/constants.ts` (statuses), `doc/connections/CONNECTOR-PLAYBOOK.md`.
- Run `pnpm check:tokens`. Result: no forbidden tokens.
- Docs only. No typecheck, test, or build surface changes.

## Risks

- Minimal direct risk: one markdown file, no code.
- Design risk sits in the open questions on purpose. Merging the proposal endorses discussion, not the schema. Each phase needs its own review.

## Model Used

- Provider and model: Meta Muse Spark, agentic coding assistant with tool use (file reads, shell).
- Exact model version and context window: not exposed in this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass (docs only; no code or test surface)
- [ ] I have added or updated tests where applicable (no test surface in a proposal doc)
- [ ] I have updated relevant documentation to reflect my changes (this PR is the documentation)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
