### PR TITLE
fix(claude-local): classify ACP session-limit turn failures as provider quota with the parsed reset time

### DIFF
--- a/packages/adapters/claude-local/src/server/acp.limit.test.ts
+++ b/packages/adapters/claude-local/src/server/acp.limit.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import type { AdapterExecutionResult } from "@paperclipai/adapter-utils";
+import { mapClaudeAcpLimitErrorCode } from "./acp.js";
+
+function turnFailure(overrides: Partial<AdapterExecutionResult> = {}): AdapterExecutionResult {
+  return {
+    exitCode: 1,
+    signal: null,
+    timedOut: false,
+    errorCode: "acpx_turn_failed",
+    errorMessage: null,
+    resultJson: { phase: "turn" },
+    ...overrides,
+  };
+}
+
+describe("mapClaudeAcpLimitErrorCode", () => {
+  it("classifies a session-limit turn failure as provider_quota with the parsed reset time", () => {
+    const now = new Date("2026-09-10T03:18:53.000Z"); // 10:18 in Asia/Bangkok (UTC+7)
+    const result = mapClaudeAcpLimitErrorCode(
+      turnFailure({
+        errorMessage: "Internal error: You've hit your session limit · resets 1:30pm (Asia/Bangkok)",
+      }),
+      now,
+    );
+    expect(result.errorCode).toBe("provider_quota");
+    expect(result.errorFamily).toBe("provider_quota");
+    // 1:30pm Asia/Bangkok = 06:30 UTC, same day (still ahead of `now`).
+    expect(result.retryNotBefore).toBe("2026-09-10T06:30:00.000Z");
+    expect(result.resultJson).toMatchObject({
+      phase: "turn",
+      errorFamily: "provider_quota",
+      retryNotBefore: "2026-09-10T06:30:00.000Z",
+      transientRetryNotBefore: "2026-09-10T06:30:00.000Z",
+      providerQuotaRetryNotBefore: "2026-09-10T06:30:00.000Z",
+    });
+  });
+
+  it("classifies a weekly-limit turn failure as provider_quota", () => {
+    const result = mapClaudeAcpLimitErrorCode(
+      turnFailure({
+        errorMessage: "Internal error: You've hit your weekly limit · resets 4pm (America/Chicago)",
+      }),
+      new Date("2026-09-10T03:00:00.000Z"),
+    );
+    expect(result.errorCode).toBe("provider_quota");
+    expect(result.retryNotBefore).toBe("2026-09-10T21:00:00.000Z"); // 4pm CDT = 21:00 UTC
+  });
+
+  it("keeps the quota classification when the message states no reset time", () => {
+    const result = mapClaudeAcpLimitErrorCode(
+      turnFailure({ errorMessage: "Claude usage limit reached." }),
+    );
+    expect(result.errorCode).toBe("provider_quota");
+    expect(result.retryNotBefore).toBeUndefined();
+    expect(result.resultJson).toMatchObject({ errorFamily: "provider_quota" });
+  });
+
+  it("leaves non-limit turn failures untouched", () => {
+    const input = turnFailure({ errorMessage: "Internal error: something else entirely" });
+    expect(mapClaudeAcpLimitErrorCode(input)).toBe(input);
+  });
+
+  it("leaves other error codes untouched even when the message mentions a limit", () => {
+    const input = turnFailure({
+      errorCode: "acpx_runtime_error",
+      errorMessage: "You've hit your session limit · resets 2pm (Asia/Bangkok)",
+    });
+    expect(mapClaudeAcpLimitErrorCode(input)).toBe(input);
+  });
+
+  it("never classifies from transcript noise: only the error surface is read", () => {
+    const input = turnFailure({
+      errorMessage: "Internal error: unrelated failure",
+      resultJson: {
+        phase: "turn",
+        stdout: "the agent transcript casually mentions: you've hit your session limit · resets 9am",
+      },
+    });
+    expect(mapClaudeAcpLimitErrorCode(input)).toBe(input);
+  });
+});

--- a/packages/adapters/claude-local/src/server/acp.ts
+++ b/packages/adapters/claude-local/src/server/acp.ts
@@ -43,6 +43,11 @@ import {
   prepareSandboxClaudeProbeRuntime,
 } from "./claude-config.js";
 import {
+  extractClaudeRetryNotBefore,
+  isClaudeProviderQuotaError,
+  isClaudeTransientUpstreamError,
+} from "./parse.js";
+import {
   buildAdapterTestTargetCheck,
   buildClaudeLoginRequiredHint,
   classifyThrownErrorClass,
@@ -339,6 +344,57 @@ export function mapClaudeAcpAuthErrorCode(
   return { ...result, errorCode: CLAUDE_AUTH_REQUIRED_ERROR_CODE };
 }
 
+/**
+ * The generic error code the shared acpx engine emits when the provider turn
+ * fails. Claude limit exhaustion ("You've hit your session limit · resets
+ * 1:30pm (Asia/Bangkok)") surfaces this way on the ACP lane, so without a
+ * Claude-specific translation the recovery sweep cannot classify it as a
+ * quota wait and strands the issue in `blocked` ("No live execution path").
+ */
+const ACPX_TURN_FAILED_ERROR_CODE = "acpx_turn_failed";
+
+/**
+ * Translate a generic acpx turn failure into the same limit classification the
+ * Claude CLI lane already emits (`execute.ts`): `provider_quota` /
+ * `claude_transient_upstream` plus the parsed `retryNotBefore` reset time, in
+ * both the result fields and the `resultJson` keys the server recovery sweep
+ * reads (`retryNotBefore`, `transientRetryNotBefore`,
+ * `providerQuotaRetryNotBefore`). Classification deliberately reads only the
+ * run's error surface (`errorMessage`), never the transcript/stdout, which
+ * routinely *mentions* limits it is merely talking about.
+ */
+export function mapClaudeAcpLimitErrorCode(
+  result: AdapterExecutionResult,
+  now = new Date(),
+): AdapterExecutionResult {
+  if (result.errorCode !== ACPX_TURN_FAILED_ERROR_CODE) return result;
+  const surface = { errorMessage: result.errorMessage ?? null };
+  const providerQuota = isClaudeProviderQuotaError(surface);
+  const transientUpstream = !providerQuota && isClaudeTransientUpstreamError(surface);
+  if (!providerQuota && !transientUpstream) return result;
+  const retryNotBefore = extractClaudeRetryNotBefore(surface, now);
+  const iso = retryNotBefore ? retryNotBefore.toISOString() : null;
+  const errorFamily = providerQuota ? "provider_quota" as const : "transient_upstream" as const;
+  const priorResultJson = parseObject(result.resultJson);
+  return {
+    ...result,
+    errorCode: providerQuota ? "provider_quota" : "claude_transient_upstream",
+    errorFamily,
+    ...(iso ? { retryNotBefore: iso } : {}),
+    resultJson: {
+      ...priorResultJson,
+      errorFamily,
+      ...(iso
+        ? {
+            retryNotBefore: iso,
+            transientRetryNotBefore: iso,
+            ...(providerQuota ? { providerQuotaRetryNotBefore: iso } : {}),
+          }
+        : {}),
+    },
+  };
+}
+
 export function createClaudeAcpExecutor(options: ClaudeAcpExecutorOptions = {}): ClaudeAcpExecutor {
   let executor: ClaudeAcpExecutor | null = null;
   return async (ctx) => {
@@ -356,7 +412,7 @@ export function createClaudeAcpExecutor(options: ClaudeAcpExecutorOptions = {}):
       ...ctx,
       config: buildClaudeAcpConfig(ctx.config, target?.kind === "remote" ? {} : process.env),
     });
-    return mapClaudeAcpAuthErrorCode(result);
+    return mapClaudeAcpLimitErrorCode(mapClaudeAcpAuthErrorCode(result));
   };
 }
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The recovery subsystem classifies failed runs so the heartbeat can retry, wait for a quota reset, or escalate
> - On the ACP lane, Claude limit exhaustion (`You've hit your session limit · resets 1:30pm (Asia/Bangkok)`) surfaces as a generic `acpx_turn_failed`
> - `classifyAdapterFailureForRecovery` only accepts `adapter_failed` / `provider_quota` / `configuration_incomplete`, so it never sees the quota wait
> - Recovery retries immediately, re-fails against the same exhausted session, and strands the issue in `blocked` ("No live execution path") even though the provider stated the exact reset time
> - On one production board, 836 of 1,020 terminal run errors over three weeks were this exact class
> - This pull request translates the failure at the claude-local boundary into the same limit classification the Claude CLI lane already emits, with the parsed reset time
> - The benefit is that limit-exhausted issues reschedule themselves at the provider reset time instead of stranding for human intervention

## Linked Issues or Issue Description

Fixes: #10344
Refs #11257
Refs #9730
Refs #12023

Duplicate/related PR search: #6855 and #8692 target the CLI lane's regexes and the continuation sweep; #11052 narrows classification to the error surface. None of them classifies the ACP lane's `acpx_turn_failed`. This PR is complementary to #11052 and does not overlap its diff.

## What Changed

- Add `mapClaudeAcpLimitErrorCode` in `packages/adapters/claude-local/src/server/acp.ts`. It translates an `acpx_turn_failed` result whose error surface matches the Claude limit classifiers into `provider_quota` or `claude_transient_upstream`.
- Reuse the CLI lane's existing tested classifiers (`isClaudeProviderQuotaError`, `isClaudeTransientUpstreamError`, `extractClaudeRetryNotBefore`). Phrasing and timezone coverage stay single-sourced in `parse.ts`.
- Emit the same contract the CLI lane emits: `errorCode`, `errorFamily`, top-level `retryNotBefore`, and the `resultJson` keys the recovery sweep reads (`retryNotBefore`, `transientRetryNotBefore`, `providerQuotaRetryNotBefore`).
- Chain the new mapper after the existing `mapClaudeAcpAuthErrorCode` in `createClaudeAcpExecutor`.
- Add `acp.limit.test.ts` with six cases.

## Verification

- Run: `pnpm vitest run src/server/acp.limit.test.ts src/server/parse.test.ts` in `packages/adapters/claude-local` → 53 tests pass (6 new).
- Test cases cover: session limit with an IANA timezone (Asia/Bangkok), weekly limit (America/Chicago), a quota message with no stated reset time, a non-limit turn failure, a different error code whose message mentions a limit, and transcript noise in `resultJson.stdout`.
- Manual: deployed on the production instance that produced the 836-failure sample. A dispatched probe task executed normally through the patched path.

## Risks

- Behavioral shift: limit failures that previously escalated to `blocked` now schedule a retry at the reset time. The issue waits instead of demanding attention. This matches the CLI lane's existing behavior.
- If the reset time cannot be parsed, the classification stands without `retryNotBefore`, and recovery applies its default quota backoff. No new failure mode.
- Classification reads only `result.errorMessage`, never stdout. If the engine ever stops carrying the provider message in `errorMessage`, the mapper no-ops and behavior falls back to today's. Fails safe.
- No schema change, no migration, no config change.

## Model Used

- Claude Fable 5 (Anthropic, model ID `claude-fable-5`), via the Claude Code harness with extended thinking and tool use (file inspection, test execution, live-instance verification).

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (JSDoc on the new mapper and the error-code constant)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
