### PR TITLE
ci: preserve weekly Docker tool cache across commits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,14 +103,6 @@ RUN rm -rf packages/paperclip-runner/runner/target
 FROM base AS production
 ARG USER_UID=1000
 ARG USER_GID=1000
-# Real version for this build, computed from `git describe` on the CI runner
-# (the image has no .git, so the server cannot derive it at runtime). Empty for
-# local `docker build`, which just leaves the server on its normal fallbacks.
-ARG PAPERCLIP_BUILD_VERSION=""
-# The exact commit this image was built from, for the same reason: server-info
-# falls back to PAPERCLIP_BUILD_COMMIT when git is unavailable, which feeds the
-# /api/health `commit` field that deploy tooling verifies. Empty locally.
-ARG PAPERCLIP_BUILD_COMMIT=""
 # Refreshes the tool layer below when it changes (CI stamps an ISO week, so
 # the @latest CLI tools advance weekly). Without it the cached layer would
 # freeze the tools until an unrelated cache bust.
@@ -133,6 +125,13 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 COPY --chown=node:node --from=build /app /app
 
+# Declare per-build metadata after the stable RUN layers. Docker includes
+# in-scope ARG values in a RUN's environment even when its command does not
+# mention them; declaring these earlier invalidates the weekly tool cache.
+# The build stage still receives the commit before writing dist/build-info.json.
+# Empty for local builds, preserving the server's normal version fallbacks.
+ARG PAPERCLIP_BUILD_VERSION=""
+ARG PAPERCLIP_BUILD_COMMIT=""
 ENV NODE_ENV=production \
   HOME=/paperclip \
   HOST=0.0.0.0 \

--- a/doc/DOCKER.md
+++ b/doc/DOCKER.md
@@ -18,6 +18,14 @@ Build arguments:
 |-----|---------|---------|
 | `USER_UID` | `1000` | UID for the container `node` user (match your host UID to avoid permission issues on bind mounts) |
 | `USER_GID` | `1000` | GID for the container `node` group |
