### PR TITLE
ci: skip cloud runner cleanup when disk headroom is ample

### DIFF
--- a/.github/scripts/tests/docker-disk-workflow.test.mjs
+++ b/.github/scripts/tests/docker-disk-workflow.test.mjs
@@ -1,0 +1,65 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const workflow = readFileSync(new URL("../../workflows/docker-cloud.yml", import.meta.url), "utf8");
+const step = workflow.split("      - name: Free runner disk")[1].split("      - name: Login to GitHub Container Registry")[0];
+const script = step.split("        run: |\n")[1].split("\n").map((line) => line.replace(/^ {10}/, "")).join("\n");
+const threshold = 64 * 1024 * 1024;
+
+for (const { name, dockerFree, workspaceFree, dfStatus = "0", infoStatus = "0", cleanup } of [
+  { name: "ample free space", dockerFree: threshold + 1, workspaceFree: threshold + 1, cleanup: false },
+  { name: "exactly the headroom threshold", dockerFree: threshold, workspaceFree: threshold, cleanup: false },
+  { name: "Docker filesystem below threshold", dockerFree: threshold - 1, workspaceFree: threshold + 1, cleanup: true },
+  { name: "workspace filesystem below threshold", dockerFree: threshold + 1, workspaceFree: threshold - 1, cleanup: true },
+  { name: "invalid Docker measurement", dockerFree: "unknown", workspaceFree: threshold + 1, cleanup: true },
+  { name: "invalid workspace measurement", dockerFree: threshold + 1, workspaceFree: "unknown", cleanup: true },
+  { name: "failed df command", dockerFree: threshold + 1, workspaceFree: threshold + 1, dfStatus: "1", cleanup: true },
+  { name: "failed Docker inspection", dockerFree: threshold + 1, workspaceFree: threshold + 1, infoStatus: "1", cleanup: true },
+]) {
+  test(`cloud disk cleanup: ${name}`, () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "cloud-disk-test-"));
+    const log = path.join(dir, "commands.log");
+    // Every mutating command is a recording fixture; no real SDKs, caches,
+    // images, or directories are deleted when the workflow shell executes.
+    const fixture = `#!/bin/bash
+printf '%s %s\\n' "\${0##*/}" "$*" >> "$COMMAND_LOG"
+case "\${0##*/}" in
+  df)
+    printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\\n'
+    if [ "$1" = '-Pk' ]; then
+      printf '/dev/docker 200000000 1 %s 1%% /docker\\n' "$DOCKER_FREE"
+      printf '/dev/workspace 200000000 1 %s 1%% /workspace\\n' "$WORKSPACE_FREE"
+      exit "$DF_STATUS"
+    fi
+    ;;
+  docker)
+    if [ "$1" = 'info' ]; then
+      printf '/docker-data\\n'
+      exit "$INFO_STATUS"
+    fi
+    ;;
+esac
+`;
+    try {
+      for (const command of ["df", "docker", "pnpm", "sudo"]) {
+        writeFileSync(path.join(dir, command), fixture, { mode: 0o755 });
+      }
+      const result = spawnSync("bash", ["-c", script], {
+        encoding: "utf8",
+        env: { ...process.env, PATH: `${dir}:${process.env.PATH}`, GITHUB_WORKSPACE: "/workspace", COMMAND_LOG: log,
+          DOCKER_FREE: String(dockerFree), WORKSPACE_FREE: String(workspaceFree), DF_STATUS: dfStatus, INFO_STATUS: infoStatus },
+      });
+      assert.equal(result.status, 0, result.stderr);
+      const commands = readFileSync(log, "utf8");
+      if (infoStatus === "0") assert.match(commands, /df -Pk \/docker-data \/workspace/);
+      assert.equal(commands.includes("pnpm store prune"), cleanup);
+      assert.equal(commands.includes("sudo rm -rf /usr/share/dotnet"), cleanup);
+      assert.equal(commands.includes("docker system prune -af"), cleanup);
+      assert.equal(result.stdout.includes("skipping cleanup"), !cleanup);
+    } finally { rmSync(dir, { recursive: true, force: true }); }
+  });
+}

--- a/.github/workflows/docker-cloud.yml
+++ b/.github/workflows/docker-cloud.yml
@@ -120,6 +120,18 @@ jobs:
           echo "Disk before cleanup:"
           df -h
 
+          # A measured hosted cloud build started with 86 GB available.
+          # Keep ample headroom for BuildKit and image verification, but
+          # avoid minutes deleting SDKs when neither filesystem needs space.
+          minimum_free_kib=$((64 * 1024 * 1024))
+          if docker_root="$(docker info --format '{{.DockerRootDir}}')" \
+            && available_kib="$(df -Pk "$docker_root" "$GITHUB_WORKSPACE" | awk 'NR > 1 { rows++; if ($4 !~ /^[0-9]+$/) invalid = 1; if (min == "" || $4 < min) min = $4 } END { if (invalid || rows != 2) exit 1; print min }')" \
+            && [[ "$available_kib" =~ ^[0-9]+$ ]] \
+            && (( available_kib >= minimum_free_kib )); then
+            echo "At least 64 GiB is available for Docker and the workspace; skipping cleanup."
+            exit 0
+          fi
+
           pnpm store prune || true
           sudo apt-get clean || true
           sudo rm -rf \

