### PR TITLE
fix: reconcile never-started review runs

### DIFF
--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -395,6 +395,60 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
     ]);
   });
 
+  it("checks guarded review stage and participant under the enqueue lock", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    const expectedStageId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Review continuation with stale stage",
+      status: "in_review",
+      priority: "medium",
+      assigneeAgentId: agentId,
+      executionState: {
+        status: "pending",
+        currentStageId: randomUUID(),
+        currentStageType: "approval",
+        currentStageIndex: 1,
+        completedStageIds: [],
+        currentParticipant: { type: "agent", agentId, userId: null },
+        returnAssignee: { type: "agent", agentId, userId: null },
+        reviewRequest: null,
+        lastDecisionOutcome: null,
+        changesRequestedCount: 0,
+        lastDecisionId: null,
+      },
+    });
+
+    const run = await heartbeat.wakeup(agentId, {
+      source: "automation",
+      triggerDetail: "system",
+      reason: "issue_commented",
+      payload: { issueId },
+      contextSnapshot: { issueId, wakeReason: "issue_commented" },
+      requestedByActorType: "user",
+      requestedByActorId: "responsible-user",
+      issueStateGuard: {
+        statuses: ["in_review"],
+        assigneeAgentId: agentId,
+        execution: {
+          currentStageId: expectedStageId,
+          currentStageType: "review",
+          participantAgentId: agentId,
+        },
+      },
+    });
+
+    expect(run).toBeNull();
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+    expect(await db.select().from(heartbeatRuns)).toHaveLength(0);
+    expect(await db.select({ status: agentWakeupRequests.status, reason: agentWakeupRequests.reason })
+      .from(agentWakeupRequests)).toEqual([
+      { status: "skipped", reason: "issue_state_guard_mismatch" },
+    ]);
+  });
+
   it("cancels a resolved connection-intent wake parked before queued-run claim", async () => {
     const { companyId, agentId } = await seedCompanyAndAgent();
     const issueId = randomUUID();

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1660,6 +1660,100 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect((await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.id, action!.id)))[0]).toEqual(recorded);
   });
 
