### PR TITLE
fix(cli): require explicit heartbeat scope

### DIFF
--- a/cli/src/__tests__/agent-lifecycle.test.ts
+++ b/cli/src/__tests__/agent-lifecycle.test.ts
@@ -26,6 +26,16 @@ async function run(args: string[]): Promise<void> {
   ], { from: "user" });
 }
 
+async function expectCommandFailure(args: string[], message: string): Promise<void> {
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(process, "exit").mockImplementation((code) => {
+    throw new Error(`process.exit:${code}`);
+  });
+
+  await expect(run(args)).rejects.toThrow("process.exit:1");
+  expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining(message));
+}
+
 describe("agent lifecycle commands", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -93,6 +103,42 @@ describe("agent lifecycle commands", () => {
         taskKey: ISSUE_ID,
       },
     });
+  });
+
+  it.each([
+    {
+      args: ["agent", "heartbeat:invoke", AGENT_ID],
+      message: "Specify --issue-id for task work or --allow-unscoped for a generic heartbeat",
+    },
+    {
+      args: ["agent", "heartbeat:invoke", AGENT_ID, "--issue-id", "PC-42", "--allow-unscoped"],
+      message: "Use either --issue-id or --allow-unscoped, not both",
+    },
+  ])("rejects an invalid heartbeat scope choice", async ({ args, message }) => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expectCommandFailure(args, message);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an issue assigned to another agent without posting a heartbeat", async () => {
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(jsonResponse({
+      id: ISSUE_ID,
+      identifier: "PC-42",
+      assigneeAgentId: "55555555-5555-4555-8555-555555555555",
+    })));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expectCommandFailure(
+      ["agent", "heartbeat:invoke", AGENT_ID, "--issue-id", "PC-42"],
+      `Issue PC-42 is not assigned to agent ${AGENT_ID}`,
+    );
+
+    expect(fetchMock.mock.calls.map((call) => [call[1]?.method ?? "GET", call[0]])).toEqual([
+      ["GET", "http://localhost:3100/api/issues/PC-42"],
+    ]);
   });
 
   it("wraps configuration, runtime, skills, and instructions endpoints", async () => {

--- a/cli/src/__tests__/agent-lifecycle.test.ts
+++ b/cli/src/__tests__/agent-lifecycle.test.ts
@@ -5,6 +5,7 @@ import { registerAgentCommands } from "../commands/client/agent.js";
 const COMPANY_ID = "22222222-2222-4222-8222-222222222222";
 const AGENT_ID = "11111111-1111-4111-8111-111111111111";
 const REVISION_ID = "33333333-3333-4333-8333-333333333333";
+const ISSUE_ID = "44444444-4444-4444-8444-444444444444";
 
 function createProgram(): Command {
   const program = new Command();
@@ -52,7 +53,7 @@ describe("agent lifecycle commands", () => {
     await run(["agent", "resume", AGENT_ID]);
     await run(["agent", "approve", AGENT_ID]);
     await run(["agent", "terminate", AGENT_ID]);
-    await run(["agent", "heartbeat:invoke", AGENT_ID]);
+    await run(["agent", "heartbeat:invoke", AGENT_ID, "--allow-unscoped"]);
     await run(["agent", "claude-login", AGENT_ID]);
     await run(["agent", "delete", AGENT_ID, "--yes"]);
 
@@ -68,6 +69,30 @@ describe("agent lifecycle commands", () => {
       ["POST", `http://localhost:3100/api/agents/${AGENT_ID}/claude-login`],
       ["DELETE", `http://localhost:3100/api/agents/${AGENT_ID}`],
     ]);
+  });
+
+  it("binds a manual heartbeat invoke to the assigned issue", async () => {
+    const fetchMock = vi.fn().mockImplementation(() => Promise.resolve(jsonResponse({
+      id: ISSUE_ID,
+      identifier: "PC-42",
+      assigneeAgentId: AGENT_ID,
+    })));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await run(["agent", "heartbeat:invoke", AGENT_ID, "--issue-id", "PC-42"]);
+
+    expect(fetchMock.mock.calls.map((call) => [call[1]?.method ?? "GET", call[0]])).toEqual([
+      ["GET", "http://localhost:3100/api/issues/PC-42"],
+      ["POST", `http://localhost:3100/api/agents/${AGENT_ID}/heartbeat/invoke`],
+    ]);
+    expect(JSON.parse(String(fetchMock.mock.calls[1]?.[1]?.body))).toEqual({
+      reason: "manual_issue_wake",
+      payload: {
+        issueId: ISSUE_ID,
+        taskId: ISSUE_ID,
+        taskKey: ISSUE_ID,
+      },
+    });
   });
 
   it("wraps configuration, runtime, skills, and instructions endpoints", async () => {

--- a/cli/src/commands/client/agent.ts
+++ b/cli/src/commands/client/agent.ts
@@ -56,6 +56,11 @@ interface AgentWakeOptions extends BaseClientOptions {
   forceFreshSession?: boolean;
 }
 
+interface AgentHeartbeatInvokeOptions extends BaseClientOptions {
+  issueId?: string;
+  allowUnscoped?: boolean;
+}
+
 interface AgentJsonPayloadOptions extends BaseClientOptions {
   companyId?: string;
   payloadJson: string;
@@ -420,7 +425,6 @@ export function registerAgentCommands(program: Command): void {
     ["resume", "resume", "Resume an agent"],
     ["approve", "approve", "Approve a pending agent"],
     ["terminate", "terminate", "Terminate an agent"],
-    ["heartbeat:invoke", "heartbeat/invoke", "Invoke an agent heartbeat"],
     ["claude-login", "claude-login", "Trigger Claude login for an agent"],
   ] as const) {
     addCommonClientOptions(
@@ -439,6 +443,53 @@ export function registerAgentCommands(program: Command): void {
         }),
     );
   }
+
+  addCommonClientOptions(
+    agent
+      .command("heartbeat:invoke")
+      .description("Invoke an issue-scoped agent heartbeat")
+      .argument("<agentId>", "Agent ID")
+      .option("--issue-id <idOrIdentifier>", "Issue UUID or identifier to bind to the run")
+      .option("--allow-unscoped", "Explicitly allow a run with no issue binding")
+      .action(async (agentId: string, opts: AgentHeartbeatInvokeOptions) => {
+        try {
+          if (opts.issueId && opts.allowUnscoped) {
+            throw new Error("Use either --issue-id or --allow-unscoped, not both");
+          }
+          if (!opts.issueId && !opts.allowUnscoped) {
+            throw new Error("Specify --issue-id for task work or --allow-unscoped for a generic heartbeat");
+          }
+
+          const ctx = resolveCommandContext(opts);
+          let body: Record<string, unknown> = {};
+          if (opts.issueId) {
+            const issue = await ctx.api.get<Issue>(`/api/issues/${encodeURIComponent(opts.issueId)}`);
+            if (!issue) {
+              throw new Error(`Issue not found: ${opts.issueId}`);
+            }
+            if (issue.assigneeAgentId !== agentId) {
+              throw new Error(`Issue ${issue.identifier} is not assigned to agent ${agentId}`);
+            }
+            body = {
+              reason: "manual_issue_wake",
+              payload: {
+                issueId: issue.id,
+                taskId: issue.id,
+                taskKey: issue.id,
+              },
+            };
+          }
+
+          const result = await ctx.api.post<AgentWakeupResponse>(
+            `${apiPath`/api/agents/${agentId}`}/heartbeat/invoke`,
+            body,
+          );
+          printOutput(result, { json: ctx.json });
+        } catch (err) {
+          handleCommandError(err);
+        }
+      }),
+  );
 
   addCommonClientOptions(
     agent

--- a/doc/CLI.md
+++ b/doc/CLI.md
@@ -541,7 +541,8 @@ npx paperclipai agent pause <agent-id>
 npx paperclipai agent resume <agent-id>
 npx paperclipai agent approve <agent-id>
 npx paperclipai agent terminate <agent-id>
-npx paperclipai agent heartbeat:invoke <agent-id>
+npx paperclipai agent heartbeat:invoke <agent-id> --issue-id <issue-id-or-identifier>
+npx paperclipai agent heartbeat:invoke <agent-id> --allow-unscoped
 npx paperclipai agent claude-login <agent-id>
 npx paperclipai agent local-cli <agent-id-or-shortname> --company-id <company-id>
 ```

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -6655,6 +6655,7 @@ registry.registerPath({
     401: r.unauthorized,
     403: r.forbidden,
     404: r.notFound,
+    409: r.conflict,
   },
 });
 

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -6638,8 +6638,24 @@ registry.registerPath({
   path: "/api/agents/{id}/heartbeat/invoke",
   tags: ["agents"],
   summary: "Invoke agent heartbeat",
-  request: { params: z.object({ id: z.string() }) },
-  responses: { 200: r.ok(), 401: r.unauthorized },
+  description:
+    "Legacy manual invoke endpoint. Bind task work by supplying payload.issueId, payload.taskId, and payload.taskKey with the same issue UUID. An omitted body creates an intentionally unscoped run.",
+  request: {
+    params: z.object({ id: z.string() }),
+    body: {
+      content: {
+        "application/json": { schema: wakeAgentSchema.omit({ failedRunId: true }) },
+      },
+      required: false,
+    },
+  },
+  responses: {
+    202: r.ok(),
+    400: r.badRequest,
+    401: r.unauthorized,
+    403: r.forbidden,
+    404: r.notFound,
+  },
 });
 
 registry.registerPath({


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages AI agents that do issue work.
> - A heartbeat run can start an agent process.
> - The process needs an issue identity to write issue comments and status updates.
> - The CLI could start a heartbeat without an issue identity by default.
> - This pull request makes the operator select an issue or explicitly allow an unscoped run.
> - The benefit is that task work does not start silently without task context.

## Linked Issues or Issue Description

**What happened?**

`paperclipai agent heartbeat:invoke <agent-id>` sent an empty request body. The new process then had no issue identity. It could do work but could not write to the related issue under the run-context guard.

**Expected behavior**

The CLI must require an explicit scope choice. For task work, it must resolve the issue, confirm that the issue is assigned to the target agent, and bind the issue UUID to the heartbeat payload. Generic maintenance heartbeats must require an explicit opt-in.

**Steps to reproduce**

1. Assign an issue to an agent.
2. Run `paperclipai agent heartbeat:invoke <agent-id>` without an issue option.
3. Observe that the heartbeat request contains no issue identity.
4. Observe that the spawned agent process has no task identity.

**Paperclip version or commit**

`932c8be`

**Deployment mode**

Self-hosted server

**Installation method**

npm / pnpm global install

**Agent adapter(s) involved**

Not adapter-specific. The problem is in the core manual invoke path.

## What Changed

- Add `--issue-id <id-or-identifier>` to `agent heartbeat:invoke`.
- Resolve the issue and confirm that it is assigned to the target agent.
- Send the issue UUID as `issueId`, `taskId`, and `taskKey`.
- Require `--allow-unscoped` for an intentionally generic heartbeat.
- Document the heartbeat request body in OpenAPI.
- Update the CLI documentation and tests.

## Verification

- `pnpm exec vitest run --no-coverage cli/src/__tests__/agent-lifecycle.test.ts`
- `pnpm exec vitest run --no-coverage server/src/__tests__/openapi-routes.test.ts`
- `pnpm --filter paperclipai exec tsc --noEmit`
- `pnpm --filter @paperclipai/server exec tsc --noEmit`
- `git diff --check`

All commands pass locally.

## Risks

Low risk. The server keeps the legacy endpoint behavior. The CLI change is intentionally stricter and requires an explicit option for existing generic invocations.

## Model Used

OpenAI Codex, model `gpt-5.6-sol`, with repository tools and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal issue ID
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
