### PR TITLE
docs: measure cloud deployment through target health

### DIFF
--- a/doc/cloud-build-readiness.md
+++ b/doc/cloud-build-readiness.md
@@ -50,10 +50,37 @@ successfully verified a real master commit.
 
 ## Timing and rollout
 
-Measure from the master push to completion of `Cloud deployable v1`. Record
-queue time and the image, source-verification, and artifact-wait durations
+Measure the complete path from a master merge to a healthy target running that
+exact commit. Keep readiness and deployment as separate milestones:
+
+| Milestone | Evidence | Elapsed time starts at |
+| --- | --- | --- |
+| Merge | Merged PR timestamp and full merge commit SHA | Merge |
+| Image available | Successful full-SHA image publication and verification | Merge |
+| Cloud deployable | Successful `Cloud deployable v1` job in the accepted push run and attempt | Merge |
+| Canary healthy | Deployment consumer's canary health gate confirms the target commit | Merge |
+| Fleet complete | Campaign succeeds for all eligible targets at that commit | Merge |
+
+Record the source SHA, workflow run ID and attempt, readiness job completion
+time, and deployment campaign identity together. Verify the run against the
+consumer contract above. A manual dispatch can test wiring, but its timestamp
+does not measure automatic merge-to-deploy latency. A preparation-only run
+resolves artifacts without deploying a target and must not be counted as a
+successful deployment.
+
+Record queue time and the image, source-verification, and artifact-wait durations
 separately. The slowest prerequisite determines readiness; shortening an already
-faster prerequisite may have no effect on the total.
+faster prerequisite may have no effect on the total. After readiness, measure
+consumer discovery delay, artifact resolution, canary health, and fleet rollout.
+An automatic consumer that still waits for the full npm canary publication has
+that queue on its critical path even if cloud artifacts are ready earlier.
+
+For a target health measurement, confirm the deployed source SHA as well as
+service health. A proxy health response alone may describe the control plane
+while the tenant still runs the previous image. Report the eligible target count,
+excluded or sleeping targets, retries, and failures with the fleet result. Record
+runner queue conditions and cache state; one warm or cold run is a sample, not a
+latency guarantee.
 
 Land full-SHA image publication, independent cloud builds, and migrator-only
 publication before enabling this workflow. Until those producers are present,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Hosted deployments need a verified image and migrator for the same source commit.
> - The cloud readiness workflow certifies those inputs before a deployment consumer acts.
> - Its completion time does not show when a tenant runs the new commit.
> - This pull request documents each milestone from merge through target health and fleet completion.
> - Operators can use the evidence to find the slow stage and measure a complete deployment.

## Linked Issues or Issue Description

Refs #13192, #13188, and #13189. Searched related issues and PRs; no duplicate timing documentation change was found.

**Issue type**

Missing documentation.

**Where is the issue?**

`doc/cloud-build-readiness.md`, Timing and rollout.

**What's wrong?**

The timing instructions stop at the readiness job. That omits consumer queues, artifact resolution, and target deployment. An image can be ready while the tenant still runs an older commit.

**Suggested fix**

Record separate merge, image, readiness, canary health, and fleet completion timestamps for the same full source SHA. Keep preparation-only runs out of deployment results.

## What Changed

- Define the evidence needed for each merge-to-deployment milestone.
- Explain how consumer queues can hide upstream build gains.
- Require target source identity as well as health, and report exclusions, retries, cache state, and queue conditions.

## Verification

- `git diff --check` passed.
- `node --test scripts/preview-artifacts.test.mjs scripts/__tests__/release-verify-workflow.test.mjs` passed: 25 tests.
- Cross-checked the readiness identity and artifact prerequisites against the current workflows and consumer contract.
- Full local `pnpm -r typecheck` passed using the session's installed Rust toolchain.
- Full local `pnpm test:run` stopped in the general-server phase on macOS: 10,471 passed, 70 failed, 70 skipped across seven failing files. Failures include missing Cargo/Runner test binaries, cache-directory permissions, test timeouts, a port allocation conflict, and a load-test count mismatch. These application files are unchanged by this documentation PR. The full Linux CI test checks passed.
- Full local `pnpm build` passed with the installed Rust toolchain on PATH.
- All CI checks pass and Greptile is 5/5 on the exact head, with no unresolved findings. This changes one documentation file and adds no runtime behavior.

- Follow-up native tests with Cargo configured and freshly built Runner fixtures passed 37 of 38 tests. One unchanged native-resume assertion still fails locally; rebuilding the debug Runner did not change that result. No application tests were modified in this PR.

## Risks

- Low risk: documentation only. Timing must still use trusted run evidence and the actual target commit. A single measured run is not a latency guarantee.

## Model Used

- OpenAI GPT-6 / Codex, with reasoning, repository editing, and command/API tools. Exact serving model ID and context-window size are not exposed by this session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass (25 focused workflow/artifact tests; full macOS suite failures disclosed above)
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
