### PR TITLE
fix(plugins): align stream publication keys

### DIFF
--- a/server/src/__tests__/plugin-routes-authz.test.ts
+++ b/server/src/__tests__/plugin-routes-authz.test.ts
@@ -536,6 +536,55 @@ describe.sequential("plugin tool and bridge authz", () => {
     vi.clearAllMocks();
   });
 
+  it("allows an agent to subscribe to a plugin stream for its own company", async () => {
+    readyPlugin();
+    const subscribe = vi.fn(() => vi.fn());
+    const { app } = await createApp({
+      type: "agent",
+      agentId: agentA,
+      companyId: companyA,
+      runId: runA,
+    }, {}, {
+      bridgeDeps: { streamBus: { subscribe } },
+    });
+
+    const res = await request(app)
+      .get(`/api/plugins/${pluginId}/bridge/stream/events`)
+      .query({ companyId: companyA })
+      .buffer(false)
+      .parse((_res, callback) => callback(null, undefined));
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("text/event-stream");
+    expect(subscribe).toHaveBeenCalledWith(
+      pluginId,
+      "events",
+      companyA,
+      expect.any(Function),
+    );
+  });
+
+  it("rejects an agent plugin stream subscription for another company", async () => {
+    readyPlugin();
+    const subscribe = vi.fn(() => vi.fn());
+    const { app } = await createApp({
+      type: "agent",
+      agentId: agentA,
+      companyId: companyA,
+      runId: runA,
+    }, {}, {
+      bridgeDeps: { streamBus: { subscribe } },
+    });
+
+    const res = await request(app)
+      .get(`/api/plugins/${pluginId}/bridge/stream/events`)
+      .query({ companyId: companyB });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Agent key cannot access another company" });
+    expect(subscribe).not.toHaveBeenCalled();
+  });
+
   it("rejects tool execution when the board user cannot access runContext.companyId", async () => {
     const executeTool = vi.fn();
     const getTool = vi.fn();

--- a/server/src/__tests__/plugin-stream-publication.test.ts
+++ b/server/src/__tests__/plugin-stream-publication.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createPluginStreamBus,
+  createPluginStreamNotificationHandler,
+} from "../services/plugin-stream-bus.js";
+
+describe("plugin worker stream publication", () => {
+  it("fans out a manifest-addressed worker emit on the installed plugin record key", () => {
+    const installedPluginId = "7c4e9157-5d59-47bf-a11a-0123456789ab";
+    const manifestPluginId = "zenfire.event-bridge";
+    const companyId = "company-a";
+    const event = { eventId: "evt-1", type: "issue.updated" };
+    const listener = vi.fn();
+    const streamBus = createPluginStreamBus();
+
+    streamBus.subscribe(installedPluginId, "board-events", companyId, listener);
+    const handleNotification = createPluginStreamNotificationHandler(installedPluginId, streamBus);
+
+    handleNotification("streams.emit", {
+      pluginId: manifestPluginId,
+      channel: "board-events",
+      companyId,
+      event,
+    });
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith(event, "message");
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -114,6 +114,7 @@ import { pluginLifecycleManager } from "./services/plugin-lifecycle.js";
 import { createPluginJobCoordinator } from "./services/plugin-job-coordinator.js";
 import { buildHostServices, flushPluginLogBuffer } from "./services/plugin-host-services.js";
 import { createPluginEventBus } from "./services/plugin-event-bus.js";
+import { createPluginStreamBus } from "./services/plugin-stream-bus.js";
 import { setPluginEventBus } from "./services/activity-log.js";
 import { createPluginDevWatcher } from "./services/plugin-dev-watcher.js";
 import { createPluginHostServiceCleanup } from "./services/plugin-host-service-cleanup.js";
@@ -563,6 +564,7 @@ export async function createApp(
   }
   const pluginRegistry = pluginRegistryService(db);
   const eventBus = createPluginEventBus();
+  const streamBus = createPluginStreamBus();
   setPluginEventBus(eventBus);
   const jobStore = pluginJobStore(db);
   const lifecycle = pluginLifecycleManager(db, { workerManager });
@@ -636,6 +638,7 @@ export async function createApp(
     },
     {
       workerManager,
+      streamBus,
       eventBus,
       jobScheduler: scheduler,
       jobStore,
@@ -676,7 +679,7 @@ export async function createApp(
       { scheduler, jobStore },
       { workerManager },
       { toolDispatcher },
-      { workerManager },
+      { workerManager, streamBus },
       { toolGateway },
     ),
   );

--- a/server/src/routes/plugins.ts
+++ b/server/src/routes/plugins.ts
@@ -1761,12 +1761,11 @@ export function pluginRoutes(
    *
    * Errors:
    * - 400 if companyId is missing
+   * - 403 if an agent selects a company other than its own
    * - 404 if plugin not found
    * - 501 if bridge deps or stream bus are not configured
    */
   router.get("/plugins/:pluginId/bridge/stream/:channel", async (req, res) => {
-    assertBoardOrgAccess(req);
-
     if (!bridgeDeps?.streamBus) {
       res.status(501).json({ error: "Plugin stream bridge is not enabled" });
       return;

--- a/server/src/services/plugin-loader.ts
+++ b/server/src/services/plugin-loader.ts
@@ -50,6 +50,10 @@ import type { PluginJobStore } from "./plugin-job-store.js";
 import type { PluginToolDispatcher } from "./plugin-tool-dispatcher.js";
 import type { PluginLifecycleManager } from "./plugin-lifecycle.js";
 import { pluginDatabaseService } from "./plugin-database.js";
+import {
+  createPluginStreamNotificationHandler,
+  type PluginStreamBus,
+} from "./plugin-stream-bus.js";
 import { resolveBundledCatalogRoot } from "./bundled-plugins.js";
 
 const execFileAsync = promisify(execFile);
@@ -349,6 +353,8 @@ export interface PluginInstallOptions {
 export interface PluginRuntimeServices {
   /** Worker process manager for spawning and managing plugin workers. */
   workerManager: PluginWorkerManager;
+  /** Process-scoped bus shared with the plugin SSE routes. */
+  streamBus?: PluginStreamBus;
   /** Event bus for registering plugin event subscriptions. */
   eventBus: PluginEventBus;
   /** Job scheduler for registering plugin cron jobs. */
@@ -2224,6 +2230,7 @@ export function pluginLoader(
 
     const {
       workerManager,
+      streamBus,
       eventBus,
       jobScheduler,
       jobStore,
@@ -2321,6 +2328,9 @@ export function pluginLoader(
         // set is exactly the plugin's configured companies — proactive access
         // never reaches an unconfigured company.
         proactiveCompanyScopes: configRows.map((row) => row.companyId),
+        onStreamNotification: streamBus
+          ? createPluginStreamNotificationHandler(pluginId, streamBus)
+          : undefined,
       };
 
       // Repo-local plugin installs can resolve workspace TS sources at runtime

--- a/server/src/services/plugin-stream-bus.ts
+++ b/server/src/services/plugin-stream-bus.ts
@@ -45,6 +45,25 @@ export interface PluginStreamBus {
   ): void;
 }
 
+export function createPluginStreamNotificationHandler(
+  installedPluginId: string,
+  streamBus: PluginStreamBus,
+): (method: string, params: Record<string, unknown>) => void {
+  return (method, params) => {
+    const channel = String(params.channel ?? "");
+    const companyId = String(params.companyId ?? "");
+    if (!channel || !companyId) return;
+
+    if (method === "streams.emit") {
+      streamBus.publish(installedPluginId, channel, companyId, params.event);
+    } else if (method === "streams.open") {
+      streamBus.publish(installedPluginId, channel, companyId, params.event, "open");
+    } else if (method === "streams.close") {
+      streamBus.publish(installedPluginId, channel, companyId, params.event, "close");
+    }
+  };
+}
+
 /**
  * Create a new PluginStreamBus instance.
  */


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages plugin workers and plugin user interfaces.
> - Plugin workers can publish events to user interfaces through SSE streams.
> - The SSE route subscribes with the installed plugin record ID.
> - The runtime did not connect worker notifications to the same process bus.
> - A manifest ID can differ from the installed plugin record ID.
> - This pull request creates each notification handler with the installed record ID.
> - The benefit is reliable worker-to-SSE event delivery.

## Linked Issues or Issue Description

**Description**

Plugin stream events can be lost when the publication key differs from the installed plugin record key used by the SSE route.

**Steps to reproduce**

Subscribe to a plugin stream by manifest ID. Emit a stream event from its worker. The subscriber receives only keepalive comments.

**Expected behavior**

The SSE subscriber receives the worker event on the resolved installed plugin record key.

## What Changed

- Create one process-scoped plugin stream bus in the application.
- Pass the bus to the plugin loader and the SSE route.
- Bind each worker notification handler to its installed plugin record ID.
- Add a focused regression test for manifest-addressed worker delivery.
- Include the company-agent stream authorization change from PR #13077 because this branch depends on it.

## Verification

- `npx --yes vitest@3.2.4 run server/src/__tests__/plugin-stream-publication.test.ts --reporter=verbose`
- Result: one test passed.
- The full route suite cannot complete in this checkout because the workspace install fails on Windows with `ENAMETOOLONG`. The isolated run then lacks built workspace packages.

## Risks

- Low risk. The bus remains process-local and company-scoped.
- Existing plugins without stream usage receive an unused callback.

## Model Used

- OpenAI Codex, GPT-5 family, with reasoning and code execution tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either linked an existing public issue or described the issue with bug report labels
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal ticket ID
- [x] I have run the focused regression test locally and it passes
- [x] I have added or updated tests where applicable
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
