### PR TITLE
fix: keep project and execution workspaces consistent

### DIFF
--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -3612,6 +3612,189 @@ describeEmbeddedPostgres("issueService.create workspace inheritance", () => {
     });
   });
 
+  it("keeps explicit project workspace consistent across inherited create and update execution linkage", async () => {
+    const companyId = randomUUID();
+    const projectId = randomUUID();
+    const agentId = randomUUID();
+    const checkoutRunId = randomUUID();
+    const parentIssueId = randomUUID();
+    const legacyParentIssueId = randomUUID();
+    const dashboardProjectWorkspaceId = randomUUID();
+    const dashboardExecutionWorkspaceId = randomUUID();
+    const wwwProjectWorkspaceId = randomUUID();
+    const wwwExecutionWorkspaceId = "00000000-0000-4000-8000-000000000090";
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "FarmHub",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await instanceSettingsService(db).updateExperimental({ enableIsolatedWorkspaces: true });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "API Engineer",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: checkoutRunId,
+      companyId,
+      agentId,
+      status: "running",
+    });
+    await db.insert(projects).values({
+      id: projectId,
+      companyId,
+      name: "Reliability",
+      status: "in_progress",
+    });
+    await db.insert(projectWorkspaces).values([
+      {
+        id: dashboardProjectWorkspaceId,
+        companyId,
+        projectId,
+        name: "dashboard",
+        repoUrl: "https://github.com/thefarmhub/dashboard.git",
+        cwd: "/workspaces/dashboard",
+      },
+      {
+        id: wwwProjectWorkspaceId,
+        companyId,
+        projectId,
+        name: "www",
+        repoUrl: "https://github.com/thefarmhub/www.git",
+        cwd: "/workspaces/www",
+        isPrimary: true,
+      },
+    ]);
+    await db.insert(executionWorkspaces).values([
+      {
+        id: dashboardExecutionWorkspaceId,
+        companyId,
+        projectId,
+        projectWorkspaceId: dashboardProjectWorkspaceId,
+        mode: "isolated_workspace",
+        strategyType: "git_worktree",
+        name: "dashboard worktree",
+        status: "active",
+        providerType: "git_worktree",
+        providerRef: "/workspaces/dashboard",
+      },
+      {
+        id: wwwExecutionWorkspaceId,
+        companyId,
+        projectId,
+        projectWorkspaceId: wwwProjectWorkspaceId,
+        mode: "shared_workspace",
+        strategyType: "project_primary",
+        name: "www checkout",
+        status: "active",
+        providerType: "local_fs",
+        providerRef: "/workspaces/www",
+        repoUrl: "https://github.com/thefarmhub/www.git",
+        cwd: "/workspaces/www",
+      },
+    ]);
+    await db.insert(issues).values({
+      id: parentIssueId,
+      companyId,
+      projectId,
+      projectWorkspaceId: dashboardProjectWorkspaceId,
+      title: "Reliability parent",
+      status: "in_progress",
+      priority: "high",
+      executionWorkspaceId: dashboardExecutionWorkspaceId,
+      executionWorkspacePreference: "reuse_existing",
+      executionWorkspaceSettings: { mode: "isolated_workspace" },
+    });
+    await db.insert(issues).values({
+      id: legacyParentIssueId,
+      companyId,
+      projectId,
+      projectWorkspaceId: null,
+      title: "Legacy reliability parent",
+      status: "in_progress",
+      priority: "high",
+      executionWorkspaceId: dashboardExecutionWorkspaceId,
+      executionWorkspacePreference: "reuse_existing",
+      executionWorkspaceSettings: { mode: "isolated_workspace" },
+    });
+
+    const child = await svc.create(companyId, {
+      parentId: parentIssueId,
+      projectId,
+      projectWorkspaceId: wwwProjectWorkspaceId,
+      title: "Fix www reliability",
+      assigneeAgentId: agentId,
+      status: "todo",
+    });
+
+    expect(child.projectWorkspaceId).toBe(wwwProjectWorkspaceId);
+    expect(child.executionWorkspaceId).toBeNull();
+
+    const legacyChild = await svc.create(companyId, {
+      parentId: legacyParentIssueId,
+      projectId,
+      title: "Child of legacy reliability parent",
+    });
+    expect(legacyChild.projectWorkspaceId).toBe(wwwProjectWorkspaceId);
+    expect(legacyChild.executionWorkspaceId).toBeNull();
+    expect(legacyChild.executionWorkspacePreference).toBeNull();
+    expect(legacyChild.executionWorkspaceSettings).toBeNull();
+
+    await expect(svc.create(companyId, {
+      projectId,
+      projectWorkspaceId: wwwProjectWorkspaceId,
+      executionWorkspaceId: dashboardExecutionWorkspaceId,
+      title: "Invalid explicit create pair",
+    })).rejects.toMatchObject({
+      status: 422,
+      message: "Execution workspace must belong to the selected project workspace",
+    });
+
+    await svc.update(child.id, {
+      executionWorkspaceId: wwwExecutionWorkspaceId,
+      executionWorkspacePreference: "reuse_existing",
+      executionWorkspaceSettings: { mode: "shared_workspace" },
+    });
+    const checkedOut = await svc.checkout(child.id, agentId, ["todo"], checkoutRunId);
+    expect(checkedOut.executionWorkspaceId).toBe(wwwExecutionWorkspaceId);
+    const [resolvedWwwWorkspace] = await db
+      .select({
+        id: executionWorkspaces.id,
+        repoUrl: executionWorkspaces.repoUrl,
+        cwd: executionWorkspaces.cwd,
+      })
+      .from(executionWorkspaces)
+      .where(eq(executionWorkspaces.id, checkedOut.executionWorkspaceId!));
+    expect(resolvedWwwWorkspace).toEqual({
+      id: wwwExecutionWorkspaceId,
+      repoUrl: "https://github.com/thefarmhub/www.git",
+      cwd: "/workspaces/www",
+    });
+    const movedToDashboard = await svc.update(child.id, {
+      projectWorkspaceId: dashboardProjectWorkspaceId,
+    });
+    expect(movedToDashboard?.projectWorkspaceId).toBe(dashboardProjectWorkspaceId);
+    expect(movedToDashboard?.executionWorkspaceId).toBeNull();
+    expect(movedToDashboard?.executionWorkspacePreference).toBeNull();
+    expect(movedToDashboard?.executionWorkspaceSettings).toBeNull();
+
+    await expect(svc.update(child.id, {
+      projectWorkspaceId: wwwProjectWorkspaceId,
+      executionWorkspaceId: dashboardExecutionWorkspaceId,
+    })).rejects.toMatchObject({
+      status: 422,
+      message: "Execution workspace must belong to the selected project workspace",
+    });
+  });
+
   it("inherits workspace linkage from an explicit source issue without creating a parent-child relationship", async () => {
     const companyId = randomUUID();
     const projectId = randomUUID();

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -7193,6 +7193,7 @@ export function issueService(db: Db) {
         id: executionWorkspaces.id,
         companyId: executionWorkspaces.companyId,
         projectId: executionWorkspaces.projectId,
+        projectWorkspaceId: executionWorkspaces.projectWorkspaceId,
       })
       .from(executionWorkspaces)
       .where(eq(executionWorkspaces.id, executionWorkspaceId))
@@ -7206,6 +7207,34 @@ export function issueService(db: Db) {
       );
     }
     return workspace;