+  it("reconciles a never-started legacy reviewer run without bypassing the pending review stage", async () => {
+    const { companyId, managerId, coderId, sourceIssueId } = await seedCompany();
+    const stageId = randomUUID();
+    const runId = randomUUID();
+    await db.update(issues).set({
+      status: "in_review",
+      assigneeAgentId: managerId,
+      executionState: {
+        status: "pending",
+        currentStageId: stageId,
+        currentStageType: "review",
+        currentStageIndex: 0,
+        completedStageIds: [],
+        currentParticipant: { type: "agent", agentId: managerId, userId: null },
+        returnAssignee: { type: "agent", agentId: coderId, userId: null },
+        reviewRequest: null,
+        lastDecisionOutcome: null,
+        changesRequestedCount: 0,
+        lastDecisionId: null,
+      },
+    }).where(eq(issues.id, sourceIssueId));
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId: managerId,
+      invocationSource: "manual",
+      status: "cancelled",
+      errorCode: "execution_reconciliation_required",
+      resultJson: {
+        stopReason: "execution_reconciliation_required",
+        timeoutSource: "stale_queued_run_gate",
+      },
+      startedAt: null,
+      finishedAt: new Date("2026-05-13T18:01:00.000Z"),
+      contextSnapshot: { issueId: sourceIssueId },
+    });
+    const [action] = await db.insert(issueRecoveryActions).values({
+      companyId,
+      sourceIssueId,
+      kind: "active_run_watchdog",
+      status: "resolved",
+      outcome: "blocked",
+      ownerType: "board",
+      returnOwnerAgentId: coderId,
+      cause: "legacy_execution_requires_reconciliation",
+      fingerprint: `legacy-execution:${runId}`,
+      nextAction: "Reconcile the stopped legacy reviewer run.",
+      evidence: {
+        runId,
+        automaticRecovery: { replay: "blocked", actionOutcome: "unknown" },
+      },
+    }).returning();
+    const app = createApp();
+
+    const resolved = await request(app)
+      .post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`)
+      .send({
+        actionId: action!.id,
+        outcome: "restored",
+        sourceIssueStatus: "in_review",
+        resolutionNote: "The reviewer run never started; preserve the pending CTO review stage.",
+        executionReconciliation: {
+          runId,
+          providerStopped: true,
+          actionOutcome: "not_performed",
+          outcomeEvidence: "startedAt is null, no process or lease exists, and the run stopped at stale_queued_run_gate.",
+        },
+      })
+      .expect(200);
+
+    expect(resolved.body.issue).toMatchObject({
+      id: sourceIssueId,
+      status: "in_review",
+      assigneeAgentId: managerId,
+      activeRecoveryAction: null,
+    });
+    expect(resolved.body.issue.executionState).toMatchObject({
+      status: "pending",
+      currentParticipant: { type: "agent", agentId: managerId },
+      returnAssignee: { type: "agent", agentId: coderId },
+    });
+    expect(resolved.body.recoveryAction).toMatchObject({
+      id: action!.id,
+      status: "resolved",
+      outcome: "restored",
+    });
+    const [recorded] = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.id, action!.id));
+    expect(recorded!.evidence).not.toHaveProperty("automaticRecovery");
+    expect(recorded!.evidence).toMatchObject({
+      executionReconciliation: { runId, actionOutcome: "not_performed" },
+      continuationDelivery: "pending",
+    });
+  });
+
   async function seedReconciledDelivery() {
     const fixture = await seedCompany();
     const { companyId, coderId, sourceIssueId } = fixture;

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1772,7 +1772,18 @@ describeEmbeddedPostgres("issue recovery actions", () => {
 
     expect(wake).toHaveBeenCalledWith(
       managerId,
-      expect.objectContaining({ reason: "issue_recovery_action_restored" }),
+      expect.objectContaining({
+        reason: "issue_recovery_action_restored",
+        issueStateGuard: {
+          statuses: ["in_review"],
+          assigneeAgentId: managerId,
+          execution: {
+            currentStageId: stageId,
+            currentStageType: "review",
+            participantAgentId: managerId,
+          },
+        },
+      }),
     );
     const [delivered] = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.id, action!.id));
     expect(delivered!.evidence).toMatchObject({

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -1935,6 +1935,57 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(unchangedAction).toMatchObject({ status: "resolved", outcome: "blocked" });
   });
 
+  it("invalidates a review continuation when the governed stage drifts before delivery", async () => {
+    const { companyId, managerId, coderId, sourceIssueId } = await seedCompany();
+    const runId = randomUUID();
+    await db.update(issues).set({
+      status: "in_review",
+      assigneeAgentId: managerId,
+      executionState: {
+        status: "pending",
+        currentStageId: randomUUID(),
+        currentStageType: "approval",
+        currentStageIndex: 0,
+        completedStageIds: [],
+        currentParticipant: { type: "agent", agentId: managerId, userId: null },
+        returnAssignee: { type: "agent", agentId: coderId, userId: null },
+        reviewRequest: null,
+        lastDecisionOutcome: null,
+        changesRequestedCount: 0,
+        lastDecisionId: null,
+      },
+    }).where(eq(issues.id, sourceIssueId));
+    const [action] = await db.insert(issueRecoveryActions).values({
+      companyId,
+      sourceIssueId,
+      kind: "active_run_watchdog",
+      status: "resolved",
+      outcome: "restored",
+      ownerType: "board",
+      returnOwnerAgentId: coderId,
+      cause: "legacy_execution_requires_reconciliation",
+      fingerprint: `legacy-execution:${runId}`,
+      nextAction: "Continue from the verified reconciliation.",
+      evidence: {
+        continuationDelivery: "pending",
+        continuationDeliveryMode: "review",
+        executionReconciliation: {
+          runId,
+          providerStopped: true,
+          actionOutcome: "not_performed",
+          outcomeEvidence: "Verified absent provider effect.",
+        },
+      },
+    }).returning();
+    const wake = vi.fn();
+
+    await deliverReconciledExecutions(db, wake as never);
+
+    expect(wake).not.toHaveBeenCalled();
+    const [invalidated] = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.id, action!.id));
+    expect(invalidated!.evidence).toMatchObject({ continuationDelivery: "invalidated" });
+  });
+
   async function seedReconciledDelivery() {
     const fixture = await seedCompany();
     const { companyId, coderId, sourceIssueId } = fixture;

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -14,6 +14,7 @@ import {
   environmentLeases,
   environments,
   heartbeatRuns,
+  heartbeatRunEvents,
   issueComments,
   issueInboxArchives,
   issueRecoveryActions,
@@ -142,6 +143,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     await db.delete(issueComments);
     await db.delete(environmentLeases);
     await db.delete(activityLog);
+    await db.delete(heartbeatRunEvents);
     await db.delete(heartbeatRuns);
     await db.delete(agentWakeupRequests);
     await db.delete(environments);
@@ -1752,6 +1754,185 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       executionReconciliation: { runId, actionOutcome: "not_performed" },
       continuationDelivery: "pending",
     });
+
+    const successorId = randomUUID();
+    const wake = vi.fn(async (agentId: string, input: { contextSnapshot?: unknown }) => {
+      await db.insert(heartbeatRuns).values({
+        id: successorId,
+        companyId,
+        agentId,
+        invocationSource: "automation",
+        status: "queued",
+        startedAt: null,
+        contextSnapshot: input.contextSnapshot as Record<string, unknown>,
+      });
+      return { id: successorId } as never;
+    });
+    await deliverReconciledExecutions(db, wake);
+
+    expect(wake).toHaveBeenCalledWith(
+      managerId,
+      expect.objectContaining({ reason: "issue_recovery_action_restored" }),
+    );
+    const [delivered] = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.id, action!.id));
+    expect(delivered!.evidence).toMatchObject({
+      continuationDelivery: "delivered",
+      continuationRunId: successorId,
+    });
+  });
+
+  it.each([
+    { label: "a startedAt timestamp", startedAt: new Date("2026-05-13T18:00:00.000Z"), addProviderEvent: false },
+    { label: "an adapter invocation event", startedAt: null, addProviderEvent: true },
+  ])("rejects pending-review reconciliation with %s", async ({ startedAt, addProviderEvent }) => {
+    const { companyId, managerId, coderId, sourceIssueId } = await seedCompany();
+    const stageId = randomUUID();
+    const runId = randomUUID();
+    await db.update(issues).set({
+      status: "in_review",
+      assigneeAgentId: managerId,
+      executionState: {
+        status: "pending",
+        currentStageId: stageId,
+        currentStageType: "review",
+        currentStageIndex: 0,
+        completedStageIds: [],
+        currentParticipant: { type: "agent", agentId: managerId, userId: null },
+        returnAssignee: { type: "agent", agentId: coderId, userId: null },
+        reviewRequest: null,
+        lastDecisionOutcome: null,
+        changesRequestedCount: 0,
+        lastDecisionId: null,
+      },
+    }).where(eq(issues.id, sourceIssueId));
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId: managerId,
+      invocationSource: "manual",
+      status: "cancelled",
+      errorCode: "execution_reconciliation_required",
+      startedAt,
+      finishedAt: new Date("2026-05-13T18:01:00.000Z"),
+      contextSnapshot: { issueId: sourceIssueId },
+    });
+    if (addProviderEvent) {
+      await db.insert(heartbeatRunEvents).values({
+        companyId,
+        runId,
+        agentId: managerId,
+        seq: 1,
+        eventType: "adapter.invoke",
+        stream: "system",
+        level: "info",
+        message: "adapter invocation",
+        payload: {},
+      });
+    }
+    const [action] = await db.insert(issueRecoveryActions).values({
+      companyId,
+      sourceIssueId,
+      kind: "active_run_watchdog",
+      status: "resolved",
+      outcome: "blocked",
+      ownerType: "board",
+      returnOwnerAgentId: coderId,
+      cause: "legacy_execution_requires_reconciliation",
+      fingerprint: `legacy-execution:${runId}`,
+      nextAction: "Reconcile the stopped legacy reviewer run.",
+      evidence: {
+        runId,
+        automaticRecovery: { replay: "blocked", actionOutcome: "unknown" },
+      },
+    }).returning();
+
+    await request(createApp())
+      .post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`)
+      .send({
+        actionId: action!.id,
+        outcome: "restored",
+        sourceIssueStatus: "in_review",
+        resolutionNote: "Attempted invalid never-started reconciliation.",
+        executionReconciliation: {
+          runId,
+          providerStopped: true,
+          actionOutcome: "not_performed",
+          outcomeEvidence: "Verified test evidence for this recovery attempt.",
+        },
+      })
+      .expect(409);
+
+    const [unchangedAction] = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.id, action!.id));
+    expect(unchangedAction).toMatchObject({ status: "resolved", outcome: "blocked" });
+  });
+
+  it("rejects pending-approval reconciliation", async () => {
+    const { companyId, managerId, coderId, sourceIssueId } = await seedCompany();
+    const stageId = randomUUID();
+    const runId = randomUUID();
+    await db.update(issues).set({
+      status: "in_review",
+      assigneeAgentId: managerId,
+      executionState: {
+        status: "pending",
+        currentStageId: stageId,
+        currentStageType: "approval",
+        currentStageIndex: 0,
+        completedStageIds: [],
+        currentParticipant: { type: "agent", agentId: managerId, userId: null },
+        returnAssignee: { type: "agent", agentId: coderId, userId: null },
+        reviewRequest: null,
+        lastDecisionOutcome: null,
+        changesRequestedCount: 0,
+        lastDecisionId: null,
+      },
+    }).where(eq(issues.id, sourceIssueId));
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId: managerId,
+      invocationSource: "manual",
+      status: "cancelled",
+      errorCode: "execution_reconciliation_required",
+      startedAt: null,
+      finishedAt: new Date("2026-05-13T18:01:00.000Z"),
+      contextSnapshot: { issueId: sourceIssueId },
+    });
+    const [action] = await db.insert(issueRecoveryActions).values({
+      companyId,
+      sourceIssueId,
+      kind: "active_run_watchdog",
+      status: "resolved",
+      outcome: "blocked",
+      ownerType: "board",
+      returnOwnerAgentId: coderId,
+      cause: "legacy_execution_requires_reconciliation",
+      fingerprint: `legacy-execution:${runId}`,
+      nextAction: "Reconcile the stopped legacy approval run.",
+      evidence: {
+        runId,
+        automaticRecovery: { replay: "blocked", actionOutcome: "unknown" },
+      },
+    }).returning();
+
+    await request(createApp())
+      .post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`)
+      .send({
+        actionId: action!.id,
+        outcome: "restored",
+        sourceIssueStatus: "in_review",
+        resolutionNote: "Approval stages must not use reviewer reconciliation.",
+        executionReconciliation: {
+          runId,
+          providerStopped: true,
+          actionOutcome: "not_performed",
+          outcomeEvidence: "Verified test evidence for this recovery attempt.",
+        },
+      })
+      .expect(409);
+
+    const [unchangedAction] = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.id, action!.id));
+    expect(unchangedAction).toMatchObject({ status: "resolved", outcome: "blocked" });
   });
 
   async function seedReconciledDelivery() {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -7600,6 +7600,17 @@ export function issueRoutes(
         .then((rows) => rows[0] ?? null);
       if (!lockedIssue) throw notFound("Issue not found");
 
+      const reviewState = parseIssueExecutionState(lockedIssue.executionState);
+      const isPendingReviewReconciliation =
+        sourceIssueStatus === "in_review" &&
+        outcome === "restored" &&
+        executionReconciliation != null &&
+        executionReconciliation.providerStopped === true &&
+        executionReconciliation.actionOutcome === "not_performed" &&
+        lockedIssue.status === "in_review" &&
+        reviewState?.status === "pending" &&
+        reviewState.currentParticipant?.type === "agent";
+
       let activeRecoveryAction = await recoveryActionsSvc.getActiveForIssue(
         lockedIssue.companyId,
         lockedIssue.id,
@@ -7618,7 +7629,9 @@ export function issueRoutes(
             // An automatic no-replay disposition is final until new evidence
             // arrives. Keep the supported evidence API usable without a dialog.
             assertBoard(req);
-            if (activeRecoveryAction || sourceIssueStatus !== "todo" || outcome !== "restored") {
+            const canReopenForPendingReview =
+              sourceIssueStatus === "todo" || isPendingReviewReconciliation;
+            if (activeRecoveryAction || !canReopenForPendingReview || outcome !== "restored") {
               throw conflict("Verified outcomes must restore this source recovery without replacing another active recovery action.");
             }
             const [reopened] = await tx.update(issueRecoveryActions).set({ status: "active", outcome: null, resolvedAt: null })
@@ -7639,7 +7652,9 @@ export function issueRoutes(
         { source: "recovery_action_resolution" },
       );
 
-      if (sourceIssueStatus === "todo" && requiresExecutionReconciliation(activeRecoveryAction.cause)) {
+      const canValidateExecutionReconciliation =
+        sourceIssueStatus === "todo" || isPendingReviewReconciliation;
+      if (canValidateExecutionReconciliation && requiresExecutionReconciliation(activeRecoveryAction.cause)) {
         assertBoard(req);
         await validateExecutionReconciliation({ db: tx as unknown as Db,
           companyId: lockedIssue.companyId, issueId: lockedIssue.id, agentId: lockedIssue.assigneeAgentId,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -7609,6 +7609,7 @@ export function issueRoutes(
         executionReconciliation.actionOutcome === "not_performed" &&
         lockedIssue.status === "in_review" &&
         reviewState?.status === "pending" &&
+        reviewState.currentStageId != null &&
         reviewState.currentStageType === "review" &&
         reviewState.currentParticipant?.type === "agent";
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -7609,6 +7609,7 @@ export function issueRoutes(
         executionReconciliation.actionOutcome === "not_performed" &&
         lockedIssue.status === "in_review" &&
         reviewState?.status === "pending" &&
+        reviewState.currentStageType === "review" &&
         reviewState.currentParticipant?.type === "agent";
 
       let activeRecoveryAction = await recoveryActionsSvc.getActiveForIssue(
@@ -7660,6 +7661,7 @@ export function issueRoutes(
           companyId: lockedIssue.companyId, issueId: lockedIssue.id, agentId: lockedIssue.assigneeAgentId,
           sourceRunId: activeRecoveryAction.evidence.runId ?? activeRecoveryAction.evidence.sourceRunId,
           decision: executionReconciliation,
+          requireNeverStarted: isPendingReviewReconciliation,
         });
         await markExecutionReconciliation(tx as unknown as Db, activeRecoveryAction, executionReconciliation!, actor.actorId);
       } else if (executionReconciliation) {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -7663,7 +7663,13 @@ export function issueRoutes(
           decision: executionReconciliation,
           requireNeverStarted: isPendingReviewReconciliation,
         });
-        await markExecutionReconciliation(tx as unknown as Db, activeRecoveryAction, executionReconciliation!, actor.actorId);
+        await markExecutionReconciliation(
+          tx as unknown as Db,
+          activeRecoveryAction,
+          executionReconciliation!,
+          actor.actorId,
+          isPendingReviewReconciliation ? "review" : "todo",
+        );
       } else if (executionReconciliation) {
         throw conflict("An execution reconciliation must target the current execution recovery action and continue the task.");
       }

--- a/server/src/services/execution-recovery-resolution.ts
+++ b/server/src/services/execution-recovery-resolution.ts
@@ -5,6 +5,7 @@ import { logger } from "../middleware/logger.js";
 import { and, eq, inArray, isNull, or, sql } from "drizzle-orm";
 import {
   environmentLeases,
+  heartbeatRunEvents,
   heartbeatRuns,
   issueRecoveryActions,
   issues,
@@ -27,6 +28,7 @@ export async function validateExecutionReconciliation(input: {
   agentId: string | null;
   sourceRunId: unknown;
   decision: ExecutionReconciliation | undefined;
+  requireNeverStarted?: boolean;
 }) {
   const { db, companyId, issueId, agentId, decision } = input;
   if (!decision || decision.runId !== input.sourceRunId || !agentId) {
@@ -47,6 +49,25 @@ export async function validateExecutionReconciliation(input: {
     .select()
     .from(issues)
     .where(and(eq(issues.companyId, companyId), eq(issues.id, issueId)));
+  const providerInvocations = input.requireNeverStarted
+    ? await db
+      .select({ id: heartbeatRunEvents.id })
+      .from(heartbeatRunEvents)
+      .where(and(
+        eq(heartbeatRunEvents.companyId, companyId),
+        eq(heartbeatRunEvents.runId, decision.runId),
+        eq(heartbeatRunEvents.eventType, "adapter.invoke"),
+      ))
+      .limit(1)
+    : [];
+  if (
+    input.requireNeverStarted &&
+    ((run != null && run.startedAt !== null) || providerInvocations.length > 0)
+  ) {
+    throw conflict(
+      "The reviewer run has provider-start evidence and cannot be reconciled as not performed.",
+    );
+  }
   const review =
     task?.status === "in_review"
       ? parseIssueExecutionState(task.executionState)
@@ -185,7 +206,7 @@ export async function deliverReconciledExecutions(
     try {
       const decision = action.evidence.executionReconciliation as
         ExecutionReconciliation | undefined;
-      if (!decision || !action.returnOwnerAgentId) continue;
+      if (!decision) continue;
       const pendingDecision = and(
         eq(issueRecoveryActions.companyId, action.companyId),
         eq(issueRecoveryActions.id, action.id),
@@ -202,9 +223,20 @@ export async function deliverReconciledExecutions(
             eq(issues.id, action.sourceIssueId),
           ),
         );
+      const reviewState = task?.status === "in_review"
+        ? parseIssueExecutionState(task.executionState)
+        : null;
+      const reviewParticipantAgentId =
+        reviewState?.status === "pending" &&
+        reviewState.currentStageType === "review" &&
+        reviewState.currentParticipant?.type === "agent"
+          ? reviewState.currentParticipant.agentId
+          : null;
+      const deliveryAgentId = reviewParticipantAgentId ?? action.returnOwnerAgentId;
+      if (!deliveryAgentId) continue;
       if (
         !task ||
-        task.assigneeAgentId !== action.returnOwnerAgentId ||
+        task.assigneeAgentId !== deliveryAgentId ||
         ["done", "cancelled"].includes(task.status)
       ) {
         await db
@@ -215,7 +247,7 @@ export async function deliverReconciledExecutions(
           .where(pendingDecision);
         continue;
       }
-      const run = await wake(action.returnOwnerAgentId, {
+      const run = await wake(deliveryAgentId, {
         source: "automation",
         triggerDetail: "system",
         reason: "issue_recovery_action_restored",
@@ -243,7 +275,7 @@ export async function deliverReconciledExecutions(
               and(
                 eq(heartbeatRuns.companyId, action.companyId),
                 eq(heartbeatRuns.id, run.id),
-                eq(heartbeatRuns.agentId, action.returnOwnerAgentId!),
+                eq(heartbeatRuns.agentId, deliveryAgentId),
                 sql`${heartbeatRuns.contextSnapshot}->>'recoveryActionId' = ${action.id}`,
                 sql`${heartbeatRuns.contextSnapshot}->>'previousRunId' = ${decision.runId}`,
               ),

--- a/server/src/services/execution-recovery-resolution.ts
+++ b/server/src/services/execution-recovery-resolution.ts
@@ -154,6 +154,7 @@ export async function markExecutionReconciliation(
   >,
   decision: ExecutionReconciliation,
   actorId: string,
+  deliveryMode: "review" | "todo" = "todo",
 ) {
   await db
     .update(nativeRunFinalizations)
@@ -178,6 +179,7 @@ export async function markExecutionReconciliation(
           recordedAt: new Date().toISOString(),
         },
         continuationDelivery: "pending",
+        continuationDeliveryMode: deliveryMode,
       },
     })
     .where(
@@ -232,11 +234,28 @@ export async function deliverReconciledExecutions(
         reviewState.currentParticipant?.type === "agent"
           ? reviewState.currentParticipant.agentId
           : null;
-      const deliveryAgentId = reviewParticipantAgentId ?? action.returnOwnerAgentId;
-      if (!deliveryAgentId) continue;
+      const reviewReconciliation =
+        action.evidence.continuationDeliveryMode === "review";
+      const deliveryAgentId = reviewReconciliation
+        ? reviewParticipantAgentId
+        : action.returnOwnerAgentId;
+      if (!deliveryAgentId) {
+        await db
+          .update(issueRecoveryActions)
+          .set({
+            evidence: sql`${issueRecoveryActions.evidence} || '{"continuationDelivery":"invalidated"}'::jsonb`,
+          })
+          .where(pendingDecision);
+        continue;
+      }
       if (
         !task ||
         task.assigneeAgentId !== deliveryAgentId ||
+        (reviewReconciliation &&
+          (task.status !== "in_review" ||
+            reviewState?.status !== "pending" ||
+            reviewState.currentStageType !== "review" ||
+            reviewState.currentParticipant?.type !== "agent")) ||
         ["done", "cancelled"].includes(task.status)
       ) {
         await db

--- a/server/src/services/execution-recovery-resolution.ts
+++ b/server/src/services/execution-recovery-resolution.ts
@@ -230,6 +230,7 @@ export async function deliverReconciledExecutions(
         : null;
       const reviewParticipantAgentId =
         reviewState?.status === "pending" &&
+        reviewState.currentStageId != null &&
         reviewState.currentStageType === "review" &&
         reviewState.currentParticipant?.type === "agent"
           ? reviewState.currentParticipant.agentId
@@ -284,6 +285,17 @@ export async function deliverReconciledExecutions(
           wakeReason: "issue_recovery_action_restored",
           source: "execution.reconciled",
         },
+        issueStateGuard: reviewReconciliation
+          ? {
+              statuses: ["in_review"],
+              assigneeAgentId: deliveryAgentId,
+              execution: {
+                currentStageId: reviewState!.currentStageId!,
+                currentStageType: "review",
+                participantAgentId: deliveryAgentId,
+              },
+            }
+          : undefined,
       });
       if (run)
         await db.transaction(async (tx) => {

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -3342,6 +3342,11 @@ interface WakeupOptions {
   issueStateGuard?: {
     statuses: string[];
     assigneeAgentId: string;
+    execution?: {
+      currentStageId: string;
+      currentStageType: "review";
+      participantAgentId: string;
+    };
   };
 }
 
@@ -23167,6 +23172,7 @@ export function heartbeatService(
             executionWorkspaceSettings: issues.executionWorkspaceSettings,
             assigneeAgentId: issues.assigneeAgentId,
             executionRunId: issues.executionRunId,
+            executionState: issues.executionState,
             executionAgentNameKey: issues.executionAgentNameKey,
             createdAt: issues.createdAt,
           })
@@ -23238,7 +23244,9 @@ export function heartbeatService(
             !action ||
             action.status !== "resolved" ||
             action.kind !== "active_run_watchdog" ||
-            action.returnOwnerAgentId !== agentId ||
+            (action.evidence.continuationDeliveryMode === "review"
+              ? issue.assigneeAgentId !== agentId
+              : action.returnOwnerAgentId !== agentId) ||
             !sourceRunId ||
             !isUuidLike(sourceRunId) ||
             decision.providerStopped !== true ||
@@ -23301,10 +23309,20 @@ export function heartbeatService(
         }
 
         const issueStateGuard = opts.issueStateGuard;
+        const executionStateGuard = issueStateGuard?.execution;
+        const currentExecutionState = executionStateGuard
+          ? parseIssueExecutionState(issue.executionState)
+          : null;
         if (
           issueStateGuard &&
           (!issueStateGuard.statuses.includes(issue.status) ||
-            issue.assigneeAgentId !== issueStateGuard.assigneeAgentId)
+            issue.assigneeAgentId !== issueStateGuard.assigneeAgentId ||
+            (executionStateGuard &&
+              (currentExecutionState?.status !== "pending" ||
+                currentExecutionState.currentStageId !== executionStateGuard.currentStageId ||
+                currentExecutionState.currentStageType !== executionStateGuard.currentStageType ||
+                currentExecutionState.currentParticipant?.type !== "agent" ||
+                currentExecutionState.currentParticipant.agentId !== executionStateGuard.participantAgentId)))
         ) {
           await tx.insert(agentWakeupRequests).values({
             companyId: agent.companyId,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The execution and recovery subsystem controls agent runs and review stages.
> - A legacy reviewer run can stop before provider start at the stale queued-run gate.
> - The current reconciliation path only supports a `todo` hand-back.
> - That path cannot safely run while a governed review stage is pending.
> - The result is a valid review stage that remains blocked even when no provider action occurred.
> - This pull request adds a narrow reconciliation path for that verified case.
> - The benefit is that Paperclip can retry the reviewer without clearing or bypassing review governance.

## Linked Issues or Issue Description

Refs: #13146

**What happened?**

A legacy reviewer run can be cancelled before provider start by `stale_queued_run_gate`. Paperclip records `execution_reconciliation_required`. The recovery endpoint then rejects reconciliation because the issue has a pending review stage. The issue remains blocked even though the provider did not run. The continuation worker also previously routed reconciled work to the return owner instead of the current reviewer.

**Expected behavior**

An operator should be able to reconcile a verified never-started reviewer run. Paperclip should preserve the pending review stage, reviewer, and return owner. Paperclip should then deliver one continuation to the reviewer.

**Steps to reproduce**

1. Configure an issue with an agent review stage.
2. Start the reviewer through a legacy adapter.
3. Cancel the queued reviewer run before provider start.
4. Record a recovery action with `legacy_execution_requires_reconciliation` and `automaticRecovery.replay=blocked`.
5. Submit verified reconciliation evidence with `providerStopped=true` and `actionOutcome=not_performed`.
6. Observe that the existing endpoint rejects the pending review hand-back.

**Paperclip version or commit**

The change targets the current `master` revision used by this branch. The regression test runs against commit `2a05b5ed3`.

**Deployment mode**

Docker and built from source.

**Agent adapter(s) involved**

Not adapter-specific. The defect is in the core recovery and review state transition.

## What Changed

- Add a narrowly scoped `sourceIssueStatus=in_review` reconciliation path.
- Require a pending agent review state.
- Require independent never-started evidence. Reject a non-null `startedAt` and any `adapter.invoke` event.
- Deliver reconciled review continuations to the current review participant; invalidate delivery if the governed review stage drifts.
- Preserve the reviewer, pending execution state, and return owner.
- Resolve settled automatic no-replay actions only when the new evidence is valid.
- Keep the existing `todo` safe hand-back rules for ordinary executor recovery.
- Add an embedded Postgres regression test for a never-started legacy reviewer run.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-recovery-actions.test.ts --pool=threads --maxWorkers=1`
  - 62 tests passed.
- `pnpm --filter @paperclipai/server typecheck`
  - passed.
- `git diff --check`
  - passed.
- The worktree is clean after commit `05353061c`.

## Risks

- Low risk. The new path requires board authentication and positive evidence that the provider never started.
- The path does not clear a pending review stage or change its participant.
- Ordinary executor recovery keeps the existing safe hand-back behavior.
- No database migration is required.
- The deployment must include this change before operators use the new `in_review` reconciliation path.

## Model Used

OpenAI Codex, `gpt-5.6-luna`, with tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used with version and capability details
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have described the issue in-PR using the bug report fields
- [x] I have not referenced internal or instance-local Paperclip issues or links
- [x] My branch name describes the change and contains no internal Paperclip ticket id
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented the risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
