### PR TITLE
fix(skills): trust parser for CRLF frontmatter in installed-skill audit

### DIFF
--- a/packages/shared/src/frontmatter.test.ts
+++ b/packages/shared/src/frontmatter.test.ts
@@ -120,6 +120,15 @@ describe("parseFrontmatterMarkdown", () => {
 
     expect(parsed.frontmatter.version).toBe("1.");
   });
+
+  it("detects frontmatter and reads fields when the document uses CRLF line endings", () => {
+    const parsed = parseFrontmatterMarkdown(
+      ["---", "name: crlf-skill", "description: Checked out on Windows", "---", "", "# Body"].join("\r\n"),
+    );
+
+    expect(parsed.hasFrontmatter).toBe(true);
+    expect(parsed.frontmatter).toMatchObject({ name: "crlf-skill", description: "Checked out on Windows" });
+  });
 });
 
 describe("splitFrontmatterBlock", () => {

--- a/server/src/services/company-skills.ts
+++ b/server/src/services/company-skills.ts
@@ -2560,7 +2560,12 @@ async function auditInstalledSkillBytes(skill: CompanySkill): Promise<CompanySki
   if (skillFile) {
     const markdown = skillFile.bytes.toString("utf8");
     const parsed = parseFrontmatterMarkdown(markdown);
-    if (!markdown.startsWith("---\n") || !asString(parsed.frontmatter.name)) {
+    // Trust the parser's frontmatter detection instead of re-testing the raw
+    // bytes for "---\n". parseFrontmatterMarkdown normalizes CRLF to LF first,
+    // but the raw check does not, so a skill checked out with CRLF line endings
+    // (the default on Windows) failed this check on every file and surfaced as a
+    // hard-stop "invalid_frontmatter" audit finding with nothing actually wrong.
+    if (!parsed.hasFrontmatter || !asString(parsed.frontmatter.name)) {
       pushFinding(findings, "invalid_frontmatter", "error", "SKILL.md must contain valid frontmatter with a name.", "SKILL.md");
     }
   }


### PR DESCRIPTION
## Problem

`auditInstalledSkillBytes` in `server/src/services/company-skills.ts` gates a skill's `SKILL.md` frontmatter with **two** checks:

```ts
const parsed = parseFrontmatterMarkdown(markdown);
if (!markdown.startsWith("---\n") || !asString(parsed.frontmatter.name)) {
  pushFinding(findings, "invalid_frontmatter", "error", ...);
}
```

`parseFrontmatterMarkdown` normalizes CRLF → LF before it looks for the fence, but the extra `markdown.startsWith("---\n")` test runs against the raw bytes. A skill checked out with CRLF line endings (Git's default on Windows via `core.autocrlf`) starts with `---\r\n`, so this test fails on every skill and raises a hard-stop `invalid_frontmatter` finding of severity `error` — verdict `fail` — even though the frontmatter is perfectly valid.

Effect: `POST /skills/install-catalog` and catalog skill updates fail for **all** skills on a Windows checkout.

## Fix

Use the parser's own result (`parsed.hasFrontmatter`), which already handles CRLF, instead of re-testing the raw bytes. The `name` presence check is unchanged.

## Tests

- Added a `parseFrontmatterMarkdown` regression test in `packages/shared/src/frontmatter.test.ts` that feeds a CRLF document and asserts `hasFrontmatter === true` and the fields parse. `pnpm vitest run packages/shared/src/frontmatter.test.ts` → 22 passed.

A service-level regression test in `server/src/__tests__/company-skills-catalog-service.test.ts` (install a catalog skill whose `SKILL.md` uses CRLF and assert `auditVerdict: "pass"`) is a reasonable follow-up; it needs the suite's embedded-Postgres `beforeAll` timeout raised and a host where embedded Postgres starts, which I could not run here.

## Rollback

Single revert of this commit.