### PR TITLE
[SIN-70818] Deploy: control-plane backup pg_dump-major invariant (preflight + board alert)

### DIFF
--- a/doc/architecture/control-plane-backup-pgclient-invariant.md
+++ b/doc/architecture/control-plane-backup-pgclient-invariant.md
@@ -1,0 +1,81 @@
+# Control-plane backup invariant: `postgresql-client` major == embedded PostgreSQL major
+
+Status: accepted · Owner: CTO · Refs: SIN-70814 (critical outage), SIN-70818 (parent), SIN-70819 (board alert adapter), SIN-70820 (this preflight)
+
+## Context
+
+The control-plane runs an **embedded PostgreSQL** (`embedded-postgres@^18.1.0-beta.16`,
+`packages/db/package.json` + `server/package.json`). The automatic database backup
+shells out to the host's `pg_dump` (`packages/db/src/backup-lib.ts`, resolved via
+`process.env.PAPERCLIP_PG_DUMP_PATH || "pg_dump"`).
+
+`pg_dump` **refuses to dump a server whose major is newer than the client**
+(`server version mismatch: pg_dump is version 16.x, server is version 18.x`). So the
+moment the embedded major is bumped without also bumping the host `postgresql-client`,
+the automatic backup dies — and, historically, dies **silently** (the scheduler
+swallowed the error). This has now happened three times:
+
+- SIN-65200 → SIN-70116 → **SIN-70814** (backup dead for 9 days, 2026-08-30 → 2026-09-08).
+
+## Decision (the invariant — AC1)
+
+> The host `postgresql-client` **major** MUST equal the embedded PostgreSQL **major**.
+
+Every change to the embedded Postgres version MUST, in the **same change**:
+
+1. Bump the host `postgresql-client` to the matching major, and
+2. Verify `pg_dump --version` against the running server major
+   (`<dataDir>/PG_VERSION`, where `dataDir` defaults to
+   `~/.paperclip/instances/default/data`).
+
+This invariant is enforced automatically at runtime by the preflight below, and is
+part of the review checklist for any embedded-Postgres bump.
+
+## Automated preflight (AC2)
+
+`server/src/services/pgclient-version-preflight.ts` (wired in `server/src/index.ts`,
+embedded mode only) resolves both authoritative version sources and compares their
+majors:
+
+- **Server major** — first line of `<dataDir>/PG_VERSION`.
+- **Client major** — `pg_dump --version` of the resolved binary
+  (`PAPERCLIP_PG_DUMP_PATH || "pg_dump"`).
+
+The comparison is a pure, table-tested function (`comparePgMajor`); the preflight only
+orchestrates the IO. It runs **once at boot** and then on the backup-health cadence
+(`PAPERCLIP_DB_BACKUP_HEALTH_CHECK_INTERVAL_MINUTES`, default 60 min).
+
+On divergence — or when `pg_dump` is missing (`ENOENT`) — it pushes a **LOUD**,
+idempotent signal through the SIN-70819 board adapter (a board issue plus a structured
+log), deduped by the stable fingerprint `control-plane-pgclient-major-mismatch`. When
+the majors line up again, the open alert is resolved automatically.
+
+It is deliberately **not** a boot hard-stop: the control-plane still comes up (only the
+backup is at risk), so the preflight is read-only + alert. Rollback is trivial (revert
+the change; no migration).
+
+**Least privilege / OWASP A09:** only versions and the resolved binary path are ever
+logged or written to the board. No connection string is touched.
+
+## Recovery without root (AC3)
+
+The engineer/agent cannot `apt install` without root. Paliative until the host's
+`postgresql-client-18` is installed via apt:
+
+```bash
+# 1. Fetch the noble (Ubuntu 24.04) postgresql-client-18 .deb from apt.postgresql.org,
+#    then unpack it into a user-writable prefix (no dpkg -i / no root):
+mkdir -p "$HOME/pgclient18"
+dpkg -x postgresql-client-18_*_amd64.deb "$HOME/pgclient18"
+
+# 2. Point the backup at the unpacked pg_dump. Clear LD_LIBRARY_PATH so the binary's
+#    own RPATH/loader wins (a stale LD_LIBRARY_PATH breaks the unpacked libs):
+export PAPERCLIP_PG_DUMP_PATH="$HOME/pgclient18/usr/lib/postgresql/18/bin/pg_dump"
+env -u LD_LIBRARY_PATH "$PAPERCLIP_PG_DUMP_PATH" --version   # expect: pg_dump (PostgreSQL) 18.x
+
+# 3. Restart the control-plane so the preflight re-runs and the backup uses the v18 client.
+```
+
+The durable fix is to install `postgresql-client-18` via apt on the host and drop the
+`PAPERCLIP_PG_DUMP_PATH` override; the preflight then confirms `ok` and resolves the
+board alert.

