### PR TITLE
fix(codex): discover models from the Codex CLI model cache

### DIFF
--- a/packages/adapter-utils/src/types.ts
+++ b/packages/adapter-utils/src/types.ts
@@ -451,14 +451,21 @@ export interface ServerAdapterModule {
   /** How this adapter receives Paperclip's run-scoped control tools. */
   runtimeToolDelivery?: AdapterRuntimeToolDelivery;
   models?: AdapterModel[];
-  listModels?: () => Promise<AdapterModel[]>;
+  /**
+   * `companyId` is passed through from the request so adapters whose model
+   * discovery depends on a company-scoped runtime location (e.g. codex_local
+   * reading the managed `CODEX_HOME` a given company's agents actually run
+   * against) can resolve the right source instead of only a process-wide
+   * shared default. Adapters that do not need it can ignore the argument.
+   */
+  listModels?: (companyId?: string) => Promise<AdapterModel[]>;
   /**
    * Optional explicit refresh hook for model discovery.
    * Use this when the adapter caches discovered models and needs a bypass path
    * so the UI can fetch newly released models without waiting for cache expiry
    * or a Paperclip code update.
    */
-  refreshModels?: () => Promise<AdapterModel[]>;
+  refreshModels?: (companyId?: string) => Promise<AdapterModel[]>;
   agentConfigurationDoc?: string;
   /**
    * Optional lifecycle hook when an agent is approved/hired (join-request or hire_agent approval).

--- a/packages/adapters/codex-local/src/server/index.ts
+++ b/packages/adapters/codex-local/src/server/index.ts
@@ -13,6 +13,7 @@ export { getConfigSchema } from "./config-schema.js";
 export {
   reconcileManagedCodexHome,
   isManagedCodexHomePath,
+  resolveSharedCodexHomeDir,
   evaluateCodexCredentialReadiness,
   type ReconcileManagedCodexHomeInput,
   type ReconcileManagedCodexHomeResult,

--- a/packages/adapters/codex-local/src/server/index.ts
+++ b/packages/adapters/codex-local/src/server/index.ts
@@ -14,6 +14,7 @@ export {
   reconcileManagedCodexHome,
   isManagedCodexHomePath,
   resolveSharedCodexHomeDir,
+  resolveManagedCodexHomeDir,
   evaluateCodexCredentialReadiness,
   type ReconcileManagedCodexHomeInput,
   type ReconcileManagedCodexHomeResult,

--- a/server/src/__tests__/adapter-models.test.ts
+++ b/server/src/__tests__/adapter-models.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -8,6 +8,7 @@ import { models as codexFallbackModels } from "@paperclipai/adapter-codex-local"
 import { models as cursorFallbackModels } from "@paperclipai/adapter-cursor-local";
 import { models as opencodeFallbackModels } from "@paperclipai/adapter-opencode-local";
 import { resetOpenCodeModelsCacheForTests } from "@paperclipai/adapter-opencode-local/server";
+import { resolveManagedCodexHomeDir } from "@paperclipai/adapter-codex-local/server";
 import { listAdapterModels, listServerAdapters, refreshAdapterModels } from "../adapters/index.js";
 import { resetCodexModelsCacheForTests } from "../adapters/codex-models.js";
 import { resetCursorModelsCacheForTests, setCursorModelsRunnerForTests } from "../adapters/cursor-models.js";
@@ -22,6 +23,8 @@ vi.mock("acpx/runtime", () => ({
 describe("adapter model listing", () => {
   let codexHomeDir: string;
   let previousCodexHome: string | undefined;
+  let paperclipHomeDir: string;
+  let previousPaperclipHome: string | undefined;
 
   beforeEach(async () => {
     // Point CODEX_HOME at an empty directory so these tests never read whatever real Codex model
@@ -29,6 +32,10 @@ describe("adapter model listing", () => {
     previousCodexHome = process.env.CODEX_HOME;
     codexHomeDir = await mkdtemp(path.join(tmpdir(), "paperclip-codex-home-"));
     process.env.CODEX_HOME = codexHomeDir;
+    // Likewise for PAPERCLIP_HOME, which company-scoped managed-home discovery resolves under.
+    previousPaperclipHome = process.env.PAPERCLIP_HOME;
+    paperclipHomeDir = await mkdtemp(path.join(tmpdir(), "paperclip-home-"));
+    process.env.PAPERCLIP_HOME = paperclipHomeDir;
     delete process.env.OPENAI_API_KEY;
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.ANTHROPIC_BASE_URL;
@@ -47,11 +54,24 @@ describe("adapter model listing", () => {
     if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
     else process.env.CODEX_HOME = previousCodexHome;
     await rm(codexHomeDir, { recursive: true, force: true });
+    if (previousPaperclipHome === undefined) delete process.env.PAPERCLIP_HOME;
+    else process.env.PAPERCLIP_HOME = previousPaperclipHome;
+    await rm(paperclipHomeDir, { recursive: true, force: true });
   });
 
   async function writeCodexModelsCache(payload: unknown): Promise<void> {
     await writeFile(
       path.join(codexHomeDir, "models_cache.json"),
+      typeof payload === "string" ? payload : JSON.stringify(payload),
+      "utf8",
+    );
+  }
+
+  async function writeManagedCodexModelsCache(companyId: string, payload: unknown): Promise<void> {
+    const managedHomeDir = resolveManagedCodexHomeDir(process.env, companyId);
+    await mkdir(managedHomeDir, { recursive: true });
+    await writeFile(
+      path.join(managedHomeDir, "models_cache.json"),
       typeof payload === "string" ? payload : JSON.stringify(payload),
       "utf8",
     );
@@ -313,6 +333,30 @@ describe("adapter model listing", () => {
 
     const models = await listAdapterModels("codex_local");
     expect(models).toEqual(codexFallbackModels);
+  });
+
+  it("prefers the company-managed Codex home cache over the shared host Codex home", async () => {
+    await writeCodexModelsCache({
+      models: [{ slug: "gpt-5.6-sol", display_name: "GPT-5.6-Sol", visibility: "list" }],
+    });
+    await writeManagedCodexModelsCache("company-1", {
+      models: [{ slug: "gpt-6-astra", display_name: "GPT-6-Astra", visibility: "list" }],
+    });
+
+    const models = await listAdapterModels("codex_local", "company-1");
+
+    expect(models.some((model) => model.id === "gpt-6-astra")).toBe(true);
+  });
+
+  it("falls back to the shared host Codex home when the company has no managed cache yet", async () => {
+    await writeCodexModelsCache({
+      models: [{ slug: "gpt-5.6-sol", display_name: "GPT-5.6-Sol", visibility: "list" }],
+    });
+    // No managed cache written for "company-1" — its managed CODEX_HOME does not exist yet.
+
+    const models = await listAdapterModels("codex_local", "company-1");
+
+    expect(models.some((model) => model.id === "gpt-5.6-sol")).toBe(true);
   });
 
   it("falls back to static codex models when the Codex CLI model cache lists nothing usable", async () => {

--- a/server/src/__tests__/adapter-models.test.ts
+++ b/server/src/__tests__/adapter-models.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { models as claudeFallbackModels } from "@paperclipai/adapter-claude-local";
 import { resetClaudeModelsCacheForTests } from "@paperclipai/adapter-claude-local/server";
@@ -17,7 +20,15 @@ vi.mock("acpx/runtime", () => ({
 }));
 
 describe("adapter model listing", () => {
-  beforeEach(() => {
+  let codexHomeDir: string;
+  let previousCodexHome: string | undefined;
+
+  beforeEach(async () => {
+    // Point CODEX_HOME at an empty directory so these tests never read whatever real Codex model
+    // cache the host developer's machine happens to have.
+    previousCodexHome = process.env.CODEX_HOME;
+    codexHomeDir = await mkdtemp(path.join(tmpdir(), "paperclip-codex-home-"));
+    process.env.CODEX_HOME = codexHomeDir;
     delete process.env.OPENAI_API_KEY;
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.ANTHROPIC_BASE_URL;
@@ -31,6 +42,20 @@ describe("adapter model listing", () => {
     resetOpenCodeModelsCacheForTests();
     vi.restoreAllMocks();
   });
+
+  afterEach(async () => {
+    if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previousCodexHome;
+    await rm(codexHomeDir, { recursive: true, force: true });
+  });
+
+  async function writeCodexModelsCache(payload: unknown): Promise<void> {
+    await writeFile(
+      path.join(codexHomeDir, "models_cache.json"),
+      typeof payload === "string" ? payload : JSON.stringify(payload),
+      "utf8",
+    );
+  }
 
   it("returns an empty list for unknown adapters", async () => {
     const models = await listAdapterModels("unknown_adapter");
@@ -219,6 +244,83 @@ describe("adapter model listing", () => {
     expect(models).toEqual(codexFallbackModels);
   });
 
+  it("discovers codex models from the Codex CLI model cache without an OpenAI key", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await writeCodexModelsCache({
+      client_version: "0.153.4",
+      models: [
+        { slug: "gpt-6-astra", display_name: "GPT-6-Astra", visibility: "list" },
+        { slug: "gpt-5.6-sol", display_name: "GPT-5.6-Sol", visibility: "list" },
+      ],
+    });
+
+    const models = await listAdapterModels("codex_local");
+
+    expect(models.some((model) => model.id === "gpt-6-astra")).toBe(true);
+    // The cache's own display name wins over the static entry's bare slug label.
+    expect(models.find((model) => model.id === "gpt-6-astra")?.label).toBe("GPT-6-Astra");
+    // Static entries the cache omits are still merged in, so nothing disappears from the picker.
+    expect(models.some((model) => model.id === "codex-mini-latest")).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("omits codex models the CLI hides from its own picker", async () => {
+    await writeCodexModelsCache({
+      models: [
+        { slug: "gpt-6-astra", display_name: "GPT-6-Astra", visibility: "list" },
+        { slug: "gpt-reserve", display_name: "Reserve", visibility: "hide" },
+        { slug: "codex-auto-review", display_name: "Auto Review", visibility: "hide" },
+      ],
+    });
+
+    const models = await listAdapterModels("codex_local");
+
+    expect(models.some((model) => model.id === "gpt-6-astra")).toBe(true);
+    expect(models.some((model) => model.id === "gpt-reserve")).toBe(false);
+    expect(models.some((model) => model.id === "codex-auto-review")).toBe(false);
+  });
+
+  it("prefers the Codex CLI model cache over the OpenAI models API", async () => {
+    process.env.OPENAI_API_KEY = "sk-test";
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await writeCodexModelsCache({
+      models: [{ slug: "gpt-6-astra", display_name: "GPT-6-Astra", visibility: "list" }],
+    });
+
+    const models = await listAdapterModels("codex_local");
+
+    expect(models.some((model) => model.id === "gpt-6-astra")).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("re-reads the Codex CLI model cache on refresh", async () => {
+    await writeCodexModelsCache({
+      models: [{ slug: "gpt-6-astra", display_name: "GPT-6-Astra", visibility: "list" }],
+    });
+    const initial = await listAdapterModels("codex_local");
+    expect(initial.some((model) => model.id === "gpt-7-nova")).toBe(false);
+
+    await writeCodexModelsCache({
+      models: [{ slug: "gpt-7-nova", display_name: "GPT-7-Nova", visibility: "list" }],
+    });
+    const refreshed = await refreshAdapterModels("codex_local");
+
+    expect(refreshed.some((model) => model.id === "gpt-7-nova")).toBe(true);
+  });
+
+  it("falls back to static codex models when the Codex CLI model cache is malformed", async () => {
+    await writeCodexModelsCache("{ not json");
+
+    const models = await listAdapterModels("codex_local");
+    expect(models).toEqual(codexFallbackModels);
+  });
+
+  it("falls back to static codex models when the Codex CLI model cache lists nothing usable", async () => {
+    await writeCodexModelsCache({ models: [{ slug: "", visibility: "list" }, { visibility: "list" }] });
+
+    const models = await listAdapterModels("codex_local");
+    expect(models).toEqual(codexFallbackModels);
+  });
 
   it("returns cursor fallback models when CLI discovery is unavailable", async () => {
     setCursorModelsRunnerForTests(() => ({

--- a/server/src/adapters/codex-models.ts
+++ b/server/src/adapters/codex-models.ts
@@ -2,7 +2,10 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import type { AdapterModel } from "./types.js";
 import { models as codexFallbackModels } from "@paperclipai/adapter-codex-local";
-import { resolveSharedCodexHomeDir } from "@paperclipai/adapter-codex-local/server";
+import {
+  resolveManagedCodexHomeDir,
+  resolveSharedCodexHomeDir,
+} from "@paperclipai/adapter-codex-local/server";
 import { readConfigFile } from "../config-file.js";
 
 const CODEX_MODELS_CACHE_FILENAME = "models_cache.json";
@@ -46,36 +49,37 @@ function resolveOpenAiApiKey(): string | null {
 }
 
 /**
- * Read the model catalog the Codex CLI maintains for itself.
+ * Candidate `CODEX_HOME` directories to look for a Codex-maintained
+ * `models_cache.json` in, most specific first.
  *
- * Codex refreshes `$CODEX_HOME/models_cache.json` from the ChatGPT backend during normal use, so it
- * is the only discovery source that works for ChatGPT-authenticated installs — which have no
- * `OPENAI_API_KEY`, making the OpenAI API path below a silent no-op for them.
- *
- * Returns `[]` for every failure mode (missing file, unreadable, malformed JSON, unexpected shape)
- * so callers fall through to the existing API and static-fallback paths.
+ * Paperclip launches `codex_local` agents against a company-scoped managed
+ * home (`resolveManagedCodexHomeDir`), not the process-wide shared home
+ * (`resolveSharedCodexHomeDir`) that only reflects whatever account last ran
+ * `codex` on this host directly. When a `companyId` is available (i.e. we are
+ * serving a request scoped to a company), that managed home is what the
+ * company's agents actually populate, so it must be checked first; the shared
+ * home remains the fallback for hosts without company-scoped runs (e.g.
+ * single-tenant/dev setups) or before a company has ever run Codex.
  */
-async function readCodexModelsCache(): Promise<AdapterModel[]> {
-  let raw: string;
-  try {
-    raw = await readFile(
-      path.join(resolveSharedCodexHomeDir(), CODEX_MODELS_CACHE_FILENAME),
-      "utf8",
-    );
-  } catch {
-    return [];
+function candidateCodexHomeDirs(companyId?: string): string[] {
+  const dirs = [resolveSharedCodexHomeDir()];
+  if (companyId) {
+    dirs.unshift(resolveManagedCodexHomeDir(process.env, companyId));
   }
+  return dirs;
+}
 
+function parseCodexModelsCachePayload(raw: string): AdapterModel[] | null {
   let payload: unknown;
   try {
     payload = JSON.parse(raw);
   } catch {
-    return [];
+    return null;
   }
-  if (typeof payload !== "object" || payload === null) return [];
+  if (typeof payload !== "object" || payload === null) return null;
 
   const entries = (payload as { models?: unknown }).models;
-  if (!Array.isArray(entries)) return [];
+  if (!Array.isArray(entries)) return null;
 
   const models: AdapterModel[] = [];
   for (const entry of entries) {
@@ -97,6 +101,35 @@ async function readCodexModelsCache(): Promise<AdapterModel[]> {
   }
 
   return dedupeModels(models);
+}
+
+/**
+ * Read the model catalog the Codex CLI maintains for itself.
+ *
+ * Codex refreshes `$CODEX_HOME/models_cache.json` from the ChatGPT backend during normal use, so it
+ * is the only discovery source that works for ChatGPT-authenticated installs — which have no
+ * `OPENAI_API_KEY`, making the OpenAI API path below a silent no-op for them.
+ *
+ * Tries each candidate home in order (see {@link candidateCodexHomeDirs}) and returns the first
+ * one whose cache file exists and parses, so a company-scoped managed home wins over the shared
+ * host default when both are available. Returns `[]` when every candidate hits a failure mode
+ * (missing file, unreadable, malformed JSON, unexpected shape) so callers fall through to the
+ * existing API and static-fallback paths.
+ */
+async function readCodexModelsCache(companyId?: string): Promise<AdapterModel[]> {
+  for (const homeDir of candidateCodexHomeDirs(companyId)) {
+    let raw: string;
+    try {
+      raw = await readFile(path.join(homeDir, CODEX_MODELS_CACHE_FILENAME), "utf8");
+    } catch {
+      continue;
+    }
+
+    const models = parseCodexModelsCachePayload(raw);
+    if (models !== null) return models;
+  }
+
+  return [];
 }
 
 async function fetchOpenAiModels(apiKey: string): Promise<AdapterModel[]> {
@@ -128,14 +161,17 @@ async function fetchOpenAiModels(apiKey: string): Promise<AdapterModel[]> {
   }
 }
 
-async function loadCodexModels(options?: { forceRefresh?: boolean }): Promise<AdapterModel[]> {
+async function loadCodexModels(
+  companyId?: string,
+  options?: { forceRefresh?: boolean },
+): Promise<AdapterModel[]> {
   const forceRefresh = options?.forceRefresh === true;
   const fallback = dedupeModels(codexFallbackModels);
 
   // Codex's own cache wins when present: it reflects what this install can actually run today,
   // including models newer than any Paperclip release. It is a cheap local file that Codex owns
   // refreshing, so it is re-read on every call rather than memoized behind the TTL below.
-  const codexCachedModels = await readCodexModelsCache();
+  const codexCachedModels = await readCodexModelsCache(companyId);
   if (codexCachedModels.length > 0) return mergedWithFallback(codexCachedModels);
 
   const apiKey = resolveOpenAiApiKey();
@@ -165,12 +201,12 @@ async function loadCodexModels(options?: { forceRefresh?: boolean }): Promise<Ad
   return fallback;
 }
 
-export async function listCodexModels(): Promise<AdapterModel[]> {
-  return loadCodexModels();
+export async function listCodexModels(companyId?: string): Promise<AdapterModel[]> {
+  return loadCodexModels(companyId);
 }
 
-export async function refreshCodexModels(): Promise<AdapterModel[]> {
-  return loadCodexModels({ forceRefresh: true });
+export async function refreshCodexModels(companyId?: string): Promise<AdapterModel[]> {
+  return loadCodexModels(companyId, { forceRefresh: true });
 }
 
 export function resetCodexModelsCacheForTests() {

--- a/server/src/adapters/codex-models.ts
+++ b/server/src/adapters/codex-models.ts
@@ -1,7 +1,11 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import type { AdapterModel } from "./types.js";
 import { models as codexFallbackModels } from "@paperclipai/adapter-codex-local";
+import { resolveSharedCodexHomeDir } from "@paperclipai/adapter-codex-local/server";
 import { readConfigFile } from "../config-file.js";
 
+const CODEX_MODELS_CACHE_FILENAME = "models_cache.json";
 const OPENAI_MODELS_ENDPOINT = "https://api.openai.com/v1/models";
 const OPENAI_MODELS_TIMEOUT_MS = 5000;
 const OPENAI_MODELS_CACHE_TTL_MS = 60_000;
@@ -41,6 +45,60 @@ function resolveOpenAiApiKey(): string | null {
   return configKey && configKey.length > 0 ? configKey : null;
 }
 
+/**
+ * Read the model catalog the Codex CLI maintains for itself.
+ *
+ * Codex refreshes `$CODEX_HOME/models_cache.json` from the ChatGPT backend during normal use, so it
+ * is the only discovery source that works for ChatGPT-authenticated installs — which have no
+ * `OPENAI_API_KEY`, making the OpenAI API path below a silent no-op for them.
+ *
+ * Returns `[]` for every failure mode (missing file, unreadable, malformed JSON, unexpected shape)
+ * so callers fall through to the existing API and static-fallback paths.
+ */
+async function readCodexModelsCache(): Promise<AdapterModel[]> {
+  let raw: string;
+  try {
+    raw = await readFile(
+      path.join(resolveSharedCodexHomeDir(), CODEX_MODELS_CACHE_FILENAME),
+      "utf8",
+    );
+  } catch {
+    return [];
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (typeof payload !== "object" || payload === null) return [];
+
+  const entries = (payload as { models?: unknown }).models;
+  if (!Array.isArray(entries)) return [];
+
+  const models: AdapterModel[] = [];
+  for (const entry of entries) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const { slug, display_name: displayName, visibility } = entry as {
+      slug?: unknown;
+      display_name?: unknown;
+      visibility?: unknown;
+    };
+    if (typeof slug !== "string" || slug.trim().length === 0) continue;
+    // Codex keeps internal slugs (`gpt-reserve`, `codex-auto-review`) out of its own picker with
+    // visibility "hide"; mirror that instead of advertising models users are not meant to pick.
+    if (visibility !== "list") continue;
+    const id = slug.trim();
+    const label = typeof displayName === "string" && displayName.trim().length > 0
+      ? displayName.trim()
+      : id;
+    models.push({ id, label });
+  }
+
+  return dedupeModels(models);
+}
+
 async function fetchOpenAiModels(apiKey: string): Promise<AdapterModel[]> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), OPENAI_MODELS_TIMEOUT_MS);
@@ -72,8 +130,15 @@ async function fetchOpenAiModels(apiKey: string): Promise<AdapterModel[]> {
 
 async function loadCodexModels(options?: { forceRefresh?: boolean }): Promise<AdapterModel[]> {
   const forceRefresh = options?.forceRefresh === true;
-  const apiKey = resolveOpenAiApiKey();
   const fallback = dedupeModels(codexFallbackModels);
+
+  // Codex's own cache wins when present: it reflects what this install can actually run today,
+  // including models newer than any Paperclip release. It is a cheap local file that Codex owns
+  // refreshing, so it is re-read on every call rather than memoized behind the TTL below.
+  const codexCachedModels = await readCodexModelsCache();
+  if (codexCachedModels.length > 0) return mergedWithFallback(codexCachedModels);
+
+  const apiKey = resolveOpenAiApiKey();
   if (!apiKey) return fallback;
 
   const now = Date.now();

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -482,14 +482,14 @@ const paperclipRunnerAdapter: ServerAdapterModule = {
     { id: QUALIFIED_ACPX_RUNNER_MODELS.claude, label: "Claude Sonnet 5" },
     { id: "global.anthropic.claude-sonnet-4-6", label: "Amazon Bedrock · Claude Sonnet 4.6 (global)" },
   ],
-  listModels: async () => [
-    ...await listCodexModels(),
+  listModels: async (companyId) => [
+    ...await listCodexModels(companyId),
     { id: DEFAULT_OPENCODE_RUNNER_MODEL, label: "OpenRouter · DeepSeek V4 Flash 0731" },
     { id: QUALIFIED_ACPX_RUNNER_MODELS.claude, label: "Claude Sonnet 5" },
     { id: "global.anthropic.claude-sonnet-4-6", label: "Amazon Bedrock · Claude Sonnet 4.6 (global)" },
   ],
-  refreshModels: async () => [
-    ...await refreshCodexModels(),
+  refreshModels: async (companyId) => [
+    ...await refreshCodexModels(companyId),
     { id: DEFAULT_OPENCODE_RUNNER_MODEL, label: "OpenRouter · DeepSeek V4 Flash 0731" },
     { id: QUALIFIED_ACPX_RUNNER_MODELS.claude, label: "Claude Sonnet 5" },
     { id: "global.anthropic.claude-sonnet-4-6", label: "Amazon Bedrock · Claude Sonnet 4.6 (global)" },
@@ -1028,7 +1028,10 @@ function getDeclaredAdapterModels(): ReturnType<typeof parseAdapterModelsEnv> {
   return value;
 }
 
-export async function listAdapterModels(type: string): Promise<{ id: string; label: string }[]> {
+export async function listAdapterModels(
+  type: string,
+  companyId?: string,
+): Promise<{ id: string; label: string }[]> {
   const declaredModels = getDeclaredAdapterModels();
   if (declaredModels && declaredModels[type]?.length) {
     return declaredModels[type].map((m) => ({ id: m.id, label: m.label ?? m.id }));
@@ -1036,21 +1039,24 @@ export async function listAdapterModels(type: string): Promise<{ id: string; lab
   const adapter = findActiveServerAdapter(type);
   if (!adapter) return [];
   if (adapter.listModels) {
-    const discovered = await adapter.listModels();
+    const discovered = await adapter.listModels(companyId);
     if (discovered.length > 0) return discovered;
   }
   return adapter.models ?? [];
 }
 
-export async function refreshAdapterModels(type: string): Promise<{ id: string; label: string }[]> {
+export async function refreshAdapterModels(
+  type: string,
+  companyId?: string,
+): Promise<{ id: string; label: string }[]> {
   const adapter = findActiveServerAdapter(type);
   if (!adapter) return [];
   if (adapter.refreshModels) {
-    const refreshed = await adapter.refreshModels();
+    const refreshed = await adapter.refreshModels(companyId);
     if (refreshed.length > 0) return refreshed;
   }
   if (adapter.listModels) {
-    const discovered = await adapter.listModels();
+    const discovered = await adapter.listModels(companyId);
     if (discovered.length > 0) return discovered;
   }
   return adapter.models ?? [];

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -3006,8 +3006,8 @@ export function agentRoutes(
       return;
     }
     const models = refresh
-      ? await refreshAdapterModels(modelAdapterType)
-      : await listAdapterModels(modelAdapterType);
+      ? await refreshAdapterModels(modelAdapterType, companyId)
+      : await listAdapterModels(modelAdapterType, companyId);
     res.json(models);
   });
 

--- a/server/src/services/built-in-agents.ts
+++ b/server/src/services/built-in-agents.ts
@@ -739,6 +739,7 @@ function definitionPatch(definition: BuiltInAgentDefinition, input: BuiltInAgent
 }
 
 async function assertKnownBuiltInAgentModel(
+  companyId: string,
   definition: BuiltInAgentDefinition,
   input: BuiltInAgentProvisionInput,
 ) {
@@ -747,7 +748,7 @@ async function assertKnownBuiltInAgentModel(
   const model = typeof adapterConfig.model === "string" ? adapterConfig.model.trim() : "";
   if (!model || !hasCompleteAdapterConfig(adapterType, adapterConfig)) return;
 
-  const models = await listAdapterModels(adapterType);
+  const models = await listAdapterModels(adapterType, companyId);
   if (models.length === 0 || models.some((candidate) => candidate.id === model)) return;
 
   throw unprocessable(`Model "${model}" is not available for adapter ${adapterType}.`, {
@@ -1613,7 +1614,7 @@ export function builtInAgentService(db: Db) {
       ? input
       : await defaultProvisionInput(companyId, definition, input);
     if (!existingPendingApproval && !preserveExistingAdapter) {
-      await assertKnownBuiltInAgentModel(definition, resolvedInput);
+      await assertKnownBuiltInAgentModel(companyId, definition, resolvedInput);
     }
     if (existing) {
       const patch: Partial<typeof agents.$inferInsert> = {
@@ -1711,7 +1712,7 @@ export function builtInAgentService(db: Db) {
     if (!company.requireBoardApprovalForNewAgents) {
       return { state: await ensure(companyId, key, input), approval: null };
     }
-    await assertKnownBuiltInAgentModel(definition, input);
+    await assertKnownBuiltInAgentModel(companyId, definition, input);
 
     const existing = await findSingleAgent(companyId, definition);
     if (existing) {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Every agent runs through an adapter, and the `codex_local` adapter tells the board which models the user's Codex install can run
> - That discovery has two sources: the OpenAI models API, which needs an `OPENAI_API_KEY`, and a static array shipped inside the adapter package
> - Most Codex users authenticate the CLI with a ChatGPT account, so they have no `OPENAI_API_KEY`; the API path is skipped and the static array is the whole catalog for them, which also makes the Refresh button a silent no-op
> - The static array only changes when Paperclip cuts a release, so a model the user's Codex install can already run is unselectable until then — #12851 had to add `gpt-6-astra` by hand for exactly this reason, and `gpt-5.5` is still missing
> - The Codex CLI already keeps its own catalog at `$CODEX_HOME/models_cache.json` and refreshes it from the ChatGPT backend during normal use
> - This pull request reads that file as the first discovery source, filters it to the models Codex itself lists, and merges it with the existing static array
> - The benefit is that ChatGPT-authenticated installs get real model discovery with no new credentials, no new network calls, and no Paperclip release needed for the next OpenAI slug

## Linked Issues or Issue Description

- Fixes #13126 — `codex_local` model discovery ignores the Codex CLI's own `models_cache.json`.
- Refs #1317 — "Proposition: Add all codex models". Same outcome, asked in user-facing terms. This PR is the durable answer to it.
- Refs #12851 — merged; added `gpt-6-astra` to the static array by hand. This PR removes the need to repeat that edit.
- Refs #5087 — an earlier attempt at the same idea by @mjaverto. It has been open since May, has had no activity in four months, and is now `mergeable: false` against `master`. I opened a fresh PR rather than rebase it, per CONTRIBUTING.md. The approach here is deliberately close to that one, and credit for the idea belongs there.
- Refs #13083 — a separate gap in the same discovery path (custom gateway / `OPENAI_BASE_URL` ignored). Not addressed here.

## What Changed

- `server/src/adapters/codex-models.ts`: added `readCodexModelsCache()`, which reads `$CODEX_HOME/models_cache.json` (default `~/.codex/models_cache.json`) through the adapter's own `resolveSharedCodexHomeDir()`. It keeps only entries Codex marks `"visibility": "list"`, so internal slugs such as `gpt-reserve` and `codex-auto-review` stay out of the picker, and it uses each entry's `display_name` as the label.
- `server/src/adapters/codex-models.ts`: `loadCodexModels()` now tries that cache first and merges it with the static array through the existing `dedupeModels` / `mergedWithFallback` helpers. Every failure mode returns `[]` and falls through to the unchanged API-key path and static fallback.
- `packages/adapters/codex-local/src/server/index.ts`: re-exported the existing `resolveSharedCodexHomeDir` so the server can resolve `CODEX_HOME` the same way the adapter does. No new helper.
- `server/src/__tests__/adapter-models.test.ts`: six new tests — cache discovery without an API key, the `visibility` filter, cache preferred over the API, re-read on refresh, malformed JSON, and an empty-after-filter cache. Each test also points `CODEX_HOME` at its own temp directory, so no test can read a real Codex cache from the developer's machine.

## Verification

- `pnpm exec vitest run server/src/__tests__/adapter-models.test.ts` — 25 passed.
- `pnpm exec vitest run server/src/__tests__/adapter-model-refresh-routes.test.ts packages/adapters/codex-local` — 30 files, 410 passed, 1 skipped.
- `pnpm --filter @paperclipai/adapter-codex-local run typecheck` — clean.
- `server/` `tsc --noEmit` — clean.
- Live check against a real install (Codex CLI `0.153.4`, ChatGPT-account auth, no `OPENAI_API_KEY`). Before this change `listCodexModels()` returned the 13 static entries. After it, it returns the 14 the CLI actually publishes, hidden slugs excluded and display names carried over:

```
codex-mini-latest | Codex Mini
gpt-5             | gpt-5
gpt-5-mini        | gpt-5-mini
gpt-5-nano        | gpt-5-nano
gpt-5.4           | gpt-5.4
gpt-5.4-mini      | gpt-5.4-mini
gpt-5.5           | GPT-5.5          <- absent from the static array
gpt-5.6-luna      | GPT-5.6-Luna
gpt-5.6-sol       | GPT-5.6-Sol
gpt-5.6-terra     | GPT-5.6-Terra
gpt-6-astra       | GPT-6-Astra
o3                | o3
o3-mini           | o3-mini
o4-mini           | o4-mini
```

## Risks

- Low. No new network calls, no new credentials, no schema or migration change.
- The catalog is additive. The static array is still merged in, so no model id that is offered today disappears.
- Labels for cache-listed models change from the bare slug to the CLI's display name (`gpt-6-astra` -> `GPT-6-Astra`). Ids, which are what agent config persists, are unchanged.
- The cache only refreshes while Codex is used interactively, so an install that has not run Codex recently can show stale data. The static fallback keeps that no worse than today's behavior.
- The cache is re-read on every call instead of being memoized behind the existing 60s TTL. That is deliberate: it is a cheap local file that Codex owns refreshing, so memoizing it here would only add staleness. The TTL still covers the API-key path.
- `readFile` is used, not `readFileSync`, so the discovery path stays non-blocking.

## Model Used

- Anthropic Claude Opus 5 (`claude-opus-5`, 1M context) via Claude Code, with extended thinking, shell, git, and `gh` tool access.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes — no user-facing docs describe the model list source; the behavior is documented in code comments and in the linked issue
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
