### PR TITLE
ci: publish verified full-SHA cloud image tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -520,6 +520,7 @@ jobs:
             io.github.paperclipai.schema.migration-count=${{ steps.schema.outputs.count }}
 
       - name: Build and push (cloud)
+        id: build-cloud
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -557,18 +558,16 @@ jobs:
 
       - name: Verify the pushed image resolves the declared Sentry version
         env:
-          IMAGE_TAGS: ${{ steps.meta-cloud.outputs.tags }}
+          IMAGE: ghcr.io/${{ github.repository }}@${{ steps.build-cloud.outputs.digest }}
         run: |
           set -euo pipefail
-          image="$(printf '%s\n' "$IMAGE_TAGS" | head -n 1)"
-          test -n "$image"
 
           expected="$(node -e "process.stdout.write(require('./server/package.json').peerDependencies['@sentry/node'])")"
           test -n "$expected"
 
           installed="$(docker run --rm --pull always \
             -v "$PWD/scripts/assert-cloud-image-sentry.mjs:/app/server/.ci-sentry-probe.mjs:ro" \
-            --entrypoint node "$image" /app/server/.ci-sentry-probe.mjs)"
+            --entrypoint node "$IMAGE" /app/server/.ci-sentry-probe.mjs)"
 
           echo "Declared optional peer version: $expected"
           echo "Installed in the pushed image: $installed"
@@ -577,6 +576,21 @@ jobs:
             exit 1
           fi
           echo "The pushed image resolves the declared @sentry/node version."
+
+      # Cloud's commit resolver and preview-artifact planner use the full SHA.
+      # Publish that address only after checking this build's exact digest.
+      # Retagging reuses the registry manifest and does not rebuild the image.
+      - name: Publish verified full-SHA cloud tag
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}@${{ steps.build-cloud.outputs.digest }}
+          FULL_SHA_TAG: ghcr.io/${{ github.repository }}:sha-${{ github.sha }}-cloud
+        run: |
+          set -euo pipefail
+          revision="$(docker image inspect "$IMAGE" --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')"
+          platform="$(docker image inspect "$IMAGE" --format '{{ .Os }}/{{ .Architecture }}')"
+          test "$revision" = "$GITHUB_SHA"
+          test "$platform" = linux/amd64
+          docker buildx imagetools create --prefer-index=false --tag "$FULL_SHA_TAG" "$IMAGE"
 
   # Moves the mutable `:canary` / `:canary-cloud` channel tags. Kept OUT
   # of the build jobs and serialized in its own lane, and — the load-

--- a/doc/DOCKER.md
+++ b/doc/DOCKER.md
@@ -24,6 +24,19 @@ docker build -t paperclip-local \
   --build-arg USER_UID=$(id -u) --build-arg USER_GID=$(id -g) .
 ```
 
+## Cloud image addresses
+
+The Docker workflow publishes the managed deployment image for Linux AMD64.
+After the pushed image passes its Sentry check, the workflow verifies its
+commit label and platform and adds `ghcr.io/paperclipai/paperclip:sha-<full-commit-sha>-cloud`.
+This address lets commit-based deployment tooling reuse the normal build.
+Existing short-SHA and release tags remain available.
+
+The full-SHA tag identifies the source commit. It does not certify that source
+tests passed or that a compatible database migrator is available. Deployment
+tooling must still check those prerequisites and pin the resolved image digest;
+a rebuild of the same source can update the tag's digest.
+
 ## One-liner (build + run)
 
 ```sh

