### PR TITLE
fix(skills): make SKILL.md frontmatter audit CRLF-safe

### DIFF
--- a/packages/shared/src/frontmatter.test.ts
+++ b/packages/shared/src/frontmatter.test.ts
@@ -120,6 +120,15 @@ describe("parseFrontmatterMarkdown", () => {
 
     expect(parsed.frontmatter.version).toBe("1.");
   });
+
+  it("detects frontmatter and reads fields when the document uses CRLF line endings", () => {
+    const parsed = parseFrontmatterMarkdown(
+      ["---", "name: crlf-skill", "description: Checked out on Windows", "---", "", "# Body"].join("\r\n"),
+    );
+
+    expect(parsed.hasFrontmatter).toBe(true);
+    expect(parsed.frontmatter).toMatchObject({ name: "crlf-skill", description: "Checked out on Windows" });
+  });
 });
 
 describe("splitFrontmatterBlock", () => {

--- a/server/src/__tests__/company-skills-catalog-service.test.ts
+++ b/server/src/__tests__/company-skills-catalog-service.test.ts
@@ -55,6 +55,17 @@ const sampleCatalogSkill: CatalogSkill = {
   contentHash: contentHash(sampleFiles),
 };
 
+const crlfSkillMarkdown = sampleSkillMarkdown.replace(/\n/g, "\r\n");
+const crlfFiles: CatalogSkillFile[] = [
+  { path: "SKILL.md", kind: "skill", sizeBytes: Buffer.byteLength(crlfSkillMarkdown), sha256: sha256(crlfSkillMarkdown) },
+  { path: "references/checklist.md", kind: "reference", sizeBytes: Buffer.byteLength(sampleReferenceMarkdown), sha256: sha256(sampleReferenceMarkdown) },
+];
+const crlfCatalogSkill: CatalogSkill = {
+  ...sampleCatalogSkill,
+  files: crlfFiles,
+  contentHash: contentHash(crlfFiles),
+};
+
 const mockCatalogService = vi.hoisted(() => ({
   getCatalogPackageMetadata: vi.fn(() => ({
     packageName: "@paperclipai/skills-catalog",
@@ -77,7 +88,7 @@ if (!embeddedPostgresSupport.supported) {
   );
 }
 
-describeEmbeddedPostgres("companySkillService.installFromCatalog", () => {
+describeEmbeddedPostgres("companySkillService.installFromCatalog", { timeout: 30_000 }, () => {
   let db!: ReturnType<typeof createDb>;
   let svc!: Awaited<ReturnType<typeof createService>>;
   let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
@@ -105,7 +116,7 @@ describeEmbeddedPostgres("companySkillService.installFromCatalog", () => {
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-company-skills-catalog-");
     db = createDb(tempDb.connectionString);
     svc = await createService();
-  }, 20_000);
+  }, 60_000);
 
   beforeEach(async () => {
     const home = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-catalog-home-"));
@@ -458,6 +469,32 @@ describeEmbeddedPostgres("companySkillService.installFromCatalog", () => {
         }),
       }),
     });
+  });
+
+  it("installs a catalog skill whose SKILL.md uses CRLF line endings without a false frontmatter hard-stop", async () => {
+    const companyId = await createCompany();
+    mockCatalogService.getCatalogSkillOrThrow.mockReturnValue(crlfCatalogSkill);
+    mockCatalogService.resolveCatalogSkillReference.mockReturnValue({ skill: crlfCatalogSkill, ambiguous: false });
+    mockCatalogService.readCatalogSkillFile.mockImplementation(async (_ref: string, filePath: string) => ({
+      catalogSkillId: crlfCatalogSkill.id,
+      path: filePath,
+      kind: filePath === "SKILL.md" ? "skill" : "reference",
+      content: filePath === "SKILL.md" ? crlfSkillMarkdown : sampleReferenceMarkdown,
+      language: "markdown",
+      markdown: true,
+    }));
+    mockCatalogService.copyCatalogSkillFile.mockImplementation(async (_ref: string, filePath: string, targetPath: string) => {
+      const content = filePath === "SKILL.md" ? crlfSkillMarkdown : sampleReferenceMarkdown;
+      await fs.writeFile(targetPath, content, "utf8");
+    });
+
+    const result = await svc.installFromCatalog(companyId, { catalogSkillId: crlfCatalogSkill.id });
+
+    expect(result.action).toBe("created");
+    expect(result.skill.metadata).toEqual(expect.objectContaining({ auditVerdict: "pass" }));
+    await expect(
+      fs.readFile(path.join(result.skill.sourceLocator!, "SKILL.md"), "utf8"),
+    ).resolves.toBe(crlfSkillMarkdown);
   });
 
   it("resets a modified catalog skill back to the pinned origin when forced", async () => {

--- a/server/src/__tests__/company-skills-catalog-service.test.ts
+++ b/server/src/__tests__/company-skills-catalog-service.test.ts
@@ -475,14 +475,6 @@ describeEmbeddedPostgres("companySkillService.installFromCatalog", { timeout: 30
     const companyId = await createCompany();
     mockCatalogService.getCatalogSkillOrThrow.mockReturnValue(crlfCatalogSkill);
     mockCatalogService.resolveCatalogSkillReference.mockReturnValue({ skill: crlfCatalogSkill, ambiguous: false });
-    mockCatalogService.readCatalogSkillFile.mockImplementation(async (_ref: string, filePath: string) => ({
-      catalogSkillId: crlfCatalogSkill.id,
-      path: filePath,
-      kind: filePath === "SKILL.md" ? "skill" : "reference",
-      content: filePath === "SKILL.md" ? crlfSkillMarkdown : sampleReferenceMarkdown,
-      language: "markdown",
-      markdown: true,
-    }));
     mockCatalogService.copyCatalogSkillFile.mockImplementation(async (_ref: string, filePath: string, targetPath: string) => {
       const content = filePath === "SKILL.md" ? crlfSkillMarkdown : sampleReferenceMarkdown;
       await fs.writeFile(targetPath, content, "utf8");

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -2527,7 +2527,11 @@ async function auditInstalledSkillBytes(skill: CompanySkill): Promise<CompanySki
   if (skillFile) {
     const markdown = skillFile.bytes.toString("utf8");
     const parsed = parseFrontmatterMarkdown(markdown);
-    if (!markdown.startsWith("---\n") || !asString(parsed.frontmatter.name)) {
+    // Ask the parser whether it found frontmatter rather than re-testing the
+    // raw bytes for "---\n": the parser normalizes line endings first, and the
+    // raw test failed every skill on a CRLF checkout, which reads as a
+    // hard-stop audit finding with nothing wrong in the file.
+    if (!parsed.hasFrontmatter || !asString(parsed.frontmatter.name)) {
       pushFinding(findings, "invalid_frontmatter", "error", "SKILL.md must contain valid frontmatter with a name.", "SKILL.md");
     }
   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The company-skills subsystem installs and updates catalog skills. It runs a static audit on the installed bytes before it accepts them.
> - The audit checks that `SKILL.md` starts with a frontmatter block. It does this with `markdown.startsWith("---\n")`.
> - On a checkout with CRLF line endings, the file starts with `---\r\n`. The check is then false. The audit raises an `invalid_frontmatter` error and returns a hard-stop `fail` verdict.
> - As a result, every catalog skill install and update fails on Windows, even when the `SKILL.md` file is valid.
> - This pull request replaces the raw-byte check with the shared parser result, which normalizes line endings first.
> - The benefit is that catalog skill install and update work on all platforms, independent of the checkout EOL style.

## Linked Issues or Issue Description

No public GitHub issue exists. The problem is described below with the bug report labels.

**What happened?**
On Windows, `POST /skills/install-catalog` and the skill update-status flow fail for every catalog skill. The audit returns `invalid_frontmatter` (severity `error`) and a hard-stop `fail` verdict. The `SKILL.md` file is valid; it only uses CRLF line endings.

**Expected behavior**
A valid `SKILL.md` passes the frontmatter audit regardless of line endings (LF or CRLF). Catalog skill install and update succeed on Windows.

**Steps to reproduce**
1. Check out a catalog skill whose `SKILL.md` uses CRLF line endings (Git default on Windows with `core.autocrlf=true`).
2. Call `POST /skills/install-catalog` for that skill, or run the skill update-status flow.
3. The audit reports an `invalid_frontmatter` error finding and a `fail` verdict, and the install or update is blocked.

**Paperclip version or commit**
Branch `fix/skills-audit-crlf-frontmatter`, based on `master` at `5acf56658`.

**Operating system**
Windows 11. The root cause is not Windows-specific; any CRLF checkout is affected.

**Agent adapter(s) involved**
Not adapter-specific (core bug).

## What Changed

- `server/src/services/company-skills.ts`: `auditInstalledSkillBytes` now detects frontmatter with `parseFrontmatterMarkdown(markdown).hasFrontmatter` instead of `markdown.startsWith("---\n")`. The parser normalizes line endings before it locates the frontmatter block. The `frontmatter.name` presence check is unchanged.
- `packages/shared/src/frontmatter.test.ts`: adds a case that confirms `parseFrontmatterMarkdown` detects frontmatter and reads fields when the document uses CRLF line endings.
- `server/src/__tests__/company-skills-catalog-service.test.ts`: adds a case that confirms `installFromCatalog` installs a catalog skill whose `SKILL.md` uses CRLF line endings without a false frontmatter hard-stop (audit verdict `pass`), and that the file is written back byte-for-byte.

## Verification

- `pnpm --filter @paperclip/shared exec vitest run src/frontmatter.test.ts` — pass.
- `pnpm --filter @paperclip/server exec vitest run src/__tests__/company-skills-catalog-service.test.ts` — pass.
- Manual: with the patch applied on a Windows dev server (port 3100), install of the `wireframe` catalog skill returns HTTP 200 with audit verdict at `warning` (no hard-stop). Before the patch the same call failed with an `invalid_frontmatter` error.
- Paperclip CI on this PR: all `ci /` functional jobs are green.

## Risks

Low risk. The change is one condition in one audit function. It only widens frontmatter detection to accept CRLF; it does not remove any check. The `name`-presence rule and all other findings are unchanged. Rollback is a single-commit revert.

## Model Used

Claude Sonnet 5 (Anthropic), model ID `claude-sonnet-5`. Used with extended thinking and tool use (file edits, shell, test runs) inside the Paperclip Chief-of-staff agent.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above (searched `paperclipai/paperclip` PRs for "frontmatter", "CRLF", "skills audit"; none found)
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (`fix/skills-audit-crlf-frontmatter`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (no docs cover this internal audit path)
- [ ] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green (functional jobs green; bot review gates pending this description update)
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
