### PR TITLE
fix: reject done when executionPolicy replaced during active review cycle

### DIFF
--- a/server/src/__tests__/issue-execution-policy.test.ts
+++ b/server/src/__tests__/issue-execution-policy.test.ts
@@ -1629,6 +1629,139 @@ describe("issue execution policy transitions", () => {
     });
   });
 
+  describe("replacing executionPolicy mid-cycle must not discard a live review (#AUT-7902)", () => {
+    it("rejects done when a new executionPolicy regenerates the stage id during changes_requested", () => {
+      const originalPolicy = twoStagePolicy();
+      const replacementPolicy = twoStagePolicy();
+
+      expect(() =>
+        applyIssueExecutionPolicyTransition({
+          issue: {
+            status: "in_progress",
+            assigneeAgentId: coderAgentId,
+            assigneeUserId: null,
+            executionPolicy: originalPolicy,
+            executionState: {
+              status: "changes_requested",
+              currentStageId: originalPolicy.stages[0].id,
+              currentStageIndex: 0,
+              currentStageType: "review",
+              currentParticipant: { type: "agent", agentId: qaAgentId },
+              returnAssignee: { type: "agent", agentId: coderAgentId },
+              completedStageIds: [],
+              lastDecisionId: null,
+              lastDecisionOutcome: "changes_requested",
+            },
+          },
+          // A brand-new policy object has freshly generated stage ids, so the
+          // stored currentStageId from the live review no longer resolves.
+          policy: replacementPolicy,
+          requestedStatus: "done",
+          requestedAssigneePatch: {},
+          actor: { agentId: coderAgentId },
+        }),
+      ).toThrow(expect.objectContaining({ status: 422, details: { code: "unexecuted_review_stage" } }));
+    });
+
+    it("rejects a non-done status change too, so the cycle is never silently discarded", () => {
+      const originalPolicy = twoStagePolicy();
+      const replacementPolicy = twoStagePolicy();
+
+      expect(() =>
+        applyIssueExecutionPolicyTransition({
+          issue: {
+            status: "in_review",
+            assigneeAgentId: qaAgentId,
+            assigneeUserId: null,
+            executionPolicy: originalPolicy,
+            executionState: {
+              status: "pending",
+              currentStageId: originalPolicy.stages[0].id,
+              currentStageIndex: 0,
+              currentStageType: "review",
+              currentParticipant: { type: "agent", agentId: qaAgentId },
+              returnAssignee: { type: "agent", agentId: coderAgentId },
+              completedStageIds: [],
+              lastDecisionId: null,
+              lastDecisionOutcome: null,
+            },
+          },
+          policy: replacementPolicy,
+          requestedStatus: "cancelled",
+          requestedAssigneePatch: {},
+          actor: { agentId: qaAgentId },
+        }),
+      ).toThrow(expect.objectContaining({ status: 422, details: { code: "execution_policy_replaced_during_active_cycle" } }));
+    });
+
+    it("still allows a bare status: done to route to the stored reviewer when the policy is unchanged", () => {
+      const policy = twoStagePolicy();
+      const result = applyIssueExecutionPolicyTransition({
+        issue: {
+          status: "in_progress",
+          assigneeAgentId: coderAgentId,
+          assigneeUserId: null,
+          executionPolicy: policy,
+          executionState: {
+            status: "changes_requested",
+            currentStageId: policy.stages[0].id,
+            currentStageIndex: 0,
+            currentStageType: "review",
+            currentParticipant: { type: "agent", agentId: qaAgentId },
+            returnAssignee: { type: "agent", agentId: coderAgentId },
+            completedStageIds: [],
+            lastDecisionId: null,
+            lastDecisionOutcome: "changes_requested",
+          },
+        },
+        policy,
+        requestedStatus: "done",
+        requestedAssigneePatch: {},
+        actor: { agentId: coderAgentId },
+      });
+
+      expect(result.patch).toMatchObject({
+        status: "in_review",
+        assigneeAgentId: qaAgentId,
+      });
+    });
+
+    it("still allows a policy edit with no requested status to clear the orphaned stage and return to the executor", () => {
+      const originalPolicy = twoStagePolicy();
+      const replacementPolicy = twoStagePolicy();
+
+      const result = applyIssueExecutionPolicyTransition({
+        issue: {
+          status: "in_review",
+          assigneeAgentId: qaAgentId,
+          assigneeUserId: null,
+          executionPolicy: originalPolicy,
+          executionState: {
+            status: "pending",
+            currentStageId: originalPolicy.stages[0].id,
+            currentStageIndex: 0,
+            currentStageType: "review",
+            currentParticipant: { type: "agent", agentId: qaAgentId },
+            returnAssignee: { type: "agent", agentId: coderAgentId },
+            completedStageIds: [],
+            lastDecisionId: null,
+            lastDecisionOutcome: null,
+          },
+        },
+        policy: replacementPolicy,
+        requestedStatus: undefined,
+        requestedAssigneePatch: {},
+        actor: { agentId: qaAgentId },
+      });
+
+      expect(result.patch).toMatchObject({
+        status: "in_progress",
+        assigneeAgentId: coderAgentId,
+        executionState: null,
+      });
+    });
+  });
+
   describe("monitor policy", () => {
     it("schedules a one-shot monitor on an active agent-owned issue", () => {
       const policy = normalizeIssueExecutionPolicy({

--- a/server/src/services/issue-execution-policy.ts
+++ b/server/src/services/issue-execution-policy.ts
@@ -696,6 +696,31 @@ function applyIssueExecutionStageTransition(input: TransitionInput): TransitionR
   }
 
   if (existingState?.currentStageId && !currentStage) {
+    // The stored stage id no longer resolves against the (possibly just
+    // replaced) policy — e.g. the caller PATCHed a brand-new executionPolicy
+    // in the same request that regenerated stage ids. If a review cycle is
+    // genuinely live (pending, or awaiting the assignee's response to
+    // changes requested) and the caller also asked for a status change here,
+    // we must not let clearExecutionStatePatch silently drop the cycle and
+    // let the requested status stand — that would let `done` through a
+    // review that was never actually completed (#AUT-7902). A bare policy
+    // edit with no requested status still falls through to the normal
+    // clear/return-to-executor behavior below, since there is no status to
+    // smuggle through.
+    const hasLiveReviewCycle =
+      existingState.status === PENDING_STATUS || existingState.status === CHANGES_REQUESTED_STATUS;
+    if (hasLiveReviewCycle && requestedStatus !== undefined) {
+      if (requestedStatus === "done") {
+        throw unprocessable(
+          "This issue has an unexecuted review stage from a live review cycle. Resolve the review before marking it done.",
+          { code: "unexecuted_review_stage" },
+        );
+      }
+      throw unprocessable(
+        "The execution policy was replaced while a review cycle is active; this would discard the live review stage.",
+        { code: "execution_policy_replaced_during_active_cycle" },
+      );
+    }
     clearExecutionStatePatch({
       patch,
       issueStatus: input.issue.status,


### PR DESCRIPTION
Fixes a bug where PATCHing a new executionPolicy together with status: done while executionState.status is changes_requested silently discards the live review cycle.