--- a/scripts/preview-artifacts.test.mjs
+++ b/scripts/preview-artifacts.test.mjs
@@ -4,6 +4,7 @@ import { readFileSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { gzipSync } from "node:zlib";
+import { spawnSync } from "node:child_process";
 import { previewManifest, assertMetadata, validateRequest, versionFor, tarManifest, packageExists, imageExists, publishPreview, publishImage } from "./preview-artifacts.mjs";
 
 const sha = "a".repeat(40);
@@ -125,4 +126,50 @@ test("commits sharing a short prefix use separate full-SHA image addresses", asy
   await imageExists(sha, fetchImpl);
   await imageExists(other, fetchImpl);
   assert.deepEqual(urls.filter((url) => url.includes("/manifests/")), [sha, other].map((commit) => `https://ghcr.io/v2/paperclipai/paperclip/manifests/sha-${commit}-cloud`));
+});
+
+test("normal cloud builds publish the checked digest only when source and platform match", () => {
+  const workflow = readFileSync(new URL("../.github/workflows/docker.yml", import.meta.url), "utf8");
+  const cloud = workflow.split("  build-and-push-cloud:")[1].split("  promote_canary_channel:")[0];
+  const verify = cloud.indexOf("      - name: Verify the pushed image resolves the declared Sentry version");
+  const publish = cloud.indexOf("      - name: Publish verified full-SHA cloud tag");
+  assert.ok(verify >= 0 && publish > verify);
+  const verification = cloud.slice(verify, publish);
+  assert.match(verification, /IMAGE: ghcr.io\/\$\{\{ github.repository \}\}@\$\{\{ steps.build-cloud.outputs.digest \}\}/);
+  assert.doesNotMatch(verification, /continue-on-error:|if: always\(/);
+  const step = cloud.slice(publish).split(/\n(?:  #|      - name:)/)[0];
+  assert.doesNotMatch(step, /continue-on-error:|if:/);
+  assert.match(step, /FULL_SHA_TAG: ghcr.io\/\$\{\{ github.repository \}\}:sha-\$\{\{ github.sha \}\}-cloud/);
+  const script = step.split("        run: |\n")[1].split("\n").map((line) => line.replace(/^ {10}/, "")).join("\n");
+  const dir = mkdtempSync(path.join(tmpdir(), "cloud-tag-test-"));
+  const image = `ghcr.io/paperclipai/paperclip@sha256:${"b".repeat(64)}`;
+  const tag = `ghcr.io/paperclipai/paperclip:sha-${sha}-cloud`;
+  try {
+    writeFileSync(path.join(dir, "docker"), `#!/bin/sh
+case "$1 $2" in
+  'image inspect')
+    case "$5" in
+      *revision*) printf '%s\\n' "$TEST_REVISION" ;;
+      *) printf '%s\\n' "$TEST_PLATFORM" ;;
+    esac ;;
+  'buildx imagetools') printf '%s\\n' "$@" > "$TEST_CALLS" ;;
+  *) exit 99 ;;
+esac
+`, { mode: 0o755 });
+    for (const [revision, platform, succeeds] of [[sha, "linux/amd64", true], ["c".repeat(40), "linux/amd64", false], [sha, "linux/arm64", false]]) {
+      const calls = path.join(dir, "calls");
+      rmSync(calls, { force: true });
+      const result = spawnSync("bash", ["-c", script], { encoding: "utf8", env: {
+        ...process.env, PATH: `${dir}${path.delimiter}${process.env.PATH}`, GITHUB_SHA: sha,
+        IMAGE: image, FULL_SHA_TAG: tag, TEST_REVISION: revision, TEST_PLATFORM: platform, TEST_CALLS: calls,
+      } });
+      if (succeeds) {
+        assert.equal(result.status, 0, result.stderr);
+        assert.deepEqual(readFileSync(calls, "utf8").trim().split("\n"), ["buildx", "imagetools", "create", "--prefer-index=false", "--tag", tag, image]);
+      } else {
+        assert.notEqual(result.status, 0);
+        assert.throws(() => readFileSync(calls), { code: "ENOENT" });
+      }
+    }
+  } finally { rmSync(dir, { recursive: true, force: true }); }
 });


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Managed deployments use the cloud Docker image and a compatible database migrator.
> - Commit-based deployment tooling looks for a cloud image tagged with the full source SHA.
> - The normal Docker workflow currently publishes only a short-SHA cloud tag.
> - This pull request adds the full-SHA address after checking the pushed image.
> - Deployment tooling can then reuse that build without a second image build.

## Linked Issues or Issue Description

**What existing behavior does this improve?**

The normal Docker workflow publishes cloud images for commit-based deployment.

**Current behavior**

The workflow publishes `sha-<7-character-sha>-cloud`. The preview artifact planner requires `sha-<40-character-sha>-cloud` and verifies the image revision. It reports the full-SHA image as missing even when the normal merge build exists.

**Proposed behavior**

Check the pushed cloud image by digest. After its Sentry check passes, verify the source revision and Linux AMD64 platform, then add the full-SHA tag to that same digest. Existing short-SHA and release tags remain available.

**Reason and benefit**

This removes an unnecessary image rebuild from commit-based deployment. A compatible migrator and passing source checks remain separate requirements. Automatic canary discovery still follows the current release path.

Related work: #12856 reduces image size. It does not add the address required by commit-based deployment. #13185 reduces release verification time and has merged. Searched open Docker and preview PRs and cloud build issues before making this change.

## What Changed

- Verify Sentry against this build's digest instead of the first mutable output tag.
- Check the image revision and platform before publishing its full-SHA tag.
- Reuse the registry manifest with `imagetools create`; do not build another image.
- Document source tags and deployment prerequisites.
- Test matching and mismatched source/platform cases by executing the workflow shell step with a Docker fixture.

## Verification

- `node --test scripts/preview-artifacts.test.mjs`: 9 tests passed.
- `pnpm exec vitest run server/src/__tests__/docker-build-stamp.test.ts`: 2 tests passed.
- `actionlint -shellcheck= .github/workflows/docker.yml`: passed.
- `git diff --check`: passed.
- All GitHub checks passed at `01c9dbcd83d7fed0c7cc0de0c9969e32dfc10941`. Greptile: 5/5, with no review findings.
- Full local typecheck and build passed on the common application source. The full local test invocation failed with 33 failures in five unchanged suites (10,504 tests passed), including macOS permission errors and asynchronous integration checks. Targeted tests for this change passed; all equivalent Linux CI shards passed.
- The same publication step passed in the stacked branch [Docker build](https://github.com/paperclipai/paperclip/actions/runs/34550074180). A separate deployment resolver accepted that verified full-SHA image without a second build.
- After merge, inspect the cloud job's published digest and the full-SHA tag. Both must identify the same registry manifest. The existing preview planner must recognize the full-SHA image without requesting another build.

## Risks

Low risk. A failed Sentry, revision, platform, or registry check prevents the new tag from being published by that run. Existing tags retain their behavior. Rebuilding the same source can change its digest, so deployment tooling must pin the resolved digest. The new tag is not a source-test or migrator readiness signal.

## Model Used

OpenAI GPT-6 through Codex, with reasoning, repository tools, code execution, and GitHub tools. The exact serving model ID and context window are not exposed in this session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