--- a/packages/db/src/backup-lib-child-pipeline.test.ts
+++ b/packages/db/src/backup-lib-child-pipeline.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { settleBackupChildPipeline } from "./backup-lib.js";
+
+// SIN-70819 AC2: the stdout→gzip pipeline and the child-exit watcher race. The
+// child-exit watcher carries the REAL failure (captured pg_dump stderr, e.g. a
+// server-version mismatch); the gzip pipeline tends to reject first with a
+// generic stream error. settleBackupChildPipeline must always surface the
+// child-exit error over the pipeline noise, and never leak an unhandled
+// rejection when both halves reject.
+describe("settleBackupChildPipeline", () => {
+  it("prefers the child-exit error (real stderr) over a generic pipeline error", async () => {
+    const pipelineError = new Error("Premature close");
+    const childExitError = new Error(
+      "pg_dump failed with exit code 1: pg_dump: error: server version: 18.0; pg_dump version: 16.9",
+    );
+    await expect(
+      settleBackupChildPipeline(Promise.reject(pipelineError), Promise.reject(childExitError)),
+    ).rejects.toThrow("server version: 18.0");
+  });
+
+  it("surfaces a spawn ENOENT child-exit error over the pipeline error", async () => {
+    const pipelineError = new Error("Premature close");
+    const spawnError = Object.assign(new Error("spawn pg_dump ENOENT"), { code: "ENOENT" });
+    await expect(
+      settleBackupChildPipeline(Promise.reject(pipelineError), Promise.reject(spawnError)),
+    ).rejects.toThrow("ENOENT");
+  });
+
+  it("surfaces the pipeline error when the child process exited cleanly", async () => {
+    const pipelineError = new Error("ENOSPC: no space left on device");
+    await expect(
+      settleBackupChildPipeline(Promise.reject(pipelineError), Promise.resolve()),
+    ).rejects.toThrow("ENOSPC");
+  });
+
+  it("surfaces the child-exit error when the pipeline resolved", async () => {
+    const childExitError = new Error("pg_dump exited via SIGKILL");
+    await expect(
+      settleBackupChildPipeline(Promise.resolve(), Promise.reject(childExitError)),
+    ).rejects.toThrow("SIGKILL");
+  });
+
+  it("resolves when both halves succeed", async () => {
+    await expect(
+      settleBackupChildPipeline(Promise.resolve("gz-done"), Promise.resolve()),
+    ).resolves.toBeUndefined();
+  });
+
+  it("consumes both rejections (no unhandled rejection) and still throws child error", async () => {
+    // Both reject on the same tick; allSettled awaits both before we throw, so the
+    // pipeline rejection is consumed and cannot become an unhandled rejection.
+    let unhandled: unknown;
+    const onUnhandled = (reason: unknown) => {
+      unhandled = reason;
+    };
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      await expect(
+        settleBackupChildPipeline(
+          Promise.reject(new Error("pipeline noise")),
+          Promise.reject(new Error("real child failure")),
+        ),
+      ).rejects.toThrow("real child failure");
+      // Give the microtask queue a chance to flush any stray rejection.
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(unhandled).toBeUndefined();
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+});

--- a/packages/db/src/backup-lib.ts
+++ b/packages/db/src/backup-lib.ts
@@ -28,6 +28,14 @@ export type RunDatabaseBackupOptions = {
   excludeTables?: string[];
   nullifyColumns?: Record<string, string[]>;
   backupEngine?: "auto" | "pg_dump" | "javascript";
+  /**
+   * Invoked when the `auto` engine catches a pg_dump failure and is about to
+   * fall back to the JavaScript engine. Carries the real pg_dump error (with its
+   * captured stderr, e.g. a server-version mismatch) so the caller can log it
+   * loudly instead of letting the fallback swallow it silently. Never receives
+   * secrets beyond whatever pg_dump itself wrote to stderr.
+   */
+  onEngineFallback?: (error: unknown) => void;
 };
 
 export type RunDatabaseBackupResult = {
@@ -317,6 +325,38 @@ async function waitForChildExit(child: ReturnType<typeof spawn>, label: string):
   }
 }
 
+/**
+ * Settle the two halves of a CLI backup (the stdout→gzip→file pipeline and the
+ * child-process exit watcher) and surface the RIGHT error.
+ *
+ * The child-exit watcher carries the process's real failure — the captured
+ * stderr (e.g. `server version mismatch`), a fatal signal, or an ENOENT spawn
+ * error. The gzip pipeline, by contrast, tends to reject first with a generic
+ * stream error (`premature close`) the instant the failing child tears down its
+ * stdout. Racing them with `Promise.all` therefore masks the actionable error
+ * behind stream noise.
+ *
+ * Both promises are always awaited (via `allSettled`) so neither can leak an
+ * unhandled rejection, and the child-exit error wins whenever the process
+ * itself failed. Only when the process exited cleanly do we surface a pipeline
+ * error (e.g. the destination disk filled up).
+ */
+export async function settleBackupChildPipeline(
+  pipelinePromise: Promise<unknown>,
+  childExitPromise: Promise<unknown>,
+): Promise<void> {
+  const [pipelineResult, childExitResult] = await Promise.allSettled([
+    pipelinePromise,
+    childExitPromise,
+  ]);
+  if (childExitResult.status === "rejected") {
+    throw childExitResult.reason;
+  }
+  if (pipelineResult.status === "rejected") {
+    throw pipelineResult.reason;
+  }
+}
+
 async function runPgDumpBackup(opts: {
   connectionString: string;
   backupFile: string;
@@ -346,10 +386,10 @@ async function runPgDumpBackup(opts: {
     throw new Error("pg_dump did not expose stdout");
   }
 
-  await Promise.all([
+  await settleBackupChildPipeline(
     pipeline(child.stdout, createGzip(), createWriteStream(opts.backupFile)),
     waitForChildExit(child, pgDumpBin),
-  ]);
+  );
 }
 
 async function restoreWithPsql(opts: RunDatabaseRestoreOptions, connectTimeout: number): Promise<void> {
@@ -379,10 +419,10 @@ async function restoreWithPsql(opts: RunDatabaseRestoreOptions, connectTimeout: 
     ? createReadStream(opts.backupFile).pipe(createGunzip())
     : createReadStream(opts.backupFile);
 
-  await Promise.all([
+  await settleBackupChildPipeline(
     pipeline(input, child.stdin),
     waitForChildExit(child, psqlBin),
-  ]);
+  );
 }
 
 async function hasStatementBreakpoints(backupFile: string): Promise<boolean> {
@@ -570,6 +610,10 @@ export async function runDatabaseBackup(opts: RunDatabaseBackupOptions): Promise
         if (backupEngine === "pg_dump") {
           throw error;
         }
+        // Auto engine: pg_dump failed (e.g. server-version mismatch). Surface the
+        // real error before falling back to the JavaScript engine so it is never
+        // swallowed silently — the caller logs it loudly (SIN-70819 AC2).
+        opts.onEngineFallback?.(error);
         effectiveBackupEngine = "javascript";
         sql = postgres(opts.connectionString, { max: 1, connect_timeout: connectTimeout });
         sqlClosed = false;

--- a/server/src/__tests__/database-backup-alerts.test.ts
+++ b/server/src/__tests__/database-backup-alerts.test.ts
@@ -1,0 +1,462 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { inspectDatabaseBackupHealth } from "../services/database-backup-health.js";
+import {
+  buildDatabaseBackupAlertContent,
+  clearDatabaseBackupFailureMarkers,
+  createDatabaseBackupAlertReporter,
+  DATABASE_BACKUP_ALERT_FINGERPRINT,
+  raiseDatabaseBackupAlert,
+  redactDatabaseBackupErrorMessage,
+  resolveDatabaseBackupAlert,
+  summarizeDatabaseBackupWarnings,
+  writeDatabaseBackupFailureMarker,
+  type DatabaseBackupAlertBoard,
+} from "../services/database-backup-alerts.js";
+
+type FakeIssue = {
+  id: string;
+  identifier: string;
+  status: string;
+  fingerprint: string;
+  title: string;
+  description: string;
+  comments: string[];
+};
+
+function createFakeBoard(options: { failCreate?: boolean } = {}) {
+  const records: FakeIssue[] = [];
+  let counter = 0;
+  const board: DatabaseBackupAlertBoard = {
+    async findOpenAlert(_companyId, fingerprint) {
+      const open = records.find(
+        (r) => r.fingerprint === fingerprint && r.status !== "done" && r.status !== "cancelled",
+      );
+      return open ? { id: open.id, identifier: open.identifier, status: open.status } : null;
+    },
+    async createAlert(_companyId, input) {
+      if (options.failCreate) throw new Error("board create failed");
+      // Model the create-path dedup we keep: `allowDuplicate: false` in the
+      // concrete adapter dedups ONLY against a NON-terminal recent-open-title
+      // issue (the create-race guard). Crucially it must NOT be shadowed by a
+      // resolved (`done`/`cancelled`) issue — that status-agnostic shadowing is
+      // exactly the retained-idempotency-key bug this change removes. A `done`
+      // alert therefore does not block a fresh create.
+      const openSameTitle = records.find(
+        (r) => r.title === input.title && r.status !== "done" && r.status !== "cancelled",
+      );
+      if (openSameTitle) {
+        return {
+          id: openSameTitle.id,
+          identifier: openSameTitle.identifier,
+          status: openSameTitle.status,
+        };
+      }
+      counter += 1;
+      const rec: FakeIssue = {
+        id: `issue-${counter}`,
+        identifier: `SIN-${counter}`,
+        status: "todo",
+        fingerprint: input.fingerprint,
+        title: input.title,
+        description: input.description,
+        comments: [],
+      };
+      records.push(rec);
+      return { id: rec.id, identifier: rec.identifier, status: rec.status };
+    },
+    async commentAlert(issueId, body) {
+      records.find((r) => r.id === issueId)?.comments.push(body);
+    },
+    async resolveAlert(issueId, body) {
+      const rec = records.find((r) => r.id === issueId);
+      if (rec) {
+        rec.comments.push(body);
+        rec.status = "done";
+      }
+    },
+  };
+  return { board, records };
+}
+
+const FIXED_NOW = new Date("2026-09-07T12:00:00.000Z");
+
+describe("redactDatabaseBackupErrorMessage", () => {
+  it("strips postgres/postgresql connection URLs that may embed credentials", () => {
+    const message =
+      "pg_dump: error: connection to postgres://user:s3cr3t@db.internal:5432/paperclip failed";
+    const redacted = redactDatabaseBackupErrorMessage(message);
+    expect(redacted).not.toContain("s3cr3t");
+    expect(redacted).not.toContain("db.internal");
+    expect(redacted).toContain("postgres://[redacted]");
+  });
+
+  it("leaves a version-mismatch message intact (no secret content)", () => {
+    const message = "pg_dump: error: server version: 18.0; pg_dump version: 16.9";
+    expect(redactDatabaseBackupErrorMessage(message)).toBe(message);
+  });
+});
+
+describe("buildDatabaseBackupAlertContent", () => {
+  it("builds a failure alert carrying the exact (redacted) error and timestamp", () => {
+    const { title, description } = buildDatabaseBackupAlertContent({
+      reason: "failure",
+      message: "pg_dump: error: server version mismatch",
+      at: FIXED_NOW,
+    });
+    expect(title).toBe("Control-plane database backup is failing");
+    expect(description).toContain("server version mismatch");
+    expect(description).toContain("2026-09-07T12:00:00.000Z");
+    expect(description).toContain(DATABASE_BACKUP_ALERT_FINGERPRINT);
+  });
+
+  it("includes each warning code in the health-driven alert", () => {
+    const { title, description } = buildDatabaseBackupAlertContent({
+      reason: "health",
+      message: "stale",
+      warnings: [
+        { code: "database_backup_stale", message: "Latest database backup is 240h old, exceeding 36h." },
+      ],
+      at: FIXED_NOW,
+    });
+    expect(title).toBe("Control-plane database backup is unhealthy");
+    expect(description).toContain("database_backup_stale");
+    expect(description).toContain("240h old");
+  });
+});
+
+describe("summarizeDatabaseBackupWarnings", () => {
+  it("joins warning messages", () => {
+    expect(
+      summarizeDatabaseBackupWarnings([
+        { code: "database_backup_missing", message: "No backups found." },
+        { code: "database_backup_stale", message: "Too old." },
+      ]),
+    ).toBe("No backups found. Too old.");
+  });
+});
+
+describe("raiseDatabaseBackupAlert (idempotency / dedup)", () => {
+  it("creates the alert when none is open", async () => {
+    const { board, records } = createFakeBoard();
+    const result = await raiseDatabaseBackupAlert(board, {
+      companyId: "c1",
+      fingerprint: DATABASE_BACKUP_ALERT_FINGERPRINT,
+      title: "t",
+      description: "d",
+      updateComment: "again",
+    });
+    expect(result.action).toBe("created");
+    expect(records).toHaveLength(1);
+  });
+
+  it("never spawns a duplicate; updates the open issue with a comment", async () => {
+    const { board, records } = createFakeBoard();
+    await raiseDatabaseBackupAlert(board, {
+      companyId: "c1",
+      fingerprint: DATABASE_BACKUP_ALERT_FINGERPRINT,
+      title: "t",
+      description: "d",
+      updateComment: "cycle 1",
+    });
+    const second = await raiseDatabaseBackupAlert(board, {
+      companyId: "c1",
+      fingerprint: DATABASE_BACKUP_ALERT_FINGERPRINT,
+      title: "t",
+      description: "d",
+      updateComment: "cycle 2",
+    });
+    expect(second.action).toBe("updated");
+    expect(records).toHaveLength(1);
+    expect(records[0]!.comments).toEqual(["cycle 2"]);
+  });
+
+  it("creates a NEW open alert for a second incident after the first was resolved (no shadow by a done issue)", async () => {
+    // Regression for SIN-70819: a resolved (`done`) alert must not be reused for
+    // a later incident. Previously a static idempotencyKey survived resolution
+    // (7-day retention) and dedup-hit the closed issue, so a genuine second
+    // failure reported `created` with NO open board alert — the exact A09 gap.
+    const { board, records } = createFakeBoard();
+    const first = await raiseDatabaseBackupAlert(board, {
+      companyId: "c1",
+      fingerprint: DATABASE_BACKUP_ALERT_FINGERPRINT,
+      title: "Control-plane database backup is failing",
+      description: "d",
+      updateComment: "incident 1",
+    });
+    expect(first.action).toBe("created");
+
+    // Backup recovers → the open alert is resolved to done.
+    await resolveDatabaseBackupAlert(board, {
+      companyId: "c1",
+      fingerprint: DATABASE_BACKUP_ALERT_FINGERPRINT,
+      comment: "fixed",
+    });
+    expect(records[0]!.status).toBe("done");
+
+    // It fails again within the old 7-day idempotency-retention window.
+    const second = await raiseDatabaseBackupAlert(board, {
+      companyId: "c1",
+      fingerprint: DATABASE_BACKUP_ALERT_FINGERPRINT,
+      title: "Control-plane database backup is failing",
+      description: "d",
+      updateComment: "incident 2",
+    });
+    // A brand-new OPEN alert, not the resolved one.
+    expect(second.action).toBe("created");
+    expect(second.issueId).not.toBe(first.issueId);
+    expect(records).toHaveLength(2);
+    expect(records[1]!.status).toBe("todo");
+  });
+
+  it("leaves an open issue untouched when no updateComment is supplied (no comment storm)", async () => {
+    const { board, records } = createFakeBoard();
+    await raiseDatabaseBackupAlert(board, {
+      companyId: "c1",
+      fingerprint: DATABASE_BACKUP_ALERT_FINGERPRINT,
+      title: "t",
+      description: "d",
+    });
+    const second = await raiseDatabaseBackupAlert(board, {
+      companyId: "c1",
+      fingerprint: DATABASE_BACKUP_ALERT_FINGERPRINT,
+      title: "t",
+      description: "d",
+    });
+    expect(second.action).toBe("exists");
+    expect(records).toHaveLength(1);
+    expect(records[0]!.comments).toEqual([]);
+  });
+});
+
+describe("resolveDatabaseBackupAlert", () => {
+  it("resolves the open alert and no-ops when none is open", async () => {
+    const { board, records } = createFakeBoard();
+    await raiseDatabaseBackupAlert(board, {
+      companyId: "c1",
+      fingerprint: DATABASE_BACKUP_ALERT_FINGERPRINT,
+      title: "t",
+      description: "d",
+    });
+    const resolved = await resolveDatabaseBackupAlert(board, {
+      companyId: "c1",
+      fingerprint: DATABASE_BACKUP_ALERT_FINGERPRINT,
+      comment: "fixed",
+    });
+    expect(resolved.action).toBe("resolved");
+    expect(records[0]!.status).toBe("done");
+
+    const again = await resolveDatabaseBackupAlert(board, {
+      companyId: "c1",
+      fingerprint: DATABASE_BACKUP_ALERT_FINGERPRINT,
+      comment: "fixed",
+    });
+    expect(again.action).toBe("noop");
+  });
+});
+
+describe("failure marker (fs) integrates with the pure inspector", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "pc-backup-marker-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes the exact error as the first line and a timestamp, read back as last_failure", () => {
+    const markerFile = join(dir, "health", "db-backup-to-s3.failure");
+    writeDatabaseBackupFailureMarker(
+      markerFile,
+      "pg_dump: error: server version mismatch",
+      FIXED_NOW,
+    );
+    const contents = readFileSync(markerFile, "utf8");
+    expect(contents.split(/\r?\n/)[0]).toBe("pg_dump: error: server version mismatch");
+    expect(contents).toContain("failedAt=2026-09-07T12:00:00.000Z");
+
+    const status = inspectDatabaseBackupHealth({
+      enabled: true,
+      backupDir: join(dir, "backups"),
+      maxAgeHours: 36,
+      alertFile: markerFile,
+      now: FIXED_NOW,
+    });
+    expect(status.status).toBe("warning");
+    expect(status.lastFailure?.message).toBe("pg_dump: error: server version mismatch");
+    expect(status.warnings.map((w) => w.code)).toContain("database_backup_last_failure");
+  });
+
+  it("redacts a connection string before persisting it in the marker", () => {
+    const markerFile = join(dir, "db-backup-to-s3.failure");
+    writeDatabaseBackupFailureMarker(
+      markerFile,
+      "connection to postgres://user:s3cr3t@db:5432/paperclip refused",
+      FIXED_NOW,
+    );
+    const contents = readFileSync(markerFile, "utf8");
+    expect(contents).not.toContain("s3cr3t");
+    expect(contents).toContain("postgres://[redacted]");
+  });
+
+  it("clears every candidate marker path", () => {
+    const a = join(dir, "a.failure");
+    const b = join(dir, "b.failure");
+    writeDatabaseBackupFailureMarker(a, "x", FIXED_NOW);
+    writeDatabaseBackupFailureMarker(b, "y", FIXED_NOW);
+    clearDatabaseBackupFailureMarkers([a, b, join(dir, "missing.failure")]);
+    expect(existsSync(a)).toBe(false);
+    expect(existsSync(b)).toBe(false);
+  });
+});
+
+describe("createDatabaseBackupAlertReporter (defense-in-depth)", () => {
+  let dir: string;
+  let markerFile: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "pc-backup-reporter-"));
+    markerFile = join(dir, "health", "db-backup-to-s3.failure");
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reportFailure writes the marker AND raises the board issue", async () => {
+    const { board, records } = createFakeBoard();
+    const reporter = createDatabaseBackupAlertReporter({
+      markerFile,
+      clearMarkerFiles: [markerFile],
+      board,
+      companyId: "c1",
+      now: () => FIXED_NOW,
+    });
+    await reporter.reportFailure("pg_dump: error: server version mismatch");
+    expect(existsSync(markerFile)).toBe(true);
+    expect(records).toHaveLength(1);
+    expect(records[0]!.description).toContain("server version mismatch");
+  });
+
+  it("reportFailure still writes the marker when the board channel throws", async () => {
+    const { board, records } = createFakeBoard({ failCreate: true });
+    const reporter = createDatabaseBackupAlertReporter({
+      markerFile,
+      clearMarkerFiles: [markerFile],
+      board,
+      companyId: "c1",
+      now: () => FIXED_NOW,
+    });
+    // Must not throw — a board failure cannot mask the backup failure signal.
+    await expect(reporter.reportFailure("boom")).resolves.toBeUndefined();
+    expect(existsSync(markerFile)).toBe(true);
+    expect(records).toHaveLength(0);
+  });
+
+  it("reportFailure works with no board (marker-only channel)", async () => {
+    const reporter = createDatabaseBackupAlertReporter({
+      markerFile,
+      clearMarkerFiles: [markerFile],
+      board: null,
+      companyId: null,
+      now: () => FIXED_NOW,
+    });
+    await reporter.reportFailure("no board here");
+    expect(readFileSync(markerFile, "utf8").split(/\r?\n/)[0]).toBe("no board here");
+  });
+
+  it("reportSuccess clears the marker and resolves the open alert", async () => {
+    const { board, records } = createFakeBoard();
+    const reporter = createDatabaseBackupAlertReporter({
+      markerFile,
+      clearMarkerFiles: [markerFile],
+      board,
+      companyId: "c1",
+      now: () => FIXED_NOW,
+    });
+    await reporter.reportFailure("pg_dump: error: server version mismatch");
+    expect(existsSync(markerFile)).toBe(true);
+    expect(records[0]!.status).toBe("todo");
+
+    await reporter.reportSuccess();
+    expect(existsSync(markerFile)).toBe(false);
+    expect(records[0]!.status).toBe("done");
+  });
+
+  it("reportFailure → reportSuccess → reportFailure raises a fresh open alert for the second incident", async () => {
+    // End-to-end (marker + board channels) regression for SIN-70819: backup
+    // flapping (fail → recover → fail) must produce a NEW open board alert on
+    // the second failure, never silently reuse the resolved one.
+    const { board, records } = createFakeBoard();
+    const reporter = createDatabaseBackupAlertReporter({
+      markerFile,
+      clearMarkerFiles: [markerFile],
+      board,
+      companyId: "c1",
+      now: () => FIXED_NOW,
+    });
+
+    await reporter.reportFailure("pg_dump: error: server version mismatch");
+    expect(records).toHaveLength(1);
+    expect(records[0]!.status).toBe("todo");
+
+    await reporter.reportSuccess();
+    expect(existsSync(markerFile)).toBe(false);
+    expect(records[0]!.status).toBe("done");
+
+    await reporter.reportFailure("pg_dump: error: server version mismatch (again)");
+    // A second OPEN alert exists — the resolved one was not reused.
+    expect(records).toHaveLength(2);
+    expect(records[1]!.status).toBe("todo");
+    expect(records[1]!.description).toContain("server version mismatch");
+    expect(existsSync(markerFile)).toBe(true);
+  });
+
+  it("reportHealthWarnings creates one issue for a warning status and never duplicates on repeat ticks", async () => {
+    const { board, records } = createFakeBoard();
+    const reporter = createDatabaseBackupAlertReporter({
+      markerFile,
+      clearMarkerFiles: [markerFile],
+      board,
+      companyId: "c1",
+      now: () => FIXED_NOW,
+    });
+    const staleStatus = {
+      enabled: true,
+      status: "warning" as const,
+      backupDir: "/tmp/backups",
+      maxAgeHours: 36,
+      latestBackup: null,
+      lastFailure: null,
+      warnings: [
+        { code: "database_backup_stale" as const, message: "Latest database backup is 240h old, exceeding 36h." },
+      ],
+    };
+    await reporter.reportHealthWarnings(staleStatus);
+    await reporter.reportHealthWarnings(staleStatus);
+    expect(records).toHaveLength(1);
+    // No comment storm: the ensure-exists path must not append per-tick comments.
+    expect(records[0]!.comments).toEqual([]);
+  });
+
+  it("reportHealthWarnings is a no-op for an ok status", async () => {
+    const { board, records } = createFakeBoard();
+    const reporter = createDatabaseBackupAlertReporter({
+      markerFile,
+      clearMarkerFiles: [markerFile],
+      board,
+      companyId: "c1",
+      now: () => FIXED_NOW,
+    });
+    await reporter.reportHealthWarnings({
+      enabled: true,
+      status: "ok",
+      backupDir: "/tmp/backups",
+      maxAgeHours: 36,
+      latestBackup: null,
+      lastFailure: null,
+      warnings: [],
+    });
+    expect(records).toHaveLength(0);
+  });
+});