+  }
+
+  function assertProjectExecutionWorkspaceConsistency(
+    projectWorkspaceId: string | null | undefined,
+    executionWorkspace: {
+      id: string;
+      projectWorkspaceId: string | null;
+    } | null,
+  ) {
+    if (
+      !projectWorkspaceId ||
+      !executionWorkspace ||
+      executionWorkspace.projectWorkspaceId === projectWorkspaceId
+    ) {
+      return;
+    }
+    throw unprocessable(
+      "Execution workspace must belong to the selected project workspace",
+      {
+        code: "project_execution_workspace_mismatch",
+        projectWorkspaceId,
+        executionWorkspaceId: executionWorkspace.id,
+        executionWorkspaceProjectWorkspaceId:
+          executionWorkspace.projectWorkspaceId,
+        remediation:
+          "Select an execution workspace linked to the selected project workspace, or omit executionWorkspaceId.",
+      },
+    );
   }
 
   async function assertValidLabelIds(
@@ -9920,6 +9949,7 @@ export function issueService(db: Db) {
         let executionWorkspaceSettings =
           (issueData.executionWorkspaceSettings as
             Record<string, unknown> | null | undefined) ?? null;
+        let executionWorkspaceWasInherited = false;
         const workspaceInheritanceIssueId = skipExecutionWorkspaceInheritance
           ? null
           : (inheritExecutionWorkspaceFromIssueId ??
@@ -9964,6 +9994,7 @@ export function issueService(db: Db) {
               .select({
                 id: executionWorkspaces.id,
                 mode: executionWorkspaces.mode,
+                projectWorkspaceId: executionWorkspaces.projectWorkspaceId,
               })
               .from(executionWorkspaces)
               .where(
@@ -9973,8 +10004,13 @@ export function issueService(db: Db) {
                 ),
               )
               .then((rows) => rows[0] ?? null);
-            if (sourceWorkspace) {
+            if (
+              sourceWorkspace &&
+              (!projectWorkspaceId ||
+                sourceWorkspace.projectWorkspaceId === projectWorkspaceId)
+            ) {
               executionWorkspaceId = sourceWorkspace.id;
+              executionWorkspaceWasInherited = true;
               executionWorkspacePreference = "reuse_existing";
               executionWorkspaceSettings = {
                 ...((workspaceSource.executionWorkspaceSettings as
@@ -10094,12 +10130,26 @@ export function issueService(db: Db) {
           );
         }
         if (executionWorkspaceId) {
-          await assertValidExecutionWorkspace(
+          const executionWorkspace = await assertValidExecutionWorkspace(
             companyId,
             issueData.projectId,
             executionWorkspaceId,
             tx,
           );
+          if (
+            executionWorkspaceWasInherited &&
+            projectWorkspaceId &&
+            executionWorkspace.projectWorkspaceId !== projectWorkspaceId
+          ) {
+            executionWorkspaceId = null;
+            executionWorkspacePreference = null;
+            executionWorkspaceSettings = null;
+          } else {
+            assertProjectExecutionWorkspaceConsistency(
+              projectWorkspaceId,
+              executionWorkspace,
+            );
+          }
         }
         if (
           isolatedWorkspacesEnabled &&
@@ -10760,15 +10810,15 @@ export function issueService(db: Db) {
         issueData.projectWorkspaceId !== undefined
           ? issueData.projectWorkspaceId
           : existing.projectWorkspaceId;
-      const nextExecutionWorkspaceId =
+      let nextExecutionWorkspaceId =
         issueData.executionWorkspaceId !== undefined
           ? issueData.executionWorkspaceId
           : existing.executionWorkspaceId;
-      const nextExecutionWorkspacePreference =
+      let nextExecutionWorkspacePreference =
         issueData.executionWorkspacePreference !== undefined
           ? issueData.executionWorkspacePreference
           : existing.executionWorkspacePreference;
-      const nextExecutionWorkspaceSettings =
+      let nextExecutionWorkspaceSettings =
         issueData.executionWorkspaceSettings !== undefined
           ? parseIssueExecutionWorkspaceSettings(
               issueData.executionWorkspaceSettings,
@@ -10782,7 +10832,11 @@ export function issueService(db: Db) {
           : null;
       }
       let validatedProjectWorkspace: { projectId: string } | null = null;
-      let validatedExecutionWorkspace: { projectId: string } | null = null;
+      let validatedExecutionWorkspace: {
+        id: string;
+        projectId: string;
+        projectWorkspaceId: string | null;
+      } | null = null;
       if (!nextProjectId && nextProjectWorkspaceId) {
         const workspace = await assertValidProjectWorkspace(
           existing.companyId,
@@ -10814,10 +10868,29 @@ export function issueService(db: Db) {
       }
       if (nextExecutionWorkspaceId) {
         if (!validatedExecutionWorkspace) {
-          await assertValidExecutionWorkspace(
+          validatedExecutionWorkspace = await assertValidExecutionWorkspace(
             existing.companyId,
             nextProjectId,
             nextExecutionWorkspaceId,
+            dbOrTx,
+          );
+        }
+        if (
+          issueData.projectWorkspaceId !== undefined &&
+          issueData.executionWorkspaceId === undefined &&
+          validatedExecutionWorkspace.projectWorkspaceId !==
+            nextProjectWorkspaceId
+        ) {
+          nextExecutionWorkspaceId = null;
+          nextExecutionWorkspacePreference = null;
+          nextExecutionWorkspaceSettings = null;
+          patch.executionWorkspaceId = null;
+          patch.executionWorkspacePreference = null;
+          patch.executionWorkspaceSettings = null;
+        } else {
+          assertProjectExecutionWorkspaceConsistency(
+            nextProjectWorkspaceId,
+            validatedExecutionWorkspace,
           );
         }
       }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Issues can select a project workspace and an execution workspace
> - The issue service checks each workspace against the company and project
> - It did not check that both workspace selections refer to the same project workspace
> - A child issue could therefore inherit an execution workspace for a different repository
> - An update could also retain stale execution workspace data after a project workspace change
> - This pull request rejects explicit mismatches and clears stale inherited execution workspace data
> - The benefit is that issue execution stays in the repository that the issue selected

## Linked Issues or Issue Description

Refs #4453

Related: #13182

**What happened?**

An issue could select one project workspace and inherit or retain an execution workspace that belongs to another project workspace. A later checkout could then run in the wrong repository.

**Expected behavior**

The issue service must keep the project workspace and execution workspace consistent. It must reject an explicit mismatch. It must not inherit or retain a stale execution workspace after the project workspace changes.

**Steps to reproduce**

1. Create two project workspaces in one project.
2. Create an execution workspace for each project workspace.
3. Create a parent issue in the first workspace.
4. Create a child issue with the second project workspace.
5. Observe that the child inherits the first execution workspace.

**Paperclip version or commit**

`d10cbde81523a13344fc18a1f70a76edac8a93fc`

**Deployment mode**

Built from source with embedded PostgreSQL tests.

## What Changed

- Read the project workspace ID when the service validates an execution workspace.
- Reject create and update requests that explicitly select inconsistent workspaces.
- Skip inherited execution workspace data when an explicit child project workspace does not match.
- Drop a legacy inherited execution workspace when the effective default project workspace resolves to a different repository.
- Clear stale execution workspace data when an update changes the project workspace without an explicit execution workspace.
- Add regression coverage for explicit and legacy inheritance, explicit create, checkout, update clear, and explicit update rejection.

## Verification

- Exact reviewed head: `fe8f46ddc738a3016d95a83568fedaaa577661b6`.
- `pnpm exec vitest run server/src/__tests__/issues-service.test.ts` passes 128 tests.
- `pnpm -r typecheck` passes.
- `pnpm build` passes.
- `git diff --check` passes.
- `pnpm test:run` found unrelated failures in `workspace-runtime.test.ts` and `native-session-resume.test.ts`. Each failure also reproduces without the changed files. The native test run cannot find its debug fake Codex binary after the release build. The workspace runtime test expects an injected rescue commit failure, but the commit succeeds.

## Risks

- This changes invalid legacy behavior. A client that sends inconsistent workspace IDs now receives `422` with code `project_execution_workspace_mismatch`.
- A legacy child creation drops stale inherited execution linkage when it conflicts with the resolved default project workspace, allowing checkout to realize the selected repository safely.
- A project workspace change without an explicit execution workspace clears the old execution workspace preference and settings.
- The change has no database migration.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex in the GPT-5 family. The runtime did not expose an exact model ID or context window. The agent used repository tools, code execution, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
