### PR TITLE
fix(recovery): use normal lane for missing-comment retries

### DIFF
--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -3211,7 +3211,16 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
       expect(runs[1]?.contextSnapshot).toMatchObject({
         retryReason: "missing_issue_comment",
       });
-      expect(runs[1]?.contextSnapshot).not.toHaveProperty("modelProfile");
+      for (const key of [
+        "modelProfile",
+        "paperclipModelProfile",
+        "recoveryIntent",
+        "allowDeliverableWork",
+        "allowDocumentUpdates",
+        "resumeRequiresNormalModel",
+      ]) {
+        expect(runs[1]?.contextSnapshot).not.toHaveProperty(key);
+      }
     } finally {
       gateway.releaseFirstWait();
       await gateway.close();
@@ -3416,9 +3425,19 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
           ),
         );
       expect(missingCommentRetries).toHaveLength(1);
-      expect(missingCommentRetries[0]?.payload).not.toHaveProperty(
-        "modelProfile",
-      );
+        expect(missingCommentRetries[0]?.payload).toMatchObject({
+          retryReason: "missing_issue_comment",
+        });
+        for (const key of [
+          "modelProfile",
+          "paperclipModelProfile",
+          "recoveryIntent",
+          "allowDeliverableWork",
+          "allowDocumentUpdates",
+          "resumeRequiresNormalModel",
+        ]) {
+          expect(missingCommentRetries[0]?.payload).not.toHaveProperty(key);
+        }
     } finally {
       gateway.releaseFirstWait();
       await gateway.close();

--- a/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
+++ b/server/src/__tests__/heartbeat-comment-wake-batching.test.ts
@@ -3425,19 +3425,19 @@ describeEmbeddedPostgres("heartbeat comment wake batching", () => {
           ),
         );
       expect(missingCommentRetries).toHaveLength(1);
-        expect(missingCommentRetries[0]?.payload).toMatchObject({
-          retryReason: "missing_issue_comment",
-        });
-        for (const key of [
-          "modelProfile",
-          "paperclipModelProfile",
-          "recoveryIntent",
-          "allowDeliverableWork",
-          "allowDocumentUpdates",
-          "resumeRequiresNormalModel",
-        ]) {
-          expect(missingCommentRetries[0]?.payload).not.toHaveProperty(key);
-        }
+      expect(missingCommentRetries[0]?.payload).toMatchObject({
+        retryReason: "missing_issue_comment",
+      });
+      for (const key of [
+        "modelProfile",
+        "paperclipModelProfile",
+        "recoveryIntent",
+        "allowDeliverableWork",
+        "allowDocumentUpdates",
+        "resumeRequiresNormalModel",
+      ]) {
+        expect(missingCommentRetries[0]?.payload).not.toHaveProperty(key);
+      }
     } finally {
       gateway.releaseFirstWait();
       await gateway.close();

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -13388,6 +13388,8 @@ export function heartbeatService(
     const contextSnapshot = parseObject(run.contextSnapshot);
     const taskKey = deriveTaskKeyWithHeartbeatFallback(contextSnapshot, null);
     const sessionBefore = await resolveSessionBeforeForWakeup(agent, taskKey);
+    // Missing-comment retries continue the original deliverable work, so they
+    // must not inherit the status-only mutation guards.
     const retryContextSnapshot = withRecoveryContext(
       {
         ...contextSnapshot,
@@ -13396,7 +13398,7 @@ export function heartbeatService(
         retryReason: "missing_issue_comment",
         missingIssueCommentForRunId: run.id,
       },
-      "status_only",
+      "normal_model",
     );
     const responsibleUserId = await resolveResponsibleUserIdForRunContext(
       run,
@@ -13435,7 +13437,7 @@ export function heartbeatService(
               retryOfRunId: run.id,
               retryReason: "missing_issue_comment",
             },
-            "status_only",
+            "normal_model",
           ),
           status: "queued",
           requestedByActorType: "system",


### PR DESCRIPTION
## Summary

- queue `missing_issue_comment` retries on the normal work lane
- scrub stale status-only recovery guards from both the queued run context and wake payload
- strengthen regression assertions for all retired and active recovery-context keys

## Why

A missing-comment retry continues the original run's work. For routine executions, that can include updating an issue document. Marking this retry as `status_only` causes the document mutation guard to return HTTP 403 even though the retry still carries the original `routine.dispatch` context.

True status-only recovery paths remain write-gated; this change is limited to `missing_issue_comment`.

## Tests

```text
pnpm exec vitest run \
  server/src/__tests__/heartbeat-comment-wake-batching.test.ts \
  server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts

Test Files  2 passed (2)
Tests       134 passed (134)
```