--- a/server/src/__tests__/pgclient-version-preflight.test.ts
+++ b/server/src/__tests__/pgclient-version-preflight.test.ts
@@ -1,0 +1,372 @@
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { DatabaseBackupAlertBoard } from "../services/database-backup-alerts.js";
+import {
+  PGCLIENT_VERSION_ALERT_FINGERPRINT,
+  buildPgClientVersionAlertContent,
+  comparePgMajor,
+  createPgClientVersionPreflightReporter,
+  defaultPgClientVersionPreflightIo,
+  inspectPgClientVersion,
+  parsePgDumpVersionOutput,
+  parsePgVersionFileContent,
+  type PgClientVersionPreflightIo,
+} from "../services/pgclient-version-preflight.js";
+
+const AT = new Date("2026-09-10T12:00:00.000Z");
+
+function enoent(): NodeJS.ErrnoException {
+  const err = new Error("spawn pg_dump ENOENT") as NodeJS.ErrnoException;
+  err.code = "ENOENT";
+  return err;
+}
+
+/** Fake board mirroring the SIN-70819 concrete-adapter semantics (fingerprint
+ * dedup, non-terminal-title create guard, resolve-to-done). */
+function createFakeBoard() {
+  type Rec = { id: string; status: string; fingerprint: string; title: string; comments: string[] };
+  const records: Rec[] = [];
+  let counter = 0;
+  const board: DatabaseBackupAlertBoard = {
+    async findOpenAlert(_companyId, fingerprint) {
+      const open = records.find(
+        (r) => r.fingerprint === fingerprint && r.status !== "done" && r.status !== "cancelled",
+      );
+      return open ? { id: open.id, identifier: null, status: open.status } : null;
+    },
+    async createAlert(_companyId, input) {
+      const openSameTitle = records.find(
+        (r) => r.title === input.title && r.status !== "done" && r.status !== "cancelled",
+      );
+      if (openSameTitle) return { id: openSameTitle.id, identifier: null, status: openSameTitle.status };
+      counter += 1;
+      const rec: Rec = {
+        id: `issue-${counter}`,
+        status: "todo",
+        fingerprint: input.fingerprint,
+        title: input.title,
+        comments: [],
+      };
+      records.push(rec);
+      return { id: rec.id, identifier: null, status: rec.status };
+    },
+    async commentAlert(issueId, body) {
+      records.find((r) => r.id === issueId)?.comments.push(body);
+    },
+    async resolveAlert(issueId, body) {
+      const rec = records.find((r) => r.id === issueId);
+      if (rec) {
+        rec.comments.push(body);
+        rec.status = "done";
+      }
+    },
+  };
+  return { board, records };
+}
+
+function io(overrides: Partial<PgClientVersionPreflightIo>): PgClientVersionPreflightIo {
+  return {
+    async readServerVersion() {
+      return "18\n";
+    },
+    async readClientVersion() {
+      return "pg_dump (PostgreSQL) 18.1\n";
+    },
+    ...overrides,
+  };
+}
+
+describe("defaultPgClientVersionPreflightIo", () => {
+  const tmpDirs: string[] = [];
+  afterEach(() => {
+    while (tmpDirs.length) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+  });
+  function mkTmp(): string {
+    const dir = mkdtempSync(join(tmpdir(), "pgclient-preflight-"));
+    tmpDirs.push(dir);
+    return dir;
+  }
+
+  it("readServerVersion returns file contents, or null when absent", async () => {
+    const dir = mkTmp();
+    expect(await defaultPgClientVersionPreflightIo.readServerVersion(dir)).toBeNull();
+    writeFileSync(join(dir, "PG_VERSION"), "18\n", "utf8");
+    expect((await defaultPgClientVersionPreflightIo.readServerVersion(dir))?.trim()).toBe("18");
+  });
+
+  it("readClientVersion spawns the resolved binary and returns its output", async () => {
+    const dir = mkTmp();
+    const fake = join(dir, "fake-pg_dump");
+    writeFileSync(fake, "#!/bin/sh\necho 'pg_dump (PostgreSQL) 18.1'\n", "utf8");
+    chmodSync(fake, 0o755);
+    const out = await defaultPgClientVersionPreflightIo.readClientVersion(fake);
+    expect(out).toContain("pg_dump (PostgreSQL) 18.1");
+  });
+
+  it("readClientVersion rejects with ENOENT when the binary is missing", async () => {
+    await expect(
+      defaultPgClientVersionPreflightIo.readClientVersion("/no/such/pg_dump-xyz"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("inspectPgClientVersion end-to-end through the default IO (mismatch)", async () => {
+    const dir = mkTmp();
+    writeFileSync(join(dir, "PG_VERSION"), "18\n", "utf8");
+    const fake = join(dir, "fake-pg_dump");
+    writeFileSync(fake, "#!/bin/sh\necho 'pg_dump (PostgreSQL) 16.4'\n", "utf8");
+    chmodSync(fake, 0o755);
+    const r = await inspectPgClientVersion({ dataDir: dir, pgDumpPath: fake });
+    expect(r.outcome).toBe("mismatch");
+  });
+});
+
+describe("parsePgDumpVersionOutput", () => {
+  const cases: Array<[string, number | null]> = [
+    ["pg_dump (PostgreSQL) 18.1", 18],
+    ["pg_dump (PostgreSQL) 18.1\n", 18],
+    ["pg_dump (PostgreSQL) 16.4 (Ubuntu 16.4-1.pgdg22.04+1)", 16],
+    ["pg_dump (PostgreSQL) 9.6.24", 9],
+    ["", null],
+    ["not a version string", null],
+  ];
+  it.each(cases)("parses %j -> %j", (input, expected) => {
+    expect(parsePgDumpVersionOutput(input)).toBe(expected);
+  });
+});
+
+describe("parsePgVersionFileContent", () => {
+  const cases: Array<[string, number | null]> = [
+    ["18", 18],
+    ["18\n", 18],
+    ["  16 \n", 16],
+    ["9.6", 9],
+    ["", null],
+    ["\n\n", null],
+    ["garbage", null],
+  ];
+  it.each(cases)("parses %j -> %j", (input, expected) => {
+    expect(parsePgVersionFileContent(input)).toBe(expected);
+  });
+});
+
+describe("comparePgMajor", () => {
+  it("18 vs 18 -> ok", () => {
+    const d = comparePgMajor("pg_dump (PostgreSQL) 18.1", "18\n");
+    expect(d).toEqual({ status: "ok", clientMajor: 18, serverMajor: 18 });
+  });
+
+  it("16 client vs 18 server -> mismatch, clientBehind (the silent-kill case)", () => {
+    const d = comparePgMajor("pg_dump (PostgreSQL) 16.4", "18");
+    expect(d.status).toBe("mismatch");
+    if (d.status !== "mismatch") throw new Error("unreachable");
+    expect(d.clientMajor).toBe(16);
+    expect(d.serverMajor).toBe(18);
+    expect(d.clientBehind).toBe(true);
+    expect(d.message).toContain("OLDER");
+  });
+
+  it("19 client vs 18 server -> mismatch, not clientBehind", () => {
+    const d = comparePgMajor("pg_dump (PostgreSQL) 19.0", "18");
+    expect(d.status).toBe("mismatch");
+    if (d.status !== "mismatch") throw new Error("unreachable");
+    expect(d.clientBehind).toBe(false);
+  });
+
+  it("unparseable client -> unparseable", () => {
+    const d = comparePgMajor("garbage", "18");
+    expect(d.status).toBe("unparseable");
+    if (d.status !== "unparseable") throw new Error("unreachable");
+    expect(d.clientMajor).toBeNull();
+    expect(d.serverMajor).toBe(18);
+  });
+});
+
+describe("inspectPgClientVersion", () => {
+  it("matching majors -> ok", async () => {
+    const r = await inspectPgClientVersion({ dataDir: "/d", pgDumpPath: "pg_dump", io: io({}) });
+    expect(r).toEqual({ outcome: "ok", clientMajor: 18, serverMajor: 18 });
+  });
+
+  it("client older than server -> mismatch", async () => {
+    const r = await inspectPgClientVersion({
+      dataDir: "/d",
+      pgDumpPath: "pg_dump",
+      io: io({ async readClientVersion() {
+        return "pg_dump (PostgreSQL) 16.4";
+      } }),
+    });
+    expect(r.outcome).toBe("mismatch");
+    if (r.outcome !== "mismatch") throw new Error("unreachable");
+    expect(r.clientMajor).toBe(16);
+    expect(r.serverMajor).toBe(18);
+  });
+
+  it("pg_dump ENOENT -> client_missing", async () => {
+    const r = await inspectPgClientVersion({
+      dataDir: "/d",
+      pgDumpPath: "/no/such/pg_dump",
+      io: io({ async readClientVersion() {
+        throw enoent();
+      } }),
+    });
+    expect(r.outcome).toBe("client_missing");
+    if (r.outcome !== "client_missing") throw new Error("unreachable");
+    expect(r.pgDumpPath).toBe("/no/such/pg_dump");
+  });
+
+  it("non-ENOENT read failure -> unparseable", async () => {
+    const r = await inspectPgClientVersion({
+      dataDir: "/d",
+      pgDumpPath: "pg_dump",
+      io: io({ async readClientVersion() {
+        throw new Error("timed out");
+      } }),
+    });
+    expect(r.outcome).toBe("unparseable");
+  });
+
+  it("missing PG_VERSION -> skipped (no board noise)", async () => {
+    const r = await inspectPgClientVersion({
+      dataDir: "/d",
+      pgDumpPath: "pg_dump",
+      io: io({ async readServerVersion() {
+        return null;
+      } }),
+    });
+    expect(r.outcome).toBe("skipped");
+  });
+});
+
+describe("buildPgClientVersionAlertContent", () => {
+  it("mismatch content names both majors, recovery, and fingerprint", () => {
+    const { title, description } = buildPgClientVersionAlertContent(
+      { outcome: "mismatch", clientMajor: 16, serverMajor: 18, message: "client older" },
+      AT,
+      "pg_dump",
+    );
+    expect(title).toContain("pg_dump client");
+    expect(description).toContain("**16**");
+    expect(description).toContain("**18**");
+    expect(description).toContain("dpkg -x");
+    expect(description).toContain(PGCLIENT_VERSION_ALERT_FINGERPRINT);
+  });
+
+  it("never leaks a connection string (A09)", () => {
+    const { description } = buildPgClientVersionAlertContent(
+      { outcome: "client_missing", pgDumpPath: "pg_dump", message: "missing" },
+      AT,
+      "pg_dump",
+    );
+    expect(description).not.toMatch(/postgres(?:ql)?:\/\//i);
+  });
+});
+
+describe("createPgClientVersionPreflightReporter", () => {
+  it("raises a single deduped board alert on mismatch and resolves it once fixed", async () => {
+    const { board, records } = createFakeBoard();
+
+    // First run: client behind -> alert raised.
+    const mismatchReporter = createPgClientVersionPreflightReporter({
+      dataDir: "/d",
+      pgDumpPath: "pg_dump",
+      board,
+      companyId: "company-1",
+      now: () => AT,
+      io: io({ async readClientVersion() {
+        return "pg_dump (PostgreSQL) 16.4";
+      } }),
+    });
+    const first = await mismatchReporter.run();
+    expect(first.outcome).toBe("mismatch");
+    expect(records).toHaveLength(1);
+    expect(records[0]!.fingerprint).toBe(PGCLIENT_VERSION_ALERT_FINGERPRINT);
+    expect(records[0]!.status).toBe("todo");
+
+    // Second mismatch run: no duplicate issue.
+    await mismatchReporter.run();
+    expect(records).toHaveLength(1);
+
+    // Client upgraded -> ok run resolves the open alert.
+    const okReporter = createPgClientVersionPreflightReporter({
+      dataDir: "/d",
+      pgDumpPath: "pg_dump",
+      board,
+      companyId: "company-1",
+      now: () => AT,
+      io: io({}),
+    });
+    const fixed = await okReporter.run();
+    expect(fixed.outcome).toBe("ok");
+    expect(records[0]!.status).toBe("done");
+  });
+
+  it("client_missing raises an alert too", async () => {
+    const { board, records } = createFakeBoard();
+    const reporter = createPgClientVersionPreflightReporter({
+      dataDir: "/d",
+      pgDumpPath: "/no/such/pg_dump",
+      board,
+      companyId: "company-1",
+      now: () => AT,
+      io: io({ async readClientVersion() {
+        throw enoent();
+      } }),
+    });
+    const r = await reporter.run();
+    expect(r.outcome).toBe("client_missing");
+    expect(records).toHaveLength(1);
+  });
+
+  it("ok with no open alert is a no-op on the board", async () => {
+    const { board, records } = createFakeBoard();
+    const reporter = createPgClientVersionPreflightReporter({
+      dataDir: "/d",
+      pgDumpPath: "pg_dump",
+      board,
+      companyId: "company-1",
+      now: () => AT,
+      io: io({}),
+    });
+    await reporter.run();
+    expect(records).toHaveLength(0);
+  });
+
+  it("null board (channel off) still returns the decision without throwing", async () => {
+    const reporter = createPgClientVersionPreflightReporter({
+      dataDir: "/d",
+      pgDumpPath: "pg_dump",
+      board: null,
+      companyId: null,
+      now: () => AT,
+      io: io({ async readClientVersion() {
+        return "pg_dump (PostgreSQL) 16.4";
+      } }),
+    });
+    const r = await reporter.run();
+    expect(r.outcome).toBe("mismatch");
+  });
+
+  it("a board push failure never throws out of run()", async () => {
+    const { board } = createFakeBoard();
+    const throwingBoard: DatabaseBackupAlertBoard = {
+      ...board,
+      async findOpenAlert() {
+        throw new Error("board down");
+      },
+    };
+    const reporter = createPgClientVersionPreflightReporter({
+      dataDir: "/d",
+      pgDumpPath: "pg_dump",
+      board: throwingBoard,
+      companyId: "company-1",
+      now: () => AT,
+      io: io({ async readClientVersion() {
+        return "pg_dump (PostgreSQL) 16.4";
+      } }),
+    });
+    const r = await reporter.run();
+    expect(r.outcome).toBe("mismatch");
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -13,7 +13,7 @@ import { stdin, stdout } from "node:process";
 import { pathToFileURL } from "node:url";
 import type { Request as ExpressRequest, RequestHandler } from "express";
 import { warnIfUnsupportedNodeVersion } from "@paperclipai/shared/node-version";
-import { and, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import {
   createDb,
   ensurePostgresDatabase,
@@ -87,6 +87,13 @@ import {
 } from "./services/device-login-reaper.js";
 import { createProductionSetupTokenReaper } from "./services/setup-token-reaper.js";
 import { resolveWorktreeRunExecutionActivationState } from "./services/instance-settings.js";
+import { inspectDatabaseBackupHealth } from "./services/database-backup-health.js";
+import { createDatabaseBackupAlertReporter } from "./services/database-backup-alerts.js";
+// NOTE: database-backup-alert-board pulls in the issues service (and its
+// transitive `heartbeatRuns` drizzle table access via successful-run-handoff-state).
+// It is loaded lazily at boot only when board alerting is actually enabled, so
+// importing this entrypoint (e.g. in startServer tests that mock @paperclipai/db
+// without every table export) never evaluates that heavy graph.
 import {
   parseAdapterRegistryEnv,
   reconcileAdapterAvailability,
@@ -753,6 +760,35 @@ export async function startServer(): Promise<StartedServer> {
     resolve(config.databaseBackupDir, "db-backup-to-s3.failure"),
     resolve(config.databaseBackupDir, "..", "db-backup-to-s3.failure"),
   ];
+  // SIN-70819: turn a silent backup failure into a LOUD board signal. Resolve the
+  // company whose board receives the alert — an explicit override, else the
+  // oldest active company (the instance's primary board). No company (or backups
+  // disabled) leaves the board channel off; the marker + structured log still fire.
+  const databaseBackupAlertCompanyId: string | null = config.databaseBackupEnabled
+    ? (process.env.PAPERCLIP_DB_BACKUP_ALERT_COMPANY_ID?.trim() ||
+        (await db
+          .select({ id: companies.id })
+          .from(companies)
+          .where(eq(companies.status, "active"))
+          .orderBy(asc(companies.createdAt), asc(companies.id))
+          .limit(1)
+          .then((rows) => rows[0]?.id ?? null))) ??
+      null
+    : null;
+  const databaseBackupAlertBoard =
+    config.databaseBackupEnabled && databaseBackupAlertCompanyId
+      ? (await import("./services/database-backup-alert-board.js")).createDatabaseBackupAlertBoard(
+          db,
+          { priority: "high" },
+        )
+      : null;
+  const databaseBackupAlertReporter = createDatabaseBackupAlertReporter({
+    markerFile: databaseBackupAlertFile,
+    clearMarkerFiles: databaseBackupAlertFiles,
+    board: databaseBackupAlertBoard,
+    companyId: databaseBackupAlertCompanyId,
+    logger,
+  });
   let databaseBackupInFlight = false;
   const runServerDatabaseBackup = async (
     trigger: InstanceDatabaseBackupTrigger,
@@ -781,6 +817,13 @@ export async function startServer(): Promise<StartedServer> {
         backupDir: config.databaseBackupDir,
         retention,
         filenamePrefix: "paperclip",
+        // SIN-70819 AC2: never let the auto-engine fallback swallow the real
+        // pg_dump error (e.g. server-version mismatch) — log it loudly.
+        onEngineFallback: (error) =>
+          logger.warn(
+            { err: error, backupDir: config.databaseBackupDir, trigger },
+            "pg_dump backup failed; falling back to JavaScript backup engine",
+          ),
       });
       const finishedAt = new Date();
       const response: InstanceDatabaseBackupRunResult = {
@@ -804,9 +847,19 @@ export async function startServer(): Promise<StartedServer> {
         },
         `${label} database backup complete: ${formatDatabaseBackupResult(result)}`,
       );
+      // SIN-70819 AC1: a healthy backup clears the failure marker and resolves any
+      // open board alert. Guarded internally so it never masks the backup result.
+      await databaseBackupAlertReporter.reportSuccess();
       return response;
     } catch (err) {
       logger.error({ err, backupDir: config.databaseBackupDir, trigger }, `${label} database backup failed`);
+      // SIN-70819 AC1: on a scheduled-backup failure raise the LOUD signal —
+      // marker (exact error + timestamp) + structured log + idempotent board issue.
+      // Manual failures surface directly to the API caller, so only scheduled runs
+      // need the durable board alert. Guarded so it never replaces the real error.
+      if (trigger === "scheduled") {
+        await databaseBackupAlertReporter.reportFailure(err instanceof Error ? err.message : String(err));
+      }
       throw err;
     } finally {
       databaseBackupInFlight = false;
@@ -1739,8 +1792,35 @@ export async function startServer(): Promise<StartedServer> {
         // runServerDatabaseBackup already logs the failure with context.
       });
     }, backupIntervalMs);
+
+    // SIN-70819 AC3: defense-in-depth staleness detector. Independently of the
+    // failure path above, periodically inspect backup health and bridge any
+    // `warning` status (e.g. newest .gz older than the max-age threshold, or a
+    // failure marker present) to the same idempotent board alert. This catches
+    // failures that never threw — the exact gap that hid the 9-day outage.
+    const backupHealthCheckIntervalMs =
+      Math.max(1, Number(process.env.PAPERCLIP_DB_BACKUP_HEALTH_CHECK_INTERVAL_MINUTES) || 60) * 60 * 1000;
+    const runDatabaseBackupHealthBridge = async () => {
+      try {
+        const status = inspectDatabaseBackupHealth({
+          enabled: config.databaseBackupEnabled,
+          backupDir: config.databaseBackupDir,
+          maxAgeHours: databaseBackupMaxAgeHours,
+          alertFile: databaseBackupAlertFile,
+          alertFiles: databaseBackupAlertFiles,
+        });
+        await databaseBackupAlertReporter.reportHealthWarnings(status);
+      } catch (err) {
+        logger.error({ err }, "database backup health bridge tick failed");
+      }
+    };
+    // Run once at startup so an already-stale instance alerts immediately.
+    void runDatabaseBackupHealthBridge();
+    setInterval(() => {
+      void runDatabaseBackupHealthBridge();
+    }, backupHealthCheckIntervalMs);
   }
-  
+
   // Wait for external adapters to finish loading before accepting requests.
   // Without this, adapter type validation (assertKnownAdapterType) would
   // reject valid external adapter types during the startup loading window.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -89,6 +89,7 @@ import { createProductionSetupTokenReaper } from "./services/setup-token-reaper.
 import { resolveWorktreeRunExecutionActivationState } from "./services/instance-settings.js";
 import { inspectDatabaseBackupHealth } from "./services/database-backup-health.js";
 import { createDatabaseBackupAlertReporter } from "./services/database-backup-alerts.js";
+import { createPgClientVersionPreflightReporter } from "./services/pgclient-version-preflight.js";
 // NOTE: database-backup-alert-board pulls in the issues service (and its
 // transitive `heartbeatRuns` drizzle table access via successful-run-handoff-state).
 // It is loaded lazily at boot only when board alerting is actually enabled, so
@@ -1819,6 +1820,36 @@ export async function startServer(): Promise<StartedServer> {
     setInterval(() => {
       void runDatabaseBackupHealthBridge();
     }, backupHealthCheckIntervalMs);
+
+    // SIN-70820: anti-regression preflight for the SIN-70814 invariant — the
+    // embedded PostgreSQL major MUST match the host `postgresql-client` major, or
+    // pg_dump silently refuses to back up the server (the 9-day silent outage).
+    // Only meaningful in embedded mode, where the server major lives in
+    // <dataDir>/PG_VERSION. Resolve pg_dump the same way backup-lib does and
+    // compare majors; on divergence push a LOUD alert through the SIN-70819
+    // adapter (distinct fingerprint). Read-only + alert, never a boot hard-stop.
+    if (startupDbInfo.mode === "embedded-postgres") {
+      const pgClientVersionPreflight = createPgClientVersionPreflightReporter({
+        dataDir: startupDbInfo.dataDir,
+        pgDumpPath: process.env.PAPERCLIP_PG_DUMP_PATH || "pg_dump",
+        board: databaseBackupAlertBoard,
+        companyId: databaseBackupAlertCompanyId,
+        logger,
+      });
+      const runPgClientVersionPreflight = async () => {
+        try {
+          await pgClientVersionPreflight.run();
+        } catch (err) {
+          logger.error({ err }, "pg_dump client-major preflight tick failed");
+        }
+      };
+      // Run once at boot, then re-check on the same cadence as the health bridge
+      // so a later drift (or its fix) is picked up without a restart.
+      void runPgClientVersionPreflight();
+      setInterval(() => {
+        void runPgClientVersionPreflight();
+      }, backupHealthCheckIntervalMs);
+    }
   }
 
   // Wait for external adapters to finish loading before accepting requests.

--- a/server/src/services/database-backup-alert-board.ts
+++ b/server/src/services/database-backup-alert-board.ts
@@ -1,0 +1,81 @@
+import { and, asc, eq, isNull, notInArray } from "drizzle-orm";
+import type { Db } from "@paperclipai/db";
+import { issues } from "@paperclipai/db";
+import { issueService } from "./issues.js";
+import {
+  DATABASE_BACKUP_ALERT_ORIGIN_KIND,
+  type DatabaseBackupAlertBoard,
+} from "./database-backup-alerts.js";
+
+const TERMINAL_ISSUE_STATUSES = ["done", "cancelled"];
+
+/**
+ * Concrete adapter implementing the `DatabaseBackupAlertBoard` port over the
+ * issues service. Kept thin: the idempotent create-vs-update decision lives in
+ * the pure bridge (`database-backup-alerts.ts`); this only translates port calls
+ * into storage operations.
+ */
+export function createDatabaseBackupAlertBoard(
+  db: Db,
+  opts: { priority?: "critical" | "high" | "medium" | "low"; assigneeAgentId?: string | null } = {},
+): DatabaseBackupAlertBoard {
+  const svc = issueService(db);
+  const priority = opts.priority ?? "high";
+
+  return {
+    async findOpenAlert(companyId, fingerprint) {
+      return db
+        .select({ id: issues.id, identifier: issues.identifier, status: issues.status })
+        .from(issues)
+        .where(
+          and(
+            eq(issues.companyId, companyId),
+            eq(issues.originKind, DATABASE_BACKUP_ALERT_ORIGIN_KIND),
+            eq(issues.originFingerprint, fingerprint),
+            isNull(issues.hiddenAt),
+            notInArray(issues.status, TERMINAL_ISSUE_STATUSES),
+          ),
+        )
+        .orderBy(asc(issues.createdAt), asc(issues.id))
+        .limit(1)
+        .then((rows) => rows[0] ?? null);
+    },
+
+    async createAlert(companyId, input) {
+      // `allowDuplicate: false` — NOT a static idempotencyKey. The idempotency
+      // key dedup in `issueService.create` matches on (company, key) regardless
+      // of status and retains the key for 7 days, so a key from a resolved
+      // (`done`) alert would shadow a genuine second incident and report
+      // `created` with no open board issue — the exact OWASP A09 gap SIN-70819
+      // closes. `allowDuplicate: false` instead takes an advisory lock and
+      // dedups only against a NON-terminal recent-open-title issue, which guards
+      // the create-race without shadowing a resolved alert.
+      const created = await svc.create(companyId, {
+        title: input.title,
+        description: input.description,
+        status: "todo",
+        priority,
+        originKind: DATABASE_BACKUP_ALERT_ORIGIN_KIND,
+        originId: companyId,
+        originFingerprint: input.fingerprint,
+        allowDuplicate: false,
+        assigneeAgentId: opts.assigneeAgentId ?? undefined,
+      });
+      return {
+        id: created.id,
+        identifier: created.identifier ?? null,
+        status: created.status,
+      };
+    },
+
+    async commentAlert(issueId, body) {
+      await svc.addComment(issueId, body, { runId: null }, { authorType: "system" });
+    },
+
+    async resolveAlert(issueId, body) {
+      // Comment first so the resolution trail lands before the issue closes.
+      await svc.addComment(issueId, body, { runId: null }, { authorType: "system" });
+      await svc.update(issueId, { status: "done" });
+    },
+  };
+}

--- a/server/src/services/database-backup-alerts.ts
+++ b/server/src/services/database-backup-alerts.ts
@@ -1,0 +1,329 @@
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import type {
+  DatabaseBackupHealthStatus,
+  DatabaseBackupHealthWarning,
+} from "./database-backup-health.js";
+
+/**
+ * Adapter/bridge that turns a control-plane database-backup failure (or a
+ * `warning` health status) into a LOUD, idempotent board signal — the missing
+ * link behind SIN-70819 (backup died silently for 9 days).
+ *
+ * This module is deliberately dependency-light: it depends only on the board
+ * PORT (`DatabaseBackupAlertBoard`) and the filesystem for the failure marker.
+ * The domain inspector (`inspectDatabaseBackupHealth`) stays pure and is NOT
+ * imported here beyond its result types — the wiring in `index.ts` runs the
+ * inspector and hands its result to `reportHealthWarnings`.
+ */
+
+/** Origin kind stamped on auto-created alert issues so they can be de-duped. */
+export const DATABASE_BACKUP_ALERT_ORIGIN_KIND = "database_backup_failure";
+/** Stable fingerprint used to find/update the single open alert issue. */
+export const DATABASE_BACKUP_ALERT_FINGERPRINT = "control-plane-backup-failure";
+
+/** A board issue reference the bridge can act on. */
+export type DatabaseBackupAlertIssueRef = {
+  id: string;
+  identifier: string | null;
+  status: string;
+};
+
+/**
+ * Port the bridge needs from the board. The concrete adapter over the issues
+ * service lives in `database-backup-alert-board.ts`.
+ */
+export type DatabaseBackupAlertBoard = {
+  /** Newest-first: the single open (non-terminal, visible) alert issue, if any. */
+  findOpenAlert(
+    companyId: string,
+    fingerprint: string,
+  ): Promise<DatabaseBackupAlertIssueRef | null>;
+  /**
+   * Create the alert issue. The create MUST be status-aware: it may only
+   * deduplicate against a NON-terminal issue (the create-race guard). It must
+   * NOT be shadowed by a resolved (`done`/`cancelled`) issue — otherwise a
+   * second incident after a resolution would silently report `created` while no
+   * open alert exists on the board (the SIN-70819 A09 gap). The concrete adapter
+   * satisfies this with `allowDuplicate: false` (advisory-lock + non-terminal
+   * recent-open-title dedup), NOT with a static idempotency key.
+   */
+  createAlert(
+    companyId: string,
+    input: {
+      title: string;
+      description: string;
+      fingerprint: string;
+    },
+  ): Promise<DatabaseBackupAlertIssueRef>;
+  commentAlert(issueId: string, body: string): Promise<void>;
+  resolveAlert(issueId: string, body: string): Promise<void>;
+};
+
+export type DatabaseBackupAlertLogger = {
+  warn(obj: unknown, msg?: string): void;
+  error(obj: unknown, msg?: string): void;
+  info(obj: unknown, msg?: string): void;
+};
+
+const POSTGRES_URL_PATTERN = /postgres(?:ql)?:\/\/[^\s"'`]+/gi;
+
+/**
+ * Strip anything that looks like a Postgres connection URL (which can embed
+ * credentials) before the message reaches a marker file or a board issue.
+ * OWASP A09: never persist secrets in the alert signal.
+ */
+export function redactDatabaseBackupErrorMessage(message: string): string {
+  return message.replace(POSTGRES_URL_PATTERN, "postgres://[redacted]").trim();
+}
+
+/** First non-empty line of the (already redacted) message, for the marker. */
+function firstLine(message: string): string {
+  const line = message
+    .split(/\r?\n/)
+    .map((value) => value.trim())
+    .find((value) => value.length > 0);
+  return line || "Database backup failed.";
+}
+
+/**
+ * Write the `db-backup-to-s3.failure` marker that `inspectDatabaseBackupHealth`
+ * reads. First line is the exact (redacted) error; a second line carries the
+ * timestamp. This is channel 1 of the defense-in-depth signal and must succeed
+ * independently of the board push.
+ */
+export function writeDatabaseBackupFailureMarker(
+  markerFile: string,
+  message: string,
+  at: Date,
+): void {
+  mkdirSync(dirname(markerFile), { recursive: true });
+  const redacted = redactDatabaseBackupErrorMessage(message);
+  writeFileSync(markerFile, `${firstLine(redacted)}\nfailedAt=${at.toISOString()}\n`, "utf8");
+}
+
+/** Best-effort removal of every candidate marker path (clear on success). */
+export function clearDatabaseBackupFailureMarkers(markerFiles: string[]): void {
+  for (const markerFile of markerFiles) {
+    if (!existsSync(markerFile)) continue;
+    try {
+      unlinkSync(markerFile);
+    } catch {
+      // Best-effort: a stale marker we cannot remove must not fail the backup.
+    }
+  }
+}
+
+/** Summarize warnings into a single human line (used for the stale/missing path). */
+export function summarizeDatabaseBackupWarnings(
+  warnings: DatabaseBackupHealthWarning[],
+): string {
+  if (warnings.length === 0) return "Database backup health check reported a warning.";
+  return warnings.map((warning) => warning.message).join(" ");
+}
+
+/** Pure payload builder: warning/failure context → issue title + description. */
+export function buildDatabaseBackupAlertContent(input: {
+  reason: "failure" | "health";
+  message: string;
+  warnings?: DatabaseBackupHealthWarning[];
+  at: Date;
+}): { title: string; description: string } {
+  const redacted = redactDatabaseBackupErrorMessage(input.message);
+  const title =
+    input.reason === "failure"
+      ? "Control-plane database backup is failing"
+      : "Control-plane database backup is unhealthy";
+  const lines: string[] = [
+    input.reason === "failure"
+      ? "The automatic control-plane database backup failed."
+      : "The control-plane database backup health check is reporting a warning.",
+    "",
+    `First observed: ${input.at.toISOString()}`,
+    "",
+    "```",
+    redacted || "(no error message captured)",
+    "```",
+  ];
+  if (input.warnings && input.warnings.length > 0) {
+    lines.push("", "Warnings:");
+    for (const warning of input.warnings) {
+      lines.push(`- \`${warning.code}\`: ${redactDatabaseBackupErrorMessage(warning.message)}`);
+    }
+  }
+  lines.push(
+    "",
+    "This issue is auto-managed (deduplicated by origin fingerprint " +
+      `\`${DATABASE_BACKUP_ALERT_FINGERPRINT}\`). It updates in place while the ` +
+      "backup keeps failing and is resolved automatically on the next successful backup.",
+  );
+  return { title, description: lines.join("\n") };
+}
+
+/**
+ * Idempotent board push: update the open alert issue if one exists, otherwise
+ * create it. Never spawns a duplicate (alert-storm guard). When `updateComment`
+ * is omitted, an existing open issue is left untouched (used by the periodic
+ * staleness bridge so it doesn't comment every tick).
+ */
+export async function raiseDatabaseBackupAlert(
+  board: DatabaseBackupAlertBoard,
+  input: {
+    companyId: string;
+    fingerprint: string;
+    title: string;
+    description: string;
+    updateComment?: string;
+  },
+): Promise<{ action: "created" | "updated" | "exists"; issueId: string }> {
+  const open = await board.findOpenAlert(input.companyId, input.fingerprint);
+  if (open) {
+    if (input.updateComment) {
+      await board.commentAlert(open.id, input.updateComment);
+      return { action: "updated", issueId: open.id };
+    }
+    return { action: "exists", issueId: open.id };
+  }
+  // `findOpenAlert` above (origin fingerprint, non-terminal) is the primary,
+  // status-aware dedup. The create itself is guarded status-awarely by the
+  // concrete adapter (`allowDuplicate: false`) so a resolved alert can never
+  // shadow a fresh incident. Deliberately NO static idempotency key here: a
+  // retained key survives the alert being resolved to `done` and would make a
+  // second incident dedup-hit the old closed issue (SIN-70819 A09 regression).
+  const created = await board.createAlert(input.companyId, {
+    title: input.title,
+    description: input.description,
+    fingerprint: input.fingerprint,
+  });
+  return { action: "created", issueId: created.id };
+}
+
+/** Resolve the open alert (on a successful backup). No-op when none is open. */
+export async function resolveDatabaseBackupAlert(
+  board: DatabaseBackupAlertBoard,
+  input: { companyId: string; fingerprint: string; comment: string },
+): Promise<{ action: "resolved" | "noop"; issueId?: string }> {
+  const open = await board.findOpenAlert(input.companyId, input.fingerprint);
+  if (!open) return { action: "noop" };
+  await board.resolveAlert(open.id, input.comment);
+  return { action: "resolved", issueId: open.id };
+}
+
+export type DatabaseBackupAlertReporterDeps = {
+  /** Marker path to write on failure (the primary alert file). */
+  markerFile: string;
+  /** All candidate marker paths to clear on success. */
+  clearMarkerFiles: string[];
+  /** Board port + target company. Null disables the board channel (marker/log only). */
+  board: DatabaseBackupAlertBoard | null;
+  companyId: string | null;
+  fingerprint?: string;
+  now?: () => Date;
+  logger?: DatabaseBackupAlertLogger;
+};
+
+/**
+ * Composes the three defense-in-depth channels (marker file, structured log,
+ * board issue). The marker + log always run; a board-channel failure is caught
+ * and logged so it can never mask the underlying backup failure.
+ */
+export function createDatabaseBackupAlertReporter(deps: DatabaseBackupAlertReporterDeps) {
+  const fingerprint = deps.fingerprint ?? DATABASE_BACKUP_ALERT_FINGERPRINT;
+  const now = deps.now ?? (() => new Date());
+
+  return {
+    /** AC1: a single scheduled-backup failure → marker + board issue. */
+    async reportFailure(rawMessage: string): Promise<void> {
+      const at = now();
+      const message = redactDatabaseBackupErrorMessage(rawMessage);
+
+      // Channel 1: marker (must persist even if the board push fails).
+      try {
+        writeDatabaseBackupFailureMarker(deps.markerFile, message, at);
+      } catch (err) {
+        deps.logger?.error({ err }, "failed to write database backup failure marker");
+      }
+
+      // Channel 3: board issue (idempotent, guarded).
+      if (!deps.board || !deps.companyId) return;
+      try {
+        const { title, description } = buildDatabaseBackupAlertContent({
+          reason: "failure",
+          message,
+          at,
+        });
+        const result = await raiseDatabaseBackupAlert(deps.board, {
+          companyId: deps.companyId,
+          fingerprint,
+          title,
+          description,
+          updateComment: `Automatic control-plane database backup failed again at ${at.toISOString()}.\n\n\`\`\`\n${message || "(no error message captured)"}\n\`\`\``,
+        });
+        deps.logger?.warn(
+          { action: result.action, issueId: result.issueId },
+          "raised control-plane database backup failure board alert",
+        );
+      } catch (err) {
+        deps.logger?.error({ err }, "failed to raise database backup failure board alert");
+      }
+    },
+
+    /** AC3: periodic staleness/health bridge → ensure the board alert exists. */
+    async reportHealthWarnings(status: DatabaseBackupHealthStatus): Promise<void> {
+      if (status.status !== "warning") return;
+      if (!deps.board || !deps.companyId) return;
+      const at = now();
+      try {
+        const { title, description } = buildDatabaseBackupAlertContent({
+          reason: "health",
+          message: summarizeDatabaseBackupWarnings(status.warnings),
+          warnings: status.warnings,
+          at,
+        });
+        // No updateComment: only ensure the issue exists so the hourly bridge
+        // never storms an already-open alert with comments.
+        const result = await raiseDatabaseBackupAlert(deps.board, {
+          companyId: deps.companyId,
+          fingerprint,
+          title,
+          description,
+        });
+        deps.logger?.warn(
+          { action: result.action, issueId: result.issueId, warnings: status.warnings.map((w) => w.code) },
+          "control-plane database backup health warning bridged to board",
+        );
+      } catch (err) {
+        deps.logger?.error({ err }, "failed to bridge database backup health warning to board");
+      }
+    },
+
+    /** On a successful backup: clear the marker(s) and resolve the open alert. */
+    async reportSuccess(): Promise<void> {
+      try {
+        clearDatabaseBackupFailureMarkers(deps.clearMarkerFiles);
+      } catch (err) {
+        deps.logger?.error({ err }, "failed to clear database backup failure marker");
+      }
+
+      if (!deps.board || !deps.companyId) return;
+      try {
+        const at = now();
+        const result = await resolveDatabaseBackupAlert(deps.board, {
+          companyId: deps.companyId,
+          fingerprint,
+          comment: `Automatic control-plane database backup succeeded at ${at.toISOString()}; resolving this alert.`,
+        });
+        if (result.action === "resolved") {
+          deps.logger?.info(
+            { issueId: result.issueId },
+            "resolved control-plane database backup board alert after a successful backup",
+          );
+        }
+      } catch (err) {
+        deps.logger?.error({ err }, "failed to resolve database backup board alert");
+      }
+    },
+  };
+}
+
+export type DatabaseBackupAlertReporter = ReturnType<typeof createDatabaseBackupAlertReporter>;

--- a/server/src/services/pgclient-version-preflight.ts
+++ b/server/src/services/pgclient-version-preflight.ts
@@ -1,0 +1,385 @@
+import { execFile } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  raiseDatabaseBackupAlert,
+  resolveDatabaseBackupAlert,
+  type DatabaseBackupAlertBoard,
+  type DatabaseBackupAlertLogger,
+} from "./database-backup-alerts.js";
+
+/**
+ * SIN-70820 — control-plane pg_dump-client vs embedded-PostgreSQL major preflight.
+ *
+ * Anti-regression invariant behind SIN-70814 (3rd occurrence:
+ * SIN-65200 → SIN-70116 → SIN-70814): every embedded-Postgres major bump that
+ * is NOT matched by a host `postgresql-client` bump silently kills the automatic
+ * backup — `pg_dump` refuses to dump a server whose major is newer than the
+ * client (`server version mismatch`). The failure is quiet because the backup
+ * scheduler swallows it; the outage stayed hidden for 9 days.
+ *
+ * This module resolves the two authoritative version sources and compares their
+ * **majors**. On divergence it pushes a LOUD, idempotent signal through the
+ * SIN-70819 board adapter (a distinct alert fingerprint so it dedups
+ * independently of the backup-failure alert). It never hard-stops the boot —
+ * the control-plane still comes up; it is the backup that is at risk.
+ *
+ * Hexagonal split (CTO lens): the comparison is pure, testable logic
+ * (`comparePgMajor` + the two parsers). The IO — reading `<dataDir>/PG_VERSION`
+ * and spawning `pg_dump --version` — is isolated behind injectable readers so
+ * the tests need neither a real Postgres nor a real `pg_dump` binary.
+ *
+ * OWASP A09 / least privilege: only versions and the resolved binary path are
+ * ever logged or written to the board. No connection string is touched here.
+ */
+
+/**
+ * Stable alert fingerprint. Deliberately different from the backup-failure
+ * fingerprint (`control-plane-backup-failure`) so the pg-client mismatch alert
+ * is its own board issue and dedups on its own lifecycle, while still flowing
+ * through the same SIN-70819 adapter/bridge.
+ */
+export const PGCLIENT_VERSION_ALERT_FINGERPRINT = "control-plane-pgclient-major-mismatch";
+
+/**
+ * Parse a Postgres major from a `pg_dump --version` line such as
+ * `pg_dump (PostgreSQL) 18.1` or `pg_dump (PostgreSQL) 16.4 (Ubuntu 16.4-1.pgdg22.04+1)`.
+ * Returns null when no major can be recovered.
+ */
+export function parsePgDumpVersionOutput(output: string): number | null {
+  if (!output) return null;
+  // Prefer the version token that follows the "PostgreSQL" product name, so a
+  // package suffix like "(Ubuntu 16.4-1.pgdg22.04+1)" cannot win.
+  const labelled = output.match(/PostgreSQL\)?\s+(\d+)(?:\.\d+)*/i);
+  if (labelled) return Number.parseInt(labelled[1]!, 10);
+  // Fallback: the first standalone integer that looks like a version.
+  const loose = output.match(/\b(\d+)(?:\.\d+)*\b/);
+  return loose ? Number.parseInt(loose[1]!, 10) : null;
+}
+
+/**
+ * Parse the embedded server major from the raw contents of `<dataDir>/PG_VERSION`.
+ * That file holds just the major (e.g. `18`), or `9.6` on the pre-10 scheme.
+ */
+export function parsePgVersionFileContent(content: string): number | null {
+  if (!content) return null;
+  const firstLine = content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  if (!firstLine) return null;
+  const match = firstLine.match(/^(\d+)/);
+  return match ? Number.parseInt(match[1]!, 10) : null;
+}
+
+export type PgMajorComparison =
+  | { status: "ok"; clientMajor: number; serverMajor: number }
+  | {
+      status: "mismatch";
+      clientMajor: number;
+      serverMajor: number;
+      /** True when the client is OLDER than the server — the silent-kill case. */
+      clientBehind: boolean;
+      message: string;
+    }
+  | {
+      status: "unparseable";
+      clientMajor: number | null;
+      serverMajor: number | null;
+      message: string;
+    };
+
+/**
+ * Pure decision: does the resolved `pg_dump` client major match the embedded
+ * server major? Input is the raw version strings (client = `pg_dump --version`
+ * output, server = `PG_VERSION` contents) so parsing stays inside the pure unit.
+ */
+export function comparePgMajor(
+  clientVersion: string,
+  serverVersion: string,
+): PgMajorComparison {
+  const clientMajor = parsePgDumpVersionOutput(clientVersion);
+  const serverMajor = parsePgVersionFileContent(serverVersion);
+
+  if (clientMajor === null || serverMajor === null) {
+    return {
+      status: "unparseable",
+      clientMajor,
+      serverMajor,
+      message:
+        `Unable to determine the PostgreSQL major to compare (client=` +
+        `${clientMajor ?? "unknown"}, server=${serverMajor ?? "unknown"}).`,
+    };
+  }
+
+  if (clientMajor === serverMajor) {
+    return { status: "ok", clientMajor, serverMajor };
+  }
+
+  const clientBehind = clientMajor < serverMajor;
+  const message = clientBehind
+    ? `pg_dump client major ${clientMajor} is OLDER than the embedded PostgreSQL server major ${serverMajor}; ` +
+      `pg_dump will refuse to dump this server (server version mismatch) and the automatic backup is broken.`
+    : `pg_dump client major ${clientMajor} does not match the embedded PostgreSQL server major ${serverMajor}; ` +
+      `the postgresql-client pin has drifted from the embedded server.`;
+  return { status: "mismatch", clientMajor, serverMajor, clientBehind, message };
+}
+
+export type PgClientVersionPreflightResult =
+  | { outcome: "ok"; clientMajor: number; serverMajor: number }
+  | { outcome: "mismatch"; clientMajor: number; serverMajor: number; message: string }
+  | { outcome: "client_missing"; pgDumpPath: string; message: string }
+  | { outcome: "unparseable"; message: string }
+  | { outcome: "skipped"; message: string };
+
+/** Reads the two version sources. Injectable so tests need no PG and no spawn. */
+export type PgClientVersionPreflightIo = {
+  /** Raw contents of `<dataDir>/PG_VERSION`, or null when the file is absent. */
+  readServerVersion(dataDir: string): Promise<string | null>;
+  /**
+   * Raw `pg_dump --version` output. Throws with `code === "ENOENT"` when the
+   * binary cannot be resolved on the PATH.
+   */
+  readClientVersion(pgDumpPath: string): Promise<string>;
+};
+
+function hasErrnoCode(err: unknown, code: string): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code?: unknown }).code === code
+  );
+}
+
+/** Default IO: real `<dataDir>/PG_VERSION` read + real `pg_dump --version` spawn. */
+export const defaultPgClientVersionPreflightIo: PgClientVersionPreflightIo = {
+  async readServerVersion(dataDir) {
+    const file = join(dataDir, "PG_VERSION");
+    if (!existsSync(file)) return null;
+    return readFileSync(file, "utf8");
+  },
+  async readClientVersion(pgDumpPath) {
+    return await new Promise<string>((resolve, reject) => {
+      execFile(pgDumpPath, ["--version"], { timeout: 10_000 }, (err, stdout, stderr) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve((stdout || stderr || "").toString());
+      });
+    });
+  },
+};
+
+/**
+ * Resolve both version sources and compare their majors. Pure orchestration of
+ * the injectable IO — no board push here (that is the reporter's job).
+ */
+export async function inspectPgClientVersion(opts: {
+  dataDir: string;
+  pgDumpPath: string;
+  io?: PgClientVersionPreflightIo;
+}): Promise<PgClientVersionPreflightResult> {
+  const io = opts.io ?? defaultPgClientVersionPreflightIo;
+
+  const serverVersion = await io.readServerVersion(opts.dataDir);
+  if (serverVersion === null) {
+    return {
+      outcome: "skipped",
+      message:
+        `No PG_VERSION file under ${opts.dataDir}; the embedded server major is unknown, ` +
+        `skipping the pg_dump-client preflight.`,
+    };
+  }
+
+  let clientVersion: string;
+  try {
+    clientVersion = await io.readClientVersion(opts.pgDumpPath);
+  } catch (err) {
+    if (hasErrnoCode(err, "ENOENT")) {
+      return {
+        outcome: "client_missing",
+        pgDumpPath: opts.pgDumpPath,
+        message:
+          `pg_dump was not found (resolved path: ${opts.pgDumpPath}). The automatic control-plane ` +
+          `backup cannot run without a postgresql-client whose major matches the embedded server.`,
+      };
+    }
+    return {
+      outcome: "unparseable",
+      message: `Failed to read pg_dump --version (${opts.pgDumpPath}): ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    };
+  }
+
+  const comparison = comparePgMajor(clientVersion, serverVersion);
+  switch (comparison.status) {
+    case "ok":
+      return {
+        outcome: "ok",
+        clientMajor: comparison.clientMajor,
+        serverMajor: comparison.serverMajor,
+      };
+    case "mismatch":
+      return {
+        outcome: "mismatch",
+        clientMajor: comparison.clientMajor,
+        serverMajor: comparison.serverMajor,
+        message: comparison.message,
+      };
+    case "unparseable":
+      return { outcome: "unparseable", message: comparison.message };
+  }
+}
+
+/** Pure payload builder: preflight result → board issue title + description. */
+export function buildPgClientVersionAlertContent(
+  result: Extract<
+    PgClientVersionPreflightResult,
+    { outcome: "mismatch" | "client_missing" | "unparseable" }
+  >,
+  at: Date,
+  pgDumpPath: string,
+): { title: string; description: string } {
+  const title = "Control-plane pg_dump client does not match embedded PostgreSQL";
+  const lines: string[] = [
+    "The control-plane backup preflight found a `pg_dump` client that cannot back up the " +
+      "embedded PostgreSQL server. **The automatic backup is at risk** until the " +
+      "`postgresql-client` major is aligned with the embedded server major.",
+    "",
+    `First observed: ${at.toISOString()}`,
+    `Resolved pg_dump path: \`${pgDumpPath}\``,
+    "",
+  ];
+  if (result.outcome === "mismatch") {
+    lines.push(
+      `- pg_dump client major: **${result.clientMajor}**`,
+      `- embedded server major: **${result.serverMajor}**`,
+      "",
+      result.message,
+    );
+  } else {
+    lines.push(result.message);
+  }
+  lines.push(
+    "",
+    "**Recovery (agent-doable, no root):** unpack the noble `postgresql-client-18` `.deb` with " +
+      "`dpkg -x` into a user-writable prefix and invoke it as " +
+      "`env -u LD_LIBRARY_PATH <prefix>/usr/lib/postgresql/18/bin/pg_dump ...`, pointing " +
+      "`PAPERCLIP_PG_DUMP_PATH` at that binary, until `postgresql-client-18` is installed via apt.",
+    "",
+    "This issue is auto-managed (deduplicated by origin fingerprint " +
+      `\`${PGCLIENT_VERSION_ALERT_FINGERPRINT}\`). It is resolved automatically once the ` +
+      "client major matches the embedded server major.",
+  );
+  return { title, description: lines.join("\n") };
+}
+
+export type PgClientVersionPreflightReporterDeps = {
+  dataDir: string;
+  pgDumpPath: string;
+  /** Board port + target company. Null disables the board channel (log only). */
+  board: DatabaseBackupAlertBoard | null;
+  companyId: string | null;
+  fingerprint?: string;
+  io?: PgClientVersionPreflightIo;
+  now?: () => Date;
+  logger?: DatabaseBackupAlertLogger;
+};
+
+/**
+ * Reporter that runs the preflight and pushes the result through the SIN-70819
+ * board adapter: raise a LOUD alert on divergence / missing client, resolve the
+ * open alert when the majors line up again. The board push is guarded so it can
+ * never mask or crash the boot path.
+ */
+export function createPgClientVersionPreflightReporter(
+  deps: PgClientVersionPreflightReporterDeps,
+) {
+  const fingerprint = deps.fingerprint ?? PGCLIENT_VERSION_ALERT_FINGERPRINT;
+  const now = deps.now ?? (() => new Date());
+
+  return {
+    async run(): Promise<PgClientVersionPreflightResult> {
+      const result = await inspectPgClientVersion({
+        dataDir: deps.dataDir,
+        pgDumpPath: deps.pgDumpPath,
+        io: deps.io,
+      });
+
+      if (result.outcome === "skipped") {
+        deps.logger?.info({ pgDumpPath: deps.pgDumpPath }, result.message);
+        return result;
+      }
+
+      if (result.outcome === "ok") {
+        deps.logger?.info(
+          { clientMajor: result.clientMajor, serverMajor: result.serverMajor, pgDumpPath: deps.pgDumpPath },
+          "pg_dump client major matches embedded PostgreSQL; backup preflight ok",
+        );
+        // Symmetric resolve: if a prior mismatch alert is open and the client
+        // has since been aligned, close it automatically.
+        if (deps.board && deps.companyId) {
+          try {
+            const resolved = await resolveDatabaseBackupAlert(deps.board, {
+              companyId: deps.companyId,
+              fingerprint,
+              comment:
+                `pg_dump client major ${result.clientMajor} now matches the embedded PostgreSQL ` +
+                `server major ${result.serverMajor} (checked ${now().toISOString()}); resolving this alert.`,
+            });
+            if (resolved.action === "resolved") {
+              deps.logger?.info(
+                { issueId: resolved.issueId },
+                "resolved control-plane pg_dump client-major mismatch board alert",
+              );
+            }
+          } catch (err) {
+            deps.logger?.error({ err }, "failed to resolve pg_dump client-major board alert");
+          }
+        }
+        return result;
+      }
+
+      // mismatch | client_missing | unparseable → LOUD signal.
+      deps.logger?.warn(
+        {
+          outcome: result.outcome,
+          pgDumpPath: deps.pgDumpPath,
+          ...(result.outcome === "mismatch"
+            ? { clientMajor: result.clientMajor, serverMajor: result.serverMajor }
+            : {}),
+        },
+        `control-plane pg_dump-client preflight failed: ${result.message}`,
+      );
+
+      if (!deps.board || !deps.companyId) return result;
+      try {
+        const { title, description } = buildPgClientVersionAlertContent(
+          result,
+          now(),
+          deps.pgDumpPath,
+        );
+        const raised = await raiseDatabaseBackupAlert(deps.board, {
+          companyId: deps.companyId,
+          fingerprint,
+          title,
+          description,
+        });
+        deps.logger?.warn(
+          { action: raised.action, issueId: raised.issueId, outcome: result.outcome },
+          "raised control-plane pg_dump client-major mismatch board alert",
+        );
+      } catch (err) {
+        deps.logger?.error({ err }, "failed to raise pg_dump client-major board alert");
+      }
+      return result;
+    },
+  };
+}
+
+export type PgClientVersionPreflightReporter = ReturnType<
+  typeof createPgClientVersionPreflightReporter
+>;


### PR DESCRIPTION
## Deploy: control-plane backup pg_dump-major invariant (anti-regressão SIN-70814)

Promove para upstream a correção do incidente **SIN-70814** (3ª ocorrência da classe: SIN-65200 → SIN-70116 → SIN-70814): bump de major do embedded Postgres sem bump do `postgresql-client` do host mata o backup automático silenciosamente (pg_dump v16 aborta contra servidor v18).

Delta = 2 commits já revisados e merged no fork `ia-dev-sindireceita/paperclip` (dual-channel CTO review).

### Changelog (infra/platform)
- **Closes SIN-70819** — Alertar no board quando o backup do control-plane falha (marker + issue + staleness>36h, OWASP A09). PR fork #3 (`ace80fdcf`).
- **Closes SIN-70820** — Preflight `pg_dump`-client major vs embedded `PG_VERSION`: falha alto no board se o major divergir. PR fork #4 (`f2fc01afc`).

### O que entra
- `server/src/services/pgclient-version-preflight.ts` — preflight no boot: compara major do `pg_dump` resolvido no PATH vs versão do servidor embedded; major divergente ⇒ FALHA ALTA (board + log), não silenciosa. Core puro (`comparePgMajor`/parsers) com IO atrás de porta injetável (`PgClientVersionPreflightIo`) — hexagonal.
- `server/src/services/database-backup-alerts.ts` + `database-backup-alert-board.ts` — alerta no board quando o backup fica stale (>36h) ou o marker some.
- `doc/architecture/control-plane-backup-pgclient-invariant.md` — ADR do invariante `postgresql-client major == embedded PG major`, com o recovery agent-doable sem root (`dpkg -x` do deb noble `postgresql-client-18` + `env -u LD_LIBRARY_PATH pg_dump`).
- Wiring em `server/src/index.ts`; testes em `server/src/__tests__/` e `packages/db/src/`.

Parent incidente: SIN-70814. Tracker permanente CEO-owned: SIN-70116.

Reviewer: **Pericles** (merge upstream). CTO não faz self-merge upstream.
