### PR TITLE
fix(process): fail signaled child runs

### DIFF
--- a/server/src/adapters/process/execute.test.ts
+++ b/server/src/adapters/process/execute.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  runChildProcess: vi.fn(),
+}));
+
+vi.mock("../utils.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../utils.js")>()),
+  runChildProcess: mocks.runChildProcess,
+}));
+
+import { execute } from "./execute.js";
+
+describe("process adapter execution", () => {
+  it("fails when a child is terminated by a signal with no exit code", async () => {
+    mocks.runChildProcess.mockResolvedValueOnce({
+      exitCode: null,
+      signal: "SIGTERM",
+      timedOut: false,
+      stdout: "",
+      stderr: "",
+    });
+
+    const result = await execute({
+      runId: "signal-test",
+      agent: { id: "agent", companyId: "company" },
+      config: { command: process.execPath },
+      onLog: async () => {},
+      onMeta: async () => {},
+    } as any);
+
+    expect(result).toMatchObject({
+      exitCode: null,
+      signal: "SIGTERM",
+      timedOut: false,
+    });
+    expect(result.errorMessage).toContain("SIGTERM");
+    expect(result.resultJson).toEqual({ stdout: "", stderr: "" });
+  });
+});

--- a/server/src/adapters/process/execute.ts
+++ b/server/src/adapters/process/execute.ts
@@ -80,6 +80,19 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
     };
   }
 
+  if (proc.signal) {
+    return {
+      exitCode: proc.exitCode,
+      signal: proc.signal,
+      timedOut: false,
+      errorMessage: `Process terminated by signal ${proc.signal}`,
+      resultJson: {
+        stdout: proc.stdout,
+        stderr: proc.stderr,
+      },
+    };
+  }
+
   if ((proc.exitCode ?? 0) !== 0) {
     return {
       exitCode: proc.exitCode,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the control plane for companies that use AI agents for work
> - Process adapters run external commands and report their run result
> - Node reports a null exit code when a child ends because of a signal
> - The process adapter used a nullish-zero fallback and treated that result as success
> - This pull request checks the signal before the exit code and returns a failed result
> - The benefit is that terminated children cannot be persisted as successful runs

## Linked Issues or Issue Description

Fixes: #13151

The process adapter returned a success-shaped result when a child ended with a signal and no numeric exit code. The adapter now returns a signal-specific error result for this case.

## What Changed

- Detect a child termination signal before applying the exit-code fallback.
- Return the signal, captured output, and a clear error message.
- Add a focused regression test for a `SIGTERM` result with `exitCode: null`.

## Verification

- `pnpm dlx vitest@4.1.11 run src/adapters/process/execute.test.ts --config vitest.config.ts` — 1 test passed.
- `pnpm exec tsc --noEmit --ignoreConfig --target ES2022 --module NodeNext --moduleResolution NodeNext --skipLibCheck server/src/adapters/process/execute.ts server/src/adapters/process/execute.test.ts` — passed.
- `pnpm run check:node-version` — passed.
- `pnpm run test:check-no-git-push` — 14 tests passed.
- `pnpm run check:tokens` and `pnpm run check:module-boundaries` — passed.
- The full server typecheck remains blocked by existing generated runner artifacts and unrelated baseline errors in the current checkout.

## Risks

Low risk. This changes only the process adapter result for children that report a termination signal. Clean exits and timeout results keep their existing paths.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. This is a focused bug fix, not a feature contribution.

## Model Used

OpenAI GPT-5.6 Luna (`gpt-5.6-luna`), xhigh reasoning, tool use, code execution, and repository review. Runtime context window size is not exposed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes: #` / `Refs: #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes (no user-facing documentation changed)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
