### PR TITLE
Fix racy Daytona plugin test: releaseDownload is not a function

### DIFF
--- a/packages/plugins/sandbox-providers/daytona/src/plugin.test.ts
+++ b/packages/plugins/sandbox-providers/daytona/src/plugin.test.ts
@@ -2618,7 +2618,11 @@ describe("Daytona sandbox provider plugin", () => {
       mockGet.mockResolvedValue(sandbox);
 
       const executePromise = plugin.definition.onEnvironmentExecute?.(execParams("lease-a"));
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      // Poll for the actual executeCommand call instead of guessing a tick
+      // count, so resolveExecute is guaranteed to be assigned before it's used.
+      await vi.waitFor(() => {
+        expect(sandbox.process.executeCommand).toHaveBeenCalled();
+      });
 
       const releasePromise = plugin.definition.onEnvironmentReleaseLease?.({
         driverKey: "daytona",
@@ -2757,7 +2761,11 @@ describe("Daytona sandbox provider plugin", () => {
       mockGet.mockResolvedValue(sandbox);
 
       const executePromise = plugin.definition.onEnvironmentExecute?.(execParams("lease-a"));
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      // Poll for the actual executeCommand call instead of guessing a tick
+      // count, so resolveExecute is guaranteed to be assigned before it's used.
+      await vi.waitFor(() => {
+        expect(sandbox.process.executeCommand).toHaveBeenCalled();
+      });
 
       const cancelPromise = plugin.definition.onEnvironmentCancelInteractiveSetup?.({
         driverKey: "daytona",
@@ -2857,7 +2865,11 @@ describe("Daytona sandbox provider plugin", () => {
       mockGet.mockResolvedValue(sandbox);
 
       const firstExecutePromise = plugin.definition.onEnvironmentExecute?.(execParams("lease-a"));
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      // Poll for the actual executeCommand call instead of guessing a tick
+      // count, so resolveFirstExecute is guaranteed to be assigned before it's used.
+      await vi.waitFor(() => {
+        expect(sandbox.process.executeCommand).toHaveBeenCalled();
+      });
 
       const cancelPromise = plugin.definition.onEnvironmentCancelInteractiveSetup?.({
         driverKey: "daytona",
@@ -2910,7 +2922,11 @@ describe("Daytona sandbox provider plugin", () => {
         config: { timeoutMs: 300000, reuseLease: false },
         templateLabel: "snapshot-check",
       });
-      await new Promise((resolve) => setTimeout(resolve, 0));
+      // Poll for the actual snapshot call instead of guessing a tick count, so
+      // resolveSnapshot is guaranteed to be assigned before it's used.
+      await vi.waitFor(() => {
+        expect(sandbox._experimental_createSnapshot).toHaveBeenCalled();
+      });
 
       const destroyPromise = plugin.definition.onEnvironmentDestroyLease?.({
         driverKey: "daytona",
@@ -4828,15 +4844,31 @@ describe("daytona native file-sync hooks", () => {
 
     const sandbox = createMockSandbox({ id: "sandbox-123" });
     // Hold the inbound upload and the outbound download open at the same time, so
-    // the shared lease has two active sync calls when teardown starts.
+    // the shared lease has two active sync calls when teardown starts. Each mock
+    // resolves a deferred as its first statement, so the test can wait for both
+    // transfers to actually be parked instead of guessing a tick count — the
+    // outbound path takes materially longer to reach its mock (a sandbox round
+    // trip plus a per-target mkdir before the download call ever fires), so a
+    // fixed setTimeout(0) barrier can assert before the outbound transfer parks
+    // and leave releaseDownload unassigned.
     let releaseUpload!: () => void;
+    let uploadEnteredResolve!: () => void;
+    const uploadEntered = new Promise<void>((resolve) => {
+      uploadEnteredResolve = resolve;
+    });
     sandbox.fs.uploadFiles.mockImplementation(async () => {
+      uploadEnteredResolve();
       await new Promise<void>((resolve) => {
         releaseUpload = resolve;
       });
     });
     let releaseDownload!: () => void;
+    let downloadEnteredResolve!: () => void;
+    const downloadEntered = new Promise<void>((resolve) => {
+      downloadEnteredResolve = resolve;
+    });
     sandbox.fs.downloadFiles.mockImplementation(async (requests: Array<{ source: string; destination: string }>) => {
+      downloadEnteredResolve();
       await new Promise<void>((resolve) => {
         releaseDownload = resolve;
       });
@@ -4855,9 +4887,9 @@ describe("daytona native file-sync hooks", () => {
     const outboundCall = plugin.definition.onEnvironmentSyncOut?.(
       syncOutParams({ operationId: "out-active", sourcePath: `${REMOTE_DIR}/out.txt`, targetPath: outboundTarget }),
     );
-    // Let both sync calls register on the activity gate and reach their hung
-    // transfer, so teardown sees a refCount of two.
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Wait for both transfers to actually reach their hung mock before relying
+    // on refCount being two, instead of guessing a tick count.
+    await Promise.all([uploadEntered, downloadEntered]);
 
     const destroyCall = plugin.definition.onEnvironmentDestroyLease?.({
       driverKey: "daytona",


### PR DESCRIPTION
<!-- Write all pull request text in Simplified Technical English (ASD-STE100): short sentences, one instruction per sentence, simple approved vocabulary, and the active voice. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The Daytona sandbox provider plugin has a test suite covering native file-sync hooks that gate sandbox teardown on active upload/download transfers.
> - One test in that suite (`plugin.test.ts`) is racy: it uses a fixed `setTimeout(0)` tick as a barrier before asserting both an inbound and an outbound transfer are parked, but the outbound path takes longer than one tick to reach its mock.
> - When the outbound mock has not run yet, the test calls an undefined `releaseDownload` binding and throws `TypeError: releaseDownload is not a function`, failing intermittently.
> - This is a test bug, not a plugin bug — the plugin's actual teardown/gating behavior in `plugin.ts` and `file-sync.ts` is correct.
> - This pull request replaces the tick-counting barrier with explicit deferred entry signals so the test only proceeds once both mocks have actually run, and applies the same fix to four other instances of the same pattern in the same file.
> - The benefit is a deterministic test that no longer flakes under load or with `--sequence.shuffle`, with no change to production code.

## Linked Issues or Issue Description

No public GitHub issue exists for this yet. Filing per the Bug report template:

**What happened?**
`plugin.test.ts` (Daytona sandbox provider) intermittently fails with `TypeError: releaseDownload is not a function` in the test "waits for one active inbound and one active outbound call before teardown releases the sandbox". Root cause: `releaseDownload` is assigned only inside the `downloadFiles` mock body, and the test uses a bare `await new Promise((r) => setTimeout(r, 0))` as its readiness barrier. The outbound path (`performSyncOut` → `syncOutFileMappings` in `file-sync.ts`) awaits a sandbox round trip (`snapshotOutboundFileSources`) and a per-target `fs.mkdir` before ever calling `sandbox.fs.downloadFiles`, so it reliably needs more than one tick to reach the mock. When it hasn't, the test calls the still-unassigned `releaseDownload` and throws.

**Expected behavior**
The test should wait for both the inbound and outbound mocks to actually be entered before asserting the refCount-of-two precondition, and should pass deterministically on every run, including under `--sequence.shuffle`.

**Steps to reproduce**
1. Run `vitest run packages/plugins/sandbox-providers/daytona/src/plugin.test.ts` repeatedly, or with `--sequence.shuffle`.
2. Observe intermittent `TypeError: releaseDownload is not a function` at the "waits for one active inbound and one active outbound call before teardown releases the sandbox" test.
3. Compare against `src/file-sync.test.ts`, which is unaffected and fully green.

## What Changed

- `plugin.test.ts`: named test now uses two deferreds (`uploadEntered` / `downloadEntered`), each resolved as the first statement inside its respective mock (`uploadFiles` / `downloadFiles`), and awaits both via `Promise.all` before relying on the refCount-of-two precondition. Removed the `setTimeout(0)` barrier this test relied on.
- `plugin.test.ts`: scanned the rest of the file for the same pattern (a mock-assigned release handle invoked after a bare `setTimeout(0)` with no confirmation the mock actually ran) and converted 4 more instances to `vi.waitFor(() => expect(mock).toHaveBeenCalled())`, matching an idiom already used elsewhere in the file.
- No changes to `plugin.ts` or `file-sync.ts` — this is a test-only fix.

## Verification

- `vitest run` on the daytona package: 225 passed | 6 skipped (the previously-failing test now passes, on top of the "224 passed" baseline from the bug report).
- Named test run 5x individually: passes deterministically.
- Full `plugin.test.ts` run 3x with `--sequence.shuffle`: 150/150 passes each time.

## Risks

Low risk. This is a test-only change — no production code in `plugin.ts` or `file-sync.ts` was touched. The only behavioral change is that the affected tests now wait on explicit signals instead of a fixed tick, which can only make them more, not less, reliable.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

Claude Sonnet 5 (`claude-sonnet-5`), used as the coding agent to diagnose the race, author the deferred-based fix, apply it to `plugin.test.ts`, and run local verification (repeat runs and `--sequence.shuffle`). No extended-thinking/tool-execution details beyond standard agentic coding (read/edit/run tests) were required.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