+| `CLI_TOOLS_CACHE_EPOCH` | empty | Refresh the CLI-install layer; CI supplies the current ISO week |
+| `PAPERCLIP_BUILD_VERSION` | empty | Runtime version when Git metadata is unavailable |
+| `PAPERCLIP_BUILD_COMMIT` | empty | Source commit written into the server build stamp and runtime environment |
+
+Changing the build version or commit preserves the CLI-install cache. The
+tool layer refreshes when its weekly epoch, base image, installation command,
+or earlier build inputs change. Local builds can set a new epoch explicitly
+to refresh tools without clearing the entire build cache.
 
 ```sh
 docker build -t paperclip-local \

--- a/server/src/__tests__/docker-build-stamp.test.ts
+++ b/server/src/__tests__/docker-build-stamp.test.ts
@@ -35,6 +35,25 @@ function stageBody(source: string, stageName: string): string {
   return source.slice(start, end);
 }
 
+it("keeps per-build runtime metadata out of the weekly CLI-install cache", () => {
+  const production = stageBody(dockerfile, "production");
+  const tools = production.search(/^RUN echo "cli-tools-epoch:/m);
+  const entrypoint = production.search(/^RUN chmod \+x \/usr\/local\/bin\/docker-entrypoint\.sh/m);
+  const runtime = production.search(/^ENV NODE_ENV=production/m);
+  const epoch = production.search(/^ARG CLI_TOOLS_CACHE_EPOCH\b/m);
+  expect(tools).toBeGreaterThanOrEqual(0);
+  expect(entrypoint).toBeGreaterThan(tools);
+  expect(epoch).toBeGreaterThanOrEqual(0);
+  expect(epoch).toBeLessThan(tools);
+  for (const name of ["PAPERCLIP_BUILD_VERSION", "PAPERCLIP_BUILD_COMMIT"]) {
+    const declarations = [...production.matchAll(new RegExp(`^ARG ${name}\\b`, "gm"))];
+    expect(declarations).toHaveLength(1);
+    expect(declarations[0].index).toBeGreaterThan(entrypoint);
+    expect(declarations[0].index).toBeLessThan(runtime);
+    expect(production.slice(runtime)).toContain(`${name}=\${${name}}`);
+  }
+});
+
 describe("docker build-stamp wiring", () => {
   it("declares PAPERCLIP_BUILD_COMMIT in the build stage before the server build", () => {
     const build = stageBody(dockerfile, "build");


### PR DESCRIPTION
## Thinking Path

> - Paperclip runs AI-agent companies and ships common agent CLIs in its Docker image.
> - CI intends to refresh those tools weekly while building app images for every commit.
> - Docker includes declared build arguments in subsequent RUN environments.
> - The per-commit version and SHA currently invalidate the tool-install layer even though its command does not reference them.
> - Declaring that metadata after the stable layers preserves weekly tool caching.
> - The server build still gets the exact commit before writing its build stamp.

## Linked Issues or Issue Description

**What existing behavior does this improve?**

Docker cache reuse across ordinary app commits.

**Current behavior**

The production stage declares `PAPERCLIP_BUILD_VERSION` and `PAPERCLIP_BUILD_COMMIT` before its CLI-install RUN. Each new commit changes that RUN's environment and invalidates its cache. The following entrypoint chmod layer is also invalidated.

**Proposed behavior**

Declare those two arguments immediately before the runtime ENV. The CLI-install layer continues to use `CLI_TOOLS_CACHE_EPOCH`, while application metadata still reaches the runtime and server build stamp.

**Reason and benefit**

Avoid reinstalling and exporting the large CLI layer for each app commit. Sampled CI tool installs took roughly 30–46 seconds. This work can overlap compilation, so that time is not a guaranteed end-to-end saving; registry layer reuse should also reduce export and transfer work. Docker documents the implicit RUN environment in its [build-cache reference](https://docs.docker.com/reference/dockerfile/#impact-on-build-caching).

Related: #13187, #13188, and #13189 address commit-based cloud artifact availability and scheduling. #12856 addresses runtime dependency pruning. This PR changes argument scope only and can merge independently. Searched existing Docker PRs before making this change.

## What Changed

- Move production-stage version and commit declarations below the stable RUN layers.
- Keep the build-stage commit declaration before the server build.
- Document the cache epoch and build metadata arguments.
- Extend the build-stamp test to guard argument scope and preserve the weekly epoch.

## Verification

- `pnpm exec vitest run server/src/__tests__/docker-build-stamp.test.ts`: 3 tests passed.
- `node scripts/check-docker-deps-stage.mjs` and `docker buildx build --file .github/docker-context-checks.Dockerfile .`: passed.
- `git diff --check`: passed.
- Built the actual base and CLI-install stages in an isolated Docker fixture twice with different version/commit arguments. The second build cached every filesystem layer, exported layers in 0.1 seconds, and preserved identical layer digests while exposing the new version/commit in its runtime environment. This fixture isolates the changed layers; it is not a complete app-image timing comparison.
- All GitHub CI checks passed at `672da3f0796f4e8c192b680c6515be149d387ed8`. Greptile: 5/5, with the review thread resolved.
- Full local typecheck and build passed on the common application source. The full local test invocation failed: 33 failures in five unchanged suites (10,504 tests passed). Failures include macOS permission errors and asynchronous integration checks; the equivalent Linux CI shards passed. Targeted tests for this PR passed.

## Risks

The first build after the argument-scope change may rebuild the tool layer. Subsequent builds reuse it while the epoch and earlier inputs match. Tools keep their weekly CI refresh. No tool versions, application dependencies, entrypoint, runtime variables, or build-stamp behavior change. Reverting this PR restores the old cache behavior.

## Model Used

OpenAI GPT-6 through Codex, with reasoning, repository tools, code execution, and GitHub tools. The exact serving model ID and context window are not exposed in this session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
