### PR TITLE
test: guard against historical execution blockers

### DIFF
--- a/server/src/modules/run-dispatch/adapters/postgres.test.ts
+++ b/server/src/modules/run-dispatch/adapters/postgres.test.ts
@@ -708,6 +708,46 @@ describeEmbeddedPostgres("run-dispatch postgres adapter", () => {
     await expect(adapter.cancelStaleQueuedRun({ companyId, runId, expectedStatus: "queued", now: new Date() })).resolves.toMatchObject({ outcome: "cancelled", errorCode: "execution_reconciliation_required" });
   });
 
+  it("selects the newest applicable blocker instead of a historical reconciliation action", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    await seedIssue({ companyId, issueId, status: "in_progress", assigneeAgentId: agentId });
+
+    const historicalUpdatedAt = new Date("2026-09-09T00:00:00.000Z");
+    const currentUpdatedAt = new Date("2026-09-10T00:00:00.000Z");
+    await db.insert(issueRecoveryActions).values({
+      companyId,
+      sourceIssueId: issueId,
+      kind: "active_run_watchdog",
+      ownerType: "board",
+      cause: "legacy_execution_requires_reconciliation",
+      status: "resolved",
+      evidence: { automaticRecovery: { replay: "blocked" } },
+      fingerprint: randomUUID(),
+      nextAction: "Inspect the historical execution before continuing.",
+      updatedAt: historicalUpdatedAt,
+      createdAt: historicalUpdatedAt,
+    });
+    const [currentAction] = await db.insert(issueRecoveryActions).values({
+      companyId,
+      sourceIssueId: issueId,
+      kind: "active_run_watchdog",
+      ownerType: "board",
+      cause: "legacy_execution_requires_reconciliation",
+      status: "active",
+      evidence: {},
+      fingerprint: randomUUID(),
+      nextAction: "Reconcile the current execution before continuing.",
+      updatedAt: currentUpdatedAt,
+      createdAt: currentUpdatedAt,
+    }).returning({ id: issueRecoveryActions.id });
+
+    expect(await getExecutionBlocker(db, companyId, issueId)).toMatchObject({
+      recoveryActionId: currentAction!.id,
+      nextAction: "Reconcile the current execution before continuing.",
+    });
+  });
+
   it("links the stopped run's agent instead of its return owner, within the same company", async () => {
     const { companyId, agentId: ownerId } = await seedCompanyAndAgent();
     const reviewerId = randomUUID(), issueId = randomUUID(), runId = randomUUID();

--- a/server/src/services/execution-blocker.ts
+++ b/server/src/services/execution-blocker.ts
@@ -12,7 +12,9 @@ export function executionBlockerPredicate() {
   );
 }
 
+/** A resolved no-replay disposition remains an effective hold. */
 export async function getExecutionBlocker(db: Db, companyId: string, issueId: string): Promise<ExecutionBlocker | null> {
+  // An older recovery action must not shadow the newest applicable blocker.
   const [action] = await db.select().from(issueRecoveryActions).where(and(
     eq(issueRecoveryActions.companyId, companyId),
     eq(issueRecoveryActions.sourceIssueId, issueId),


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The run-dispatch subsystem decides whether a queued run may reach an agent provider.
> - Legacy executions with uncertain external outcomes create reconciliation blockers that must remain safe.
> - A resolved no-replay action can remain an effective hold, but an older action must not shadow a newer applicable blocker.
> - The runtime implementation now selects the newest applicable blocker in upstream PR #13119, but the multi-action case was not covered directly.
> - This pull request adds deterministic regression coverage and documents the ordering invariant beside the query.
> - The benefit is protection against reintroducing stale historical blockers into the execution gate.

## Linked Issues or Issue Description

This is a follow-up to the merged public PR #13119, which introduced the shared execution-blocker query and newest-blocker ordering.

**What happened?**

The execution blocker query can consider active reconciliation actions and resolved no-replay actions. Without deterministic newest-action ordering, a historical action can be returned before the current blocker.

**Expected behavior**

The newest applicable recovery action must be returned. Older actions must not determine the current stale-run cancellation reason.

**Steps to reproduce**

1. Create an issue with a resolved no-replay recovery action.
2. Create a newer active reconciliation action for the same issue.
3. Query the execution blocker through the run-dispatch adapter.
4. Confirm that the newer action and its next action are returned.

**Paperclip version or commit**

Current upstream `master` at `2a05b5ed3457ea33efd6895520447d1d97fe98d8`.

**Deployment mode**

Built from source with an embedded Postgres test database.

## What Changed

- Add a run-dispatch regression test with both a historical resolved no-replay action and a newer active action.
- Assert that `getExecutionBlocker` returns the newest applicable action and its next action.
- Document the ordering invariant in `execution-blocker.ts`.

## Verification

- `pnpm exec vitest run server/src/modules/run-dispatch/adapters/postgres.test.ts --pool=threads --maxWorkers=1` — passed, 1 file and 19 tests.
- `pnpm exec vitest run server/src/services/legacy-execution-recovery.test.ts --pool=threads --maxWorkers=1` — passed, 1 file and 5 tests.
- `pnpm --filter @paperclipai/server typecheck` — passed.
- GitHub CI and Greptile review are pending for this pull request.

## Risks

- Low risk. The change adds test coverage and a source comment only.
- No database schema, API, provider, or runtime decision logic changes are included.
- The test uses fixed timestamps and a disposable embedded Postgres database.

## Model Used

OpenAI Codex, model `gpt-5.6-luna`, with repository tools, code execution, web research, and Git operations. The runtime does not expose the context-window size or a separate reasoning-mode identifier.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs: #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub references)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
