### PR TITLE
fix(tool-gateway): omit structuredContent when a tool returns no structured data

### DIFF
--- a/server/src/__tests__/tool-gateway-service.test.ts
+++ b/server/src/__tests__/tool-gateway-service.test.ts
@@ -1155,7 +1155,7 @@ describeEmbeddedPostgres("tool gateway service", () => {
       parameters: { target: "tampered" },
     });
     expect(result.status).toBe("completed");
-    expect((result.result as { result?: { data?: { target?: string } } }).result?.data?.target).toBe("repo");
+    expect(result.result).toMatchObject({ content: "deleted", data: { target: "repo" } });
   });
 
   it("maps remote MCP elicitation to a durable issue interaction", async () => {

--- a/server/src/__tests__/tool-gateway.test.ts
+++ b/server/src/__tests__/tool-gateway.test.ts
@@ -2838,6 +2838,236 @@ rl.on("line", (line) => {
     }
   });
 
+  it("omits structuredContent from normalized MCP results when the remote server returns none", async () => {
+    const company = await createCompany(db);
+    const agent = await createAgent(db, company.id);
+    const { run } = await createIssueAndRun(db, company.id, agent.id);
+    const fake = await startFakeRemoteMcpServer((fakeRequest) => ({
+      body: {
+        jsonrpc: "2.0",
+        id: fakeRequest.body?.id,
+        result: { content: [{ type: "text", text: "text only" }] },
+      },
+    }));
+    try {
+      await createRemoteMcpTool(db, company.id, {
+        applicationKey: "kv-demo",
+        connectionName: "KV Demo text-only",
+        toolName: "kv_set",
+        title: "Set KV value",
+        url: fake.url,
+        credentialRefs: [],
+        credentialSecretRefs: [],
+      });
+      await allowAllToolsForAgent(db, company.id, agent.id);
+      const gateway = createTestToolGatewayService(db);
+      const session = await gateway.createSession({ companyId: company.id, agentId: agent.id, runId: run.id });
+      const connectedTool = (await gateway.listToolsForSession(session.token))
+        .find((tool) => tool.providerType === "mcp_remote_http");
+      expect(connectedTool).toBeTruthy();
+
+      const result = await gateway.executeTool({
+        sessionToken: session.token,
+        tool: connectedTool!.name,
+        parameters: { key: "alpha", value: "one" },
+      });
+      expect(result).toMatchObject({
+        status: "completed",
+        result: { content: "text only", data: { isError: false, transport: "mcp_http" } },
+      });
+      expect(result.result as Record<string, unknown>).not.toHaveProperty("data.structuredContent");
+    } finally {
+      await fake.close();
+    }
+  });
+
+  it("forwards only the remote tool's structuredContent for connected-MCP tools over the named gateway", async () => {
+    const company = await createCompany(db);
+    const fake = await startFakeRemoteMcpServer((fakeRequest) => {
+      const args = ((fakeRequest.body?.params as Record<string, unknown> | undefined)?.arguments ?? {}) as Record<string, unknown>;
+      return {
+        body: {
+          jsonrpc: "2.0",
+          id: fakeRequest.body?.id,
+          result: args.key === "structured"
+            ? {
+                content: [{ type: "text", text: "saved structured" }],
+                structuredContent: { saved: true, key: "structured" },
+              }
+            : { content: [{ type: "text", text: "saved text only" }] },
+        },
+      };
+    });
+    try {
+      const { application, connection, catalogEntry } = await createRemoteMcpTool(db, company.id, {
+        url: fake.url,
+        applicationKey: "kv-named-gateway",
+        connectionName: "KV named gateway",
+        toolName: "kv_set",
+        title: "Set KV value",
+        riskLevel: "write",
+      });
+      const gatewayToolName = expectedConnectedToolName({
+        applicationKey: application.applicationKey,
+        connectionId: connection.id,
+        toolName: catalogEntry.toolName,
+      });
+      const [profile] = await db.insert(toolProfiles).values({
+        companyId: company.id,
+        profileKey: `connected-mcp-structured-${randomUUID()}`,
+        name: `Connected MCP structured ${randomUUID()}`,
+        defaultAction: "deny",
+      }).returning();
+      await db.insert(toolProfileEntries).values({
+        companyId: company.id,
+        profileId: profile.id,
+        selectorType: "tool_name",
+        effect: "include",
+        toolName: gatewayToolName,
+      });
+      const gateway = createTestToolGatewayService(db);
+      const created = await gateway.createNamedGateway({
+        companyId: company.id,
+        body: { name: "Connected MCP structured content", profileId: profile.id },
+      });
+      const token = await gateway.createNamedGatewayToken({
+        companyId: company.id,
+        gatewayId: created.id,
+        body: { name: "MCP client", clientLabel: "MCP client" },
+      });
+      const app = createGatewayRouteApp(db, gateway);
+      const endpoint = `/mcp/gateways/${created.gatewayPublicId}`;
+      const call = (id: number, key: string) => request(app)
+        .post(endpoint)
+        .set("authorization", `Bearer ${token.token}`)
+        .send({ jsonrpc: "2.0", id, method: "tools/call", params: { name: gatewayToolName, arguments: { key, value: "v" } } });
+
+      const structured = await call(1, "structured").expect(200);
+      expect(structured.body.result).toEqual({
+        content: [{ type: "text", text: "saved structured" }],
+        structuredContent: { saved: true, key: "structured" },
+        isError: false,
+      });
+
+      const textOnly = await call(2, "text-only").expect(200);
+      expect(textOnly.body.result).toEqual({
+        content: [{ type: "text", text: "saved text only" }],
+        isError: false,
+      });
+      expect(textOnly.body.result).not.toHaveProperty("structuredContent");
+    } finally {
+      await fake.close();
+    }
+  });
+
+  it("maps plugin ToolResult data onto MCP structuredContent and omits it when the tool returns none", async () => {
+    const company = await createCompany(db);
+    const agent = await createAgent(db, company.id);
+    const { run } = await createIssueAndRun(db, company.id, agent.id);
+    const profile = await allowToolsForAgent(db, company.id, agent.id, [
+      "demo-plugin:with_data",
+      "demo-plugin:without_data",
+      "demo-plugin:broken",
+    ]);
+    const dispatcher: PluginToolDispatcher = {
+      initialize: async () => {},
+      teardown: () => {},
+      listToolsForAgent: () => ["with_data", "without_data", "broken", "not_allowed"].map((toolName) => ({
+        name: `demo-plugin:${toolName}`,
+        displayName: toolName,
+        description: `Plugin fixture ${toolName}.`,
+        parametersSchema: { type: "object" },
+        pluginId: "demo-plugin",
+      })),
+      getTool: () => null,
+      executeTool: async (tool) => {
+        if (tool === "demo-plugin:broken") throw new Error("plugin worker is not running");
+        return {
+          pluginId: "demo-plugin",
+          toolName: tool.split(":")[1]!,
+          result: tool === "demo-plugin:with_data"
+            ? { content: "plugin ok", data: { ok: true, items: [1, 2] } }
+            : { content: "plugin text only" },
+        };
+      },
+      registerPluginTools: () => {},
+      unregisterPluginTools: () => {},
+      toolCount: () => 4,
+      getRegistry: () => {
+        throw new Error("not used");
+      },
+    };
+    const gateway = createTestToolGatewayService(db, { pluginToolDispatcher: dispatcher });
+    const namedGateway = await gateway.createNamedGateway({
+      companyId: company.id,
+      body: {
+        name: `Plugin gateway ${randomUUID()}`,
+        profileId: profile.id,
+        defaultProfileMode: "gateway_only",
+      },
+    });
+    const token = await gateway.createNamedGatewayToken({
+      companyId: company.id,
+      gatewayId: namedGateway.id,
+      body: {
+        name: "Plugin runtime token",
+        subjectType: "heartbeat_run",
+        subjectId: run.id,
+        clientLabel: "Heartbeat runtime",
+        allowedActions: ["tools/list", "tools/call"],
+        expiresAt: new Date(Date.now() + 60_000),
+      },
+      actor: { agentId: agent.id },
+    });
+    const app = createGatewayRouteApp(db, gateway);
+    const endpoint = `/api/tool-gateway/gateways/${namedGateway.id}/mcp`;
+    const call = (id: number, name: string) => request(app)
+      .post(endpoint)
+      .set("authorization", `Bearer ${token.token}`)
+      .send({ jsonrpc: "2.0", id, method: "tools/call", params: { name, arguments: {} } });
+
+    const listed = await request(app)
+      .post(endpoint)
+      .set("authorization", `Bearer ${token.token}`)
+      .send({ jsonrpc: "2.0", id: 1, method: "tools/list" })
+      .expect(200);
+    expect(listed.body.result.tools.map((tool: { name: string }) => tool.name)).toEqual(
+      expect.arrayContaining(["demo-plugin:with_data", "demo-plugin:without_data"]),
+    );
+
+    const withData = await call(2, "demo-plugin:with_data").expect(200);
+    expect(withData.body.result).toEqual({
+      content: [{ type: "text", text: "plugin ok" }],
+      structuredContent: { ok: true, items: [1, 2] },
+      isError: false,
+    });
+
+    const withoutData = await call(3, "demo-plugin:without_data").expect(200);
+    expect(withoutData.body.result).toEqual({
+      content: [{ type: "text", text: "plugin text only" }],
+      isError: false,
+    });
+    expect(withoutData.body.result).not.toHaveProperty("structuredContent");
+
+    const denied = await call(4, "demo-plugin:not_allowed").expect(403);
+    expect(denied.body).not.toHaveProperty("result");
+    expect(denied.body.error).toMatchObject({ code: -32000, data: { reasonCode: "deny_default" } });
+
+    const broken = await call(5, "demo-plugin:broken").expect(500);
+    expect(broken.body).not.toHaveProperty("result");
+    expect(broken.body.error).toBe("plugin worker is not running");
+
+    const invocations = await db
+      .select({ tool: toolInvocations.toolName, status: toolInvocations.status })
+      .from(toolInvocations)
+      .where(eq(toolInvocations.runId, run.id));
+    expect(invocations).toEqual(expect.arrayContaining([
+      { tool: "demo-plugin:with_data", status: "succeeded" },
+      { tool: "demo-plugin:without_data", status: "succeeded" },
+      { tool: "demo-plugin:broken", status: "failed" },
+    ]));
+  });
+
   it("discovers and calls the SDK-backed KV demo MCP server over Streamable HTTP", async () => {
     const company = await createCompany(db);
     const agent = await createAgent(db, company.id);

--- a/server/src/routes/tool-gateway.ts
+++ b/server/src/routes/tool-gateway.ts
@@ -13,7 +13,11 @@ import {
   updateToolMcpGatewaySchema,
 } from "@paperclipai/shared/validators/tool-access";
 import { assertBoard, assertBoardOrAgent, assertCompanyAccess, getActorInfo } from "./authz.js";
-import { ToolGatewayHttpError, type ToolGatewayService } from "../services/tool-gateway.js";
+import {
+  isConnectedMcpToolResultData,
+  ToolGatewayHttpError,
+  type ToolGatewayService,
+} from "../services/tool-gateway.js";
 import { forbidden, HttpError } from "../errors.js";
 import { accessService } from "../services/index.js";
 import { listConnectionLifecycleEvents } from "../services/tool-connection-activity.js";
@@ -35,6 +39,27 @@ const TOOL_GATEWAY_WINDOWS: Record<string, number | null> = {
 };
 
 const uuidPattern = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * MCP `tools/call` results may only carry `structuredContent` when it is a JSON
+ * object; clients such as Claude Code reject `null`. Return the key only when
+ * there is an object to send so it can be spread into the result.
+ */
+function mcpStructuredContent(value: unknown): { structuredContent: Record<string, unknown> } | Record<string, never> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? { structuredContent: value as Record<string, unknown> }
+    : {};
+}
+
+/**
+ * Structured content for a `tools/call` answered by `executeTool`. Plugin and built-in
+ * tools put their structured data directly on `ToolResult.data`; connected-MCP tools
+ * return the normalization envelope there, so only the remote tool's own
+ * `structuredContent` (when present) is forwarded, never the envelope.
+ */
+function toolResultStructuredContent(data: unknown) {
+  return mcpStructuredContent(isConnectedMcpToolResultData(data) ? data.structuredContent : data);
+}
 
 function gatewayToken(req: { header(name: string): string | undefined }) {
   return req.header("x-paperclip-tool-gateway-token")?.trim() || null;
@@ -161,7 +186,15 @@ async function handleMcpGatewayProtocol(
             : {},
           callerHeaders: headers,
         });
-        res.json({ jsonrpc: "2.0", id, result: { content: [{ type: "text", text: JSON.stringify(result) }], structuredContent: result, isError: false } });
+        res.json({
+          jsonrpc: "2.0",
+          id,
+          result: {
+            content: [{ type: "text", text: JSON.stringify(result) }],
+            ...mcpStructuredContent(result),
+            isError: false,
+          },
+        });
         return;
       }
       const result = await toolGateway.executeTool({
@@ -183,7 +216,7 @@ async function handleMcpGatewayProtocol(
         id,
         result: {
           content: [{ type: "text", text: contentText }],
-          structuredContent: resultRecord?.data ?? null,
+          ...toolResultStructuredContent(resultRecord?.data),
           isError: false,
         },
       });

--- a/server/src/services/tool-gateway.ts
+++ b/server/src/services/tool-gateway.ts
@@ -240,6 +240,33 @@ export type ToolGatewayProviderType =
   | "paperclip_plugin"
   | "paperclip_virtual";
 
+/**
+ * `ToolResult.data` for a connected-MCP tool (remote HTTP or local stdio) is the
+ * normalization envelope built by `normalizeMcpToolResult`, not the remote tool's own
+ * structured data: the remote `structuredContent` sits inside it, next to the raw
+ * content blocks and transport metadata.
+ */
+export interface ConnectedMcpToolResultData {
+  content: unknown[];
+  structuredContent?: unknown;
+  isError: boolean;
+  transport: "mcp_http" | "local_stdio";
+  spawnedLocalProcess: boolean;
+}
+
+export function isConnectedMcpToolResultData(
+  value: unknown,
+): value is ConnectedMcpToolResultData {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  return (
+    (record.transport === "mcp_http" || record.transport === "local_stdio") &&
+    Array.isArray(record.content) &&
+    typeof record.isError === "boolean" &&
+    typeof record.spawnedLocalProcess === "boolean"
+  );
+}
+
 export interface ConnectedMcpGatewayMetadata {
   applicationId: string;
   applicationKey: string | null;
@@ -5723,7 +5750,9 @@ export function createToolGatewayService(
       content,
       data: {
         content: record.content,
-        structuredContent: record.structuredContent ?? null,
+        ...(record.structuredContent !== undefined && record.structuredContent !== null
+          ? { structuredContent: record.structuredContent }
+          : {}),
         isError: record.isError === true,
         transport,
         spawnedLocalProcess,
@@ -10224,6 +10253,9 @@ export function createToolGatewayService(
         const result = connectedMcpExecution
           ? connectedMcpExecution.result
           : tool.providerType === "paperclip_plugin"
+            // Surface the plugin's ToolResult ({ content, data, error }) directly so plugin
+            // tools share the result shape of MCP and built-in tools and the MCP gateway
+            // can map `data` onto structuredContent.
             ? await runWithTimeout(
                 pluginToolDispatcher!.executeTool(
                   tool.name,
@@ -10234,7 +10266,7 @@ export function createToolGatewayService(
                     companyId: session.companyId,
                     projectId: session.projectId ?? "",
                   },
-                ),
+                ).then((execution) => execution.result),
                 executionTimeoutMs,
               )
             : await runWithTimeout(


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents reach governed tools through the tool gateway, which exposes builtin, connected-MCP, and plugin tools over one MCP `tools/call` surface
> - The MCP spec allows `structuredContent` only as an object or omitted; `null` is invalid
> - The gateway emitted `structuredContent: null` whenever a tool had no structured data, and plugin tools never had structured data because the gateway kept the dispatcher's routing envelope instead of the plugin `ToolResult`
> - Validating MCP clients (Claude Code) rejected those results, so plugin tools looked failed even though they ran
> - This pull request omits `structuredContent` when there is no object to send and unwraps the plugin envelope on the per-run gateway path
> - The benefit is that plugin tools and text-only tools are callable over the gateway from spec-compliant MCP clients

## Linked Issues or Issue Description

Refs #11199 (reports the same `structuredContent: null` rejection on the idempotent-replay path; the `null` emission is fixed here, replay-envelope persistence and `isError` propagation are out of scope).

Refs #10317 (prior PR by @ValeriyLapin with the same root-cause analysis and a very similar fix; it has been open without activity since July). This PR is a fresh, rebased change on current `master`. Credit to @ValeriyLapin for the original diagnosis. If maintainers prefer to land #10317, this PR can be closed.

**What happened**

A plugin tool called through the gateway's MCP endpoint executes, but the client rejects the response:

```
MCP server returned a malformed result that failed schema validation:
[{ "expected": "record", "code": "invalid_type", "path": ["structuredContent"],
   "message": "Invalid input: expected record, received null" }]
```

The same rejection happens for builtin or connected-MCP tools that return no structured data.

**Expected behavior**

The client receives the tool result. `structuredContent` is present only when the tool returned an object.

**Steps to reproduce**

1. Install a plugin that declares a tool. Return `{ content }` with no `data`, or return `{ content, data }`.
2. Allow the tool for an agent through a gateway profile.
3. Call the tool over the gateway MCP endpoint from Claude Code (or any MCP client that validates results).
4. The call executes, but the client reports the schema error above.

**Cause**

- `server/src/routes/tool-gateway.ts` built every `tools/call` reply with `structuredContent: <data> ?? null`, on both reply paths (Paperclip context methods and tool results).
- `server/src/services/tool-gateway.ts` normalized connected-MCP results with `structuredContent: <value> ?? null` inside `data`, so a remote server that returned no `structuredContent` produced the same `null`.
- `server/src/services/tool-gateway.ts` stored the plugin dispatcher's `{ pluginId, toolName, result }` envelope as the tool result on the per-run gateway path. Every other provider yields a bare `ToolResult`, so the reply builder read `data` from the wrong object and plugin `data` never reached the client.

**Paperclip version / deployment mode**

Reproduced on `master` (nightly `v2026.902.0-nightly.0`) and re-verified on current `master`. Self-hosted server. Client: Claude Code MCP.

## What Changed

- Add `mcpStructuredContent()` in `server/src/routes/tool-gateway.ts`. It returns `{ structuredContent }` only when the value is a non-array object, and `{}` otherwise. Both `tools/call` reply paths spread it instead of emitting `?? null`.
- Omit `structuredContent` from the normalized connected-MCP result in `server/src/services/tool-gateway.ts` when the remote server returned none, instead of storing `null`.
- Unwrap the plugin dispatcher result on the per-run gateway path in `server/src/services/tool-gateway.ts` (`.then((execution) => execution.result)`), so plugin tools store the plugin `ToolResult` (`{ content, data, error }`) like builtin and MCP tools do.
- Add a route test that a plugin `ToolResult` with `data` maps onto `structuredContent`, and that a plugin result without `data` omits the key.
- Add a route test that a normalized connected-MCP result without `structuredContent` omits the key.
- Update the existing service test to assert the unwrapped `ToolResult` shape.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/tool-gateway.test.ts src/__tests__/tool-gateway-service.test.ts` — 2 files, 98 tests pass on this branch (rebased on current `master`).
- Manual: call a plugin tool that returns `{ content }` from Claude Code through the gateway MCP endpoint. Before: schema-validation rejection. After: the text content is returned and no `structuredContent` key is present. Call a plugin tool that returns `{ content, data }`: `structuredContent` equals `data`.

## Risks

- Small REST contract change: the `result` field of `POST /api/tool-gateway/tools/call` for plugin tools is now the unwrapped plugin `ToolResult` instead of the `{ pluginId, toolName, result }` envelope. This aligns plugin tools with builtin and MCP tools. The audit `invocation.result` for plugin tools changes shape the same way. `/api/plugins/tools/execute` is unchanged.
- MCP replies no longer carry `structuredContent: null`. Clients that tolerated `null` see the key omitted, which the spec allows.
- No migration. No telemetry changes.

## Model Used

- Claude (Anthropic), model ID `claude-fable-5-1`, via Claude Code CLI with tool use (file editing, shell, test execution). Human-reviewed by the submitter.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (no user-facing docs describe this response shape)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