--- a/doc/DOCKER.md
+++ b/doc/DOCKER.md
@@ -47,6 +47,12 @@ legacy `buildcache-cloud` fallback. This preserves reusable layers without
 letting concurrent builds overwrite one shared cache manifest. Retain recent
 cache tags if registry cleanup is configured; deleting them makes builds colder.
 
+Cloud CI skips SDK and cache cleanup when both the Docker data filesystem and
+the checkout filesystem have at least 64 GiB available. Below that conservative
+headroom threshold, or when the measurement fails, it retains the existing
+cleanup. The threshold selects the fast path; it is not a new minimum disk
+requirement for local builds or smaller runners.
+
 After the pushed image passes its Sentry and orphan-reaping checks, the workflow verifies its
 commit label and platform and adds `ghcr.io/paperclipai/paperclip:sha-<full-commit-sha>-cloud`.
 This address lets commit-based deployment tooling reuse the normal build.


### PR DESCRIPTION
## Thinking Path

> - Paperclip cloud deployments depend on a verified Docker image for each commit.
> - The cloud build currently deletes preinstalled SDKs and caches on every hosted runner.
> - The measured build had 86 GB free before spending 1 minute 46 seconds on cleanup.
> - Skipping that work when both relevant filesystems have ample space shortens the build's startup path.
> - Smaller runners and failed measurements keep the existing cleanup.

## Linked Issues or Issue Description

**What existing behavior does this improve?**

The cloud image job's pre-build disk cleanup.

**Current behavior**

Every run prunes caches and removes large SDK directories, regardless of available disk. In [this measured cloud job](https://github.com/paperclipai/paperclip/actions/runs/34550074180/job/103110928020), cleanup took 1 minute 46 seconds with 86 GB already available.

**Proposed behavior**

Read the available space on the Docker data filesystem and the workspace filesystem. Skip cleanup only if both have at least 64 GiB free. Invalid or failed measurements and lower headroom retain the current cleanup commands.

**Reason and benefit**

Remove avoidable startup work on runners with ample disk. The fast path took 1 second in a real hosted build, compared with 1 minute 46 seconds in the baseline cleanup step. Other build and queue times vary, so this comparison isolates cleanup. This is a conservative optimization, not a new minimum disk requirement.

Depends on #13189 and targets that branch to keep the diff small. Merge #13187 and #13189 first. Related: #13188 prepares exact-source migrators and #13190 restores the weekly tool cache. Searched existing Docker PRs before this change.

## What Changed

- Add a conservative disk-headroom fast path to cloud runner preparation.
- Measure both Docker storage and the checkout, retaining cleanup when either is low or cannot be measured.
- Exercise the actual workflow shell with command fixtures for threshold boundaries, distinct filesystems, malformed output, and command errors.
- Document the fast path and fallback.

## Verification

All current-head checks passed on `07fb3d7cede5b2609d294ee68e160704c9c29bdd` in [PR CI](https://github.com/paperclipai/paperclip/actions/runs/34559674588). Greptile reviewed this exact head at 5/5 with no unresolved findings. All eight real-shell disk scenarios and workflow validation passed again after replay onto master.

- `node --test '.github/scripts/tests/*.test.mjs'`: 142 tests passed, including 8 new disk-cleanup cases.
- `actionlint -shellcheck= .github/workflows/docker-cloud.yml`: passed.
- `git diff --check`: passed.
- [Real Docker build](https://github.com/paperclipai/paperclip/actions/runs/34552367243): production AMD64, production ARM64, cloud, manifest publication, Sentry, and PID 1 checks all passed. Cloud cleanup ran from 01:52:36 to 01:52:37 UTC. Its verified full-SHA tag was published at 02:03:57 UTC, 11m56s after job start. This was a branch build, not a merge-to-deploy measurement.
- All GitHub checks passed at `9e505b29c0b00e283631f74b0ec23731d4b3b8a4`. Greptile: 5/5, with no findings.
- Full local typecheck and build passed on the common application source. The full local test invocation failed with 33 failures in five unchanged suites (10,504 tests passed), including macOS permission errors and asynchronous integration checks. Targeted tests for this change passed; all equivalent Linux CI shards passed.

## Risks

Builds that grow beyond the conservative headroom allowance could exhaust disk. Both filesystems are measured; low or unknown space keeps the established cleanup. Smaller runners are not rejected for having less than 64 GiB free. Reverting the added condition restores unconditional cleanup.

## Model Used

OpenAI GPT-6 through Codex, with reasoning, repository tools, code execution, and GitHub tools. The exact serving model ID and context window are not exposed in this session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
