### PR TITLE
fix(secrets): send ClientRequestToken on AWS Secrets Manager writes

### DIFF
--- a/server/src/__tests__/aws-secrets-manager-provider.test.ts
+++ b/server/src/__tests__/aws-secrets-manager-provider.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createAwsSecretsManagerProvider } from "../secrets/aws-secrets-manager-provider.js";
 import { SecretProviderClientError } from "../secrets/types.js";
 
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
 describe("awsSecretsManagerProvider", () => {
   const previousEnv = {
     PAPERCLIP_SECRETS_AWS_REGION: process.env.PAPERCLIP_SECRETS_AWS_REGION,
@@ -229,6 +231,58 @@ describe("awsSecretsManagerProvider", () => {
     expect(headers.authorization).toContain("SignedHeaders=");
     expect(headers.authorization).toContain("Signature=");
     expect(init?.signal).toBeInstanceOf(AbortSignal);
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(body.Name).toBe("paperclip/prod/company-1/openai-api-key");
+    expect(body.SecretString).toBe("super-secret-value");
+    expect(body.ClientRequestToken).toMatch(UUID_PATTERN);
+  });
+
+  it("sends a fresh ClientRequestToken on each AWS Secrets Manager PutSecretValue request", async () => {
+    delete process.env.AWS_PROFILE;
+    delete process.env.AWS_DEFAULT_PROFILE;
+    delete process.env.AWS_CONFIG_FILE;
+    delete process.env.AWS_SHARED_CREDENTIALS_FILE;
+    delete process.env.AWS_SDK_LOAD_CONFIG;
+    process.env.AWS_ACCESS_KEY_ID = "AKIA_TEST_ACCESS";
+    process.env.AWS_SECRET_ACCESS_KEY = "test-secret-key";
+    delete process.env.AWS_SESSION_TOKEN;
+
+    const secretArn =
+      "arn:aws:secretsmanager:us-east-1:123456789012:secret:paperclip/prod/company-1/openai-api-key";
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response(JSON.stringify({ ARN: secretArn, VersionId: "aws-version-2" }), { status: 200 }),
+    );
+    const provider = createAwsSecretsManagerProvider({
+      config: {
+        region: "us-east-1",
+        endpoint: "https://secretsmanager.us-east-1.amazonaws.com",
+        deploymentId: "prod",
+        prefix: "paperclip",
+        kmsKeyId: "arn:aws:kms:us-east-1:123456789012:key/test",
+        environmentTag: "production",
+        providerOwnerTag: "paperclip",
+        deleteRecoveryWindowDays: 30,
+      },
+    });
+
+    const context = {
+      companyId: "company-1",
+      secretKey: "openai-api-key",
+      secretName: "OpenAI API Key",
+      version: 2,
+    };
+    await provider.createVersion({ value: "rotated-secret-value", externalRef: secretArn, context });
+    await provider.createVersion({ value: "rotated-again", externalRef: secretArn, context: { ...context, version: 3 } });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const bodies = fetchMock.mock.calls.map(([, init]) => JSON.parse(String(init?.body)) as Record<string, unknown>);
+    for (const [index, [, init]] of fetchMock.mock.calls.entries()) {
+      const headers = init?.headers as Record<string, string>;
+      expect(headers["x-amz-target"]).toBe("secretsmanager.PutSecretValue");
+      expect(bodies[index]!.SecretId).toBe(secretArn);
+      expect(bodies[index]!.ClientRequestToken).toMatch(UUID_PATTERN);
+    }
+    expect(bodies[0]!.ClientRequestToken).not.toBe(bodies[1]!.ClientRequestToken);
   });
 
   it("creates new AWS secret versions against a namespace-valid existing secret reference", async () => {

--- a/server/src/secrets/aws-secrets-manager-provider.ts
+++ b/server/src/secrets/aws-secrets-manager-provider.ts
@@ -1,4 +1,4 @@
-import { createHash, createHmac } from "node:crypto";
+import { createHash, createHmac, randomUUID } from "node:crypto";
 import { S3Client } from "@aws-sdk/client-s3";
 import type { DeploymentMode, SecretProviderConfigDiscoveryPreviewResult } from "@paperclipai/shared";
 import { unprocessable } from "../errors.js";
@@ -896,11 +896,13 @@ class AwsSecretsManagerJsonGateway implements AwsSecretsManagerGateway {
     Description?: string;
     Tags: AwsSecretsManagerTag[];
   }) {
+    // Secrets Manager requires ClientRequestToken on CreateSecret/PutSecretValue
+    // for callers that are not an AWS SDK (SDKs generate it automatically).
     return this.call<{
       ARN?: string;
       Name?: string;
       VersionId?: string;
-    }>("CreateSecret", input);
+    }>("CreateSecret", { ...input, ClientRequestToken: randomUUID() });
   }
 
   putSecretValue(input: {
@@ -912,7 +914,7 @@ class AwsSecretsManagerJsonGateway implements AwsSecretsManagerGateway {
       ARN?: string;
       Name?: string;
       VersionId?: string;
-    }>("PutSecretValue", input);
+    }>("PutSecretValue", { ...input, ClientRequestToken: randomUUID() });
   }
 
   getSecretValue(input: {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The secrets subsystem can store company secrets in AWS Secrets Manager through the `aws_secrets_manager` provider
> - That provider signs and sends raw Secrets Manager JSON requests. It does not use the AWS SDK client
> - AWS requires a `ClientRequestToken` on `CreateSecret` and `PutSecretValue` when the caller is not an AWS SDK. The SDKs add this token automatically
> - The provider does not send the token. AWS rejects every secret create with `InvalidRequestException: You must provide a ClientRequestToken value`. The API returns a 502 and no company secret can be created with this provider
> - This pull request adds a fresh UUID `ClientRequestToken` to each `CreateSecret` and `PutSecretValue` request inside the raw-HTTP gateway
> - The benefit is that secret creation and new-version writes succeed with the AWS Secrets Manager provider

## Linked Issues or Issue Description

- Fixes: #9970
- Refs #9973 — an earlier fix for the same issue. It has had no activity since July and two CI gates fail on it. This PR takes a smaller approach: the token is added inside `AwsSecretsManagerJsonGateway`, so the `AwsSecretsManagerGateway` interface and the in-memory test gateways do not change.

## What Changed

- `AwsSecretsManagerJsonGateway.createSecret` and `.putSecretValue` add `ClientRequestToken: randomUUID()` (from `node:crypto`) to the request body. Each call gets a new token; the gateway has no retry loop, so no token is reused.
- Read operations (`GetSecretValue`, `ListSecrets`), `DeleteSecret`, and `UpdateSecretVersionStage` are unchanged. AWS does not take the token on these.
- Tests: the existing signed-request test now parses the `CreateSecret` body and asserts a UUID-shaped `ClientRequestToken`. A new test drives two `createVersion` calls through a mocked `fetch` and asserts that both `PutSecretValue` bodies carry distinct UUID tokens.

## Verification

- `pnpm --filter @paperclipai/server exec vitest run src/__tests__/aws-secrets-manager-provider.test.ts` — 19/19 pass.
- `pnpm --filter @paperclipai/server exec tsc --noEmit` — clean.
- Manual: configure the `aws_secrets_manager` provider, create a company secret from the Secrets page. Before this change the request fails with "AWS Secrets Manager rejected the request." and CloudTrail shows `InvalidRequestException` with the `ClientRequestToken` message. After this change the secret is created.

## Risks

- Low risk. The change adds one field to two outbound request bodies. The token is the idempotency token AWS documents for these operations. No schema, API, or configuration changes.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- Claude (Anthropic), `claude-fable-5-1`, via Claude Code with tool use and local test execution. Extended thinking enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (none needed)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
