### PR TITLE
fix(run-dispatch): keep verified addressee interaction_pending wakes

### DIFF
--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -12,6 +12,7 @@ import {
   heartbeatRuns,
   issueComments,
   issueDocuments,
+  issueThreadInteractions,
   issues,
 } from "@paperclipai/db";
 import { ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY } from "@paperclipai/shared";
@@ -89,6 +90,7 @@ async function cleanupHeartbeatInvalidationFixture(db: ReturnType<typeof createD
       await db.execute(sql.raw(`
         TRUNCATE TABLE
           "company_skills",
+          "issue_thread_interactions",
           "issue_comments",
           "issue_documents",
           "document_revisions",
@@ -144,6 +146,9 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
   let afterContinuationDispatchCheck:
     | ((input: { runId: string; issueId: string }) => Promise<void>)
     | null = null;
+  let beforeClaimCheck:
+    | ((input: { runId: string; issueId: string; stage: "claim" | "dispatch" }) => Promise<void>)
+    | null = null;
 
   const countExecuteCallsForRun = (runId: string) =>
     mockAdapterExecute.mock.calls.filter(([context]) => context?.runId === runId).length;
@@ -158,6 +163,9 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
       afterResolvedInteractionContinuationDispatchCheck: async (input) => {
         await afterContinuationDispatchCheck?.(input);
       },
+      beforeChatControlRecoveryCheck: async (input) => {
+        await beforeClaimCheck?.(input);
+      },
     });
     await ensureIssueRelationsTable(db);
   }, 20_000);
@@ -165,6 +173,7 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
   afterEach(async () => {
     beforeContinuationDispatchCheck = null;
     afterContinuationDispatchCheck = null;
+    beforeClaimCheck = null;
     mockAdapterExecute.mockReset();
     mockAdapterExecute.mockImplementation(async () => ({
       exitCode: 0,
@@ -620,6 +629,137 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
       expect(countExecuteCallsForRun(runId)).toBe(0);
     },
   );
+
+  describe("named-addressee interaction_pending wakes", () => {
+    async function seedAddressedInteractionFixture() {
+      const { companyId, agentId: assigneeAgentId } = await seedCompanyAndAgent();
+      const addresseeAgentId = randomUUID();
+      await db.insert(agents).values({
+        id: addresseeAgentId,
+        companyId,
+        name: "Reviewer",
+        role: "engineer",
+        status: "active",
+        adapterType: "codex_local",
+        adapterConfig: {},
+        runtimeConfig: { heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 } },
+        permissions: {},
+      });
+      const issueId = randomUUID();
+      await db.insert(issues).values({
+        id: issueId,
+        companyId,
+        title: "Addressed confirmation on another agent's issue",
+        status: "in_progress",
+        priority: "medium",
+        assigneeAgentId,
+      });
+      const interactionId = randomUUID();
+      await db.insert(issueThreadInteractions).values({
+        id: interactionId,
+        companyId,
+        issueId,
+        kind: "request_confirmation",
+        status: "pending",
+        continuationPolicy: "wake_assignee",
+        requestedResolverPolicy: "not_creator",
+        effectiveResolverPolicy: "not_creator",
+        title: "Approve the plan",
+        createdByAgentId: assigneeAgentId,
+        addresseeAgentId,
+        payload: { version: 1, prompt: "Approve the plan?" },
+      });
+      const { runId, wakeupRequestId } = await seedQueuedRun({
+        companyId,
+        agentId: addresseeAgentId,
+        issueId,
+        wakeReason: "interaction_pending",
+        invocationSource: "automation",
+        contextExtras: {
+          taskId: issueId,
+          interactionId,
+          interactionKind: "request_confirmation",
+          mutation: "interaction",
+          source: "issue.interaction.created",
+        },
+      });
+      return { companyId, assigneeAgentId, addresseeAgentId, issueId, interactionId, runId, wakeupRequestId };
+    }
+
+    it("runs the named addressee even though another agent is the issue assignee", async () => {
+      const { runId, wakeupRequestId, issueId, assigneeAgentId } = await seedAddressedInteractionFixture();
+
+      await heartbeat.resumeQueuedRuns();
+      await waitForCondition(async () => {
+        const run = await db
+          .select({ status: heartbeatRuns.status })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, runId))
+          .then((rows) => rows[0] ?? null);
+        return run?.status === "succeeded";
+      }, 10_000);
+
+      const [run, wakeup, issue] = await Promise.all([
+        db.select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, runId))
+          .then((rows) => rows[0] ?? null),
+        db.select({ status: agentWakeupRequests.status })
+          .from(agentWakeupRequests)
+          .where(eq(agentWakeupRequests.id, wakeupRequestId))
+          .then((rows) => rows[0] ?? null),
+        db.select({ assigneeAgentId: issues.assigneeAgentId })
+          .from(issues)
+          .where(eq(issues.id, issueId))
+          .then((rows) => rows[0] ?? null),
+      ]);
+      expect(run).toMatchObject({ status: "succeeded", errorCode: null });
+      expect(wakeup).toMatchObject({ status: "completed" });
+      expect(issue?.assigneeAgentId).toBe(assigneeAgentId);
+      expect(countExecuteCallsForRun(runId)).toBe(1);
+    });
+
+    it("does not start the addressee when the interaction is resolved between the staleness gate and the claim", async () => {
+      const { runId, wakeupRequestId, interactionId } = await seedAddressedInteractionFixture();
+      let resolvedAtClaim = false;
+      beforeClaimCheck = async ({ runId: guardedRunId, stage }) => {
+        if (stage !== "claim" || guardedRunId !== runId || resolvedAtClaim) return;
+        resolvedAtClaim = true;
+        await db
+          .update(issueThreadInteractions)
+          .set({ status: "accepted", resolvedAt: new Date(), updatedAt: new Date() })
+          .where(eq(issueThreadInteractions.id, interactionId));
+      };
+
+      await heartbeat.resumeQueuedRuns();
+      // First pass: the gate admitted the run, the claim re-read the resolved
+      // interaction and left the run queued. Second pass: the gate cancels it.
+      await heartbeat.resumeQueuedRuns();
+      await waitForCondition(async () => {
+        const run = await db
+          .select({ status: heartbeatRuns.status })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, runId))
+          .then((rows) => rows[0] ?? null);
+        return run?.status === "cancelled";
+      }, 10_000);
+
+      const [run, wakeup] = await Promise.all([
+        db.select({ status: heartbeatRuns.status, errorCode: heartbeatRuns.errorCode })
+          .from(heartbeatRuns)
+          .where(eq(heartbeatRuns.id, runId))
+          .then((rows) => rows[0] ?? null),
+        db.select({ status: agentWakeupRequests.status })
+          .from(agentWakeupRequests)
+          .where(eq(agentWakeupRequests.id, wakeupRequestId))
+          .then((rows) => rows[0] ?? null),
+      ]);
+      expect(resolvedAtClaim).toBe(true);
+      expect(run).toMatchObject({ status: "cancelled", errorCode: "issue_assignee_changed" });
+      expect(wakeup).toMatchObject({ status: "skipped" });
+      expect(countExecuteCallsForRun(runId)).toBe(0);
+    });
+  });
 
   it("rejects ownership changes immediately before the final continuation handoff", async () => {
     const { companyId, agentId } = await seedCompanyAndAgent();

--- a/server/src/modules/run-dispatch/adapters/postgres.test.ts
+++ b/server/src/modules/run-dispatch/adapters/postgres.test.ts
@@ -12,6 +12,7 @@ import {
   issueDocuments,
   issueRelations,
   issueRecoveryActions,
+  issueThreadInteractions,
   issueTreeHolds,
   issues,
 } from "@paperclipai/db";
@@ -54,6 +55,7 @@ describeEmbeddedPostgres("run-dispatch postgres adapter", () => {
     await db.delete(documents);
     await db.delete(issueTreeHolds);
     await db.delete(issueRelations);
+    await db.delete(issueThreadInteractions);
     await db.delete(issues);
     await db.delete(heartbeatRunEvents);
     await db.delete(heartbeatRuns);
@@ -525,6 +527,121 @@ describeEmbeddedPostgres("run-dispatch postgres adapter", () => {
       expect(persisted?.status).toBe("cancelled");
       expect(persisted?.contextSnapshot).toMatchObject({
         paperclipWake: { privateTestMarker: "not-for-the-status-effect" },
+      });
+    });
+
+    async function seedAddressedInteraction(input: {
+      companyId: string;
+      issueId: string;
+      createdByAgentId: string;
+      addresseeAgentId: string;
+      status?: string;
+    }) {
+      const interactionId = randomUUID();
+      await db.insert(issueThreadInteractions).values({
+        id: interactionId,
+        companyId: input.companyId,
+        issueId: input.issueId,
+        kind: "request_confirmation",
+        status: input.status ?? "pending",
+        continuationPolicy: "wake_assignee",
+        requestedResolverPolicy: "not_creator",
+        effectiveResolverPolicy: "not_creator",
+        title: "Approve the plan",
+        createdByAgentId: input.createdByAgentId,
+        addresseeAgentId: input.addresseeAgentId,
+        payload: { version: 1, prompt: "Approve the plan?" },
+      });
+      return interactionId;
+    }
+
+    it("keeps a verified interaction_pending wake for the named addressee when the issue is assigned to another agent", async () => {
+      const { companyId, agentId: assigneeAgentId } = await seedCompanyAndAgent();
+      const addresseeAgentId = randomUUID();
+      await seedAgent({ id: addresseeAgentId, companyId, name: "Reviewer" });
+      const issueId = randomUUID();
+      await seedIssue({ companyId, issueId, status: "in_progress", assigneeAgentId });
+      const interactionId = await seedAddressedInteraction({
+        companyId,
+        issueId,
+        createdByAgentId: assigneeAgentId,
+        addresseeAgentId,
+      });
+
+      const runId = await seedRun({
+        companyId,
+        agentId: addresseeAgentId,
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          interactionId,
+          interactionKind: "request_confirmation",
+          wakeReason: "interaction_pending",
+          source: "issue.interaction.created",
+        },
+      });
+      const result = await createPostgresRunDispatchAdapter(db).cancelStaleQueuedRun({
+        runId,
+        companyId,
+        expectedStatus: "queued",
+        now: new Date(),
+      });
+
+      expect(result).toMatchObject({ outcome: "not_stale" });
+      const persisted = await db
+        .select({ status: heartbeatRuns.status })
+        .from(heartbeatRuns)
+        .where(eq(heartbeatRuns.id, runId))
+        .then((rows) => rows[0]);
+      expect(persisted?.status).toBe("queued");
+    });
+
+    it.each([
+      { label: "the interaction is already resolved", status: "accepted", addressee: "named" },
+      { label: "the interaction names a different addressee", status: "pending", addressee: "other" },
+      { label: "the interaction belongs to another issue", status: "pending", addressee: "named", otherIssue: true },
+    ])("still cancels an interaction_pending wake when $label", async ({ status, addressee, otherIssue }) => {
+      const { companyId, agentId: assigneeAgentId } = await seedCompanyAndAgent();
+      const addresseeAgentId = randomUUID();
+      await seedAgent({ id: addresseeAgentId, companyId, name: "Reviewer" });
+      const otherAgentId = randomUUID();
+      await seedAgent({ id: otherAgentId, companyId, name: "Bystander" });
+      const issueId = randomUUID();
+      await seedIssue({ companyId, issueId, status: "in_progress", assigneeAgentId });
+      const interactionIssueId = otherIssue ? randomUUID() : issueId;
+      if (otherIssue) {
+        await seedIssue({ companyId, issueId: interactionIssueId, status: "in_progress", assigneeAgentId });
+      }
+      const interactionId = await seedAddressedInteraction({
+        companyId,
+        issueId: interactionIssueId,
+        createdByAgentId: assigneeAgentId,
+        addresseeAgentId: addressee === "named" ? addresseeAgentId : otherAgentId,
+        status,
+      });
+
+      const runId = await seedRun({
+        companyId,
+        agentId: addresseeAgentId,
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          interactionId,
+          interactionKind: "request_confirmation",
+          wakeReason: "interaction_pending",
+          source: "issue.interaction.created",
+        },
+      });
+      const result = await createPostgresRunDispatchAdapter(db).cancelStaleQueuedRun({
+        runId,
+        companyId,
+        expectedStatus: "queued",
+        now: new Date(),
+      });
+
+      expect(result).toMatchObject({
+        outcome: "cancelled",
+        errorCode: "issue_assignee_changed",
       });
     });
 

--- a/server/src/modules/run-dispatch/adapters/postgres.ts
+++ b/server/src/modules/run-dispatch/adapters/postgres.ts
@@ -6,6 +6,7 @@ import {
   agents,
   heartbeatRuns,
   issueRecoveryActions,
+  issueThreadInteractions,
   issues,
 } from "@paperclipai/db";
 import { ISSUE_DISPOSITION_REPAIR_RETRY_REASON } from "@paperclipai/shared";
@@ -504,6 +505,30 @@ export function createPostgresRunDispatchAdapter(
       continuationParksExecutor = continuationSummaryParksExecutor(continuationSummaryBody);
     }
 
+    // A server-issued `interaction_pending` wake names the interaction it was
+    // created for. Authorize the named addressee from stored state only:
+    // the interaction must still be pending, belong to this issue and
+    // company, and name the run agent as `addresseeAgentId`. The wake
+    // reason alone is not trusted.
+    const wakeInteractionId = readNonEmptyString(context.interactionId);
+    const isVerifiedAddresseeInteractionWake =
+      issue && wakeReason === "interaction_pending" && wakeInteractionId
+        ? await dbOrTx
+            .select({ id: issueThreadInteractions.id })
+            .from(issueThreadInteractions)
+            .where(
+              and(
+                eq(issueThreadInteractions.id, wakeInteractionId),
+                eq(issueThreadInteractions.companyId, input.companyId),
+                eq(issueThreadInteractions.issueId, issue.id),
+                eq(issueThreadInteractions.addresseeAgentId, input.agentId),
+                eq(issueThreadInteractions.status, "pending"),
+              ),
+            )
+            .limit(1)
+            .then((rows) => Boolean(rows[0]))
+        : false;
+
     const recoveryActionId = readNonEmptyString(context.recoveryActionId);
     const isAuthorizedSourceScopedRecovery =
       issue && wakeReason === "source_scoped_recovery_action" && recoveryActionId
@@ -537,6 +562,7 @@ export function createPostgresRunDispatchAdapter(
       isConnectionContinuation: (isResolvedInteractionContinuation && context.interactionKind === "connection_intent")
         || context.source === "connection_tools.refreshed",
       isInteractionWake,
+      isVerifiedAddresseeInteractionWake,
       isAuthorizedSourceScopedRecovery,
       isNonAssigneeWorkspaceBusyRetry: isNonAssigneeWorkspaceBusyRetry(retryReason, context),
       resumeIntent,

--- a/server/src/modules/run-dispatch/adapters/postgres.ts
+++ b/server/src/modules/run-dispatch/adapters/postgres.ts
@@ -160,6 +160,44 @@ function statusEffect(run: HeartbeatRun, previousStatus: string | null): PostCom
   };
 }
 
+export type AddresseeInteractionWakeInput = {
+  companyId: string;
+  issueId: string;
+  agentId: string;
+  contextSnapshot: Record<string, unknown>;
+};
+
+/**
+ * Reads whether a run context is a server-issued `interaction_pending` wake
+ * whose named addressee is `agentId`, from stored interaction state: the
+ * interaction named in the context must exist, still be `pending`, belong to
+ * the same issue and company, and name the run agent as `addresseeAgentId`.
+ * Callers pass the transaction that owns the decision so the check stays
+ * current through a queued-to-running claim.
+ */
+export async function verifyAddresseeInteractionWake(
+  dbOrTx: Db,
+  input: AddresseeInteractionWakeInput,
+): Promise<boolean> {
+  const wakeReason = readNonEmptyString(input.contextSnapshot.wakeReason);
+  const interactionId = readNonEmptyString(input.contextSnapshot.interactionId);
+  if (wakeReason !== "interaction_pending" || !interactionId) return false;
+  return dbOrTx
+    .select({ id: issueThreadInteractions.id })
+    .from(issueThreadInteractions)
+    .where(
+      and(
+        eq(issueThreadInteractions.id, interactionId),
+        eq(issueThreadInteractions.companyId, input.companyId),
+        eq(issueThreadInteractions.issueId, input.issueId),
+        eq(issueThreadInteractions.addresseeAgentId, input.agentId),
+        eq(issueThreadInteractions.status, "pending"),
+      ),
+    )
+    .limit(1)
+    .then((rows) => Boolean(rows[0]));
+}
+
 export function createPostgresRunDispatchAdapter(
   db: Db,
 ): ScheduledRetryReader & RunDispatchWriter {
@@ -506,28 +544,17 @@ export function createPostgresRunDispatchAdapter(
     }
 
     // A server-issued `interaction_pending` wake names the interaction it was
-    // created for. Authorize the named addressee from stored state only:
-    // the interaction must still be pending, belong to this issue and
-    // company, and name the run agent as `addresseeAgentId`. The wake
-    // reason alone is not trusted.
-    const wakeInteractionId = readNonEmptyString(context.interactionId);
-    const isVerifiedAddresseeInteractionWake =
-      issue && wakeReason === "interaction_pending" && wakeInteractionId
-        ? await dbOrTx
-            .select({ id: issueThreadInteractions.id })
-            .from(issueThreadInteractions)
-            .where(
-              and(
-                eq(issueThreadInteractions.id, wakeInteractionId),
-                eq(issueThreadInteractions.companyId, input.companyId),
-                eq(issueThreadInteractions.issueId, issue.id),
-                eq(issueThreadInteractions.addresseeAgentId, input.agentId),
-                eq(issueThreadInteractions.status, "pending"),
-              ),
-            )
-            .limit(1)
-            .then((rows) => Boolean(rows[0]))
-        : false;
+    // created for. Authorize the named addressee from stored state only; the
+    // wake reason alone is not trusted. The same check runs again inside the
+    // queued-to-running claim transaction (see `verifyAddresseeInteractionWake`).
+    const isVerifiedAddresseeInteractionWake = issue
+      ? await verifyAddresseeInteractionWake(dbOrTx, {
+          companyId: input.companyId,
+          issueId: issue.id,
+          agentId: input.agentId,
+          contextSnapshot: context,
+        })
+      : false;
 
     const recoveryActionId = readNonEmptyString(context.recoveryActionId);
     const isAuthorizedSourceScopedRecovery =

--- a/server/src/modules/run-dispatch/domain/policy.test.ts
+++ b/server/src/modules/run-dispatch/domain/policy.test.ts
@@ -54,6 +54,7 @@ function baseStalenessFacts(): QueuedRunFacts {
     issueExecutionRunId: "run-1",
     isResolvedInteractionContinuation: false,
     isInteractionWake: false,
+    isVerifiedAddresseeInteractionWake: false,
     isAuthorizedSourceScopedRecovery: false,
     isNonAssigneeWorkspaceBusyRetry: false,
     resumeIntent: false,
@@ -442,6 +443,48 @@ describe("decideQueuedRunStaleness", () => {
       isAuthorizedSourceScopedRecovery: true,
     };
     expect(decideQueuedRunStaleness(facts, NOW)).toEqual({ stale: false });
+  });
+
+  it("allows a verified named-addressee interaction wake to bypass the ownership check", () => {
+    const facts: QueuedRunFacts = {
+      ...baseStalenessFacts(),
+      issueAssigneeAgentId: "agent-2",
+      wakeReason: "interaction_pending",
+      isVerifiedAddresseeInteractionWake: true,
+    };
+    expect(decideQueuedRunStaleness(facts, NOW)).toEqual({ stale: false });
+  });
+
+  it("allows a verified named-addressee interaction wake past the review-participant gate", () => {
+    const facts: QueuedRunFacts = {
+      ...baseStalenessFacts(),
+      issueAssigneeAgentId: "agent-2",
+      issueStatus: "in_review",
+      wakeReason: "interaction_pending",
+      isVerifiedAddresseeInteractionWake: true,
+      reviewParticipant: {
+        isInReview: true,
+        hasParticipant: true,
+        participantIsAgent: true,
+        participantAgentId: "agent-2",
+        currentStageType: "review",
+        currentParticipant: { type: "agent", agentId: "agent-2" },
+      },
+    };
+    expect(decideQueuedRunStaleness(facts, NOW)).toEqual({ stale: false });
+  });
+
+  it("still cancels an unverified interaction_pending wake for a non-assignee", () => {
+    const facts: QueuedRunFacts = {
+      ...baseStalenessFacts(),
+      issueAssigneeAgentId: "agent-2",
+      wakeReason: "interaction_pending",
+      isVerifiedAddresseeInteractionWake: false,
+    };
+    expect(decideQueuedRunStaleness(facts, NOW)).toMatchObject({
+      stale: true,
+      errorCode: "issue_assignee_changed",
+    });
   });
 });
 

--- a/server/src/modules/run-dispatch/domain/policy.ts
+++ b/server/src/modules/run-dispatch/domain/policy.ts
@@ -137,6 +137,14 @@ export type QueuedRunFacts = {
   /** A connection resolution or tool refresh can resume an agent waiting in review. */
   isConnectionContinuation?: boolean;
   isInteractionWake: boolean;
+  /**
+   * True when the run is a server-issued `interaction_pending` wake and the
+   * adapter verified, from stored state, that a pending issue-thread
+   * interaction on this issue names the run agent as `addresseeAgentId`.
+   * The named addressee owns the response even when it is not the issue
+   * assignee, so the wake must not be cancelled as `issue_assignee_changed`.
+   */
+  isVerifiedAddresseeInteractionWake: boolean;
   isAuthorizedSourceScopedRecovery: boolean;
   isNonAssigneeWorkspaceBusyRetry: boolean;
 
@@ -159,6 +167,7 @@ type OwnershipFacts = {
   issueAssigneeAgentId: string | null;
   isNonAssigneeWorkspaceBusyRetry: boolean;
   isInteractionWake?: boolean;
+  isVerifiedAddresseeInteractionWake?: boolean;
   isCurrentReviewParticipant?: boolean;
   isAuthorizedSourceScopedRecovery?: boolean;
 };
@@ -174,6 +183,7 @@ function decideIssueOwnership(facts: OwnershipFacts): OwnershipOutcome {
   if (facts.issueAssigneeAgentId === facts.runAgentId) return "current_owner";
   if (facts.isNonAssigneeWorkspaceBusyRetry) return "current_owner";
   if (facts.isInteractionWake) return "current_owner";
+  if (facts.isVerifiedAddresseeInteractionWake) return "current_owner";
   if (facts.isCurrentReviewParticipant) return "current_owner";
   if (facts.isAuthorizedSourceScopedRecovery) return "current_owner";
   return "reassigned";
@@ -536,6 +546,7 @@ export function decideQueuedRunStaleness(
     issueAssigneeAgentId: facts.issueAssigneeAgentId,
     isNonAssigneeWorkspaceBusyRetry: facts.isNonAssigneeWorkspaceBusyRetry,
     isInteractionWake: facts.isInteractionWake,
+    isVerifiedAddresseeInteractionWake: facts.isVerifiedAddresseeInteractionWake,
     isCurrentReviewParticipant:
       facts.reviewParticipant.isInReview &&
       facts.reviewParticipant.participantIsAgent &&
@@ -612,7 +623,9 @@ export function decideQueuedRunStaleness(
   const participantOutcome = decideReviewParticipant({
     ...facts.reviewParticipant,
     runAgentId: facts.runAgentId,
-    bypass: facts.wakeCommentIdPresent,
+    // A verified named-addressee wake is authorized from stored interaction
+    // state, so the review-participant gate must not cancel it on its own.
+    bypass: facts.wakeCommentIdPresent || facts.isVerifiedAddresseeInteractionWake,
   });
   if (participantOutcome === "participant_changed") {
     return {

--- a/server/src/modules/run-dispatch/index.ts
+++ b/server/src/modules/run-dispatch/index.ts
@@ -1,5 +1,7 @@
 import type { Db } from "@paperclipai/db";
 import { createPostgresRunDispatchAdapter } from "./adapters/postgres.js";
+export { verifyAddresseeInteractionWake } from "./adapters/postgres.js";
+export type { AddresseeInteractionWakeInput } from "./adapters/postgres.js";
 import {
   createCancelStaleQueuedRun,
   createDispatchResolvedInteractionIfCurrent,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -481,6 +481,7 @@ import {
   deriveCommentId,
   allowsIssueInteractionWake,
   isResolvedInteractionContinuationWakeContext,
+  verifyAddresseeInteractionWake,
 } from "../modules/run-dispatch/index.js";
 import {
   createWakeQueue,
@@ -16920,8 +16921,38 @@ export function heartbeatService(
     }
     const claimed = queuedCommentClaim
       ? queuedCommentClaim.run
-      : await withChatControlRecoveryGate(run, "claim", async (tx) =>
-          tx
+      : await withChatControlRecoveryGate(run, "claim", async (tx) => {
+          // A named-addressee interaction wake passed the staleness gate on
+          // stored interaction state. Re-read that state inside the claim
+          // transaction so a non-assignee run cannot start after the
+          // interaction was resolved in between. A wake that no longer
+          // verifies stays queued; the next claim attempt cancels it through
+          // the ordinary staleness gate.
+          if (issueId && readNonEmptyString(context.wakeReason) === "interaction_pending") {
+            const issueOwner = await tx
+              .select({ assigneeAgentId: issues.assigneeAgentId })
+              .from(issues)
+              .where(and(eq(issues.id, issueId), eq(issues.companyId, run.companyId)))
+              .limit(1)
+              .then((rows) => rows[0] ?? null);
+            if (
+              issueOwner &&
+              issueOwner.assigneeAgentId !== run.agentId &&
+              !(await verifyAddresseeInteractionWake(tx, {
+                companyId: run.companyId,
+                issueId,
+                agentId: run.agentId,
+                contextSnapshot: context,
+              }))
+            ) {
+              logger.info(
+                { runId: run.id, issueId, agentId: run.agentId },
+                "claimQueuedRun: addressee interaction is no longer actionable; leaving run queued for the staleness gate",
+              );
+              return null;
+            }
+          }
+          return tx
             .update(heartbeatRuns)
             .set({
               status: "running",
@@ -16936,8 +16967,8 @@ export function heartbeatService(
               ),
             )
             .returning()
-            .then((rows) => rows[0] ?? null),
-        );
+            .then((rows) => rows[0] ?? null);
+        });
     if (!claimed) return null;
 
     publishLiveEvent({


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Agents coordinate through issue-thread interactions. An agent can address a `request_confirmation` card to another agent with `addresseeAgentId`, and Paperclip wakes that agent with an `interaction_pending` heartbeat.
> - The queued-run staleness gate cancels a run when the run agent is not the issue assignee. It only exempts comment-driven interaction wakes. An `interaction_pending` wake has no comment id, so the named addressee's run is cancelled as `issue_assignee_changed` before it starts.
> - The named addressee is the only actor allowed to resolve the card. The card therefore stays pending until a human finds it in the thread and resolves it by hand. Agent-to-agent approval flows stall.
> - This pull request verifies the wake from stored interaction state and lets a verified named-addressee wake pass the ownership and review-participant gates.
> - The benefit is that addressed confirmations reach their addressee without human intervention, while unverified or stale wakes are still cancelled.

## Linked Issues or Issue Description

Fixes #11932
Refs #12629
Refs #7945

Related history: #8087 and PR #11376 added named-addressee interactions. No open PR addresses the cancellation reported in #11932.

## What Changed

- `server/src/modules/run-dispatch/adapters/postgres.ts`: new exported `verifyAddresseeInteractionWake(dbOrTx, input)`. It reads `contextSnapshot.interactionId` when `wakeReason` is `interaction_pending` and returns true only when the interaction exists, is `pending`, belongs to the same issue and company, and names the run agent as `addresseeAgentId`. `loadStalenessFacts` uses it for the new fact `isVerifiedAddresseeInteractionWake`. The wake reason alone is not trusted.
- `server/src/services/heartbeat.ts` (`claimQueuedRun`): the queued-to-running claim re-runs `verifyAddresseeInteractionWake` inside the claim transaction when the wake is `interaction_pending` and the run agent is not the issue assignee. If the interaction was resolved between the staleness gate and the claim, the run stays queued and the next claim attempt cancels it through the ordinary staleness gate. This addresses the review note that the earlier check could go stale before the claim.
- `server/src/modules/run-dispatch/domain/policy.ts`: `QueuedRunFacts` gains `isVerifiedAddresseeInteractionWake`. `decideIssueOwnership` treats a verified wake as current ownership. The review-participant gate also accepts it, so an in-review issue does not cancel the addressee independently.
- `server/src/modules/run-dispatch/domain/policy.test.ts`: three unit tests. A verified wake passes the ownership gate and the review-participant gate. An unverified `interaction_pending` wake for a non-assignee is still cancelled.
- `server/src/modules/run-dispatch/adapters/postgres.test.ts`: integration tests on the embedded database. A pending interaction addressed to agent B on an issue assigned to agent A keeps B's queued run. The run is still cancelled when the interaction is already resolved, names a different addressee, or belongs to another issue.
- `server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts`: two end-to-end tests through `resumeQueuedRuns` with the mocked adapter. The named addressee runs while another agent stays the assignee. When the interaction is resolved between the staleness gate and the claim (injected through `beforeChatControlRecoveryCheck` at stage `claim`), the adapter never starts and the run is cancelled as `issue_assignee_changed`.

## Verification

- `cd server && npx vitest run src/modules/run-dispatch/domain/policy.test.ts` → 56 passed.
- `cd server && npx vitest run src/modules/run-dispatch/adapters/postgres.test.ts` → 30 passed.
- `cd server && npx vitest run src/__tests__/heartbeat-stale-queue-invalidation.test.ts src/modules/run-dispatch` → 5 files, 134 passed.
- With `server/src/services/heartbeat.ts` stashed, the race test `does not start the addressee when the interaction is resolved between the staleness gate and the claim` fails. With the change it passes.
- With the two source files stashed, the new adapter test `keeps a verified interaction_pending wake for the named addressee when the issue is assigned to another agent` fails with `issue_assignee_changed`. With the change it passes.
- Manual reproduction on a self-hosted 2026.831.1 instance before the fix: agent-addressed confirmations produced `agent_wakeup_requests` rows with status `skipped` and the error `Cancelled because issue assignee changed before the queued run could start`. Sixteen cards addressed to four agents stayed pending for 12 to 18 hours until a human resolved them from the thread.
- `tsc --noEmit` on `server` reports no new errors in the changed files. The pre-existing errors come from workspace packages that are not built in a fresh checkout.

## Risks

- Low risk. The bypass applies only when a pending interaction row names the run agent as addressee for the same issue, and it is re-checked inside the claim transaction. All other staleness rules are unchanged.
- Target freshness for target-bound confirmations is not evaluated here. The claim-time check requires the row to still be `pending`; a target-stale confirmation that has not yet been expired by its routine is treated like any other pending card, exactly as the resolve endpoint treats it today.
- The exemption adds one indexed primary-key lookup on `issue_thread_interactions` per `interaction_pending` wake.
- Not covered by this change: the blocked-dependencies gate in `claimQueuedRun` still cancels an `interaction_pending` wake when the issue has unresolved blockers. That is a separate decision and can be a follow-up.

## Model Used

Claude Fable 5.1 (`claude-fable-5-1`, Anthropic) in Claude Code, extended thinking and tool use. Review and test execution were run locally by the same session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
