### PR TITLE
fix(issues): read the checkout lock's premise instead of inferring it from status

### DIFF
--- a/server/src/__tests__/external-object-routes.test.ts
+++ b/server/src/__tests__/external-object-routes.test.ts
@@ -11,6 +11,7 @@ const ownerRunId = "55555555-5555-4555-8555-555555555555";
 const mockIssueService = vi.hoisted(() => ({
   assertCheckoutOwner: vi.fn(),
   getById: vi.fn(),
+  resolveActiveRunLock: vi.fn(),
 }));
 
 const mockAccessService = vi.hoisted(() => ({
@@ -176,6 +177,11 @@ describe("external object routes", () => {
     vi.resetAllMocks();
     mockIssueService.getById.mockResolvedValue(makeIssue());
     mockIssueService.assertCheckoutOwner.mockResolvedValue({ adoptedFromRunId: null });
+    // The peer-refusal case here is premised on a live checkout; state it.
+    mockIssueService.resolveActiveRunLock.mockResolvedValue({
+      checkoutRunId: ownerRunId,
+      executionRunId: ownerRunId,
+    });
     mockAccessService.hasPermission.mockResolvedValue(false);
     mockAccessService.decide.mockImplementation(async ({ action }: { action: string }) => ({
       allowed: action === "issue:read" || action === "issue:mutate",

--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -14,6 +14,7 @@ const recoveryActionId = "77777777-7777-4777-8777-777777777777";
 const mockIssueService = vi.hoisted(() => ({
   addComment: vi.fn(),
   assertCheckoutOwner: vi.fn(),
+  resolveActiveRunLock: vi.fn(),
   create: vi.fn(),
   createChild: vi.fn(),
   decomposeAcceptedPlan: vi.fn(),
@@ -290,6 +291,9 @@ function makeIssue(overrides: Record<string, unknown> = {}) {
     title: "Owned active issue",
     executionPolicy: null,
     executionState: null,
+    // Left null deliberately: the recovery-source guard reads these columns for
+    // a different purpose. The checkout lock this suite is about is expressed
+    // through resolveActiveRunLock, which is what the mutation guard consults.
     checkoutRunId: null,
     executionRunId: null,
     hiddenAt: null,
@@ -472,6 +476,7 @@ describe("agent issue mutation checkout ownership", () => {
     mockProjectService.getById.mockResolvedValue(null);
     mockIssueService.addComment.mockReset();
     mockIssueService.assertCheckoutOwner.mockReset();
+    mockIssueService.resolveActiveRunLock.mockReset();
     mockIssueService.create.mockReset();
     mockIssueService.createChild.mockReset();
     mockIssueService.decomposeAcceptedPlan.mockReset();
@@ -618,6 +623,13 @@ describe("agent issue mutation checkout ownership", () => {
     });
     mockIssueService.list.mockResolvedValue([makeIssue()]);
     mockIssueService.assertCheckoutOwner.mockResolvedValue({ adoptedFromRunId: null });
+    // This suite's premise is a live checkout held by ownerAgentId. The route
+    // now reads that premise instead of inferring it from the status column,
+    // so it has to be stated rather than assumed.
+    mockIssueService.resolveActiveRunLock.mockResolvedValue({
+      checkoutRunId: ownerRunId,
+      executionRunId: ownerRunId,
+    });
     mockIssueService.create.mockImplementation(async (_companyId: string, input: Record<string, unknown>) => ({
       ...makeIssue({
         id: "88888888-8888-4888-8888-888888888888",

--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -541,4 +541,153 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
       executionRunId: currentRunId,
     });
   });
+
+  // ------------------------------------------------------------------
+  // A peer agent facing a checkout lock with no run behind it.
+  //
+  // The stale-lock recovery above is assignee-only: every path that reads
+  // the lock's premise (clearExecutionRunIfTerminal / clearCheckoutRunIfTerminal,
+  // adoptStaleCheckoutRun) sits behind `issue.assigneeAgentId === actorAgentId`.
+  // A peer is refused earlier, on `status === "in_progress"` alone, so an issue
+  // whose assignee stopped without releasing it stays unwritable by everyone
+  // else for as long as the row says in_progress — with no expiry.
+  // ------------------------------------------------------------------
+
+  async function seedPeerAgent(companyId: string) {
+    const peerAgentId = randomUUID();
+    const peerRunId = randomUUID();
+    await db.insert(agents).values({
+      id: peerAgentId,
+      companyId,
+      name: "PeerCoder",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    // The peer acts from its own live run on its own task, reaching across to
+    // the abandoned one — so the run carries a source issue, as a real
+    // cross-issue write does.
+    const peerSourceIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: peerSourceIssueId,
+      companyId,
+      title: "Peer's own work",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: peerAgentId,
+    });
+    await db.insert(heartbeatRuns).values({
+      id: peerRunId,
+      companyId,
+      agentId: peerAgentId,
+      status: "running",
+      invocationSource: "manual",
+      startedAt: new Date(),
+      contextSnapshot: { issueId: peerSourceIssueId },
+    });
+    return { peerAgentId, peerRunId, peerSourceIssueId };
+  }
+
+  it("lets a peer agent write an issue left in_progress with no run behind the lock", async () => {
+    const { companyId, agentId } = await seedCompanyAgentAndRuns();
+    const { peerAgentId, peerRunId } = await seedPeerAgent(companyId);
+    const issueId = randomUUID();
+    // Exactly the abandoned shape: in_progress, assigned, and every lock
+    // column null because the assignee stopped without ever releasing it.
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Abandoned in_progress",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+    });
+
+    const res = await request(createApp(agentActor(companyId, peerAgentId, peerRunId)))
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "Peer recovered it" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body.title).toBe("Peer recovered it");
+  });
+
+  it("lets a peer agent write once the assignee's lock run has gone terminal", async () => {
+    const { companyId, agentId, failedRunId } = await seedCompanyAgentAndRuns();
+    const { peerAgentId, peerRunId } = await seedPeerAgent(companyId);
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Lock held by a dead run",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: failedRunId,
+      executionRunId: failedRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, peerAgentId, peerRunId)))
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "Peer wrote past the dead lock" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+
+    // The dead lock is not merely ignored, it is cleared — otherwise the next
+    // reader re-derives the same false premise.
+    const row = await db
+      .select({
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+        executionLockedAt: issues.executionLockedAt,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toEqual({ checkoutRunId: null, executionRunId: null, executionLockedAt: null });
+  });
+
+  // The control. If this ever goes green alongside the two above, the guard has
+  // stopped fencing anything and the fix has overshot into removing the lock.
+  it("still refuses a peer agent while the assignee's lock run is genuinely live", async () => {
+    const { companyId, agentId } = await seedCompanyAgentAndRuns();
+    const { peerAgentId, peerRunId } = await seedPeerAgent(companyId);
+    const liveOwnerRunId = randomUUID();
+    const issueId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: liveOwnerRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "manual",
+      startedAt: new Date(),
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Genuinely locked",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: liveOwnerRunId,
+      executionRunId: liveOwnerRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, peerAgentId, peerRunId)))
+      .patch(`/api/issues/${issueId}`)
+      .send({ title: "Should still fail" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body?.details?.code).toBe("issue_write_assignee_run_lock");
+  });
 });

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -4347,11 +4347,23 @@ export function issueRoutes(
       if (issue.status === "in_progress") {
         // Run/checkout ownership stays assignee-scoped even though writes are
         // open, so this lock clears on its own — the copy routes to comments.
-        return denyIssueWrite(req, res, issue, "issue_write_assignee_run_lock", {
-          issueId: issue.id,
-          assigneeAgentId: issue.assigneeAgentId,
-          actorAgentId,
-        });
+        //
+        // "Clears on its own" is only true of a lock a run is actually holding,
+        // so the premise is read rather than inferred from the status column.
+        // An assignee that stops without releasing leaves the row in_progress
+        // forever; inferring the lock from that made every such issue
+        // permanently unwritable by every other agent, with no expiry and no
+        // remedy short of the manage-active-checkouts grant above.
+        const runLock = await svc.resolveActiveRunLock(issue.id);
+        if (runLock) {
+          return denyIssueWrite(req, res, issue, "issue_write_assignee_run_lock", {
+            issueId: issue.id,
+            assigneeAgentId: issue.assigneeAgentId,
+            actorAgentId,
+          });
+        }
+        // No run stands behind the status, so there is no lock to respect and
+        // the issue is treated as idle by the paths below.
       }
       // Past the run lock the issue is idle, so only channels that have not
       // adopted the default-open rule still refuse another agent's issue.

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -5543,6 +5543,40 @@ export function issueService(db: Db) {
     });
   }
 
+  /**
+   * Report the run lock an issue actually holds, or null when it holds none.
+   *
+   * `status === "in_progress"` is a status, not a lock. The two helpers above
+   * already encode the rule that decides the difference — "a terminal run holds
+   * no real claim regardless of who is assigned or what status the issue is
+   * currently in" — but until now only the assignee's own paths ran them, so a
+   * caller asking "is this issue locked?" about someone else's issue had nothing
+   * to ask and inferred the answer from the status column instead.
+   *
+   * Clearing first is what makes the answer trustworthy: afterwards a non-null
+   * lock column is one a live run still stands behind, so the caller reads live
+   * state rather than a run that ended without releasing anything.
+   */
+  async function resolveActiveRunLock(issueId: string): Promise<
+    { checkoutRunId: string | null; executionRunId: string | null } | null
+  > {
+    await clearExecutionRunIfTerminal(issueId);
+    await clearCheckoutRunIfTerminal(issueId);
+
+    const current = await db
+      .select({
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0] ?? null);
+
+    if (!current) return null;
+    if (current.checkoutRunId == null && current.executionRunId == null) return null;
+    return current;
+  }
+
   async function addStopRelayCommentIfNeeded(
     child: typeof issues.$inferSelect,
     dbOrTx: any = db,
@@ -5641,6 +5675,7 @@ export function issueService(db: Db) {
   return {
     clearExecutionRunIfTerminal,
     clearCheckoutRunIfTerminal,
+    resolveActiveRunLock,
     addStopRelayCommentIfNeeded,
 
     list: async (companyId: string, filters?: IssueFilters) => {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents write to each other's tasks. The server controls these writes in `assertAgentIssueMutationAllowed` in `server/src/routes/issues.ts`
> - That function refuses a write with `issue_write_assignee_run_lock`. The message says "a run is live". The code does not read a run. It reads the `status` column
> - An agent can stop without releasing its task. The row stays `in_progress`. The message is then false, and no other agent can write to the task
> - No timer clears this state. Only an agent with the `manage-active-checkouts` permission can clear it. Most agents do not have this permission
> - This pull request makes the guard read the lock before it refuses the write
> - The benefit is that a task stops being permanently locked when no run holds it

## Linked Issues or Issue Description

No public issue exists. The problem follows.

**What happened?**

A peer agent sent `PATCH /api/issues/{id}`. The server refused with HTTP 409 and code `issue_write_assignee_run_lock`. The message said:

> \<assignee\> has \<issue\> checked out and a run is live.

No run was live. These values were read at the same time:

| reading | value |
|---|---|
| `GET /api/issues/{id}/active-run` | `null` |
| `checkoutRunId` | `null` |
| `executionRunId` | `null` |
| `executionLockedAt` | `null` |
| `executionAgentNameKey` | `null` |
| the assignee in `/live-runs` | absent |

The assignee had stopped. It did not release the task first. The task stayed `in_progress`.

**Expected behavior**

The server must refuse the write only when a run holds the lock. When no run holds the lock, the server must treat the task as idle.

**Steps to reproduce**

1. Create two agents in one company.
2. Assign a task to the first agent. Set the task status to `in_progress`.
3. Set `checkoutRunId` and `executionRunId` to `null`. This is the state an agent leaves when it stops without a release.
4. Send `PATCH /api/issues/{id}` as the second agent.
5. The server refuses with HTTP 409 and code `issue_write_assignee_run_lock`.

**Paperclip version or commit**

Reproduced on `master` at 7cf9a3779. Found on the released package `paperclipai@2026.824.1`.

Related pull requests. None of them fix this guard:

- Refs #9749 — this changes `POST /api/issues/:id/checkout`. It permits a takeover when the assignee is paused or terminated. This pull request changes the write guard instead. It reads the run, not the state of the assignee. An active agent can also leave a task locked.
- Refs #12792, Refs #12383 — these two make terminal checkouts inert. They do not change the write guard.
- Refs #11386 — this adds tests at the same boundary.

## What Changed

- Added `resolveActiveRunLock(issueId)` to `server/src/services/issues.ts`. The function first calls `clearExecutionRunIfTerminal` and `clearCheckoutRunIfTerminal`. It then reads the lock columns. It returns the lock, or `null` when no lock remains.
- Changed `assertAgentIssueMutationAllowed` in `server/src/routes/issues.ts`. The guard now calls `resolveActiveRunLock` before it refuses the write. It refuses only when the function returns a lock.
- Added three route tests to `server/src/__tests__/issue-stale-execution-lock-routes.test.ts`. The tests use embedded Postgres.
- Changed two mocked test suites. They now state the live checkout that their names describe.

The two `clear*IfTerminal` functions already contain the necessary rule. The comment on `clearCheckoutRunIfTerminal` states it:

> No assignee/status precondition: a terminal run holds no real claim regardless of who is assigned or what status the issue is currently in.

These functions only ran behind `issue.assigneeAgentId === actorAgentId`. Recovery worked for the assignee. It did not work for other agents. This pull request makes the same rule available to the guard.

## Verification

```
pnpm --filter @paperclipai/server exec vitest run \
  src/__tests__/issue-stale-execution-lock-routes.test.ts \
  src/__tests__/issue-agent-mutation-ownership-routes.test.ts \
  src/__tests__/low-trust-red-team-routes.test.ts \
  src/__tests__/external-object-routes.test.ts \
  src/__tests__/issues-service.test.ts \
  src/__tests__/issues-checkout-wakeup.test.ts \
  src/__tests__/heartbeat-auto-checkout.test.ts
```

All of these tests pass. `packages/shared/src/issue-write-denial.test.ts` also passes.

The three new tests are:

1. *lets a peer agent write an issue left in_progress with no run behind the lock*. This test failed before the change. It failed with the "a run is live" message. All lock columns were `null`.
2. *lets a peer agent write once the assignee's lock run has gone terminal*. This test also failed before the change. It confirms that the server clears the dead lock. A server that only ignores the dead lock leaves it for the next reader.
3. *still refuses a peer agent while the assignee's lock run is genuinely live*. This test is the control.

To confirm that the control works, change `resolveActiveRunLock` to always return `null`. Test 3 then fails. The other 13 tests in the file continue to pass.

`tsc --noEmit` on `server/` gives the same errors before and after the change. All of these errors already existed. They come from an unbuilt `@paperclipai/plugin-sdk` in this environment.

## Risks

Low risk.

- The guard refuses the write in the same way when a run is live. Test 3 confirms this.
- The new query runs only on the path that was going to return HTTP 409. This path needs an agent actor, a task assigned to a different agent, no `manage-active-checkouts` permission, and the status `in_progress`. There is no new query on the common path.
- `resolveActiveRunLock` writes to the database, because the two `clear*IfTerminal` functions clear dead lock columns. These functions already ran on the checkout path and the assignee path. This pull request does not change what they clear.
- There is no migration.
- Behavior changes for one state only: a task is `in_progress`, and no live run holds its lock. Before, the server refused all peer writes. Now, the server treats the task as idle. The existing idle path then applies.
- Two mocked test suites used a fixture with `null` lock columns. They depended on the same inference. They now state the live checkout. No test became weaker.

## Model Used

Claude Opus 5 (`claude-opus-5`), by Anthropic. Used through Claude Code with extended thinking, tool use, and code execution. The tests ran locally against embedded Postgres.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes — no documentation describes this guard. Tell me if a page needs an update.
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green — the gates are still running. I will report the result.
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups — the review has not finished.
- [x] I will address all Greptile and reviewer comments before requesting merge