### PR TITLE
fix(adapters): probe Git context in the remote workspace

### DIFF
--- a/packages/adapter-utils/src/execution-target.ts
+++ b/packages/adapter-utils/src/execution-target.ts
@@ -1650,7 +1650,9 @@ printf '\0PAPERCLIP_GIT_CONTEXT_END\0'
 `;
     const result = await adapterExecutionTargetCommandRunner(remote).execute({
       command: "sh", args: ["-c", probe, "paperclip-git-context", input.hostCredentials ? "host" : "managed"],
-      cwd: input.cwd, timeoutMs: 15_000,
+      // The caller's cwd belongs to the controller. Copied sandbox/SSH
+      // workspaces can live at a different path on the execution target.
+      cwd: remote.remoteCwd, timeoutMs: 15_000,
     });
     if (result.exitCode !== 0) throw new Error("Could not read execution-target Git context");
     const payload = result.stdout.split("\0PAPERCLIP_GIT_CONTEXT_V1\0")[1]?.split("\0PAPERCLIP_GIT_CONTEXT_END\0")[0];

--- a/packages/adapter-utils/src/github-launcher-environment.test.ts
+++ b/packages/adapter-utils/src/github-launcher-environment.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -66,6 +66,41 @@ async function sandbox(layout: string) {
 }
 
 describe("managed GitHub launcher environment", () => {
+  it.each([false, true])("probes the remote workspace when the controller cwd is absent (host credentials: %s)", async (hostCredentials) => {
+    const fixture = await sandbox("usr/bin");
+    const env = await prepareGitHubExecutionEnvironment({
+      target: fixture.target,
+      cwd: path.join(fixture.root, "controller-only", "agent-workspace"),
+      env: {},
+      hostCredentials,
+      networkAccess: true,
+    });
+
+    expect(env.PAPERCLIP_RUNNER_NETWORK_ACCESS).toBe("enabled");
+    expect(env.PAPERCLIP_GIT_METADATA_ROOTS).toBe("[]");
+    expect(JSON.parse(env.PAPERCLIP_RUNNER_NETWORK_ROOTS!)).not.toHaveLength(0);
+    expect(fixture.runner.execute).toHaveBeenCalledWith(expect.objectContaining({ cwd: fixture.root }));
+  });
+
+  it("reads Git metadata from the SSH workspace instead of an existing controller directory", async () => {
+    const fixture = await sandbox("ssh-toolchain/bin");
+    // Use real Git for the probe, not the launcher fixture's stub.
+    await rm(path.join(fixture.bin, "git"));
+    await exec("git", ["init", fixture.root]);
+    const controllerCwd = path.join(fixture.root, "controller");
+    await mkdir(controllerCwd);
+    vi.spyOn(ssh, "createSshCommandManagedRuntimeRunner").mockReturnValue(fixture.runner);
+    const target = { kind: "remote" as const, transport: "ssh" as const, remoteCwd: fixture.root,
+      spec: { host: "sandbox.example.test", port: 22, username: "runner", remoteCwd: fixture.root,
+        remoteWorkspacePath: fixture.root, privateKey: null, knownHosts: null, strictHostKeyChecking: true } };
+
+    const env = await prepareGitHubExecutionEnvironment({
+      target, cwd: controllerCwd, env: {}, hostCredentials: false, networkAccess: true,
+    });
+
+    expect(JSON.parse(env.PAPERCLIP_GIT_METADATA_ROOTS!)).toEqual([await realpath(path.join(fixture.root, ".git"))]);
+  });
+
   it("uses target Git configuration without importing controller credentials", async () => {
     const fixture = await sandbox("usr/bin");
     vi.stubEnv("GH_TOKEN", "controller-secret");


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Remote environments realize the workspace at a provider-owned path.
> - Run startup probes Git and network context before it starts the agent.
> - The probe used the controller path inside the remote environment.
> - A missing directory stopped the run before any provider work began.
> - This pull request uses the remote execution target's working directory.

## Linked Issues or Issue Description

Refs #13094, which introduced this probe. Related: #8997 and #10419 address other workspace-directory handoffs; this patch fixes the newer Git-context probe.

**What happened?**

Remote runs failed with `setup_failed: Could not read execution-target Git context`, including tasks that did not use Git. The provider shell could not enter the controller's workspace directory.

**Expected behavior**

Startup must inspect Git and network context in the realized remote workspace.

**Steps to reproduce**

1. Select a remote sandbox whose workspace is `/home/daytona/paperclip-workspace`.
2. Start a task whose controller workspace is under `/paperclip/instances/default/workspaces/`.
3. The startup probe exits when the controller directory does not exist in the sandbox.

**Paperclip version or commit**

Reproduced on `622376e99` and in the regression test before this patch.

**Deployment mode**

Docker controller with a remote Daytona sandbox. The same helper also serves SSH targets.

## What Changed

- Use `remote.remoteCwd` for the remote Git-context probe.
- Cover a missing controller directory in both credential modes.
- Verify that SSH reads Git metadata from the remote workspace even when the caller directory exists.

## Verification

- Before the fix, both new missing-directory tests failed with the reported error.
- The launcher environment suite passes: 18 tests.
- The adapter-utils suite passes: 1,085 passed, 11 skipped.
- Adapter-utils typecheck passes.
- A disposable sandbox with the affected deployment's image reproduced the old `cd` failure and passed with the corrected helper. The sandbox was deleted afterward.
- Full repository typecheck and build pass locally. All CI gates pass at `61b522c`: regular test shards, serialized server suites, browser shards, Runner verification, build, policy, and security checks.
- The first CI Build attempt hit a Runner suspension-acknowledgment timeout outside the changed code. The affected 13-case recovery group passes locally with its Rust fixtures built, and the unchanged CI job passed on its single retry.
- The full serial local test run was stopped in favor of the complete CI matrix; it is not claimed as a local pass.

## Risks

The probe now uses the provider-resolved target directory for sandbox and SSH execution. Local execution keeps its existing directory. There are no schema or API changes. Existing local credential and Git metadata tests pass.

## Model Used

OpenAI GPT-6 in Codex, with tool-assisted code analysis, implementation, and live and automated testing. The exact model identifier and context-window size are not exposed by this session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
