### PR TITLE
fix(build): give two orphaned test setup files a governing tsconfig

### DIFF
--- a/server/src/__tests__/tsconfig.json
+++ b/server/src/__tests__/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "../../dist-tests",
+    "rootDir": "."
+  },
+  "include": ["."]
+}

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -16,5 +16,5 @@
       "lexical": ["./node_modules/lexical/index.d.ts"]
     }
   },
-  "include": ["src", "storybook"]
+  "include": ["src", "storybook", "vitest.setup.ts"]
 }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Paperclip uses separate server and UI TypeScript projects to build and test the app
> - The test transform tool finds the nearest tsconfig that includes each test file
> - Two test setup files had no governing tsconfig inside the repository
> - The lookup then read a tsconfig outside the repository and stopped test runs when that file was invalid
> - This pull request adds a server test tsconfig and includes the UI setup file in the UI tsconfig
> - The benefit is stable test configuration in every repository worktree

## Linked Issues or Issue Description

**What happened?**

The test transform tool walked outside the repository because two test setup files had no tsconfig that included them. A stale or invalid parent checkout then stopped server and UI test runs with `TSCONFIG_ERROR`.

**Expected behavior**

Each test setup file must use a governing tsconfig inside the repository. Test runs must not depend on a tsconfig outside the repository.

**Steps to reproduce**

1. Run the server test command in a clean worktree.
2. Run the UI test command in the same worktree.
3. Observe that the transform tool searches above the repository for the setup files when no local tsconfig includes them.

**Paperclip version or commit**

`04eb274fa12007392e468fc808d3ad12fbdcb02e`

**Deployment mode**

Built from source with the local test commands.

**Installation method**

Built from source with pnpm.

**Agent adapter(s) involved**

Not adapter-specific (core bug).

**Database mode**

Not database-related.

## What Changed

- Add `server/src/__tests__/tsconfig.json` for the server test setup directory.
- Add `vitest.setup.ts` to the `include` array in `ui/tsconfig.json`.
- Keep `server/tsconfig.json` unchanged, so the build graph does not change.

## Verification

- Run `pnpm exec vitest run --project @paperclipai/server server/src/modules/wake-queue/domain/policy.test.ts`.
- Run `pnpm exec vitest run --project @paperclipai/ui ui/src/adapters/adapter-display-registry.test.ts`.
- Run `pnpm --filter @paperclipai/server run typecheck`.
- Run `pnpm --filter @paperclipai/ui run typecheck`.
- Confirm that the test commands report no `TSCONFIG_ERROR`.
- Confirm that the full pull request workflow passes.

## Risks

This change adds one scoped server tsconfig and expands one UI tsconfig include list. It does not change application runtime code, database schema, or production build settings. Risk is low.

## Model Used

OpenAI Codex, GPT-5, accessed through the Codex agent with tool use and repository execution. The model used reasoning and code inspection to assist this change.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs: #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
