### PR TITLE
fix(openclaw-gateway): bind the device signature to the presented credential (deviceToken reconnect)

### DIFF
--- a/packages/adapters/openclaw-gateway/src/server/execute.test.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { buildAgentParams, resolveClaimedApiKeyPath, resolveSessionKey } from "./execute.js";
+import {
+  buildAgentParams,
+  buildDeviceAuthPayloadV3,
+  resolveClaimedApiKeyPath,
+  resolveDeviceSignatureToken,
+  resolveSessionKey,
+} from "./execute.js";
 
 describe("resolveSessionKey", () => {
   it("prefixes run-scoped session keys with the configured agent", () => {
@@ -121,5 +127,44 @@ describe("resolveClaimedApiKeyPath", () => {
   it("falls back to the shared default when value is not a string", () => {
     expect(resolveClaimedApiKeyPath(42)).toBe(DEFAULT_PATH);
     expect(resolveClaimedApiKeyPath({})).toBe(DEFAULT_PATH);
+  });
+});
+
+describe("device signature token binding", () => {
+  const basePayload = {
+    deviceId: "device-id",
+    clientId: "cli",
+    clientMode: "cli",
+    role: "operator",
+    scopes: ["operator.read", "operator.write"],
+    signedAtMs: 1_700_000_000_000,
+    nonce: "nonce-1",
+    platform: "linux",
+    deviceFamily: null,
+  };
+
+  it("binds the device token when no shared token is configured (device-token-only reconnect)", () => {
+    const token = resolveDeviceSignatureToken({ authToken: null, deviceToken: "D" });
+    expect(token).toBe("D");
+    const payload = buildDeviceAuthPayloadV3({ ...basePayload, token });
+    expect(payload.split("|")[7]).toBe("D");
+  });
+
+  it("binds the shared token when both are configured (gateway precedence: token, then deviceToken)", () => {
+    const token = resolveDeviceSignatureToken({ authToken: "S", deviceToken: "D" });
+    expect(token).toBe("S");
+    const payload = buildDeviceAuthPayloadV3({ ...basePayload, token });
+    expect(payload.split("|")[7]).toBe("S");
+  });
+
+  it("leaves the token slot empty only when no credential of either kind is configured", () => {
+    expect(resolveDeviceSignatureToken({ authToken: "  ", deviceToken: undefined })).toBeNull();
+    const payload = buildDeviceAuthPayloadV3({ ...basePayload, token: null });
+    expect(payload.split("|")[7]).toBe("");
+  });
+
+  it("keeps the v3 payload field order stable", () => {
+    const payload = buildDeviceAuthPayloadV3({ ...basePayload, token: "D" });
+    expect(payload).toBe("v3|device-id|cli|cli|operator|operator.read,operator.write|1700000000000|D|nonce-1|linux|");
   });
 });

--- a/packages/adapters/openclaw-gateway/src/server/execute.ts
+++ b/packages/adapters/openclaw-gateway/src/server/execute.ts
@@ -559,7 +559,21 @@ function signDevicePayload(privateKeyPem: string, payload: string): string {
   return base64UrlEncode(sig);
 }
 
-function buildDeviceAuthPayloadV3(params: {
+/**
+ * The OpenClaw gateway verifies the signed device payload against the credential the client
+ * actually presents for the connection: `auth.token` when a shared token is supplied, otherwise
+ * `auth.deviceToken`. Binding only the shared token breaks every device-token-only reconnect
+ * (the gateway answers "device signature invalid"), so the signature token must follow the
+ * same precedence as the `auth` object built for `connect`.
+ */
+export function resolveDeviceSignatureToken(params: {
+  authToken?: string | null;
+  deviceToken?: string | null;
+}): string | null {
+  return nonEmpty(params.authToken) ?? nonEmpty(params.deviceToken) ?? null;
+}
+
+export function buildDeviceAuthPayloadV3(params: {
   deviceId: string;
   clientId: string;
   clientMode: string;
@@ -1276,7 +1290,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
             role,
             scopes,
             signedAtMs,
-            token: authToken,
+            token: resolveDeviceSignatureToken({ authToken, deviceToken }),
             nonce,
             platform: process.platform,
             deviceFamily,


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The `openclaw_gateway` adapter connects to an OpenClaw gateway over WebSocket and presents a signed device identity.
> - The gateway verifies that signature against the credential actually presented for the connection (shared token when supplied, otherwise the device token).
> - The adapter signed with the shared token only, so a paired device configured with `deviceToken` alone could never reconnect.
> - This change binds the signature to `authToken ?? deviceToken`, matching the `auth` object the adapter already sends.

## Linked Issues or Issue Description

Fixes #13218 — device-token-only reconnect fails with `device signature invalid`.

## What changed

- `resolveDeviceSignatureToken({ authToken, deviceToken })` returns the credential the signature must bind (`authToken ?? deviceToken`) and is used when building the v3 device payload.
- `buildDeviceAuthPayloadV3` is exported so the payload binding can be tested directly.
- Focused tests: device-token-only binds the device token; shared + device binds the shared token (gateway precedence); no credential leaves the slot empty; v3 field order stays stable.

No behaviour change for shared-token connections. No new configuration.

## Verification

- `pnpm --filter @paperclipai/adapter-openclaw-gateway exec vitest run src/server/execute.test.ts` → 14 passed.
- Live: a paired device reconnecting with `deviceToken` only (no `authToken`) now completes the connect handshake and the heartbeat run against an OpenClaw 2026.9.x gateway (protocol v4); before the change the same configuration failed with `device signature invalid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
