### PR TITLE
fix: skip the workspace reopen for comments that do not resume a terminal issue

### DIFF
--- a/server/src/__tests__/issue-closed-workspace-routes.test.ts
+++ b/server/src/__tests__/issue-closed-workspace-routes.test.ts
@@ -308,6 +308,56 @@ describe.sequential("closed isolated workspace issue routes", () => {
     expect(mockIssueService.addComment).not.toHaveBeenCalled();
   });
 
+  it("accepts a plain comment on a done issue without touching the closed workspace", async () => {
+    // A comment that does not resume a terminal issue is a pure record: it
+    // must not rebuild the worktree, and it must not be blocked by a
+    // workspace it never needed.
+    mockIssueService.getById.mockResolvedValue({ ...makeIssue(), status: "done", assigneeAgentId: null });
+    mockIssueService.addComment.mockResolvedValue({ id: "comment-1", body: "decision recorded" });
+
+    const res = await request(createApp())
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "decision recorded" });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalledTimes(1);
+    expect(mockExecutionWorkspaceService.reopenClosedIsolatedExecutionWorkspaceForIssue).not.toHaveBeenCalled();
+  });
+
+  it("accepts a plain comment on a done issue even when the workspace cannot be reopened", async () => {
+    // The audit comment is not resuming anything, so a workspace that is
+    // un-reopenable must not turn it into a 409.
+    mockIssueService.getById.mockResolvedValue({ ...makeIssue(), status: "done", assigneeAgentId: null });
+    mockIssueService.addComment.mockResolvedValue({ id: "comment-1", body: "decision recorded" });
+    mockExecutionWorkspaceService.reopenClosedIsolatedExecutionWorkspaceForIssue.mockResolvedValue({
+      ok: false,
+      code: "not_reopenable",
+      message: "Execution workspace is not reopenable",
+    });
+
+    const res = await request(createApp())
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "decision recorded" });
+
+    expect(res.status).toBe(201);
+    expect(mockIssueService.addComment).toHaveBeenCalledTimes(1);
+  });
+
+  it("still reopens the closed workspace for a comment that resumes a done issue", async () => {
+    // `reopen: true` on a terminal issue is a resume: it needs the worktree,
+    // so the reopen still runs and still blocks when the rebuild fails.
+    mockIssueService.getById.mockResolvedValue({ ...makeIssue(), status: "done", assigneeAgentId: null });
+    mockIssueService.update.mockResolvedValue({ ...makeIssue(), status: "todo" });
+    mockIssueService.addComment.mockResolvedValue({ id: "comment-1", body: "hello" });
+
+    const res = await request(createApp())
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "please continue", reopen: true });
+
+    expect(mockExecutionWorkspaceService.reopenClosedIsolatedExecutionWorkspaceForIssue).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(201);
+  });
+
   it("returns 503 and blocks the checkout when the rebuild fails", async () => {
     mockExecutionWorkspaceService.reopenClosedIsolatedExecutionWorkspaceForIssue.mockResolvedValue({
       ok: false,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -17065,9 +17065,14 @@ export function issueRoutes(
       // blocker, and run-cap gate passes. A rejected comment must not rebuild and
       // republish the workspace as active, because the issue stays terminal and the
       // reaper then skips the leaked workspace.
+      //
+      // A comment on a terminal issue that does not resume the work is a plain
+      // record: it never needs the worktree. Rebuilding one for it would either
+      // churn a workspace the reaper immediately reaps again or block an audit
+      // comment with a 409 the workspace was never needed for.
       let reopenedWorkspace: Pick<ExecutionWorkspace, "id"> | null = null;
       let reopenedGeneration: number | null = null;
-      if (closedExecutionWorkspace) {
+      if (closedExecutionWorkspace && (!isClosed || effectiveMoveToTodoRequested)) {
         const reopenOutcome =
           await reopenClosedIssueExecutionWorkspaceOrRespond(
             req,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - A comment on an issue linked to a closed isolated workspace reopens the workspace so resumed work has a live worktree
> - The comments route attempted that reopen for every comment, including a pure audit record on a terminal issue that never moves it out of done or cancelled
> - Such a comment either churned a workspace the reaper immediately reaped again, or hit a 409 when the workspace could not be rebuilt
> - This pull request scopes the reopen to comments that can still use the worktree: anything on a non-terminal issue, and any comment that actually resumes a terminal one
> - The benefit is that governance notes and decisions can be recorded on finished work without triggering workspace lifecycle side effects

## Linked Issues or Issue Description

Refs #11472 — the flat rejection reported there predates the reopen machinery; this closes the residual where a comment that never resumes the issue was still gated on the workspace being rebuildable.

## What Changed

- `server/src/routes/issues.ts`: the comments route attempts the closed-workspace reopen only when the issue is non-terminal (`!isClosed`) or the comment will move it out of a terminal status (`effectiveMoveToTodoRequested`). A plain record on a done or cancelled issue lands without a rebuild and cannot 409 on an un-reopenable workspace.
- `server/src/__tests__/issue-closed-workspace-routes.test.ts`: coverage for the no-resume comment, the same comment against an un-reopenable workspace, and a `reopen: true` comment still driving the rebuild.

## Verification

- `pnpm --filter @paperclipai/server vitest run src/__tests__/issue-closed-workspace-routes.test.ts` — 15 tests pass.
- Before: `POST /api/issues/{done-issue}/comments` where the linked workspace is archived and not reopenable → 409 even though the comment only records a decision. After: 201.

## Risks

- Low risk. The only skipped reopen is for a comment that provably does not move the issue, so no resumed run can arrive at a missing worktree that this route was supposed to rebuild. Non-terminal issues and resume comments behave exactly as before.

## Model Used

- Anthropic Claude — SWE-2 Max agent via Devin CLI, tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge