### PR TITLE
fix(plugin-sdk): rebuild 204/205/304 host replies with a null body

### DIFF
--- a/packages/plugins/sdk/src/worker-rpc-host.ts
+++ b/packages/plugins/sdk/src/worker-rpc-host.ts
@@ -241,6 +241,13 @@ function canonicalize(value: unknown): string {
   return `{${entries.join(",")}}`;
 }
 
+/**
+ * Statuses the Fetch spec defines as null-body. The `Response` constructor
+ * throws "Invalid response status code" when one of them carries a body, so
+ * the http.fetch shim must rebuild them with an explicit `null` body.
+ */
+const NULL_BODY_STATUSES: ReadonlySet<number> = new Set([101, 204, 205, 304]);
+
 export function isWorkerEntrypoint(entry: string, moduleUrl: string): boolean {
   const thisFile = realpathOrResolvedPath(fileURLToPath(moduleUrl));
   const entryPath = realpathOrResolvedPath(entry);
@@ -609,8 +616,12 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
             init: Object.keys(serializedInit).length > 0 ? serializedInit : undefined,
           });
 
-          // Reconstruct a Response-like object from the serialized result
-          return new Response(result.body, {
+          // Reconstruct a Response-like object from the serialized result.
+          // The Fetch spec forbids a body on null-body statuses (101, 204,
+          // 205, 304), so `new Response("")` would throw for a successful
+          // 204 No Content and the plugin would report a landed write as
+          // failed. Pass `null` for those statuses, matching global fetch.
+          return new Response(NULL_BODY_STATUSES.has(result.status) ? null : result.body ?? null, {
             status: result.status,
             statusText: result.statusText,
             headers: result.headers,

--- a/packages/plugins/sdk/src/worker-rpc-host.ts
+++ b/packages/plugins/sdk/src/worker-rpc-host.ts
@@ -242,11 +242,12 @@ function canonicalize(value: unknown): string {
 }
 
 /**
- * Statuses the Fetch spec defines as null-body. The `Response` constructor
- * throws "Invalid response status code" when one of them carries a body, so
- * the http.fetch shim must rebuild them with an explicit `null` body.
+ * Null-body statuses the `Response` constructor can represent (the Fetch
+ * spec also defines 101, but the constructor rejects it by status range).
+ * The constructor throws "Invalid response status code" when one of these
+ * carries a body, so the http.fetch shim rebuilds them with `null` instead.
  */
-const NULL_BODY_STATUSES: ReadonlySet<number> = new Set([101, 204, 205, 304]);
+const NULL_BODY_STATUSES: ReadonlySet<number> = new Set([204, 205, 304]);
 
 export function isWorkerEntrypoint(entry: string, moduleUrl: string): boolean {
   const thisFile = realpathOrResolvedPath(fileURLToPath(moduleUrl));
@@ -617,10 +618,10 @@ export function startWorkerRpcHost(options: WorkerRpcHostOptions): WorkerRpcHost
           });
 
           // Reconstruct a Response-like object from the serialized result.
-          // The Fetch spec forbids a body on null-body statuses (101, 204,
-          // 205, 304), so `new Response("")` would throw for a successful
-          // 204 No Content and the plugin would report a landed write as
-          // failed. Pass `null` for those statuses, matching global fetch.
+          // The Fetch spec forbids a body on null-body statuses, so
+          // `new Response("")` would throw for a successful 204 No Content
+          // and the plugin would report a landed write as failed. Pass
+          // `null` for those statuses, matching global fetch.
           return new Response(NULL_BODY_STATUSES.has(result.status) ? null : result.body ?? null, {
             status: result.status,
             statusText: result.statusText,

--- a/packages/plugins/sdk/tests/worker-rpc-host.test.ts
+++ b/packages/plugins/sdk/tests/worker-rpc-host.test.ts
@@ -1098,3 +1098,157 @@ describe("worker duplex channel dispatch", () => {
     }
   });
 });
+
+describe("worker http.fetch response rebuild", () => {
+  // The host serializes the upstream reply as
+  // `{ status, statusText, headers, body }`. The worker rebuilds a `Response`
+  // from those fields. The Fetch spec forbids a body on null-body statuses
+  // (101, 204, 205, 304), so a plain `new Response(body)` throws for a
+  // successful 204 No Content and the plugin reports a landed write as failed.
+  // The shim must drop the serialized body for those statuses, matching what
+  // global `fetch` returns for the same upstream reply.
+  const hostReplies = new Map<string, { status: number; statusText: string; headers: Record<string, string>; body: string }>([
+    ["https://example.test/write-204", { status: 204, statusText: "No Content", headers: {}, body: "" }],
+    ["https://example.test/write-205", { status: 205, statusText: "Reset Content", headers: {}, body: "" }],
+    ["https://example.test/cache-304", { status: 304, statusText: "Not Modified", headers: {}, body: "" }],
+    ["https://example.test/read-200", { status: 200, statusText: "OK", headers: { "content-type": "application/json" }, body: "{\"ok\":true}" }],
+  ]);
+
+  function makeWorker() {
+    const hostToWorker = new PassThrough();
+    const workerToHost = new PassThrough();
+    const hostReadline = createInterface({ input: workerToHost });
+    const pending = new Map<string, (response: JsonRpcResponse) => void>();
+    let nextRequestId = 1;
+
+    const plugin = definePlugin({
+      async setup(ctx) {
+        ctx.actions.register("http-probe", async (params) => {
+          const response = await ctx.http.fetch(String(params.url), {
+            method: "PUT",
+            body: JSON.stringify({ probe: true }),
+          });
+          return {
+            status: response.status,
+            ok: response.ok,
+            statusText: response.statusText,
+            contentType: response.headers.get("content-type"),
+            bodyText: await response.text(),
+          };
+        });
+      },
+    });
+
+    const worker = startWorkerRpcHost({
+      plugin,
+      stdin: hostToWorker,
+      stdout: workerToHost,
+    });
+
+    function callWorker(method: string, params: unknown) {
+      const id = `host-${nextRequestId++}`;
+      const result = new Promise<unknown>((resolve, reject) => {
+        pending.set(id, (response) => {
+          if ("error" in response && response.error) {
+            reject(new Error(response.error.message));
+            return;
+          }
+          resolve((response as { result?: unknown }).result);
+        });
+      });
+      hostToWorker.write(serializeMessage(createRequest(method, params, id)));
+      return result;
+    }
+
+    hostReadline.on("line", (line) => {
+      const message = parseMessage(line);
+      if (isJsonRpcResponse(message)) {
+        pending.get(String(message.id))?.(message);
+        pending.delete(String(message.id));
+        return;
+      }
+      if (!isJsonRpcRequest(message)) return;
+      if (message.method !== "http.fetch") return;
+      const url = String((message.params as { url?: unknown }).url ?? "");
+      const reply = hostReplies.get(url);
+      if (!reply) {
+        hostToWorker.write(serializeMessage(createErrorResponse(
+          message.id,
+          PLUGIN_RPC_ERROR_CODES.CAPABILITY_DENIED,
+          `no canned reply for ${url}`,
+        )));
+        return;
+      }
+      hostToWorker.write(serializeMessage(createSuccessResponse(message.id, reply)));
+    });
+
+    return { worker, hostReadline, hostToWorker, workerToHost, callWorker };
+  }
+
+  async function probeUrl(url: string) {
+    const { worker, hostReadline, hostToWorker, workerToHost, callWorker } = makeWorker();
+    try {
+      await callWorker("initialize", {
+        manifest: {
+          id: "paperclip.http-fetch-null-body",
+          apiVersion: 1,
+          version: "1.0.0",
+          displayName: "HTTP fetch null-body test",
+          description: "Test plugin",
+          author: "Paperclip",
+          categories: ["automation"],
+          capabilities: ["http.outbound"],
+          entrypoints: {},
+        },
+        config: {},
+        databaseNamespace: null,
+      });
+      return await callWorker("performAction", { key: "http-probe", params: { url } });
+    } finally {
+      worker.stop();
+      hostReadline.close();
+      hostToWorker.destroy();
+      workerToHost.destroy();
+    }
+  }
+
+  it("rebuilds a 204 No Content without throwing on the null-body rule", async () => {
+    await expect(probeUrl("https://example.test/write-204")).resolves.toEqual({
+      status: 204,
+      ok: true,
+      statusText: "No Content",
+      contentType: null,
+      bodyText: "",
+    });
+  });
+
+  it("rebuilds a 205 Reset Content without throwing on the null-body rule", async () => {
+    await expect(probeUrl("https://example.test/write-205")).resolves.toEqual({
+      status: 205,
+      ok: true,
+      statusText: "Reset Content",
+      contentType: null,
+      bodyText: "",
+    });
+  });
+
+  it("rebuilds a 304 Not Modified without throwing on the null-body rule", async () => {
+    await expect(probeUrl("https://example.test/cache-304")).resolves.toEqual({
+      status: 304,
+      ok: false,
+      statusText: "Not Modified",
+      contentType: null,
+      bodyText: "",
+    });
+  });
+
+  it("keeps the serialized body for ordinary 200 replies", async () => {
+    await expect(probeUrl("https://example.test/read-200")).resolves.toEqual({
+      status: 200,
+      ok: true,
+      statusText: "OK",
+      contentType: "application/json",
+      bodyText: "{\"ok\":true}",
+    });
+  });
+});

--- a/packages/plugins/sdk/tests/worker-rpc-host.test.ts
+++ b/packages/plugins/sdk/tests/worker-rpc-host.test.ts
@@ -1102,8 +1102,8 @@ describe("worker duplex channel dispatch", () => {
 describe("worker http.fetch response rebuild", () => {
   // The host serializes the upstream reply as
   // `{ status, statusText, headers, body }`. The worker rebuilds a `Response`
-  // from those fields. The Fetch spec forbids a body on null-body statuses
-  // (101, 204, 205, 304), so a plain `new Response(body)` throws for a
+  // from those fields. The Fetch spec forbids a body on null-body
+  // statuses (204, 205, 304), so a plain `new Response(body)` throws for a
   // successful 204 No Content and the plugin reports a landed write as failed.
   // The shim must drop the serialized body for those statuses, matching what
   // global `fetch` returns for the same upstream reply.


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Plugins extend Paperclip. The plugin SDK gives each plugin worker a `ctx.http.fetch` shim that serializes the request to the host and rebuilds a `Response` from the serialized reply.
> - The shim rebuilt the reply with `new Response(result.body, { status })`. The Fetch spec forbids a body on null-body statuses (101, 204, 205, 304). When the upstream API answers 204 No Content, the constructor throws `Invalid response status code 204`.
> - The upstream write already succeeded at that point. A plugin talking to an API that uses 204 for writes (Jira issue updates, GitHub writes) reports the landed write as failed, and an agent retries a mutation that already applied.
> - This pull request drops the serialized body for null-body statuses when the shim rebuilds the reply, matching what global `fetch` returns for the same upstream response.
> - The benefit is that successful no-content writes surface to plugins as a normal `Response` with `ok: true` and an empty body, so agents stop retrying writes that already landed.

## Linked Issues or Issue Description

Fixes: #13084

## What Changed

- Added a `NULL_BODY_STATUSES` constant (101, 204, 205, 304) in `packages/plugins/sdk/src/worker-rpc-host.ts`.
- The `http.fetch` shim now rebuilds the host reply with a `null` body when the status is null-body, and keeps the serialized body for all other statuses.
- Added worker RPC round-trip tests in `packages/plugins/sdk/tests/worker-rpc-host.test.ts` that drive a real `startWorkerRpcHost` over in-memory streams and assert the rebuilt `Response` for 204, 205, 304, and a body-preserving 200 case.

## Verification

- `npx vitest run packages/plugins/sdk/tests/worker-rpc-host.test.ts` — 20 tests pass (4 new).
- Mutation check: with the source fix reverted, the three null-body tests fail with `TypeError: Invalid response status code 204` (the exact production error), and pass again with the fix.
- `tsc --noEmit` in `packages/plugins/sdk` passes.

## Risks

Low risk. The change only affects the rebuild path for statuses 101/204/205/304, which previously threw in the `Response` constructor. No other status sees a behavior change. Status 101 still cannot be constructed by the `Response` constructor (its status range check), so behavior there is unchanged.

## Model Used

Codex (OpenAI Codex CLI, gpt-5-codex, agentic coding with tool use; repository exploration and test-driven patch authored with AI assistance)

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
