### PR TITLE
fix(codex): discover models via custom OpenAI base URL

### DIFF
--- a/server/src/__tests__/adapter-models.test.ts
+++ b/server/src/__tests__/adapter-models.test.ts
@@ -229,6 +229,32 @@ describe("adapter model listing", () => {
     expect(models.some((model) => model.id === "provider-model-b")).toBe(true);
   });
 
+  it("ignores PAPERCLIP_CODEX_PROVIDERS base_url when model_provider is unset", async () => {
+    process.env.OPENAI_API_KEY = "sk-test";
+    process.env.PAPERCLIP_CODEX_PROVIDERS = JSON.stringify({
+      providers: {
+        custom: {
+          name: "Custom gateway",
+          base_url: "https://gateway.example.com/v1/",
+          env_key: "OPENAI_API_KEY",
+          wire_api: "responses",
+        },
+      },
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: "openai-default-model" }],
+      }),
+    } as Response);
+
+    const models = await listAdapterModels("codex_local");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe("https://api.openai.com/v1/models");
+    expect(models.some((model) => model.id === "openai-default-model")).toBe(true);
+  });
+
   it("refreshes cached codex models on demand", async () => {
     process.env.OPENAI_API_KEY = "sk-test";
     const fetchSpy = vi.spyOn(globalThis, "fetch")

--- a/server/src/__tests__/adapter-models.test.ts
+++ b/server/src/__tests__/adapter-models.test.ts
@@ -19,6 +19,8 @@ vi.mock("acpx/runtime", () => ({
 describe("adapter model listing", () => {
   beforeEach(() => {
     delete process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_BASE_URL;
+    delete process.env.PAPERCLIP_CODEX_PROVIDERS;
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.ANTHROPIC_BASE_URL;
     delete process.env.ANTHROPIC_BEDROCK_BASE_URL;
@@ -177,9 +179,54 @@ describe("adapter model listing", () => {
     const second = await listAdapterModels("codex_local");
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe("https://api.openai.com/v1/models");
     expect(first).toEqual(second);
     expect(first.some((model) => model.id === "gpt-5-pro")).toBe(true);
     expect(first.some((model) => model.id === "codex-mini-latest")).toBe(true);
+  });
+
+  it("discovers codex models from OPENAI_BASE_URL instead of api.openai.com", async () => {
+    process.env.OPENAI_API_KEY = "sk-test";
+    process.env.OPENAI_BASE_URL = "https://gateway.example.com/v1";
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: "gateway-model-a" }],
+      }),
+    } as Response);
+
+    const models = await listAdapterModels("codex_local");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe("https://gateway.example.com/v1/models");
+    expect(models.some((model) => model.id === "gateway-model-a")).toBe(true);
+  });
+
+  it("discovers codex models from PAPERCLIP_CODEX_PROVIDERS base_url when OPENAI_BASE_URL is unset", async () => {
+    process.env.OPENAI_API_KEY = "sk-test";
+    process.env.PAPERCLIP_CODEX_PROVIDERS = JSON.stringify({
+      providers: {
+        custom: {
+          name: "Custom gateway",
+          base_url: "https://gateway.example.com/v1/",
+          env_key: "OPENAI_API_KEY",
+          wire_api: "responses",
+        },
+      },
+      model_provider: "custom",
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: "provider-model-b" }],
+      }),
+    } as Response);
+
+    const models = await listAdapterModels("codex_local");
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe("https://gateway.example.com/v1/models");
+    expect(models.some((model) => model.id === "provider-model-b")).toBe(true);
   });
 
   it("refreshes cached codex models on demand", async () => {

--- a/server/src/adapters/codex-models.ts
+++ b/server/src/adapters/codex-models.ts
@@ -68,7 +68,7 @@ function resolveBaseUrlFromCodexProviders(): string | null {
     const selected =
       typeof record.model_provider === "string" && record.model_provider.trim().length > 0
         ? record.model_provider.trim()
-        : Object.keys(providers)[0];
+        : null;
     if (!selected) return null;
     const entry = providers[selected];
     if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;

--- a/server/src/adapters/codex-models.ts
+++ b/server/src/adapters/codex-models.ts
@@ -2,11 +2,13 @@ import type { AdapterModel } from "./types.js";
 import { models as codexFallbackModels } from "@paperclipai/adapter-codex-local";
 import { readConfigFile } from "../config-file.js";
 
-const OPENAI_MODELS_ENDPOINT = "https://api.openai.com/v1/models";
+const OPENAI_MODELS_PATH = "/models";
+const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
 const OPENAI_MODELS_TIMEOUT_MS = 5000;
 const OPENAI_MODELS_CACHE_TTL_MS = 60_000;
 
-let cached: { keyFingerprint: string; expiresAt: number; models: AdapterModel[] } | null = null;
+let cached: { keyFingerprint: string; baseUrl: string; expiresAt: number; models: AdapterModel[] } | null =
+  null;
 
 function fingerprint(apiKey: string): string {
   return `${apiKey.length}:${apiKey.slice(-6)}`;
@@ -41,11 +43,48 @@ function resolveOpenAiApiKey(): string | null {
   return configKey && configKey.length > 0 ? configKey : null;
 }
 
-async function fetchOpenAiModels(apiKey: string): Promise<AdapterModel[]> {
+/** Prefer OPENAI_BASE_URL; else active PAPERCLIP_CODEX_PROVIDERS base_url; else OpenAI. */
+function resolveOpenAiBaseUrl(): string {
+  const envUrl = process.env.OPENAI_BASE_URL?.trim();
+  if (envUrl) return envUrl.replace(/\/+$/, "");
+
+  const fromProviders = resolveBaseUrlFromCodexProviders();
+  if (fromProviders) return fromProviders;
+
+  return DEFAULT_OPENAI_BASE_URL;
+}
+
+function resolveBaseUrlFromCodexProviders(): string | null {
+  const raw = process.env.PAPERCLIP_CODEX_PROVIDERS?.trim();
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    const record = parsed as { providers?: unknown; model_provider?: unknown };
+    if (!record.providers || typeof record.providers !== "object" || Array.isArray(record.providers)) {
+      return null;
+    }
+    const providers = record.providers as Record<string, unknown>;
+    const selected =
+      typeof record.model_provider === "string" && record.model_provider.trim().length > 0
+        ? record.model_provider.trim()
+        : Object.keys(providers)[0];
+    if (!selected) return null;
+    const entry = providers[selected];
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;
+    const baseUrl = (entry as { base_url?: unknown }).base_url;
+    if (typeof baseUrl !== "string" || baseUrl.trim().length === 0) return null;
+    return baseUrl.trim().replace(/\/+$/, "");
+  } catch {
+    return null;
+  }
+}
+
+async function fetchOpenAiModels(apiKey: string, baseUrl: string): Promise<AdapterModel[]> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), OPENAI_MODELS_TIMEOUT_MS);
   try {
-    const response = await fetch(OPENAI_MODELS_ENDPOINT, {
+    const response = await fetch(`${baseUrl}${OPENAI_MODELS_PATH}`, {
       headers: {
         Authorization: `Bearer ${apiKey}`,
       },
@@ -77,23 +116,36 @@ async function loadCodexModels(options?: { forceRefresh?: boolean }): Promise<Ad
   if (!apiKey) return fallback;
 
   const now = Date.now();
+  const baseUrl = resolveOpenAiBaseUrl();
   const keyFingerprint = fingerprint(apiKey);
-  if (!forceRefresh && cached && cached.keyFingerprint === keyFingerprint && cached.expiresAt > now) {
+  if (
+    !forceRefresh &&
+    cached &&
+    cached.keyFingerprint === keyFingerprint &&
+    cached.baseUrl === baseUrl &&
+    cached.expiresAt > now
+  ) {
     return cached.models;
   }
 
-  const fetched = await fetchOpenAiModels(apiKey);
+  const fetched = await fetchOpenAiModels(apiKey, baseUrl);
   if (fetched.length > 0) {
     const merged = mergedWithFallback(fetched);
     cached = {
       keyFingerprint,
+      baseUrl,
       expiresAt: now + OPENAI_MODELS_CACHE_TTL_MS,
       models: merged,
     };
     return merged;
   }
 
-  if (cached && cached.keyFingerprint === keyFingerprint && cached.models.length > 0) {
+  if (
+    cached &&
+    cached.keyFingerprint === keyFingerprint &&
+    cached.baseUrl === baseUrl &&
+    cached.models.length > 0
+  ) {
     return cached.models;
   }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Codex local adapter discovers available models for agent configuration
> - Model listing always called `https://api.openai.com/v1/models`, even when runs use a custom OpenAI-compatible gateway via `OPENAI_BASE_URL` or `PAPERCLIP_CODEX_PROVIDERS`
> - That mismatch hides gateway models in the UI while Claude already honors `ANTHROPIC_BASE_URL`
> - This pull request resolves the Codex models base URL the same way and caches lists per base URL
> - The benefit is correct model discovery for custom OpenAI-compatible gateways

## Linked Issues or Issue Description

Fixes #13083

## What Changed

- Resolve Codex model discovery base URL from `OPENAI_BASE_URL`, then selected `PAPERCLIP_CODEX_PROVIDERS` `base_url` (only when `model_provider` is set), else `https://api.openai.com/v1`
- Include `baseUrl` in the models cache key so gateway switches do not serve a stale list
- Add unit coverage for default, `OPENAI_BASE_URL`, and provider `base_url` paths

## Verification

- `pnpm --filter @paperclipai/server test -- adapter-models`
- Default env hits `https://api.openai.com/v1/models`
- With `OPENAI_BASE_URL=https://gateway.example.com/v1`, list hits `{base}/models`
- With `PAPERCLIP_CODEX_PROVIDERS` and `model_provider` set, uses that provider `base_url`
- With providers JSON but no `model_provider`, falls back to the default OpenAI models URL

## Risks

- Low risk. Discovery-only change; run-time Codex HTTP path is unchanged
- If `model_provider` is omitted, discovery no longer guesses the first provider key (aligns with runtime). Operators must set `model_provider` or `OPENAI_BASE_URL` for custom gateways

## Model Used

- Cursor Agent (Composer) with tool use for implementation and PR drafting

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge