### PR TITLE
fix(cursor_cloud): inject PAPERCLIP_TOKEN and enable run JWT

### DIFF
--- a/packages/adapters/cursor-cloud/src/index.ts
+++ b/packages/adapters/cursor-cloud/src/index.ts
@@ -30,5 +30,7 @@ Notes:
 - Paperclip reuses the durable Cursor agent across heartbeats when the repo/runtime identity still matches.
 - Each Paperclip heartbeat maps to a Cursor run on that durable agent.
 - Paperclip injects PAPERCLIP_* runtime env vars into the cloud agent shell through Cursor SDK cloud envVars.
+- Run auth is injected as PAPERCLIP_TOKEN (not PAPERCLIP_API_KEY) because Cursor strips envVars matching *_API_KEY; PAPERCLIP_API_URL is retained when a run JWT is present.
+- Never put CURSOR_API_KEY into cloud envVars (used only for the SDK client).
 - Paperclip remains the source of truth for issue/task state; Cursor provides the remote execution surface.
 `;

--- a/packages/adapters/cursor-cloud/src/server/execute.test.ts
+++ b/packages/adapters/cursor-cloud/src/server/execute.test.ts
@@ -177,11 +177,13 @@ describe("cursor_cloud execute", () => {
       PAPERCLIP_RUN_ID: "run-heartbeat-1",
       PAPERCLIP_TASK_ID: "issue-1",
       PAPERCLIP_WAKE_REASON: "issue_commented",
-      PAPERCLIP_API_KEY: "paperclip-run-jwt",
+      PAPERCLIP_TOKEN: "paperclip-run-jwt",
     });
     // When a run JWT is present the callback URL is retained so the worker can
-    // authenticate its Paperclip API calls.
+    // authenticate its Paperclip API calls. Cursor strips *_API_KEY from envVars,
+    // so the token is injected as PAPERCLIP_TOKEN instead of PAPERCLIP_API_KEY.
     expect(createMock.mock.calls[0]?.[0]?.cloud?.envVars).toHaveProperty("PAPERCLIP_API_URL");
+    expect(createMock.mock.calls[0]?.[0]?.cloud?.envVars).not.toHaveProperty("PAPERCLIP_API_KEY");
     expect(createMock.mock.calls[0]?.[0]?.cloud?.envVars).not.toHaveProperty("CURSOR_API_KEY");
 
     expect(result).toMatchObject({
@@ -250,14 +252,14 @@ describe("cursor_cloud execute", () => {
     const run = createMockRun({ agentId: "agent-no-jwt" });
     const sdkAgent = createMockSdkAgent({ agentId: "agent-no-jwt", sendRun: run });
     createMock.mockResolvedValue(sdkAgent);
-    // cursor_cloud is registered with supportsLocalAgentJwt=false, so heartbeat
-    // passes no authToken. A remote cloud worker must not receive a callback URL
-    // it can neither reach nor authenticate against (the source of 401 noise).
+    // When heartbeat cannot mint a run JWT, a remote cloud worker must not
+    // receive a callback URL it can neither reach nor authenticate against.
     const ctx = createContext({ authToken: undefined });
 
     await execute(ctx);
 
     const envVars = (createMock.mock.calls[0]?.[0]?.cloud?.envVars ?? {}) as Record<string, string>;
+    expect(envVars).not.toHaveProperty("PAPERCLIP_TOKEN");
     expect(envVars).not.toHaveProperty("PAPERCLIP_API_KEY");
     expect(envVars).not.toHaveProperty("PAPERCLIP_API_URL");
     expect(envVars).not.toHaveProperty("PAPERCLIP_API_BRIDGE_MODE");

--- a/packages/adapters/cursor-cloud/src/server/execute.ts
+++ b/packages/adapters/cursor-cloud/src/server/execute.ts
@@ -527,6 +527,23 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       runId: run.id,
       ...(model?.id ? { model: model.id } : {}),
     }));
+    await onLog(
+      "stdout",
+      `${JSON.stringify({
+        type: "cursor_cloud.env",
+        reuseSession: Boolean(canReuseSession && session),
+        envKeys: Object.keys(remoteEnv).sort(),
+        hasPaperclipToken: Boolean(remoteEnv.PAPERCLIP_TOKEN),
+        hasPaperclipApiUrl: Boolean(remoteEnv.PAPERCLIP_API_URL),
+        paperclipApiUrlHost: (() => {
+          try {
+            return remoteEnv.PAPERCLIP_API_URL ? new URL(remoteEnv.PAPERCLIP_API_URL).host : null;
+          } catch {
+            return null;
+          }
+        })(),
+      })}\n`,
+    );
     await emitStatus(onLog, "running", `Started Cursor run ${run.id}.`);
 
     const streamPromise = streamRun(run, onLog).catch((err) => {

--- a/packages/adapters/cursor-cloud/src/server/execute.ts
+++ b/packages/adapters/cursor-cloud/src/server/execute.ts
@@ -110,9 +110,11 @@ function buildWakeEnv(ctx: AdapterExecutionContext, configEnv: Record<string, st
     ...buildRuntimeToolsEnv(ctx.runtimeTools),
     PAPERCLIP_RUN_ID: runId,
   };
-  // PAPERCLIP_API_KEY is never accepted from config — the harness-minted run
-  // token is the only source of Paperclip API identity.
+  // Paperclip API identity comes only from the harness-minted run JWT.
+  // Cursor Cloud strips envVars matching *_API_KEY, so never inject
+  // PAPERCLIP_API_KEY into remote env — use PAPERCLIP_TOKEN instead.
   delete env.PAPERCLIP_API_KEY;
+  delete env.PAPERCLIP_TOKEN;
 
   const wakeTaskId = trimNullable(context.taskId) ?? trimNullable(context.issueId);
   const wakeReason = trimNullable(context.wakeReason);
@@ -134,19 +136,16 @@ function buildWakeEnv(ctx: AdapterExecutionContext, configEnv: Record<string, st
   if (wakePayloadJson) env.PAPERCLIP_WAKE_PAYLOAD_JSON = wakePayloadJson;
   if (issueWorkMode) env.PAPERCLIP_ISSUE_WORK_MODE = issueWorkMode;
   if (authToken) {
-    env.PAPERCLIP_API_KEY = authToken;
+    env.PAPERCLIP_TOKEN = authToken;
   }
 
-  // cursor_cloud runs remotely in Cursor's cloud and is intentionally not
-  // issued a Paperclip run JWT (registry: supportsLocalAgentJwt=false).
-  // buildPaperclipEnv always sets PAPERCLIP_API_URL, defaulting to the local
-  // runtime host — which a remote worker can neither reach nor authenticate
-  // against, so any agent-initiated Paperclip API call would fail with a 401
-  // (or be unreachable) and add noise. When there is no usable key, drop the
-  // callback wiring so cloud-side Paperclip tools degrade to a clean no-op.
-  // Run results are delivered server-side via the Cursor Agent SDK (getRun /
-  // wait), not through this callback, so nothing is lost.
-  if (!trimNullable(env.PAPERCLIP_API_KEY)) {
+  // When no run JWT is available, drop callback URL/bridge wiring so cloud-side
+  // Paperclip tools degrade to a clean no-op (no dead localhost URL, no 401 noise).
+  // With a token present, keep PAPERCLIP_API_URL from buildPaperclipEnv (prefer
+  // process.env.PAPERCLIP_API_URL / public base URL on deployed hosts).
+  // Run results are also delivered server-side via the Cursor Agent SDK (getRun /
+  // wait); the callback is for agent-initiated board API calls during the run.
+  if (!trimNullable(env.PAPERCLIP_TOKEN)) {
     delete env.PAPERCLIP_API_URL;
     delete env.PAPERCLIP_API_BRIDGE_MODE;
   }

--- a/packages/adapters/cursor-cloud/vitest.config.ts
+++ b/packages/adapters/cursor-cloud/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/server/src/adapters/registry.ts
+++ b/server/src/adapters/registry.ts
@@ -692,7 +692,9 @@ const cursorCloudAdapter: ServerAdapterModule = {
   sessionCodec: cursorCloudSessionCodec,
   sessionManagement: getAdapterSessionManagement("cursor_cloud") ?? undefined,
   models: [],
-  supportsLocalAgentJwt: false,
+  // Mint a run JWT so remote Cursor Cloud workers can call Paperclip APIs.
+  // Injected as PAPERCLIP_TOKEN (not PAPERCLIP_API_KEY) because Cursor strips *_API_KEY from envVars.
+  supportsLocalAgentJwt: true,
   supportsInstructionsBundle: true,
   instructionsPathKey: "instructionsFilePath",
   requiresMaterializedRuntimeSkills: false,

--- a/skills/paperclip-board/SKILL.md
+++ b/skills/paperclip-board/SKILL.md
@@ -16,7 +16,7 @@ You are a board-level assistant helping a human manage their AI-agent company th
 - `PAPERCLIP_API_URL` — base URL of the Paperclip server (e.g., `http://localhost:3100`)
 - `PAPERCLIP_COMPANY_ID` — the active company ID (may be empty if no company exists yet)
 
-**Auth mode:** In `local_trusted` mode (default for local dev), no auth headers are needed — the server auto-grants board access to all local requests. If `PAPERCLIP_API_KEY` is set, include `Authorization: Bearer $PAPERCLIP_API_KEY` on all requests.
+**Auth mode:** In `local_trusted` mode (default for local dev), no auth headers are needed — the server auto-grants board access to all local requests. If `PAPERCLIP_API_KEY` is set, include `Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}` on all requests.
 
 **Making API calls:** Use `curl -sS` via bash. All endpoints are under `/api`. All request/response bodies are JSON. Always use `Content-Type: application/json` on POST/PATCH/PUT requests.
 

--- a/skills/paperclip-create-agent/SKILL.md
+++ b/skills/paperclip-create-agent/SKILL.md
@@ -25,25 +25,25 @@ If you do not have this permission, escalate to your CEO or board.
 
 ```sh
 curl -sS "$PAPERCLIP_API_URL/api/agents/me" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}"
 ```
 
 ### 2. Discover adapter configuration for this Paperclip instance
 
 ```sh
 curl -sS "$PAPERCLIP_API_URL/llms/agent-configuration.txt" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}"
 
 # Then the specific adapter you plan to use, e.g. claude_local:
 curl -sS "$PAPERCLIP_API_URL/llms/agent-configuration/claude_local.txt" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}"
 ```
 
 ### 3. Compare existing agent configurations
 
 ```sh
 curl -sS "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-configurations" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}"
 ```
 
 Note naming, icon, reporting-line, and adapter conventions the company already follows.
@@ -68,7 +68,7 @@ State which path you took in your hire-request comment so the board can see the 
 
 ```sh
 curl -sS "$PAPERCLIP_API_URL/llms/agent-icons.txt" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}"
 ```
 
 ### 6. Draft the new hire config
@@ -97,7 +97,7 @@ Before submitting, walk the draft-review checklist end-to-end and fix any item t
 
 ```sh
 curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-hires" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "CTO",
@@ -123,10 +123,10 @@ curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-h
 
 ```sh
 curl -sS "$PAPERCLIP_API_URL/api/approvals/<approval-id>" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}"
 
 curl -sS -X POST "$PAPERCLIP_API_URL/api/approvals/<approval-id>/comments" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"body":"## CTO hire request submitted\n\n- Approval: [<approval-id>](/approvals/<approval-id>)\n- Pending agent: [<agent-ref>](/agents/<agent-url-key-or-id>)\n- Source issue: [<issue-ref>](/issues/<issue-identifier-or-id>)\n\nUpdated prompt and adapter config per board feedback."}'
 ```
@@ -135,7 +135,7 @@ If the approval already exists and needs manual linking to the issue:
 
 ```sh
 curl -sS -X POST "$PAPERCLIP_API_URL/api/issues/<issue-id>/approvals" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"approvalId":"<approval-id>"}'
 ```
@@ -144,10 +144,10 @@ After approval is granted, run this follow-up loop:
 
 ```sh
 curl -sS "$PAPERCLIP_API_URL/api/approvals/$PAPERCLIP_APPROVAL_ID" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}"
 
 curl -sS "$PAPERCLIP_API_URL/api/approvals/$PAPERCLIP_APPROVAL_ID/issues" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}"
 ```
 
 For each linked issue, either:

--- a/skills/paperclip/SKILL.md
+++ b/skills/paperclip/SKILL.md
@@ -17,7 +17,7 @@ In Paperclip, **task** and **issue** refer to the same work item. The UI may use
 
 ## Authentication
 
-Env vars auto-injected: `PAPERCLIP_AGENT_ID`, `PAPERCLIP_COMPANY_ID`, `PAPERCLIP_API_URL`, `PAPERCLIP_RUN_ID`. Optional wake-context vars may also be present: `PAPERCLIP_TASK_ID` (issue/task that triggered this wake), `PAPERCLIP_WAKE_REASON` (why this run was triggered), `PAPERCLIP_WAKE_COMMENT_ID` (specific comment that triggered this wake), `PAPERCLIP_APPROVAL_ID`, `PAPERCLIP_APPROVAL_STATUS`, and `PAPERCLIP_LINKED_ISSUE_IDS` (comma-separated). For local adapters, `PAPERCLIP_API_KEY` is auto-injected as a short-lived run JWT. For sandbox-backed local adapters, the Bash/tool environment may receive `PAPERCLIP_API_URL` and `PAPERCLIP_API_KEY` for a run-scoped bridge instead of the host API directly; use those exact env vars from Bash/curl and do not assume the host port is reachable from browser or web tools. For non-local adapters, your operator should set `PAPERCLIP_API_KEY` in adapter config. All requests use `Authorization: Bearer $PAPERCLIP_API_KEY`. All endpoints under `/api`, all JSON. Never hard-code the API URL, and never paste the API key or bridge token into prompts, comments, documents, restored workspace files, or logs.
+Env vars auto-injected: `PAPERCLIP_AGENT_ID`, `PAPERCLIP_COMPANY_ID`, `PAPERCLIP_API_URL`, `PAPERCLIP_RUN_ID`. Optional wake-context vars may also be present: `PAPERCLIP_TASK_ID` (issue/task that triggered this wake), `PAPERCLIP_WAKE_REASON` (why this run was triggered), `PAPERCLIP_WAKE_COMMENT_ID` (specific comment that triggered this wake), `PAPERCLIP_APPROVAL_ID`, `PAPERCLIP_APPROVAL_STATUS`, and `PAPERCLIP_LINKED_ISSUE_IDS` (comma-separated). Auth token: prefer `PAPERCLIP_TOKEN` (Cursor Cloud / adapters that cannot use `*_API_KEY` env names because Cursor strips them); fall back to `PAPERCLIP_API_KEY` for local adapters. Resolve with `PAPERCLIP_AUTH="${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}"` and send `Authorization: Bearer $PAPERCLIP_AUTH`. For sandbox-backed local adapters, the Bash/tool environment may receive `PAPERCLIP_API_URL` plus the auth token for a run-scoped bridge instead of the host API directly; use those env vars from Bash/curl and do not assume the host port is reachable from browser or web tools. All endpoints under `/api`, all JSON. Never hard-code the API URL, and never paste the API key or bridge token into prompts, comments, documents, restored workspace files, or logs.
 
 Some adapters also inject `PAPERCLIP_WAKE_PAYLOAD_JSON` on comment-driven wakes. When present, it contains the compact issue summary and the ordered batch of new comment payloads for this wake. Use it first. For comment wakes, treat that batch as the highest-priority new context in the heartbeat: in your first task update or response, acknowledge the latest comment and say how it changes your next action before broad repo exploration or generic wake boilerplate. Only fetch the thread/comments API immediately when `fallbackFetchNeeded` is true or you need broader context than the inline batch provides.
 
@@ -102,7 +102,7 @@ Overrides and special cases:
 
 ```
 POST /api/issues/{issueId}/checkout
