### PR TITLE
fix(plugins): allow company agents on SSE streams

### DIFF
--- a/server/src/__tests__/plugin-routes-authz.test.ts
+++ b/server/src/__tests__/plugin-routes-authz.test.ts
@@ -443,6 +443,55 @@ describe.sequential("plugin tool and bridge authz", () => {
     vi.clearAllMocks();
   });
 
+  it("allows an agent to subscribe to a plugin stream for its own company", async () => {
+    readyPlugin();
+    const subscribe = vi.fn(() => vi.fn());
+    const { app } = await createApp({
+      type: "agent",
+      agentId: agentA,
+      companyId: companyA,
+      runId: runA,
+    }, {}, {
+      bridgeDeps: { streamBus: { subscribe } },
+    });
+
+    const res = await request(app)
+      .get(`/api/plugins/${pluginId}/bridge/stream/events`)
+      .query({ companyId: companyA })
+      .buffer(false)
+      .parse((_res, callback) => callback(null, undefined));
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("text/event-stream");
+    expect(subscribe).toHaveBeenCalledWith(
+      pluginId,
+      "events",
+      companyA,
+      expect.any(Function),
+    );
+  });
+
+  it("rejects an agent plugin stream subscription for another company", async () => {
+    readyPlugin();
+    const subscribe = vi.fn(() => vi.fn());
+    const { app } = await createApp({
+      type: "agent",
+      agentId: agentA,
+      companyId: companyA,
+      runId: runA,
+    }, {}, {
+      bridgeDeps: { streamBus: { subscribe } },
+    });
+
+    const res = await request(app)
+      .get(`/api/plugins/${pluginId}/bridge/stream/events`)
+      .query({ companyId: companyB });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Agent key cannot access another company" });
+    expect(subscribe).not.toHaveBeenCalled();
+  });
+
   it("rejects tool execution when the board user cannot access runContext.companyId", async () => {
     const executeTool = vi.fn();
     const getTool = vi.fn();

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -1365,12 +1365,11 @@ export function pluginRoutes(
    *
    * Errors:
    * - 400 if companyId is missing
+   * - 403 if an agent selects a company other than its own
    * - 404 if plugin not found
    * - 501 if bridge deps or stream bus are not configured
    */
   router.get("/plugins/:pluginId/bridge/stream/:channel", async (req, res) => {
-    assertBoardOrgAccess(req);
-
     if (!bridgeDeps?.streamBus) {
       res.status(501).json({ error: "Plugin stream bridge is not enabled" });
       return;


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates autonomous agents within strict company boundaries
> - Plugins can push live events through the host's SSE bridge
> - The stream route was board-only even though normal agent runs already carry authenticated company identity
> - That prevented plugin builders from verifying their own company's live stream without an over-privileged board credential
> - Existing company access checks already reject cross-company agent selection
> - This pull request removes only the redundant board-only gate and exercises own-company and cross-company agent behavior
> - The benefit is least-privilege live plugin verification without minting or exposing board credentials

## What Changed

- Allow authenticated company agents through the plugin SSE subscription route.
- Preserve company isolation through `assertCompanyAccess`, rejecting cross-company `companyId` selection.
- Add focused authorization coverage for allowed own-company and rejected cross-company subscriptions.
- Document the stream route's cross-company 403 behavior inline.

## Verification

- `corepack pnpm --filter @paperclipai/server typecheck` — passed.
- Focused Vitest collection was attempted after a locked install and plugin SDK build, but this Windows host's Node 24 runtime fails all tests during Drizzle ESM loading before test bodies execute (`Cannot require() ES Module ... drizzle-orm/operations.js in a cycle`).

## Risks

- Low: the change removes one board-only precondition from one read-only SSE route. Authentication and exact company scoping remain enforced before subscription.
- An authenticated agent can hold an SSE connection for its own company, which is the intended new capability.

> Checked `ROADMAP.md`: this is a narrowly scoped plugin authorization bug fix within the completed plugin-system milestone, not a competing roadmap feature.

## Model Used

- OpenAI Codex, GPT-5 family, agentic reasoning with repository tools and command execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [ ] I have run tests locally and they pass — blocked before test execution by the host's Node 24/Drizzle ESM loader incompatibility; server typecheck passes
- [x] I have added or updated tests where applicable
- [x] If this change affects the UI, I have included before/after screenshots — not applicable; no UI change
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] I will address all Greptile and reviewer comments before requesting merge