### PR TITLE
fix(routines): accept signed Sentry webhooks

### DIFF
--- a/server/src/__tests__/routines-routes.test.ts
+++ b/server/src/__tests__/routines-routes.test.ts
@@ -325,6 +325,33 @@ describe("routine routes", () => {
     expect(mockRoutineService.list).toHaveBeenCalledWith(companyId, { projectId });
   });
 
+  it("forwards the Sentry signature header to public webhook verification", async () => {
+    mockRoutineService.firePublicTrigger.mockResolvedValue({
+      id: "run-1",
+      source: "webhook",
+      status: "issue_created",
+    });
+    const app = await createApp({ type: "public" });
+    const payload = {
+      action: "created",
+      data: { issue: { id: "7625432288", project: { slug: "api" } } },
+    };
+
+    const res = await request(app)
+      .post("/api/routine-triggers/public/sentry-trigger/fire")
+      .set("Sentry-Hook-Signature", "signed-digest")
+      .send(payload);
+
+    expect(res.status).toBe(202);
+    expect(mockRoutineService.firePublicTrigger).toHaveBeenCalledWith(
+      "sentry-trigger",
+      expect.objectContaining({
+        sentrySignatureHeader: "signed-digest",
+        payload,
+      }),
+    );
+  });
+
   it("lists routine revisions for a board member in newest-first service order", async () => {
     const app = await createApp({
       type: "board",

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -2363,7 +2363,7 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(run.status).toBe("issue_created");
   });
 
-  it("accepts Sentry signatures and deduplicates retries by immutable issue id", async () => {
+  it("deduplicates identical Sentry event retries but delivers distinct issue actions", async () => {
     const { routine, svc } = await seedFixture();
     const { trigger, secretMaterial } = await svc.createTrigger(
       routine.id,
@@ -2394,30 +2394,74 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
       payload,
     };
 
-    const retryPayload = {
+    const resolvedPayload = {
       ...payload,
       action: "resolved",
       actor: { type: "application", name: "Sentry" },
     };
-    const retryRawBody = Buffer.from(JSON.stringify(retryPayload));
-    const retryRequest = {
+    const resolvedRawBody = Buffer.from(JSON.stringify(resolvedPayload));
+    const resolvedRequest = {
       sentrySignatureHeader: createHmac("sha256", secretMaterial!.webhookSecret)
-        .update(retryRawBody)
+        .update(resolvedRawBody)
         .digest("hex"),
-      rawBody: retryRawBody,
-      payload: retryPayload,
+      rawBody: resolvedRawBody,
+      payload: resolvedPayload,
     };
 
     const first = await svc.firePublicTrigger(trigger.publicId!, request);
-    const retry = await svc.firePublicTrigger(trigger.publicId!, retryRequest);
+    const retry = await svc.firePublicTrigger(trigger.publicId!, request);
+    const resolved = await svc.firePublicTrigger(trigger.publicId!, resolvedRequest);
 
     expect(first).toMatchObject({ source: "webhook", status: "issue_created" });
     expect(retry.id).toBe(first.id);
     expect(retry.linkedIssueId).toBe(first.linkedIssueId);
-    expect(await db.select().from(routineRuns).where(eq(routineRuns.triggerId, trigger.id))).toHaveLength(1);
+    expect(resolved.id).not.toBe(first.id);
+    expect(resolved.linkedIssueId).not.toBe(first.linkedIssueId);
+    expect(await db.select().from(routineRuns).where(eq(routineRuns.triggerId, trigger.id))).toHaveLength(2);
     expect(
       await db.select().from(issues).where(eq(issues.originId, routine.id)),
-    ).toHaveLength(1);
+    ).toHaveLength(2);
+  });
+
+  it("prefers a provider delivery id when deduplicating Sentry webhook retries", async () => {
+    const { routine, svc } = await seedFixture();
+    const { trigger, secretMaterial } = await svc.createTrigger(
+      routine.id,
+      { kind: "webhook", signingMode: "github_hmac" },
+      {},
+    );
+    const payload = {
+      action: "created",
+      data: { issue: { id: "7625432288", project: { slug: "api" } } },
+    };
+    const requestFor = (idempotencyKey: string, body: Record<string, unknown>) => {
+      const rawBody = Buffer.from(JSON.stringify(body));
+      return {
+        idempotencyKey,
+        sentrySignatureHeader: createHmac("sha256", secretMaterial!.webhookSecret)
+          .update(rawBody)
+          .digest("hex"),
+        rawBody,
+        payload: body,
+      };
+    };
+
+    const first = await svc.firePublicTrigger(
+      trigger.publicId!,
+      requestFor("sentry-delivery-1", payload),
+    );
+    const retry = await svc.firePublicTrigger(
+      trigger.publicId!,
+      requestFor("sentry-delivery-1", { ...payload, actor: { type: "application" } }),
+    );
+    const separateDelivery = await svc.firePublicTrigger(
+      trigger.publicId!,
+      requestFor("sentry-delivery-2", payload),
+    );
+
+    expect(retry.id).toBe(first.id);
+    expect(separateDelivery.id).not.toBe(first.id);
+    expect(await db.select().from(routineRuns).where(eq(routineRuns.triggerId, trigger.id))).toHaveLength(2);
   });
 
   it("rejects invalid signature for github_hmac signing mode", async () => {

--- a/server/src/__tests__/routines-service.test.ts
+++ b/server/src/__tests__/routines-service.test.ts
@@ -2363,6 +2363,63 @@ describeEmbeddedPostgres("routine service live-execution coalescing", () => {
     expect(run.status).toBe("issue_created");
   });
 
+  it("accepts Sentry signatures and deduplicates retries by immutable issue id", async () => {
+    const { routine, svc } = await seedFixture();
+    const { trigger, secretMaterial } = await svc.createTrigger(
+      routine.id,
+      {
+        kind: "webhook",
+        signingMode: "github_hmac",
+      },
+      {},
+    );
+
+    const payload = {
+      action: "created",
+      data: {
+        issue: {
+          id: "7625432288",
+          shortId: "API-FX",
+          project: { slug: "api" },
+        },
+      },
+    };
+    const rawBody = Buffer.from(JSON.stringify(payload));
+    const signature = createHmac("sha256", secretMaterial!.webhookSecret)
+      .update(rawBody)
+      .digest("hex");
+    const request = {
+      sentrySignatureHeader: signature,
+      rawBody,
+      payload,
+    };
+
+    const retryPayload = {
+      ...payload,
+      action: "resolved",
+      actor: { type: "application", name: "Sentry" },
+    };
+    const retryRawBody = Buffer.from(JSON.stringify(retryPayload));
+    const retryRequest = {
+      sentrySignatureHeader: createHmac("sha256", secretMaterial!.webhookSecret)
+        .update(retryRawBody)
+        .digest("hex"),
+      rawBody: retryRawBody,
+      payload: retryPayload,
+    };
+
+    const first = await svc.firePublicTrigger(trigger.publicId!, request);
+    const retry = await svc.firePublicTrigger(trigger.publicId!, retryRequest);
+
+    expect(first).toMatchObject({ source: "webhook", status: "issue_created" });
+    expect(retry.id).toBe(first.id);
+    expect(retry.linkedIssueId).toBe(first.linkedIssueId);
+    expect(await db.select().from(routineRuns).where(eq(routineRuns.triggerId, trigger.id))).toHaveLength(1);
+    expect(
+      await db.select().from(issues).where(eq(issues.originId, routine.id)),
+    ).toHaveLength(1);
+  });
+
   it("rejects invalid signature for github_hmac signing mode", async () => {
     const { routine, svc } = await seedFixture();
     const { trigger } = await svc.createTrigger(

--- a/server/src/routes/routines.ts
+++ b/server/src/routes/routines.ts
@@ -658,6 +658,7 @@ export function routineRoutes(
       authorizationHeader: req.header("authorization"),
       signatureHeader: req.header("x-paperclip-signature"),
       hubSignatureHeader: req.header("x-hub-signature-256"),
+      sentrySignatureHeader: req.header("sentry-hook-signature"),
       timestampHeader: req.header("x-paperclip-timestamp"),
       idempotencyKey: req.header("idempotency-key"),
       rawBody: (req as { rawBody?: Buffer }).rawBody ?? null,

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -311,6 +311,14 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function sentryIssueIdFromWebhookPayload(payload: Record<string, unknown> | null | undefined) {
+  if (!payload) return null;
+  const data = isPlainRecord(payload.data) ? payload.data : null;
+  const issue = data && isPlainRecord(data.issue) ? data.issue : null;
+  const id = issue?.id;
+  return typeof id === "string" || typeof id === "number" ? String(id) : null;
+}
+
 function parseBooleanVariableValue(name: string, raw: unknown) {
   if (typeof raw === "boolean") return raw;
   if (typeof raw === "number" && (raw === 0 || raw === 1)) return raw === 1;
@@ -2869,6 +2877,7 @@ export function routineService(
       authorizationHeader?: string | null;
       signatureHeader?: string | null;
       hubSignatureHeader?: string | null;
+      sentrySignatureHeader?: string | null;
       timestampHeader?: string | null;
       idempotencyKey?: string | null;
       rawBody?: Buffer | null;
@@ -2890,10 +2899,12 @@ export function routineService(
       } else if (trigger.signingMode === "github_hmac") {
         const secretValue = await resolveTriggerSecret(trigger, routine.companyId);
         const rawBody = input.rawBody ?? Buffer.from(JSON.stringify(input.payload ?? {}));
-        // Accept X-Hub-Signature-256 (GitHub/Sentry) or fall back to the
-        // generic X-Paperclip-Signature header so operators can use github_hmac
-        // mode with either header convention.
-        const providedSignature = (input.hubSignatureHeader ?? input.signatureHeader)?.trim() ?? "";
+        // GitHub prefixes its digest in X-Hub-Signature-256. Sentry sends the
+        // unprefixed digest in Sentry-Hook-Signature. Keep the generic header
+        // fallback for existing integrations using this raw-body HMAC mode.
+        const providedSignature = (
+          input.hubSignatureHeader ?? input.sentrySignatureHeader ?? input.signatureHeader
+        )?.trim() ?? "";
         if (!providedSignature) throw unauthorized();
         const expectedHmac = crypto
           .createHmac("sha256", secretValue)
@@ -2906,6 +2917,15 @@ export function routineService(
           normalizedBuf.length === expectedBuf.length &&
           crypto.timingSafeEqual(normalizedBuf, expectedBuf);
         if (!valid) throw unauthorized();
+        if (input.sentrySignatureHeader) {
+          const sentryIssueId = sentryIssueIdFromWebhookPayload(input.payload);
+          if (sentryIssueId) {
+            hmacReplayKey = `webhook-sentry-issue:${crypto
+              .createHash("sha256")
+              .update(`${trigger.id}:${sentryIssueId}`)
+              .digest("hex")}`;
+          }
+        }
       } else if (trigger.signingMode === "bearer") {
         const secretValue = await resolveTriggerSecret(trigger, routine.companyId);
         const expected = `Bearer ${secretValue}`;
@@ -2968,7 +2988,8 @@ export function routineService(
           ? input.payload.variables
           : null,
         idempotencyKey: hmacReplayKey ?? input.idempotencyKey,
-        rejectIdempotencyReplay: hmacReplayKey !== null,
+        rejectIdempotencyReplay:
+          hmacReplayKey !== null && !hmacReplayKey.startsWith("webhook-sentry-issue:"),
       });
     },
 

--- a/server/src/services/routines.ts
+++ b/server/src/services/routines.ts
@@ -319,6 +319,11 @@ function sentryIssueIdFromWebhookPayload(payload: Record<string, unknown> | null
   return typeof id === "string" || typeof id === "number" ? String(id) : null;
 }
 
+function sentryActionFromWebhookPayload(payload: Record<string, unknown> | null | undefined) {
+  const action = payload?.action;
+  return typeof action === "string" && action.trim().length > 0 ? action.trim() : null;
+}
+
 function parseBooleanVariableValue(name: string, raw: unknown) {
   if (typeof raw === "boolean") return raw;
   if (typeof raw === "number" && (raw === 0 || raw === 1)) return raw === 1;
@@ -2920,9 +2925,14 @@ export function routineService(
         if (input.sentrySignatureHeader) {
           const sentryIssueId = sentryIssueIdFromWebhookPayload(input.payload);
           if (sentryIssueId) {
-            hmacReplayKey = `webhook-sentry-issue:${crypto
+            const providerDeliveryId = input.idempotencyKey?.trim();
+            const action = sentryActionFromWebhookPayload(input.payload);
+            const deliveryIdentity = providerDeliveryId
+              ? `delivery:${providerDeliveryId}`
+              : `issue:${sentryIssueId}:action:${action ?? "unknown"}`;
+            hmacReplayKey = `webhook-sentry-event:${crypto
               .createHash("sha256")
-              .update(`${trigger.id}:${sentryIssueId}`)
+              .update(`${trigger.id}:${deliveryIdentity}`)
               .digest("hex")}`;
           }
         }
@@ -2989,7 +2999,7 @@ export function routineService(
           : null,
         idempotencyKey: hmacReplayKey ?? input.idempotencyKey,
         rejectIdempotencyReplay:
-          hmacReplayKey !== null && !hmacReplayKey.startsWith("webhook-sentry-issue:"),
+          hmacReplayKey !== null && !hmacReplayKey.startsWith("webhook-sentry-event:"),
       });
     },
 


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Scheduled routines can expose signed webhook endpoints for event-driven work
> - Sentry signs webhook payloads and sends the signature in its provider-specific header
> - The routine route did not pass request headers into webhook verification, so valid signed events could be rejected before delivery work was created
> - Retry safety must distinguish a retry of the same provider event from a distinct lifecycle action on the same immutable issue
> - This pull request forwards request headers, accepts the Sentry signature header, and derives lifecycle-aware idempotency from the immutable issue ID plus provider event/action identity
> - The benefit is reliable Sentry-driven intake without duplicate work on true retries or suppression of later issue lifecycle events

## Linked Issues or Issue Description

### Pre-submission checklist

- [x] I searched existing open and closed issues and found no duplicate.
- [x] The bug is reproducible on the current `master` lineage.
- [x] The failure originates in Paperclip's webhook intake path, not an agent adapter or provider configuration.

### What happened?

Valid signed Sentry issue webhooks can fail authentication because the provider signature header is not available to the verifier. Deduplicating only by immutable issue ID also suppresses distinct lifecycle actions for the same issue.

### Expected behavior

A valid signed event creates one routine delivery; a retry of that same event reuses the delivery, while a different lifecycle action for the same immutable issue creates its own delivery. Invalid signatures and unsupported projects remain rejected.

### Steps to reproduce

1. Configure a routine with a webhook secret.
2. Send a Sentry issue webhook signed in the provider-specific signature header.
3. Observe the pre-fix request is rejected before routine delivery work is created.
4. Send the same event twice and a different action for the same issue; observe the pre-fix path either lacks stable retry identity or suppresses the distinct action.

### Paperclip version or commit

Reproduced on parent commit `dda4dff645da9eebe532cf9c59d6c5debdf05070`.

### Deployment mode

Self-hosted server.

### Installation method

Built from source.

### Agent adapter(s) involved

Not adapter-specific (core bug).

### Database mode

Not database-related.

### Access context

Unclear / not applicable.

### Privacy checklist

- [x] I reviewed this description for PII and secrets.

## What Changed

- Forward incoming request headers into routine webhook handling.
- Recognize Sentry's signature header during HMAC verification.
- Normalize the immutable Sentry issue identifier and combine it with stable provider event/action identity for idempotency.
- Add route and service regression coverage for signed events, exact retries, and distinct lifecycle actions.
- Exact review head: `0ef779610cb263ca5142b79098e4dda007b462a1`.

## Verification

- Focused exact-head regression: `pnpm exec vitest run server/src/__tests__/routines-routes.test.ts server/src/__tests__/routines-service.test.ts`
- Result: 2 files and 81 tests passed on `0ef779610cb263ca5142b79098e4dda007b462a1`.
- GitHub PR workflow run `34594626449`: all required checks terminal green, including build, typecheck/release registry, server and workspace shards, serialized suites, canary, and e2e.
- Greptile, Superagent, Socket, Snyk, commit review, and policy checks are green; Storybook visual regression is intentionally skipped for this non-UI change.

## Risks

- Moderate risk: this changes authentication and idempotency on the webhook intake path. Coverage distinguishes invalid signatures, exact retries, and different actions for one immutable issue.
- No schema, tenant boundary, permission, mobile/native, billing, or dependency change is included.
- No secret values or customer payloads are logged.
- Deployment verification remains separate from this repository PR and is not claimed here.

> This fixes existing scheduled-routine reliability behavior and does not duplicate planned roadmap work.

## Model Used

- OpenAI Codex, `gpt-5.6-sol`, with repository tools and code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] Documentation impact was assessed; no user-facing documentation change is required
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is green with no open blocking findings
- [x] I will address all reviewer comments before requesting merge