-Headers: Authorization: Bearer $PAPERCLIP_API_KEY, X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
+Headers: Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}, X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID
 { "agentId": "{your-agent-id}", "expectedStatuses": ["todo", "backlog", "blocked", "in_review"] }
 ```
 
@@ -508,14 +508,15 @@ When authenticated with the current run's agent JWT, list the secrets available 
 ```bash
 PAPERCLIP_API_BASE="${PAPERCLIP_API_URL%/}"
 PAPERCLIP_API_BASE="${PAPERCLIP_API_BASE%/api}"
-curl -s -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+PAPERCLIP_AUTH="${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}"
+curl -s -H "Authorization: Bearer $PAPERCLIP_AUTH" \
   "$PAPERCLIP_API_BASE/api/agents/me/secrets"
 ```
 
 The list is metadata-only. Fetch a specific value only when needed; the request has no body:
 
 ```bash
-curl -s -X POST -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+curl -s -X POST -H "Authorization: Bearer $PAPERCLIP_AUTH" \
   "$PAPERCLIP_API_BASE/api/agents/me/secrets/github_token/value"
 ```
 

--- a/skills/paperclip/references/api-reference.md
+++ b/skills/paperclip/references/api-reference.md
@@ -1369,7 +1369,7 @@ jq -n \
   --arg justification "Credential supplied for the current task" \
   '{kind:"secret", name:$name, value:$value, justification:$justification}' |
 curl -s -X POST \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}" \
   -H "Content-Type: application/json" \
   --data-binary @- \
   "$PAPERCLIP_API_BASE/api/agents/me/secret-proposals"
@@ -1399,7 +1399,7 @@ jq -n \
   --arg justification "Inject the approved credential into my adapter environment" \
   '{kind:"binding", secretProposalId:$secretProposalId, configPath:$configPath, justification:$justification}' |
 curl -s -X POST \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}" \
   -H "Content-Type: application/json" \
   --data-binary @- \
   "$PAPERCLIP_API_BASE/api/agents/me/secret-proposals"
@@ -1420,7 +1420,7 @@ jq -n \
   --arg justification "Use the existing OpenAI credential under the eval-specific alias" \
   '{kind:"binding", sourceConfigPath:$sourceConfigPath, configPath:$configPath, justification:$justification}' |
 curl -s -X POST \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}" \
   -H "Content-Type: application/json" \
   --data-binary @- \
   "$PAPERCLIP_API_BASE/api/agents/me/secret-proposals"
@@ -1442,7 +1442,7 @@ The card uses `continuationPolicy: "wake_assignee"`. On resolution the issue ass
 
 ```bash
 curl -s \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}" \
   "$PAPERCLIP_API_BASE/api/agents/me/secrets"
 ```
 

--- a/skills/paperclip/references/artifacts.md
+++ b/skills/paperclip/references/artifacts.md
@@ -54,7 +54,7 @@ Create the work product with:
 ```bash
 curl -sS -X POST \
   "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID/work-products" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}" \
   -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
   -H "Content-Type: application/json" \
   --data-binary @workspace-file-work-product.json
@@ -65,7 +65,7 @@ If the helper is unavailable, use the Paperclip API directly:
 ```bash
 curl -sS -X POST \
   "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/issues/$PAPERCLIP_TASK_ID/attachments" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}" \
   -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
   -F 'file=@"path/to/output.webm";type=video/webm'
 ```
@@ -75,7 +75,7 @@ Then create a work product when the file is the deliverable. The server canonica
 ```bash
 curl -sS -X POST \
   "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID/work-products" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}" \
   -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
   -H "Content-Type: application/json" \
   --data-binary '{

--- a/skills/paperclip/references/company-skills.md
+++ b/skills/paperclip/references/company-skills.md
@@ -80,13 +80,13 @@ skills are role- or domain-specific.
 
 ```sh
 curl -sS "$PAPERCLIP_API_URL/api/skills/catalog?kind=bundled" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}"
 
 curl -sS "$PAPERCLIP_API_URL/api/skills/catalog/ref?ref=github-pr-workflow" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}"
 
 curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/install-catalog" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
     "catalogSkillId": "paperclipai:bundled:software-development:github-pr-workflow"
@@ -117,7 +117,7 @@ Import using a **skills.sh URL**, a key-style source string, a GitHub URL, or a 
 
 ```sh
 curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/import" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
     "source": "https://skills.sh/google-labs-code/stitch-skills/design-md"
@@ -128,7 +128,7 @@ Or equivalently using the key-style string:
 
 ```sh
 curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/import" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
     "source": "google-labs-code/stitch-skills/design-md"
@@ -139,7 +139,7 @@ curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/
 
 ```sh
 curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/import" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
     "source": "https://github.com/vercel-labs/agent-browser"
@@ -156,7 +156,7 @@ If the task is to discover skills from the company project workspaces first:
 
 ```sh
 curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/scan-projects" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{}'
 ```
@@ -165,17 +165,17 @@ curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/
 
 ```sh
 curl -sS "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}"
 ```
 
 Read the skill entry and its `SKILL.md`:
 
 ```sh
 curl -sS "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/<skill-id>" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}"
 
 curl -sS "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/skills/<skill-id>/files?path=SKILL.md" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}"
 ```
 
 ## Assign Skills To An Existing Agent
@@ -196,7 +196,7 @@ The request must include a merge mode:
 
 ```sh
 curl -sS -X POST "$PAPERCLIP_API_URL/api/agents/<agent-id>/skills/sync" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
     "mode": "add",
@@ -210,7 +210,7 @@ If you need the current state first:
 
 ```sh
 curl -sS "$PAPERCLIP_API_URL/api/agents/<agent-id>/skills" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY"
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}"
 ```
 
 ## Include Skills During Hire Or Create
@@ -219,7 +219,7 @@ Use the same company skill keys or references in `desiredSkills` when hiring or 
 
 ```sh
 curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agent-hires" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "QA Browser Agent",
@@ -238,7 +238,7 @@ For direct create without approval:
 
 ```sh
 curl -sS -X POST "$PAPERCLIP_API_URL/api/companies/$PAPERCLIP_COMPANY_ID/agents" \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{
     "name": "QA Browser Agent",

--- a/skills/paperclip/references/issue-workspaces.md
+++ b/skills/paperclip/references/issue-workspaces.md
@@ -7,7 +7,7 @@ Use this reference when an issue has an isolated execution workspace and you nee
 Start from the issue, not from memory:
 
 ```sh
-curl -sS -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+curl -sS -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}" \
   "$PAPERCLIP_API_URL/api/issues/$PAPERCLIP_TASK_ID/heartbeat-context"
 ```
 
@@ -27,7 +27,7 @@ Prefer Paperclip-managed runtime service controls over manual `pnpm dev &` or ad
 ```sh
 # Start all configured services; waits for configured readiness checks.
 curl -sS -X POST \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}" \
   -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
   -H "Content-Type: application/json" \
   "$PAPERCLIP_API_URL/api/execution-workspaces/<workspace-id>/runtime-services/start" \
@@ -35,7 +35,7 @@ curl -sS -X POST \
 
 # Restart all configured services.
 curl -sS -X POST \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}" \
   -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
   -H "Content-Type: application/json" \
   "$PAPERCLIP_API_URL/api/execution-workspaces/<workspace-id>/runtime-services/restart" \
@@ -43,7 +43,7 @@ curl -sS -X POST \
 
 # Stop all running services.
 curl -sS -X POST \
-  -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+  -H "Authorization: Bearer ${PAPERCLIP_TOKEN:-$PAPERCLIP_API_KEY}" \
   -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
   -H "Content-Type: application/json" \
   "$PAPERCLIP_API_URL/api/execution-workspaces/<workspace-id>/runtime-services/stop" \

--- a/skills/paperclip/scripts/paperclip-upload-artifact.sh
+++ b/skills/paperclip/scripts/paperclip-upload-artifact.sh
@@ -11,7 +11,7 @@ Uploads a generated file from the current workspace to the current Paperclip
 issue, then creates an attachment-backed artifact work product by default.
 
 Required environment for live uploads:
-  PAPERCLIP_API_URL, PAPERCLIP_API_KEY, PAPERCLIP_COMPANY_ID, PAPERCLIP_TASK_ID, PAPERCLIP_RUN_ID
+  PAPERCLIP_API_URL, PAPERCLIP_TOKEN (or PAPERCLIP_API_KEY), PAPERCLIP_COMPANY_ID, PAPERCLIP_TASK_ID, PAPERCLIP_RUN_ID
 
 Options:
   --issue-id ID          Issue id to attach to (default: PAPERCLIP_TASK_ID)
@@ -125,7 +125,7 @@ request_json() {
     status_code="$(
       curl -sS -X "$method" -w '%{http_code}' -o "$response_file" \
         "$url" \
-        -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+        -H "Authorization: Bearer $PAPERCLIP_AUTH" \
         -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
         -H 'Content-Type: application/json' \
         --data-binary "$body"
@@ -134,7 +134,7 @@ request_json() {
     status_code="$(
       curl -sS -X "$method" -w '%{http_code}' -o "$response_file" \
         "$url" \
-        -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+        -H "Authorization: Bearer $PAPERCLIP_AUTH" \
         -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID"
     )"
   fi
@@ -166,7 +166,7 @@ upload_file() {
   status_code="$(
     curl -sS -X POST -w '%{http_code}' -o "$response_file" \
       "$url" \
-      -H "Authorization: Bearer $PAPERCLIP_API_KEY" \
+      -H "Authorization: Bearer $PAPERCLIP_AUTH" \
       -H "X-Paperclip-Run-Id: $PAPERCLIP_RUN_ID" \
       -F "file=@\"${escaped_path}\";type=${content_type}"
   )" || curl_status=$?
@@ -392,8 +392,9 @@ if [[ "$dry_run" == "1" ]]; then
   exit 0
 fi
 
-if [[ -z "${PAPERCLIP_API_URL:-}" || -z "${PAPERCLIP_API_KEY:-}" || -z "${PAPERCLIP_RUN_ID:-}" ]]; then
-  printf 'Missing PAPERCLIP_API_URL, PAPERCLIP_API_KEY, or PAPERCLIP_RUN_ID.\n' >&2
+PAPERCLIP_AUTH="${PAPERCLIP_TOKEN:-${PAPERCLIP_API_KEY:-}}"
+if [[ -z "${PAPERCLIP_API_URL:-}" || -z "${PAPERCLIP_AUTH}" || -z "${PAPERCLIP_RUN_ID:-}" ]]; then
+  printf 'Missing PAPERCLIP_API_URL, PAPERCLIP_TOKEN/PAPERCLIP_API_KEY, or PAPERCLIP_RUN_ID.\n' >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Enable `supportsLocalAgentJwt` for `cursor_cloud` so heartbeats mint a run JWT
- Inject auth as `PAPERCLIP_TOKEN` (Cursor Cloud strips `*_API_KEY` from `envVars`) and retain `PAPERCLIP_API_URL` when a token is present
- Teach bundled skills/scripts to prefer `PAPERCLIP_TOKEN` with `PAPERCLIP_API_KEY` fallback for local adapters

## Why
Remote Cursor Cloud agents were waking without callable Paperclip auth (`NO_API_KEY_SKIP_AUTH_CALLS`): JWT minting was off, callback URL was dropped, and even a minted `PAPERCLIP_API_KEY` would be stripped by Cursor.

## Test plan
- [x] `vitest run packages/adapters/cursor-cloud/src/server/execute.test.ts` (9 passed)
- [ ] Heartbeat on a public Paperclip host with `PAPERCLIP_API_URL` set shows `PAPERCLIP_TOKEN` + URL and can call `/api/agents/me`


Made with [Cursor](https://cursor.com)