### PR TITLE
fix(redaction): redact fine-grained GitHub PATs and scrub secrets from tool output

### DIFF
--- a/packages/adapter-utils/src/command-redaction.ts
+++ b/packages/adapter-utils/src/command-redaction.ts
@@ -19,7 +19,11 @@ const COMMAND_ENV_SECRET_ASSIGNMENT_RE = new RegExp(
 const COMMAND_AUTHORIZATION_BEARER_RE =
   /(\bAuthorization\s*:\s*Bearer\s+)[^\s"'`]+/gi;
 const COMMAND_OPENAI_KEY_RE = /\bsk-[A-Za-z0-9_-]{12,}\b/g;
-const COMMAND_GITHUB_TOKEN_RE = /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/g;
+const COMMAND_GITHUB_TOKEN_RE =
+  /\b(?:gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})\b/g;
+// Any credential embedded in a remote URL (`https://user:secret@host`), whatever
+// the provider or token format. This is how git stores a push credential.
+const COMMAND_URL_USERINFO_RE = /\b([a-z][a-z0-9+.-]*:\/\/[^\s/@:]+:)[^\s/@]+@/gi;
 const COMMAND_JWT_RE =
   /\b[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}(?:\.[A-Za-z0-9_-]{8,})?\b/g;
 const COMMAND_SECRET_HINTS = [
@@ -41,9 +45,12 @@ const COMMAND_SECRET_HINTS = [
   "ghu_",
   "ghs_",
   "ghr_",
+  "github_pat_",
+  // Reaches the URL-userinfo scrub for hosts with no dot, e.g. `http://u:p@localhost/`.
+  "://",
 ] as const;
 
-function maybeContainsSecretText(command: string) {
+export function maybeContainsSecretText(command: string) {
   const lower = command.toLowerCase();
   return (
     COMMAND_SECRET_HINTS.some((hint) => lower.includes(hint)) ||
@@ -74,6 +81,7 @@ export function redactCommandText(
           : `${prefix}${redactedValue}`;
       },
     )
+    .replace(COMMAND_URL_USERINFO_RE, `$1${redactedValue}@`)
     .replace(COMMAND_OPENAI_KEY_RE, redactedValue)
     .replace(COMMAND_GITHUB_TOKEN_RE, redactedValue)
     .replace(COMMAND_JWT_RE, redactedValue);

--- a/packages/adapter-utils/src/index.ts
+++ b/packages/adapter-utils/src/index.ts
@@ -66,6 +66,7 @@ export {
 } from "./log-redaction.js";
 export {
   REDACTED_COMMAND_TEXT_VALUE,
+  maybeContainsSecretText,
   redactCommandText,
   redactDiagnosticText,
 } from "./command-redaction.js";

--- a/packages/adapter-utils/src/log-redaction.test.ts
+++ b/packages/adapter-utils/src/log-redaction.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { REDACTED_COMMAND_TEXT_VALUE, redactCommandText } from "./command-redaction.js";
+import { redactTranscriptEntryPaths } from "./log-redaction.js";
+import type { TranscriptEntry } from "./types.js";
+
+const FINE_GRAINED_PAT = `github_pat_${"1".repeat(22)}_${"a".repeat(59)}`;
+const CLASSIC_PAT = `ghp_${"b".repeat(36)}`;
+const REMOTE_LINE = `origin\thttps://x-access-token:${FINE_GRAINED_PAT}@github.com/acme/widgets.git (fetch)`;
+
+function toolResult(content: string): TranscriptEntry {
+  return { kind: "tool_result", ts: "2026-01-01T00:00:00.000Z", toolUseId: "u1", content, isError: false };
+}
+
+function stdout(text: string): TranscriptEntry {
+  return { kind: "stdout", ts: "2026-01-01T00:00:00.000Z", text };
+}
+
+function contentOf(entry: TranscriptEntry) {
+  if (entry.kind !== "tool_result") throw new Error(`expected tool_result, got ${entry.kind}`);
+  return entry.content;
+}
+
+function textOf(entry: TranscriptEntry) {
+  if (entry.kind !== "stdout") throw new Error(`expected stdout, got ${entry.kind}`);
+  return entry.text;
+}
+
+describe("redactCommandText github tokens", () => {
+  it("redacts a fine-grained personal access token", () => {
+    expect(redactCommandText(`gh auth login --with-token ${FINE_GRAINED_PAT}`)).not.toContain(FINE_GRAINED_PAT);
+  });
+
+  it("still redacts classic personal access tokens", () => {
+    expect(redactCommandText(`echo ${CLASSIC_PAT}`)).toBe(`echo ${REDACTED_COMMAND_TEXT_VALUE}`);
+  });
+
+  it("scrubs any credential embedded in a remote url", () => {
+    expect(redactCommandText("git remote add origin https://someuser:hunter2@git.example.com/acme/widgets.git")).toBe(
+      `git remote add origin https://someuser:${REDACTED_COMMAND_TEXT_VALUE}@git.example.com/acme/widgets.git`,
+    );
+  });
+
+  it("leaves credential-free urls alone", () => {
+    const url = "git clone https://github.com/acme/widgets.git";
+    expect(redactCommandText(url)).toBe(url);
+  });
+});
+
+describe("redactTranscriptEntryPaths secret scrubbing", () => {
+  it("redacts a fine-grained token in git remote output (the FEA-476 case)", () => {
+    const redacted = contentOf(redactTranscriptEntryPaths(toolResult(REMOTE_LINE)));
+    expect(redacted).not.toContain(FINE_GRAINED_PAT);
+    expect(redacted).toContain(REDACTED_COMMAND_TEXT_VALUE);
+    expect(redacted).toContain("github.com/acme/widgets.git");
+  });
+
+  it("redacts a bare fine-grained token in stdout", () => {
+    expect(textOf(redactTranscriptEntryPaths(stdout(FINE_GRAINED_PAT)))).toBe(REDACTED_COMMAND_TEXT_VALUE);
+  });
+
+  it("redacts a classic token in a tool result, independently of the fine-grained gap", () => {
+    expect(contentOf(redactTranscriptEntryPaths(toolResult(CLASSIC_PAT)))).toBe(REDACTED_COMMAND_TEXT_VALUE);
+  });
+
+  it("redacts secrets in tool call input", () => {
+    const entry = redactTranscriptEntryPaths({
+      kind: "tool_call",
+      ts: "2026-01-01T00:00:00.000Z",
+      toolUseId: "u1",
+      name: "Bash",
+      input: { command: `git push https://x-access-token:${FINE_GRAINED_PAT}@github.com/acme/widgets.git` },
+    });
+    expect(JSON.stringify(entry)).not.toContain(FINE_GRAINED_PAT);
+  });
+
+  it("scrubs secrets even when home-path masking is disabled", () => {
+    const redacted = contentOf(redactTranscriptEntryPaths(toolResult(REMOTE_LINE), { enabled: false }));
+    expect(redacted).not.toContain(FINE_GRAINED_PAT);
+  });
+
+  it("still masks home path user segments", () => {
+    expect(textOf(redactTranscriptEntryPaths(stdout("/Users/sagiw/Dev/paperclip")))).toBe("/Users/s****/Dev/paperclip");
+  });
+});

--- a/packages/adapter-utils/src/log-redaction.ts
+++ b/packages/adapter-utils/src/log-redaction.ts
@@ -1,3 +1,4 @@
+import { redactCommandText } from "./command-redaction.js";
 import type { TranscriptEntry } from "./types.js";
 
 export const REDACTED_HOME_PATH_USER = "*";
@@ -42,12 +43,12 @@ export function redactHomePathUserSegments(text: string, opts?: HomePathRedactio
   return result;
 }
 
-export function redactHomePathUserSegmentsInValue<T>(value: T, opts?: HomePathRedactionOptions): T {
+function mapStrings<T>(value: T, fn: (text: string) => string): T {
   if (typeof value === "string") {
-    return redactHomePathUserSegments(value, opts) as T;
+    return fn(value) as T;
   }
   if (Array.isArray(value)) {
-    return value.map((entry) => redactHomePathUserSegmentsInValue(entry, opts)) as T;
+    return value.map((entry) => mapStrings(entry, fn)) as T;
   }
   if (!isPlainObject(value)) {
     return value;
@@ -55,9 +56,24 @@ export function redactHomePathUserSegmentsInValue<T>(value: T, opts?: HomePathRe
 
   const redacted: Record<string, unknown> = {};
   for (const [key, entry] of Object.entries(value)) {
-    redacted[key] = redactHomePathUserSegmentsInValue(entry, opts);
+    redacted[key] = mapStrings(entry, fn);
   }
   return redacted as T;
+}
+
+export function redactHomePathUserSegmentsInValue<T>(value: T, opts?: HomePathRedactionOptions): T {
+  return mapStrings(value, (text) => redactHomePathUserSegments(text, opts));
+}
+
+// Tool output is the one surface that never sees `redactCommandText`, which is
+// how a `git remote -v` credential reached a run log verbatim. Secret scrubbing
+// is unconditional here: `opts.enabled` only governs home-path masking.
+function redactEntryText(text: string, opts?: HomePathRedactionOptions) {
+  return redactCommandText(redactHomePathUserSegments(text, opts));
+}
+
+function redactEntryValue<T>(value: T, opts?: HomePathRedactionOptions): T {
+  return mapStrings(value, (text) => redactEntryText(text, opts));
 }
 
 export function redactTranscriptEntryPaths(entry: TranscriptEntry, opts?: HomePathRedactionOptions): TranscriptEntry {
@@ -69,15 +85,15 @@ export function redactTranscriptEntryPaths(entry: TranscriptEntry, opts?: HomePa
     case "system":
     case "stdout":
     case "diff":
-      return { ...entry, text: redactHomePathUserSegments(entry.text, opts) };
+      return { ...entry, text: redactEntryText(entry.text, opts) };
     case "tool_call":
       return {
         ...entry,
         name: redactHomePathUserSegments(entry.name, opts),
-        input: redactHomePathUserSegmentsInValue(entry.input, opts),
+        input: redactEntryValue(entry.input, opts),
       };
     case "tool_result":
-      return { ...entry, content: redactHomePathUserSegments(entry.content, opts) };
+      return { ...entry, content: redactEntryText(entry.content, opts) };
     case "init":
       return {
         ...entry,
@@ -87,9 +103,9 @@ export function redactTranscriptEntryPaths(entry: TranscriptEntry, opts?: HomePa
     case "result":
       return {
         ...entry,
-        text: redactHomePathUserSegments(entry.text, opts),
+        text: redactEntryText(entry.text, opts),
         subtype: redactHomePathUserSegments(entry.subtype, opts),
-        errors: entry.errors.map((error) => redactHomePathUserSegments(error, opts)),
+        errors: entry.errors.map((error) => redactEntryText(error, opts)),
       };
     default:
       return entry;

--- a/server/src/__tests__/heartbeat-run-log.test.ts
+++ b/server/src/__tests__/heartbeat-run-log.test.ts
@@ -40,4 +40,14 @@ describe("compactRunLogChunk", () => {
     expect(compacted).not.toContain("paperclip-json-secret");
     expect(compacted).not.toContain("paperclip-flag-secret");
   });
+
+  it("redacts a fine-grained GitHub PAT embedded in a git remote line (FEA-476)", () => {
+    const token = `github_pat_${"1".repeat(22)}_${"a".repeat(59)}`;
+    const chunk = `origin\thttps://x-access-token:${token}@github.com/acme/widgets.git (fetch)\n`;
+
+    const compacted = compactRunLogChunk(chunk);
+
+    expect(compacted).toContain("***REDACTED***");
+    expect(compacted).not.toContain(token);
+  });
 });

--- a/server/src/__tests__/redaction.test.ts
+++ b/server/src/__tests__/redaction.test.ts
@@ -341,6 +341,7 @@ describe("redaction", () => {
     const jwt =
       "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
     const githubToken = "ghp_1234567890abcdefghijklmnopqrstuvwxyz";
+    const fineGrainedToken = `github_pat_${"1".repeat(22)}_${"a".repeat(59)}`;
     const input = [
       "Authorization: Bearer live-bearer-token-value",
       `payload {"apiKey":"json-secret-value"}`,
@@ -349,6 +350,8 @@ describe("redaction", () => {
       `export PAPERCLIP_API_KEY='paperclip-shell-secret'`,
       `GITHUB_TOKEN=${githubToken}`,
       `session=${jwt}`,
+      // FEA-476: a `git remote -v` line with an embedded fine-grained PAT.
+      `origin\thttps://x-access-token:${fineGrainedToken}@github.com/acme/widgets.git (fetch)`,
     ].join("\n");
 
     const result = redactSensitiveText(input);
@@ -360,6 +363,7 @@ describe("redaction", () => {
     expect(result).not.toContain("escaped-json-secret");
     expect(result).not.toContain("paperclip-shell-secret");
     expect(result).not.toContain(githubToken);
+    expect(result).not.toContain(fineGrainedToken);
     expect(result).not.toContain(jwt);
   });
 

--- a/server/src/redaction.ts
+++ b/server/src/redaction.ts
@@ -1,4 +1,4 @@
-import { redactCommandText } from "@paperclipai/adapter-utils";
+import { maybeContainsSecretText, redactCommandText } from "@paperclipai/adapter-utils";
 
 const SECRET_FIELD_NAME_PATTERN = String.raw`[A-Za-z0-9_-]*(?:api[-_]?key|access[-_]?token|auth(?:_?token)?|token|authorization|bearer|secret|passwd|password|credential|jwt|private[-_]?key|cookie|connectionstring|browser[-_]?code|login[-_]?url)[A-Za-z0-9_-]*`;
 
@@ -347,35 +347,7 @@ const ESCAPED_JSON_SECRET_FIELD_TEXT_RE = new RegExp(
   String.raw`((?:\\")?${SECRET_FIELD_NAME_PATTERN}(?:\\")?\s*:\s*(?:\\"))[^\\\r\n]+((?:\\"))`,
   "gi",
 );
-const SECRET_TEXT_HINTS = [
-  "api",
-  "key",
-  "token",
-  "auth",
-  "bearer",
-  "secret",
-  "pass",
-  "credential",
-  "jwt",
-  "private",
-  "cookie",
-  "connectionstring",
-  "sk-",
-  "ghp_",
-  "gho_",
-  "ghu_",
-  "ghs_",
-  "ghr_",
-] as const;
 export const REDACTED_EVENT_VALUE = "***REDACTED***";
-
-function maybeContainsSecretText(input: string) {
-  const lower = input.toLowerCase();
-  return (
-    SECRET_TEXT_HINTS.some((hint) => lower.includes(hint)) ||
-    input.includes(".")
-  );
-}
 
 function inlineWhitespaceEnd(input: string, start: number): number {
   let index = start;

--- a/server/src/services/workspace-operations.ts
+++ b/server/src/services/workspace-operations.ts
@@ -5,6 +5,7 @@ import type { WorkspaceOperation, WorkspaceOperationPhase, WorkspaceOperationSta
 import { asc, desc, eq, gte, inArray, isNull, lt, or, and } from "drizzle-orm";
 import { conflict, notFound } from "../errors.js";
 import { redactCurrentUserText, redactCurrentUserValue } from "../log-redaction.js";
+import { redactSensitiveText } from "../redaction.js";
 import { instanceSettingsService } from "./instance-settings.js";
 import { getWorkspaceOperationLogStore } from "./workspace-operation-log-store.js";
 
@@ -474,7 +475,9 @@ export function workspaceOperationService(db: Db) {
           let stderrExcerpt = "";
           const append = async (stream: "stdout" | "stderr" | "system", chunk: string | null | undefined) => {
             if (!chunk) return;
-            const sanitizedChunk = redactCurrentUserText(chunk, currentUserRedactionOptions);
+            // Same raw-tool-output path as the FEA-476 leak in heartbeat.ts:
+            // home-path masking alone does not scrub secrets.
+            const sanitizedChunk = redactSensitiveText(redactCurrentUserText(chunk, currentUserRedactionOptions));
             if (stream === "stdout") stdoutExcerpt = appendExcerpt(stdoutExcerpt, sanitizedChunk);
             if (stream === "stderr") stderrExcerpt = appendExcerpt(stderrExcerpt, sanitizedChunk);
             await logStore.append(handle, {


### PR DESCRIPTION
## Summary

FEA-476 (a prior fix) closed one secret-redaction gap but left two more, both of which let a live token reach a run log verbatim:

1. **Fine-grained GitHub PAT pattern was missing.** The secret regex/hints matched classic `ghp_...` tokens but never matched fine-grained `github_pat_...` tokens, so a fine-grained PAT embedded in something like a `git remote -v` URL (`https://x-access-token:<token>@github.com/...`) was never recognized as a secret.
2. **Tool *output* wasn't redacted at all.** Redaction was applied to command *text* (`redactCommandText`) and to home-path segments, but transcript `tool_result` / `tool_call` content (i.e. raw stdout from an executed tool) had no secret scrubbing applied. Running a command like `git remote -v` in a session with a token-bearing remote URL would leak the token straight into the run log.

## Changes

- Add `github_pat_` to the token pattern in `packages/adapter-utils/src/command-redaction.ts`, plus a generic URL-userinfo scrub for provider/token shapes in general.
- Route transcript `text` / `tool_result` / `tool_call` entries through `redactCommandText` in `packages/adapter-utils/src/log-redaction.ts` so tool *output*, not just command text, gets scrubbed.
- Export the shared secret-detection helper (`maybeContainsSecretText`) from `packages/adapter-utils/src/index.ts` and have `server/src/redaction.ts` consume it instead of maintaining its own duplicate copy, so command-text and tool-output redaction can't silently drift apart again.
- Apply the same output scrub to workspace-operation logs in `server/src/services/workspace-operations.ts`, which shares the same raw-tool-output surface.
- New/updated tests in `packages/adapter-utils/src/log-redaction.test.ts` and `server/src/__tests__/redaction.test.ts` covering the fine-grained PAT case and the tool-output path; a small addition to `server/src/__tests__/heartbeat-run-log.test.ts`.

No behavior change outside redaction.

## Test plan

- [x] `npx vitest run log-redaction redaction` — 65/65 tests pass across all 8 matched test files
- [x] `npx vitest run heartbeat-run-log` — 4/4 tests pass
- [x] `pnpm --filter @paperclipai/adapter-utils typecheck` — clean
- [x] `tsc --noEmit` on `server` — clean
- [x] Rebased cleanly onto current `master`, diff scoped to redaction-only files, no secrets/real tokens in the diff (only synthetic fixed-pattern test fixtures)
