### PR TITLE
fix: keep the JWT run-mismatch audit when the claimed run is missing

### DIFF
--- a/server/src/__tests__/agent-auth-middleware.test.ts
+++ b/server/src/__tests__/agent-auth-middleware.test.ts
@@ -372,6 +372,38 @@ describe("agent auth middleware", () => {
     });
   });
 
+  it("audits a run header mismatch even when the claimed run does not exist", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const claimedRunId = randomUUID();
+    const spoofedRunId = randomUUID();
+    const { db, activity } = createDbState({
+      agent: { id: agentId, companyId },
+    });
+    const token = createLocalAgentJwt(agentId, companyId, "codex_local", claimedRunId, "user-claim");
+
+    const res = await request(createApp(db))
+      .get("/actor")
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Paperclip-Run-Id", spoofedRunId);
+
+    expect(res.status).toBe(422);
+    expect(res.body.code).toBe("agent_jwt_run_id_mismatch");
+    expect(activity).toHaveLength(1);
+    expect(activity[0]).toMatchObject({
+      companyId,
+      actorType: "agent",
+      actorId: agentId,
+      action: "auth.agent_jwt_run_header_mismatch",
+      entityType: "heartbeat_run",
+      entityId: claimedRunId,
+      details: { claimRunId: claimedRunId, headerRunId: spoofedRunId },
+    });
+    // run_id carries a real FK to heartbeat_runs; a nonexistent claim must not
+    // be written into it or the whole audit row is lost to the FK violation.
+    expect(activity[0].runId).toBeUndefined();
+  });
+
   it("falls back to the run row responsible user for legacy claim-less agent JWTs", async () => {
     const companyId = randomUUID();
     const agentId = randomUUID();

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -157,6 +157,18 @@ async function auditAgentJwtRunHeaderMismatch(
   input: { companyId: string; agentId: string; claimRunId: string; headerRunId: string; method: string; url: string },
 ) {
   try {
+    // The claimed run id is untrusted input from a rejected token. activity_log
+    // .run_id is a real FK to heartbeat_runs, so writing it unconditionally
+    // makes the insert fail — and the catch swallows it — exactly when the
+    // claim is bogus. Keep the claim in entityId/details and populate the FK
+    // column only when the row actually exists.
+    const claimedRunExists = isUuidLike(input.claimRunId)
+      ? await db
+          .select({ id: heartbeatRuns.id })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, input.claimRunId))
+          .then((rows) => rows.length > 0)
+      : false;
     await db.insert(activityLog).values({
       companyId: input.companyId,
       actorType: "agent",
@@ -165,7 +177,7 @@ async function auditAgentJwtRunHeaderMismatch(
       entityType: "heartbeat_run",
       entityId: input.claimRunId,
       ...(isUuidLike(input.agentId) ? { agentId: input.agentId } : {}),
-      ...(isUuidLike(input.claimRunId) ? { runId: input.claimRunId } : {}),
+      ...(claimedRunExists ? { runId: input.claimRunId } : {}),
       details: {
         claimRunId: input.claimRunId,
         headerRunId: input.headerRunId,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Rejected agent JWTs whose run header disagrees with the signed claim are audited into `activity_log` so operators can see spoof attempts
> - The audit insert writes the claimed run id into `run_id`, which is a real foreign key to `heartbeat_runs`; a bogus claim violates the FK and the catch swallows it, so the audit row is silently lost exactly when it matters most
> - This pull request verifies the claimed run exists before trusting it into the FK column; the claim itself stays in `entityId` and `details`
> - The benefit is a reliable audit trail for rejected credentials

## Linked Issues or Issue Description

Refs #10498 — the anonymous fall-through half was fixed on master already (every failed-credential branch now returns an explicit 401/403/422); this closes the residual FK-swallowed audit defect.

## What Changed

- `server/src/middleware/auth.ts`: `auditAgentJwtRunHeaderMismatch` looks up the claimed run id and populates `runId` only when the row exists; `entityId` and `details.claimRunId` carry the claim either way.
- `server/src/__tests__/agent-auth-middleware.test.ts`: a mismatch whose claimed run does not exist still produces the audit row with `runId` omitted.

## Verification

- `pnpm --filter @paperclipai/server vitest run src/__tests__/agent-auth-middleware.test.ts` — 17 tests pass.
- Before: a run-header mismatch whose claimed run id was absent from `heartbeat_runs` violated the `activity_log.run_id` FK, and the catch swallowed it — no audit row. After: the row lands with `runId` null and the claim preserved in `entityId`/`details`.

## Risks

- Low risk. One extra indexed select on a rare rejection path; the audit payload is unchanged apart from `runId` now being conditional on existence.

## Model Used

- Anthropic Claude — SWE-2 Max agent via Devin CLI, tool use and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge