### PR TITLE
fix(security): reject expired Tool Gateway approvals

### DIFF
--- a/server/src/__tests__/tool-gateway-service.test.ts
+++ b/server/src/__tests__/tool-gateway-service.test.ts
@@ -6,6 +6,7 @@ import {
   agents,
   approvals,
   companies,
+  companyMemberships,
   companySecretBindings,
   companySecrets,
   connectionGrants,
@@ -182,6 +183,7 @@ describeEmbeddedPostgres("tool gateway service", () => {
     await db.delete(toolPolicies);
     await db.delete(heartbeatRuns);
     await db.delete(issues);
+    await db.delete(companyMemberships);
     await db.delete(agents);
     await db.delete(companies);
   });
@@ -360,16 +362,22 @@ describeEmbeddedPostgres("tool gateway service", () => {
       parameters,
     })).rejects.toMatchObject({ reasonCode: "approval_required" });
     const [actionRequest] = await db.select().from(toolActionRequests);
+    const now = Date.now();
     await db
       .update(toolActionRequests)
-      .set({ expiresAt: new Date(Date.now() - 1_000) })
+      .set({ expiresAt: new Date(now - 1_000) })
       .where(eq(toolActionRequests.id, actionRequest.id));
 
-    await expect(gateway.approveActionRequest({
-      companyId: company.id,
-      actionRequestId: actionRequest.id,
-      actor: { userId: "board-user" },
-    })).resolves.toMatchObject({ status: "expired" });
+    const applicationClock = vi.spyOn(Date, "now").mockReturnValue(now - 5_000);
+    try {
+      await expect(gateway.approveActionRequest({
+        companyId: company.id,
+        actionRequestId: actionRequest.id,
+        actor: { userId: "board-user" },
+      })).resolves.toMatchObject({ status: "expired" });
+    } finally {
+      applicationClock.mockRestore();
+    }
 
     const [expired] = await db.select().from(toolActionRequests).where(eq(toolActionRequests.id, actionRequest.id));
     expect(expired).toMatchObject({
@@ -461,6 +469,152 @@ describeEmbeddedPostgres("tool gateway service", () => {
       eq(toolCallEvents.reasonCode, "approved_action_executed"),
     ));
     expect(dispatchEvents).toHaveLength(0);
+  });
+
+  it("rejects an expired explicit action request using the database clock and clears replay state", async () => {
+    const { company, agent, run } = await createRunFixture(db);
+    await db.insert(toolPolicies).values({
+      companyId: company.id,
+      name: "Review explicit expiry",
+      policyType: "require_approval",
+      selectors: { toolName: "mcp-remote-fixture:update_note" },
+    });
+    const gateway = createTestToolGatewayService(db);
+    const session = await gateway.createSession({ companyId: company.id, agentId: agent.id, runId: run.id });
+    const parameters = { noteId: "n1", body: "must remain inert" };
+
+    await expect(gateway.executeTool({
+      sessionToken: session.token,
+      tool: "mcp-remote-fixture:update_note",
+      parameters,
+      idempotencyKey: "explicit-expiry-key",
+    })).rejects.toMatchObject({ reasonCode: "approval_required" });
+    const [actionRequest] = await db.select().from(toolActionRequests);
+    const now = Date.now();
+    await db
+      .update(issueThreadInteractions)
+      .set({
+        status: "accepted",
+        resolvedByUserId: "board-user",
+        resolvedAt: new Date(now - 10_000),
+      })
+      .where(eq(issueThreadInteractions.id, actionRequest.interactionId!));
+    await db
+      .update(toolActionRequests)
+      .set({ expiresAt: new Date(now - 1_000) })
+      .where(eq(toolActionRequests.id, actionRequest.id));
+
+    const applicationClock = vi.spyOn(Date, "now").mockReturnValue(now - 5_000);
+    try {
+      await expect(gateway.executeTool({
+        sessionToken: session.token,
+        tool: "mcp-remote-fixture:update_note",
+        parameters,
+        approvedActionRequestId: actionRequest.id,
+      })).rejects.toMatchObject({ reasonCode: "action_expired" });
+    } finally {
+      applicationClock.mockRestore();
+    }
+
+    const [expired] = await db
+      .select()
+      .from(toolActionRequests)
+      .where(eq(toolActionRequests.id, actionRequest.id));
+    const [invocation] = await db
+      .select()
+      .from(toolInvocations)
+      .where(eq(toolInvocations.id, actionRequest.invocationId));
+    const expiryEvents = await db.select().from(toolCallEvents).where(and(
+      eq(toolCallEvents.actionRequestId, actionRequest.id),
+      eq(toolCallEvents.reasonCode, "action_expired"),
+    ));
+    expect(expired.status).toBe("expired");
+    expect(invocation).toMatchObject({
+      status: "awaiting_approval",
+      approvalState: "expired",
+      idempotencyKey: null,
+    });
+    expect(expiryEvents).toHaveLength(1);
+  });
+
+  it("keeps test-origin dispatch inert when expiry wins after approval commits", async () => {
+    const { company, agent } = await createRunFixture(db);
+    const { connection } = await createRemoteMcpToolFixture(db, company.id);
+    await db.insert(toolPolicies).values({
+      companyId: company.id,
+      name: "Review test expiry",
+      policyType: "require_approval",
+      selectors: { connectionId: connection.id },
+    });
+    await db.insert(companyMemberships).values({
+      companyId: company.id,
+      principalType: "user",
+      principalId: "board-user",
+      status: "active",
+      membershipRole: "owner",
+    });
+    const provider = vi.fn(async (_url: string, init: RequestInit) => {
+      const payload = JSON.parse(String(init.body)) as { id: string };
+      return new Response(JSON.stringify({
+        jsonrpc: "2.0",
+        id: payload.id,
+        result: { content: [{ type: "text", text: "provider executed" }] },
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    });
+    const expiryGateway = createTestToolGatewayService(db, { remoteHttpRequest: provider });
+    const pending = await expiryGateway.executeTestCall({
+      companyId: company.id,
+      agentId: agent.id,
+      userId: "board-user",
+      connectionId: connection.id,
+      toolName: "needs_input",
+      parameters: {},
+    });
+    expect(pending).toMatchObject({ decision: "ask_first" });
+    const [actionRequest] = await db.select().from(toolActionRequests);
+    let expiredDuringPause = false;
+    const pausedDb = new Proxy(db, {
+      get(target, property, receiver) {
+        if (property !== "transaction") return Reflect.get(target, property, receiver);
+        return async (...args: any[]) => {
+          const result = await (target.transaction as any)(...args);
+          if (result?.status === "approved") {
+            await db
+              .update(toolActionRequests)
+              .set({ expiresAt: new Date(Date.now() - 1_000) })
+              .where(eq(toolActionRequests.id, actionRequest.id));
+            const expired = await expiryGateway.approveActionRequest({
+              companyId: company.id,
+              actionRequestId: actionRequest.id,
+              actor: { userId: "second-board-user" },
+            });
+            expect(expired).toMatchObject({ status: "expired" });
+            expiredDuringPause = true;
+          }
+          return result;
+        };
+      },
+    });
+    const gateway = createTestToolGatewayService(pausedDb, { remoteHttpRequest: provider });
+
+    await expect(gateway.approveActionRequest({
+      companyId: company.id,
+      actionRequestId: actionRequest.id,
+      actor: { userId: "board-user" },
+    })).resolves.toMatchObject({ status: "expired" });
+
+    expect(expiredDuringPause).toBe(true);
+    const [settled] = await db
+      .select()
+      .from(toolActionRequests)
+      .where(eq(toolActionRequests.id, actionRequest.id));
+    const [invocation] = await db
+      .select()
+      .from(toolInvocations)
+      .where(eq(toolInvocations.id, actionRequest.invocationId));
+    expect(settled.status).toBe("expired");
+    expect(invocation.status).not.toBe("succeeded");
+    expect(provider).not.toHaveBeenCalled();
   });
 
   it("refuses to approve an action request through a different interaction", async () => {

--- a/server/src/__tests__/tool-gateway-service.test.ts
+++ b/server/src/__tests__/tool-gateway-service.test.ts
@@ -342,6 +342,127 @@ describeEmbeddedPostgres("tool gateway service", () => {
     expect(consumed.status).toBe("executed");
   });
 
+  it("expires a late approval atomically without dispatching the stored invocation", async () => {
+    const { company, agent, run } = await createRunFixture(db);
+    await db.insert(toolPolicies).values({
+      companyId: company.id,
+      name: "Review note writes",
+      policyType: "require_approval",
+      selectors: { toolName: "mcp-remote-fixture:update_note" },
+    });
+    const gateway = createTestToolGatewayService(db);
+    const session = await gateway.createSession({ companyId: company.id, agentId: agent.id, runId: run.id });
+    const parameters = { noteId: "n1", body: "must never run" };
+
+    await expect(gateway.executeTool({
+      sessionToken: session.token,
+      tool: "mcp-remote-fixture:update_note",
+      parameters,
+    })).rejects.toMatchObject({ reasonCode: "approval_required" });
+    const [actionRequest] = await db.select().from(toolActionRequests);
+    await db
+      .update(toolActionRequests)
+      .set({ expiresAt: new Date(Date.now() - 1_000) })
+      .where(eq(toolActionRequests.id, actionRequest.id));
+
+    await expect(gateway.approveActionRequest({
+      companyId: company.id,
+      actionRequestId: actionRequest.id,
+      actor: { userId: "board-user" },
+    })).resolves.toMatchObject({ status: "expired" });
+
+    const [expired] = await db.select().from(toolActionRequests).where(eq(toolActionRequests.id, actionRequest.id));
+    expect(expired).toMatchObject({
+      status: "expired",
+      decidedAt: null,
+      resolvedByUserId: null,
+    });
+    const [invocation] = await db.select().from(toolInvocations).where(eq(toolInvocations.id, actionRequest.invocationId));
+    expect(invocation).toMatchObject({ status: "awaiting_approval", approvalState: "expired" });
+
+    const expiryEvents = await db.select().from(toolCallEvents).where(and(
+      eq(toolCallEvents.actionRequestId, actionRequest.id),
+      eq(toolCallEvents.reasonCode, "action_expired"),
+    ));
+    expect(expiryEvents).toEqual([
+      expect.objectContaining({
+        eventType: "approval_resolved",
+        outcome: "timeout",
+        actorType: "user",
+        actorId: "board-user",
+      }),
+    ]);
+    const dispatchEvents = await db.select().from(toolCallEvents).where(and(
+      eq(toolCallEvents.actionRequestId, actionRequest.id),
+      eq(toolCallEvents.reasonCode, "approved_action_executed"),
+    ));
+    expect(dispatchEvents).toHaveLength(0);
+  });
+
+  it("lets expiry win a stale-read approval race without dispatching", async () => {
+    const { company, agent, run } = await createRunFixture(db);
+    await db.insert(toolPolicies).values({
+      companyId: company.id,
+      name: "Review raced note writes",
+      policyType: "require_approval",
+      selectors: { toolName: "mcp-remote-fixture:update_note" },
+    });
+    let observeApproval!: () => void;
+    const approvalObserved = new Promise<void>((resolve) => {
+      observeApproval = resolve;
+    });
+    let releaseApproval!: () => void;
+    const approvalBlocked = new Promise<void>((resolve) => {
+      releaseApproval = resolve;
+    });
+    const gateway = createTestToolGatewayService(db, {
+      beforeActionRequestApproval: async () => {
+        observeApproval();
+        await approvalBlocked;
+      },
+    });
+    const session = await gateway.createSession({ companyId: company.id, agentId: agent.id, runId: run.id });
+    const parameters = { noteId: "n1", body: "expiry wins" };
+
+    await expect(gateway.executeTool({
+      sessionToken: session.token,
+      tool: "mcp-remote-fixture:update_note",
+      parameters,
+    })).rejects.toMatchObject({ reasonCode: "approval_required" });
+    const [actionRequest] = await db.select().from(toolActionRequests);
+
+    const approval = gateway.approveActionRequest({
+      companyId: company.id,
+      actionRequestId: actionRequest.id,
+      actor: { userId: "board-user" },
+    });
+    await approvalObserved;
+    await db
+      .update(toolActionRequests)
+      .set({ expiresAt: new Date(Date.now() - 1_000) })
+      .where(eq(toolActionRequests.id, actionRequest.id));
+    await expect(gateway.executeTool({
+      sessionToken: session.token,
+      tool: "mcp-remote-fixture:update_note",
+      parameters,
+    })).rejects.toMatchObject({ reasonCode: "approval_required" });
+    releaseApproval();
+
+    await expect(approval).resolves.toMatchObject({ status: "expired" });
+    const [expired] = await db.select().from(toolActionRequests).where(eq(toolActionRequests.id, actionRequest.id));
+    expect(expired.status).toBe("expired");
+    const expiryEvents = await db.select().from(toolCallEvents).where(and(
+      eq(toolCallEvents.actionRequestId, actionRequest.id),
+      eq(toolCallEvents.reasonCode, "action_expired"),
+    ));
+    expect(expiryEvents).toHaveLength(1);
+    const dispatchEvents = await db.select().from(toolCallEvents).where(and(
+      eq(toolCallEvents.actionRequestId, actionRequest.id),
+      eq(toolCallEvents.reasonCode, "approved_action_executed"),
+    ));
+    expect(dispatchEvents).toHaveLength(0);
+  });
+
   it("refuses to approve an action request through a different interaction", async () => {
     const { company, agent, issue, run } = await createRunFixture(db);
     await db.insert(toolPolicies).values({

--- a/server/src/services/tool-gateway.ts
+++ b/server/src/services/tool-gateway.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { createHash, randomBytes, randomUUID } from "node:crypto";
-import { and, desc, eq, inArray, isNull, lte, ne, or, sql } from "drizzle-orm";
+import { and, desc, eq, gt, inArray, isNotNull, isNull, lte, ne, or, sql } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
 import {
   agents,
@@ -866,6 +866,8 @@ export function createToolGatewayService(
     beforeManagedArgumentDriftExpiry?: () => Promise<void>;
     /** Test seam for pausing a legacy approved request before its execution claim. */
     beforeLegacyApprovedActionClaim?: () => Promise<void>;
+    /** Test seam for racing direct approval against action-request expiry. */
+    beforeActionRequestApproval?: () => Promise<void>;
     mcpGatewayProtocolLimits?: Partial<{
       authFailures: Partial<McpGatewayRateLimitConfig>;
       gatewayRequests: Partial<McpGatewayRateLimitConfig>;
@@ -5270,6 +5272,85 @@ export function createToolGatewayService(
     };
   }
 
+  async function expireDueActionRequest(input: {
+    actionRequestId: string;
+    invocation: typeof toolInvocations.$inferSelect;
+    fromStatuses: Array<"pending" | "approved">;
+    actor?: { agentId?: string | null; userId?: string | null };
+  }) {
+    const expired = await db.transaction(async (tx) => {
+      const [updated] = await tx
+        .update(toolActionRequests)
+        .set({
+          status: "expired",
+          resolvedAt: sql`clock_timestamp()`,
+          updatedAt: sql`clock_timestamp()`,
+        })
+        .where(and(
+          eq(toolActionRequests.id, input.actionRequestId),
+          inArray(toolActionRequests.status, input.fromStatuses),
+          isNotNull(toolActionRequests.expiresAt),
+          lte(toolActionRequests.expiresAt, sql`clock_timestamp()`),
+        ))
+        .returning();
+      if (!updated) return null;
+
+      await tx
+        .update(toolInvocations)
+        .set({
+          approvalState: "expired",
+          idempotencyKey: null,
+          updatedAt: updated.resolvedAt ?? new Date(),
+        })
+        .where(eq(toolInvocations.id, input.invocation.id));
+
+      const actorType = input.actor?.userId
+        ? "user"
+        : input.actor?.agentId
+          ? "agent"
+          : "system";
+      const actorId = input.actor?.userId
+        ?? input.actor?.agentId
+        ?? input.invocation.agentId
+        ?? input.invocation.companyId;
+      await tx.insert(toolCallEvents).values({
+        companyId: input.invocation.companyId,
+        eventType: "approval_resolved",
+        actorType,
+        actorId,
+        agentId: input.invocation.agentId,
+        runId: input.invocation.runId,
+        issueId: input.invocation.issueId,
+        gatewayId: input.invocation.gatewayId,
+        gatewayTokenId: input.invocation.gatewayTokenId,
+        gatewayPublicId: input.invocation.gatewayPublicId,
+        clientSubjectType: input.invocation.clientSubjectType,
+        clientSubjectId: input.invocation.clientSubjectId,
+        clientName: input.invocation.clientName,
+        mcpSessionId: input.invocation.mcpSessionId,
+        correlationId: input.invocation.correlationId,
+        applicationId: input.invocation.applicationId,
+        connectionId: input.invocation.connectionId,
+        catalogEntryId: input.invocation.catalogEntryId,
+        invocationId: input.invocation.id,
+        actionRequestId: updated.id,
+        toolName: input.invocation.toolName,
+        decision: "require_approval",
+        outcome: "timeout",
+        reasonCode: "action_expired",
+        metadata: {
+          expiresAt: updated.expiresAt?.toISOString() ?? null,
+          expiredAt: updated.resolvedAt?.toISOString() ?? null,
+        },
+      });
+      return updated;
+    });
+    if (expired) {
+      await reflectToolActionInteractionLifecycle({ actionRequestId: expired.id, status: "expired" });
+    }
+    return expired;
+  }
+
   async function markApprovedActionFailed(input: {
     actionRequestId: string;
     invocationId: string;
@@ -5432,9 +5513,33 @@ export function createToolGatewayService(
     const [claimed] = await db
       .update(toolActionRequests)
       .set({ status: "executing", updatedAt: new Date() })
-      .where(and(eq(toolActionRequests.id, actionRequest.id), eq(toolActionRequests.status, "approved")))
+      .where(and(
+        eq(toolActionRequests.id, actionRequest.id),
+        eq(toolActionRequests.status, "approved"),
+        or(
+          isNull(toolActionRequests.expiresAt),
+          gt(toolActionRequests.expiresAt, sql`clock_timestamp()`),
+        ),
+      ))
       .returning();
     if (!claimed) {
+      const expired = await expireDueActionRequest({
+        actionRequestId: actionRequest.id,
+        invocation,
+        fromStatuses: ["approved"],
+        actor: {
+          agentId: actionRequest.resolvedByAgentId,
+          userId: actionRequest.resolvedByUserId,
+        },
+      });
+      if (expired) {
+        throw new ToolGatewayHttpError(
+          409,
+          "Tool action request approval has expired",
+          "action_expired",
+          { actionRequestId: actionRequest.id, invocationId: invocation.id },
+        );
+      }
       const settled = await waitForActionRequestExecution(actionRequest.id);
       const [settledInvocation] = await db
         .select()
@@ -5449,6 +5554,14 @@ export function createToolGatewayService(
           502,
           settledInvocation?.errorMessage ?? "Approved tool action failed",
           settledInvocation?.errorCode ?? "tool_execution_failed",
+          { actionRequestId: actionRequest.id, invocationId: invocation.id },
+        );
+      }
+      if (settled?.status === "expired") {
+        throw new ToolGatewayHttpError(
+          409,
+          "Tool action request approval has expired",
+          "action_expired",
           { actionRequestId: actionRequest.id, invocationId: invocation.id },
         );
       }
@@ -5718,7 +5831,7 @@ export function createToolGatewayService(
       pendingRequest.status === "pending"
       && pendingRequest.expiresAt !== null
       && pendingRequest.expiresAt.getTime() <= Date.now();
-    if (pendingUnsigned || pendingExpired) {
+    if (pendingUnsigned) {
       const now = new Date();
       await db.update(toolActionRequests).set({ status: "expired", resolvedAt: now, updatedAt: now }).where(and(
         eq(toolActionRequests.id, match.actionRequest.id),
@@ -5731,6 +5844,26 @@ export function createToolGatewayService(
       }).where(eq(toolInvocations.id, match.invocation.id));
       await reflectToolActionInteractionLifecycle({ actionRequestId: match.actionRequest.id, status: "expired" });
       return null;
+    }
+    if (pendingExpired) {
+      const expired = await expireDueActionRequest({
+        actionRequestId: pendingRequest.id,
+        invocation: match.invocation,
+        fromStatuses: ["pending"],
+        actor: { agentId: input.session.agentId },
+      });
+      if (expired) return null;
+
+      // The Date.now() precheck above is only a fast path. The database clock
+      // and the compare-and-set are authoritative, so if expiry lost to an
+      // approval race, replay the winner instead of creating a second request.
+      const [settled] = await db
+        .select({ actionRequest: toolActionRequests, invocation: toolInvocations })
+        .from(toolActionRequests)
+        .innerJoin(toolInvocations, eq(toolInvocations.id, toolActionRequests.invocationId))
+        .where(eq(toolActionRequests.id, pendingRequest.id))
+        .limit(1);
+      return settled ?? null;
     }
     return match;
   }
@@ -6608,6 +6741,13 @@ export function createToolGatewayService(
       if (actionRequest.status !== "pending" && actionRequest.status !== "approved") {
         throw new ToolGatewayHttpError(409, "Tool action request is no longer pending", "action_not_pending");
       }
+      const alreadyExpired = await expireDueActionRequest({
+        actionRequestId: actionRequest.id,
+        invocation,
+        fromStatuses: [actionRequest.status],
+        actor: input.actor,
+      });
+      if (alreadyExpired) return actionRequestResolution(alreadyExpired);
       let signedPayload: ReturnType<typeof readSignedToolArgumentsPayload> = null;
       try {
         signedPayload = readSignedToolArgumentsPayload({
@@ -6664,28 +6804,50 @@ export function createToolGatewayService(
         }
         return actionRequest;
       }
-      const now = new Date();
-      const [updated] = await db
-        .update(toolActionRequests)
-        .set({
-          status: "approved",
-          resolvedByAgentId: input.actor.agentId ?? null,
-          resolvedByUserId: input.actor.userId ?? null,
-          decidedByAgentId: input.actor.agentId ?? null,
-          decidedByUserId: input.actor.userId ?? null,
-          decidedAt: now,
-          resolvedAt: now,
-          updatedAt: now,
-        })
-        .where(and(eq(toolActionRequests.id, actionRequest.id), eq(toolActionRequests.status, "pending")))
-        .returning();
+      await options.beforeActionRequestApproval?.();
+      const updated = await db.transaction(async (tx) => {
+        const [approved] = await tx
+          .update(toolActionRequests)
+          .set({
+            status: "approved",
+            resolvedByAgentId: input.actor.agentId ?? null,
+            resolvedByUserId: input.actor.userId ?? null,
+            decidedByAgentId: input.actor.agentId ?? null,
+            decidedByUserId: input.actor.userId ?? null,
+            decidedAt: sql`clock_timestamp()`,
+            resolvedAt: sql`clock_timestamp()`,
+            updatedAt: sql`clock_timestamp()`,
+          })
+          .where(and(
+            eq(toolActionRequests.id, actionRequest.id),
+            eq(toolActionRequests.status, "pending"),
+            isNotNull(toolActionRequests.expiresAt),
+            gt(toolActionRequests.expiresAt, sql`clock_timestamp()`),
+          ))
+          .returning();
+        if (!approved) return null;
+        await tx
+          .update(toolInvocations)
+          .set({ approvalState: "approved", updatedAt: approved.resolvedAt ?? new Date() })
+          .where(eq(toolInvocations.id, invocation.id));
+        return approved;
+      });
       if (!updated) {
+        const expired = await expireDueActionRequest({
+          actionRequestId: actionRequest.id,
+          invocation,
+          fromStatuses: ["pending"],
+          actor: input.actor,
+        });
+        if (expired) return actionRequestResolution(expired);
+        const [settled] = await db
+          .select()
+          .from(toolActionRequests)
+          .where(eq(toolActionRequests.id, actionRequest.id))
+          .limit(1);
+        if (settled?.status === "expired") return actionRequestResolution(settled);
         throw new ToolGatewayHttpError(409, "Tool action request has already been resolved", "action_already_resolved");
       }
-      await db
-        .update(toolInvocations)
-        .set({ approvalState: "approved", updatedAt: now })
-        .where(eq(toolInvocations.id, invocation.id));
       await reflectToolActionInteractionLifecycle({ actionRequestId: updated.id, status: "approved" });
       // A test-tab ask-first request has no agent run to carry out the parked
       // call, so approving it is what runs it. Execute against the signed

--- a/server/src/services/tool-gateway.ts
+++ b/server/src/services/tool-gateway.ts
@@ -5128,6 +5128,32 @@ export function createToolGatewayService(
     const agentId = invocation.agentId;
     if (!invocation.connectionId || !agentId) return;
     const userId = invocation.actorId ?? "board";
+    // Linearize provider execution against expiry before doing any outbound
+    // work. Once this approved -> executing claim wins, a concurrent expiry
+    // can no longer revoke the request; if expiry wins first, this path stays
+    // completely inert.
+    const [claimed] = await db
+      .update(toolActionRequests)
+      .set({ status: "executing", updatedAt: sql`clock_timestamp()` })
+      .where(and(
+        eq(toolActionRequests.id, actionRequestId),
+        eq(toolActionRequests.status, "approved"),
+        or(
+          isNull(toolActionRequests.expiresAt),
+          gt(toolActionRequests.expiresAt, sql`clock_timestamp()`),
+        ),
+      ))
+      .returning();
+    if (!claimed) {
+      await expireDueActionRequest({
+        actionRequestId,
+        invocation,
+        fromStatuses: ["approved"],
+        actor: { userId },
+      });
+      return;
+    }
+    await reflectToolActionInteractionLifecycle({ actionRequestId, status: "executing" });
     const session: ToolGatewaySession = {
       id: "test-call",
       token: "test-call",
@@ -5152,16 +5178,24 @@ export function createToolGatewayService(
       tool = undefined;
     }
     if (!tool) {
+      const failedAt = new Date();
       await db
         .update(toolInvocations)
         .set({
           status: "failed",
           errorCode: "tool_not_found",
           errorMessage: `Tool "${invocation.toolName}" is no longer connected`,
-          completedAt: new Date(),
-          updatedAt: new Date(),
+          completedAt: failedAt,
+          updatedAt: failedAt,
         })
         .where(eq(toolInvocations.id, invocation.id));
+      await db
+        .update(toolActionRequests)
+        .set({ status: "failed", resolvedAt: failedAt, updatedAt: failedAt })
+        .where(and(
+          eq(toolActionRequests.id, actionRequestId),
+          eq(toolActionRequests.status, "executing"),
+        ));
       await reflectToolActionInteractionLifecycle({
         actionRequestId,
         status: "failed",
@@ -5177,7 +5211,7 @@ export function createToolGatewayService(
       promptInjectionMode: "ignore",
     }).summary;
     try {
-      await runTestToolInvocation({
+      const result = await runTestToolInvocation({
         session,
         tool,
         parameters,
@@ -5189,19 +5223,51 @@ export function createToolGatewayService(
         reasonCode: "approval_granted",
         matchedPolicyIds: invocation.matchedPolicyIds ?? [],
       });
-      await reflectToolActionInteractionLifecycle({ actionRequestId, status: "executed" });
+      const settledAt = new Date();
+      if ("error" in result) {
+        await db
+          .update(toolActionRequests)
+          .set({ status: "failed", resolvedAt: settledAt, updatedAt: settledAt })
+          .where(and(
+            eq(toolActionRequests.id, actionRequestId),
+            eq(toolActionRequests.status, "executing"),
+          ));
+        await reflectToolActionInteractionLifecycle({
+          actionRequestId,
+          status: "failed",
+          errorCode: result.error.reasonCode,
+          errorMessage: result.error.message,
+        });
+      } else {
+        await db
+          .update(toolActionRequests)
+          .set({ status: "executed", resolvedAt: settledAt, updatedAt: settledAt })
+          .where(and(
+            eq(toolActionRequests.id, actionRequestId),
+            eq(toolActionRequests.status, "executing"),
+          ));
+        await reflectToolActionInteractionLifecycle({ actionRequestId, status: "executed" });
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+      const failedAt = new Date();
       await db
         .update(toolInvocations)
         .set({
           status: "failed",
           errorCode: "tool_execution_failed",
           errorMessage: message,
-          completedAt: new Date(),
-          updatedAt: new Date(),
+          completedAt: failedAt,
+          updatedAt: failedAt,
         })
         .where(eq(toolInvocations.id, invocation.id));
+      await db
+        .update(toolActionRequests)
+        .set({ status: "failed", resolvedAt: failedAt, updatedAt: failedAt })
+        .where(and(
+          eq(toolActionRequests.id, actionRequestId),
+          eq(toolActionRequests.status, "executing"),
+        ));
       await reflectToolActionInteractionLifecycle({
         actionRequestId,
         status: "failed",
@@ -7109,20 +7175,19 @@ export function createToolGatewayService(
         if (storedInvocation.toolName !== tool.name) {
           throw new ToolGatewayHttpError(409, "Approved action request is for a different tool", "action_tool_mismatch");
         }
-        if (actionRequest.expiresAt && actionRequest.expiresAt.getTime() <= Date.now()) {
-          const expiredAt = new Date();
-          const [expired] = await db
-            .update(toolActionRequests)
-            .set({ status: "expired", resolvedAt: expiredAt, updatedAt: expiredAt })
-            .where(and(
-              eq(toolActionRequests.id, actionRequest.id),
-              inArray(toolActionRequests.status, ["pending", "approved"]),
-            ))
-            .returning({ id: toolActionRequests.id });
-          if (expired) {
-            await reflectToolActionInteractionLifecycle({ actionRequestId: expired.id, status: "expired" });
-          }
+        if (actionRequest.status === "expired") {
           throw new ToolGatewayHttpError(409, "Tool action request approval has expired", "action_expired");
+        }
+        if (actionRequest.status === "pending" || actionRequest.status === "approved") {
+          const expiredBeforeApproval = await expireDueActionRequest({
+            actionRequestId: actionRequest.id,
+            invocation: storedInvocation,
+            fromStatuses: [actionRequest.status],
+            actor: { agentId: session.agentId },
+          });
+          if (expiredBeforeApproval) {
+            throw new ToolGatewayHttpError(409, "Tool action request approval has expired", "action_expired");
+          }
         }
         if (actionRequest.status === "pending" && actionRequest.interactionId) {
           const [interaction] = await db
@@ -7141,21 +7206,54 @@ export function createToolGatewayService(
             ))
             .limit(1);
           if (interaction?.kind === "request_confirmation" && interaction.status === "accepted") {
-            const [approved] = await db
-              .update(toolActionRequests)
-              .set({
-                status: "approved",
-                resolvedByAgentId: interaction.resolvedByAgentId ?? null,
-                resolvedByUserId: interaction.resolvedByUserId ?? null,
-                decidedByAgentId: interaction.resolvedByAgentId ?? null,
-                decidedByUserId: interaction.resolvedByUserId ?? null,
-                decidedAt: interaction.resolvedAt ?? new Date(),
-                resolvedAt: interaction.resolvedAt ?? new Date(),
-                updatedAt: new Date(),
-              })
-              .where(and(eq(toolActionRequests.id, actionRequest.id), eq(toolActionRequests.status, "pending")))
-              .returning();
+            const approved = await db.transaction(async (tx) => {
+              const [updated] = await tx
+                .update(toolActionRequests)
+                .set({
+                  status: "approved",
+                  resolvedByAgentId: interaction.resolvedByAgentId ?? null,
+                  resolvedByUserId: interaction.resolvedByUserId ?? null,
+                  decidedByAgentId: interaction.resolvedByAgentId ?? null,
+                  decidedByUserId: interaction.resolvedByUserId ?? null,
+                  decidedAt: sql`clock_timestamp()`,
+                  resolvedAt: sql`clock_timestamp()`,
+                  updatedAt: sql`clock_timestamp()`,
+                })
+                .where(and(
+                  eq(toolActionRequests.id, actionRequest.id),
+                  eq(toolActionRequests.status, "pending"),
+                  isNotNull(toolActionRequests.expiresAt),
+                  gt(toolActionRequests.expiresAt, sql`clock_timestamp()`),
+                ))
+                .returning();
+              if (!updated) return null;
+              await tx
+                .update(toolInvocations)
+                .set({ approvalState: "approved", updatedAt: updated.resolvedAt ?? new Date() })
+                .where(eq(toolInvocations.id, storedInvocation.id));
+              return updated;
+            });
             if (!approved) {
+              const expired = await expireDueActionRequest({
+                actionRequestId: actionRequest.id,
+                invocation: storedInvocation,
+                fromStatuses: ["pending"],
+                actor: {
+                  agentId: interaction.resolvedByAgentId,
+                  userId: interaction.resolvedByUserId,
+                },
+              });
+              if (expired) {
+                throw new ToolGatewayHttpError(409, "Tool action request approval has expired", "action_expired");
+              }
+              const [settled] = await db
+                .select({ status: toolActionRequests.status })
+                .from(toolActionRequests)
+                .where(eq(toolActionRequests.id, actionRequest.id))
+                .limit(1);
+              if (settled?.status === "expired") {
+                throw new ToolGatewayHttpError(409, "Tool action request approval has expired", "action_expired");
+              }
               throw new ToolGatewayHttpError(409, "Tool action request has already been resolved", "action_already_resolved");
             }
             actionRequest = approved;
@@ -7222,9 +7320,38 @@ export function createToolGatewayService(
             .where(and(
               eq(toolActionRequests.id, actionRequest.id),
               eq(toolActionRequests.status, "approved"),
+              or(
+                isNull(toolActionRequests.expiresAt),
+                gt(toolActionRequests.expiresAt, sql`clock_timestamp()`),
+              ),
             ))
             .returning();
           if (!claimed) {
+            const expired = await expireDueActionRequest({
+              actionRequestId: actionRequest.id,
+              invocation: storedInvocation,
+              fromStatuses: ["approved"],
+              actor: { agentId: session.agentId },
+            });
+            if (expired) {
+              throw new ToolGatewayHttpError(
+                409,
+                "Tool action request approval has expired",
+                "action_expired",
+              );
+            }
+            const [settled] = await db
+              .select({ status: toolActionRequests.status })
+              .from(toolActionRequests)
+              .where(eq(toolActionRequests.id, actionRequest.id))
+              .limit(1);
+            if (settled?.status === "expired") {
+              throw new ToolGatewayHttpError(
+                409,
+                "Tool action request approval has expired",
+                "action_expired",
+              );
+            }
             throw new ToolGatewayHttpError(
               409,
               "Tool action request was already consumed",
@@ -7291,9 +7418,41 @@ export function createToolGatewayService(
             resolvedByAgentId: session.agentId,
             updatedAt: claimedAt,
           })
-          .where(and(eq(toolActionRequests.id, actionRequest.id), eq(toolActionRequests.status, "approved")))
+          .where(and(
+            eq(toolActionRequests.id, actionRequest.id),
+            eq(toolActionRequests.status, "approved"),
+            or(
+              isNull(toolActionRequests.expiresAt),
+              gt(toolActionRequests.expiresAt, sql`clock_timestamp()`),
+            ),
+          ))
           .returning();
         if (!claimed) {
+          const expired = await expireDueActionRequest({
+            actionRequestId: actionRequest.id,
+            invocation: storedInvocation,
+            fromStatuses: ["approved"],
+            actor: { agentId: session.agentId },
+          });
+          if (expired) {
+            throw new ToolGatewayHttpError(
+              409,
+              "Tool action request approval has expired",
+              "action_expired",
+            );
+          }
+          const [settled] = await db
+            .select({ status: toolActionRequests.status })
+            .from(toolActionRequests)
+            .where(eq(toolActionRequests.id, actionRequest.id))
+            .limit(1);
+          if (settled?.status === "expired") {
+            throw new ToolGatewayHttpError(
+              409,
+              "Tool action request approval has expired",
+              "action_expired",
+            );
+          }
           throw new ToolGatewayHttpError(409, "Tool action request was already consumed", "action_already_consumed");
         }
         await reflectToolActionInteractionLifecycle({ actionRequestId: claimed.id, status: "executing" });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The Tool Gateway controls calls to external tools
> - Some tool calls require an action request and operator approval
> - An approval could arrive after the action request expired
> - The old approval path could then execute the stored tool call
> - This pull request makes approval and expiry use atomic state transitions
> - It also checks the deadline again before provider dispatch
> - The benefit is that an expired action request cannot execute

## Linked Issues or Issue Description

**What happened?**

The Tool Gateway accepted an approval after the action request expiry time. It then executed the stored tool call.

**Expected behavior**

The approval path must reject the request when the database clock is at or after `expiresAt`. It must record the expired result and must not dispatch the tool call.

**Steps to reproduce**

1. Create a Tool Gateway action request that requires approval.
2. Let the request pass its `expiresAt` value.
3. Approve the request.
4. Observe that the old code records approval and dispatches the stored call.

**Paperclip version or commit**

The defect was observed on Paperclip `2026.831.1`. The fix is at commit `ad5d9fc64e8ffde870f007c88eee4ecfa9fba3b8`.

**Deployment mode**

Self-hosted server.

**Additional context**

The new tests cover late approval, competing approval and expiry transitions, and expiry during provider dispatch preparation.

## What Changed

- Use database-clock compare-and-set updates for approval and expiry terminal states.
- Write the expiry audit event in the same transaction as the expiry transition.
- Add a deadline guard before a claimed invocation can dispatch to the provider.
- Make losing race participants replay the winning terminal state without duplicate action requests.
- Add focused regression tests for late approval and approval-versus-expiry races.

## Verification

- Ran `pnpm --filter @paperclipai/server exec vitest run src/__tests__/tool-gateway-service.test.ts` with embedded PostgreSQL. All 27 tests passed.
- Ran the direct server TypeScript check. It passed.
- Ran `git diff --check`. It passed.
- An independent security review approved the exact commit in this pull request.

## Risks

- The change affects the terminal-state protocol for privileged tool execution.
- A bad transition could reject a valid approval or dispatch an expired request.
- The focused race tests cover both outcomes and verify that only one terminal result wins.
- This pull request does not deploy the change or enable any disabled connection.

> This is a focused security bug fix. It does not add a roadmap feature.

## Model Used

OpenAI Codex with GPT-5 assisted with the change. The exact serving snapshot and context window were not exposed. The model used reasoning, tool use, and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
