### PR TITLE
fix(ci): reuse cloud source verification for npm canaries

### DIFF
--- a/.github/workflows/cloud-readiness.yml
+++ b/.github/workflows/cloud-readiness.yml
@@ -48,6 +48,33 @@ jobs:
           SOURCE_SHA: ${{ github.sha }}
         run: node scripts/cloud-readiness.mjs "$SOURCE_SHA"
 
+  source_verified:
+    # npm canary publication reuses this exact-source verification proof.
+    # Keep it independent of image/migrator availability, and fail closed when
+    # any source check fails, is cancelled, or is skipped.
+    name: Cloud source verified v1
+    needs: [verify]
+    if: github.repository == 'paperclipai/paperclip' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+      - name: Check the source verification consumer
+        run: node --test scripts/cloud-source-verification.test.mjs
+      - name: Record source verification
+        env:
+          SOURCE_SHA: ${{ github.sha }}
+        run: |
+          echo "Cloud source verified v1: $SOURCE_SHA" >> "$GITHUB_STEP_SUMMARY"
+
   ready:
     # Versioned consumer contract. Never add always() or continue-on-error:
     # failed, cancelled, or skipped prerequisites must not report readiness.

--- a/.github/workflows/pr-trusted.yml
+++ b/.github/workflows/pr-trusted.yml
@@ -335,7 +335,7 @@ jobs:
         run: node --test ./scripts/__tests__/e2e-shard.test.mjs
 
       - name: Test release verify workflow wiring
-        run: node --test ./scripts/__tests__/release-verify-workflow.test.mjs
+        run: node --test ./scripts/__tests__/release-verify-workflow.test.mjs ./scripts/cloud-source-verification.test.mjs
 
       - name: Test standalone package build concurrency
         run: node --test ./scripts/__tests__/build-standalone-concurrency.test.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,10 +296,26 @@ jobs:
           retention-days: 30
 
   verify_canary:
-    if: github.event_name == 'push'
-    uses: ./.github/workflows/release-verify.yml
-    with:
-      ref: ${{ github.sha }}
+    name: Reuse exact-source verification
+    if: github.repository == 'paperclipai/paperclip' && github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+      - name: Require successful source checks for this exact master push
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ github.sha }}
+        run: node scripts/cloud-source-verification.mjs "$SOURCE_SHA"
 
   publish_canary:
     if: github.event_name == 'push'

--- a/doc/cloud-build-readiness.md
+++ b/doc/cloud-build-readiness.md
@@ -26,11 +26,22 @@ build with the new identity must rebuild layers that depend on the base image;
 later builds can reuse those layers.
 
 Verification and image building run concurrently, outside the full npm release's
-concurrency group. Different commits have independent groups. Source verification
-is initially duplicated with the normal npm release: this spends existing hosted
-runner capacity to avoid waiting behind an older release. No verification gate is
-removed from npm publication. Watch organization-wide runner queues when measuring
-the result.
+concurrency group. Different commits have independent groups. The npm canary
+release reuses `Cloud source verified v1` for the exact master push instead of
+starting a second copy of `Release Verify`. This source-only job depends on every
+source check but does not wait for Docker or migrator publication. npm canary
+publication remains possible when source verification passes and an image build
+fails. Stable releases and candidate-branch betas still run full verification.
+
+The canary consumer requires the expected workflow ID and path, upstream source
+repository, master push event, full SHA, and a successful job in the latest run
+attempt. It checks the run again after reading the jobs to reject a concurrent
+rerun. Missing proof waits for up to 45 minutes; failed, skipped, cancelled,
+ambiguous, or mismatched proof cannot authorize publication. API failures fail
+closed. If a source check fails, fix it and rerun Cloud readiness before retrying
+the release. Use **Re-run all jobs** when a later attempt did not rerun the source
+proof; an earlier attempt's successful job is not accepted. This avoids duplicate
+test jobs on standard runners. Measure queue time to assess the timing gain.
 
 Release verification spreads the general server suites across ten standard hosted
 runners, with the long chat suite split separately across three jobs. Each server
@@ -67,8 +78,9 @@ successfully verified a real master commit.
 ## Timing and rollout
 
 The reusable Runner chaos workflow scopes concurrency to the caller workflow
-and source ref. Cloud readiness and the npm release can verify the same commit
-at the same time. They must not cancel each other's required test job.
+and source ref. Cloud readiness, stable verification, and standalone evals can
+verify the same commit at the same time. They must not cancel each other's
+required test job.
 
 Measure the complete path from a master merge to a healthy target running that
 exact commit. Keep readiness and deployment as separate milestones:

--- a/scripts/__tests__/release-verify-workflow.test.mjs
+++ b/scripts/__tests__/release-verify-workflow.test.mjs
@@ -35,13 +35,16 @@ test("chaos verification isolates callers that verify the same source commit", (
   assert.match(chaosWorkflow, /cancel-in-progress: true/);
 });
 
-test("release workflow delegates stable and canary verification to the reusable workflow", () => {
+test("canary reuses exact-source proof while stable keeps full verification", () => {
   const releaseWorkflow = readWorkflow("release.yml");
-
-  assert.match(
-    releaseWorkflow,
-    /verify_canary:\n\s+if: github\.event_name == 'push'\n\s+uses: \.\/\.github\/workflows\/release-verify\.yml\n\s+with:\n\s+ref: \$\{\{ github\.sha \}\}/,
-  );
+  const canary = releaseWorkflow.split("  verify_canary:\n")[1].split("\n  publish_canary:")[0];
+  assert.match(canary, /github\.repository == 'paperclipai\/paperclip' && github\.event_name == 'push' && github\.ref == 'refs\/heads\/master'/);
+  assert.match(canary, /actions: read/);
+  assert.match(canary, /ref: \$\{\{ github\.sha \}\}/);
+  assert.match(canary, /SOURCE_SHA: \$\{\{ github\.sha \}\}/);
+  assert.match(canary, /run: node scripts\/cloud-source-verification\.mjs "\$SOURCE_SHA"/);
+  assert.doesNotMatch(canary, /release-verify\.yml|continue-on-error|always\(\)/);
+  assert.match(releaseWorkflow, /publish_canary:\n\s+if: github\.event_name == 'push'\n\s+needs: verify_canary/);
   // The stable lane is gated on the stable channel since the nightly lane
   // was added; a `needs:` line (for example a preflight job) may sit between
   // the gate and the delegation.
@@ -55,6 +58,17 @@ test("release workflow delegates stable and canary verification to the reusable 
     releaseWorkflow,
     /verify_(?:canary|stable):[\s\S]*?pnpm test:run(?:\n|$)/,
   );
+});
+
+test("source proof requires every source check and does not wait on image publication", () => {
+  const readiness = readWorkflow("cloud-readiness.yml");
+  const proof = readiness.split("  source_verified:\n")[1].split("\n  ready:")[0];
+  assert.match(proof, /name: Cloud source verified v1/);
+  assert.match(proof, /needs: \[verify\]/);
+  assert.match(proof, /node --test scripts\/cloud-source-verification.test.mjs/);
+  assert.match(proof, /SOURCE_SHA: \$\{\{ github\.sha \}\}/);
+  assert.doesNotMatch(proof, /always\(\)|continue-on-error|needs:.*(?:image|artifacts)/);
+  assert.match(readiness.split("  ready:\n")[1], /needs: \[verify, image, artifacts\]/);
 });
 
 test("onboard smoke container binds beyond loopback so the mapped port is reachable", () => {

--- a/scripts/cloud-source-verification.mjs
+++ b/scripts/cloud-source-verification.mjs
@@ -1,0 +1,99 @@
+import { appendFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+const repository = "paperclipai/paperclip";
+const workflowPath = ".github/workflows/cloud-readiness.yml";
+export const sourceVerificationJob = "Cloud source verified v1";
+
+function assertSha(sha) {
+  if (!/^[a-f0-9]{40}$/.test(sha ?? "")) throw new Error("A full lowercase source SHA is required.");
+}
+
+function trustedRun(run, sha, workflowId) {
+  return run.workflow_id === workflowId && run.path === workflowPath &&
+    run.repository?.full_name === repository && run.head_repository?.full_name === repository &&
+    run.head_sha === sha && run.head_branch === "master" && run.event === "push" &&
+    Number.isSafeInteger(run.id) && run.id > 0 &&
+    Number.isSafeInteger(run.run_attempt) && run.run_attempt > 0;
+}
+
+// Consume one versioned job, independent of image/migrator availability. A
+// failed image build must not invalidate source checks that already passed.
+export async function readSourceVerification(sha, api) {
+  assertSha(sha);
+  const workflow = await api(`/repos/${repository}/actions/workflows/cloud-readiness.yml`);
+  if (workflow.path !== workflowPath || !Number.isSafeInteger(workflow.id) || workflow.id < 1) {
+    throw new Error("Cloud readiness workflow identity does not match.");
+  }
+  const listing = await api(`/repos/${repository}/actions/workflows/${workflow.id}/runs?head_sha=${sha}&event=push&branch=master&per_page=100`);
+  if (!Array.isArray(listing.workflow_runs) || !Number.isSafeInteger(listing.total_count) ||
+      listing.total_count < 0 || listing.total_count > 100 || listing.workflow_runs.length !== listing.total_count) {
+    throw new Error("Cloud readiness run listing is incomplete.");
+  }
+  const run = listing.workflow_runs.filter((candidate) => trustedRun(candidate, sha, workflow.id))
+    .sort((a, b) => b.id - a.id)[0];
+  if (!run) return undefined;
+
+  // Attempt-specific jobs prevent an earlier successful attempt from blessing
+  // a later rerun. Keep pagination even though today's matrix fits one page.
+  const jobs = [];
+  for (let page = 1; page <= 10; page += 1) {
+    const batch = await api(`/repos/${repository}/actions/runs/${run.id}/attempts/${run.run_attempt}/jobs?per_page=100&page=${page}`);
+    if (!Array.isArray(batch.jobs)) throw new Error("Cloud readiness job listing is malformed.");
+    jobs.push(...batch.jobs);
+    if (batch.jobs.length < 100) break;
+    if (page === 10) throw new Error("Cloud readiness job listing is incomplete.");
+  }
+  const matches = jobs.filter((job) => job.name === sourceVerificationJob);
+  if (matches.length > 1) throw new Error("Cloud source verification job is ambiguous.");
+  const job = matches[0];
+  if (job?.status === "completed" && job.conclusion === "success" &&
+      job.head_sha === sha && job.run_id === run.id && job.run_attempt === run.run_attempt) {
+    // Re-read the run after its jobs: a rerun that started during polling must
+    // not let the previous attempt through. Changes are retried next poll.
+    const current = await api(`/repos/${repository}/actions/runs/${run.id}`);
+    if (!trustedRun(current, sha, workflow.id) || current.run_attempt !== run.run_attempt) return undefined;
+    return { sha, runId: run.id, attempt: run.run_attempt, jobId: job.id };
+  }
+  if (job?.status === "completed" || run.status === "completed") {
+    throw new Error(`Cloud source verification did not pass for ${sha} (run ${run.id}, attempt ${run.run_attempt}). Rerun Cloud readiness before retrying the release.`);
+  }
+  return undefined;
+}
+
+export async function waitForSourceVerification(sha, {
+  api, now = Date.now, sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  timeoutMs = 45 * 60_000, intervalMs = 30_000, log = console.log,
+} = {}) {
+  assertSha(sha);
+  const deadline = now() + timeoutMs;
+  log(`Waiting for ${sourceVerificationJob} for ${sha}.`);
+  while (now() < deadline) {
+    const result = await readSourceVerification(sha, api);
+    if (result) return result;
+    const remaining = deadline - now();
+    if (remaining > 0) await sleep(Math.min(intervalMs, remaining));
+  }
+  throw new Error(`Cloud source verification timed out for ${sha}. Rerun Cloud readiness before retrying the release.`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    if (!process.env.GITHUB_TOKEN) throw new Error("GITHUB_TOKEN with Actions read access is required.");
+    const api = async (path) => {
+      const response = await fetch(`https://api.github.com${path}`, {
+        headers: { Authorization: `Bearer ${process.env.GITHUB_TOKEN}`, Accept: "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28" },
+        signal: AbortSignal.timeout(30_000), redirect: "error",
+      });
+      if (!response.ok) throw new Error(`GitHub Actions read failed (HTTP ${response.status}).`);
+      return response.json();
+    };
+    const proof = await waitForSourceVerification(process.argv[2], { api });
+    const message = `Source verification passed for ${proof.sha}: https://github.com/${repository}/actions/runs/${proof.runId}/attempts/${proof.attempt} (job ${proof.jobId}).`;
+    console.log(message);
+    if (process.env.GITHUB_STEP_SUMMARY) await appendFile(process.env.GITHUB_STEP_SUMMARY, `${message}\n`);
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/cloud-source-verification.test.mjs
+++ b/scripts/cloud-source-verification.test.mjs
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readSourceVerification, sourceVerificationJob, waitForSourceVerification } from "./cloud-source-verification.mjs";
+
+const sha = "a".repeat(40);
+const workflow = { id: 123, path: ".github/workflows/cloud-readiness.yml" };
+const baseRun = {
+  id: 456, workflow_id: workflow.id, path: workflow.path, run_attempt: 2,
+  repository: { full_name: "paperclipai/paperclip" }, head_repository: { full_name: "paperclipai/paperclip" },
+  head_sha: sha, head_branch: "master", event: "push", status: "in_progress", conclusion: null,
+};
+const baseJob = { id: 789, name: sourceVerificationJob, run_id: 456, run_attempt: 2, head_sha: sha, status: "completed", conclusion: "success" };
+
+function fixture({ runs = [baseRun], jobs = [baseJob], current = baseRun, total, workflowRecord = workflow } = {}) {
+  const calls = [];
+  const api = async (path) => {
+    calls.push(path);
+    if (path.endsWith("/workflows/cloud-readiness.yml")) return workflowRecord;
+    if (path.includes("/workflows/123/runs?")) return { total_count: total ?? runs.length, workflow_runs: runs };
+    if (path.includes("/attempts/")) {
+      assert.ok(path.includes(`/attempts/${runs.at(-1).run_attempt}/jobs?`));
+      const page = Number(new URL("https://api.github.com" + path).searchParams.get("page"));
+      return { jobs: jobs.slice((page - 1) * 100, page * 100) };
+    }
+    if (path.endsWith("/runs/456")) return current;
+    throw new Error(`Unexpected API path: ${path}`);
+  };
+  return { api, calls };
+}
+
+test("source proof passes while image work is still running, or has failed", async () => {
+  for (const overrides of [{}, { status: "completed", conclusion: "failure" }]) {
+    const run = { ...baseRun, ...overrides };
+    const { api, calls } = fixture({ runs: [run], current: run });
+    assert.deepEqual(await readSourceVerification(sha, api), { sha, runId: 456, attempt: 2, jobId: 789 });
+    assert.ok(calls.some((path) => path.includes(`head_sha=${sha}&event=push&branch=master`)));
+    assert.ok(calls.some((path) => path.includes("/attempts/2/jobs?")));
+  }
+});
+
+test("only the expected workflow, repository, master push, and full SHA can supply proof", async () => {
+  for (const overrides of [
+    { workflow_id: 999 }, { path: ".github/workflows/pr.yml" },
+    { repository: { full_name: "other/paperclip" } }, { head_repository: { full_name: "fork/paperclip" } },
+    { head_sha: "b".repeat(40) }, { head_branch: "feature" }, { event: "workflow_dispatch" },
+    { run_attempt: undefined }, { run_attempt: 0 },
+  ]) {
+    const { api, calls } = fixture({ runs: [{ ...baseRun, ...overrides }] });
+    assert.equal(await readSourceVerification(sha, api), undefined, JSON.stringify(overrides));
+    assert.equal(calls.length, 2);
+  }
+});
+
+test("a newer pending run cannot fall back to an older successful run", async () => {
+  const newer = { ...baseRun, id: 457, run_attempt: 1 };
+  const { api } = fixture({ runs: [baseRun, newer], jobs: [] });
+  assert.equal(await readSourceVerification(sha, api), undefined);
+});
+
+test("job identities and terminal failures fail closed", async () => {
+  for (const overrides of [
+    { head_sha: "b".repeat(40) }, { run_id: 999 }, { run_attempt: 1 },
+    { conclusion: "failure" }, { conclusion: "cancelled" }, { conclusion: "skipped" },
+  ]) {
+    const { api } = fixture({ jobs: [{ ...baseJob, ...overrides }] });
+    await assert.rejects(readSourceVerification(sha, api), /did not pass/);
+  }
+});
+
+test("a rerun racing the jobs read cannot reuse the previous attempt", async () => {
+  const { api } = fixture({ current: { ...baseRun, run_attempt: 3 } });
+  assert.equal(await readSourceVerification(sha, api), undefined);
+});
+
+test("the versioned proof must exist and be unique", async () => {
+  for (const jobs of [[], [{ ...baseJob, name: "Cloud deployable v1" }]]) {
+    await assert.rejects(readSourceVerification(sha, fixture({ runs: [{ ...baseRun, status: "completed" }], jobs }).api), /did not pass/);
+  }
+  await assert.rejects(readSourceVerification(sha, fixture({ jobs: [baseJob, baseJob] }).api), /ambiguous/);
+});
+
+test("proof may appear after the first page of jobs", async () => {
+  const jobs = [...Array.from({ length: 100 }, (_, index) => ({ ...baseJob, name: `test ${index}` })), baseJob];
+  const { api, calls } = fixture({ jobs });
+  assert.equal((await readSourceVerification(sha, api)).jobId, 789);
+  assert.ok(calls.some((path) => path.endsWith("page=2")));
+});
+
+test("incomplete discovery and API failures cannot bless a release", async () => {
+  for (const total of [2, 101, -1]) {
+    await assert.rejects(readSourceVerification(sha, fixture({ total }).api), /incomplete/);
+  }
+  await assert.rejects(readSourceVerification(sha, fixture({ workflowRecord: { ...workflow, path: ".github/workflows/pr.yml" } }).api), /identity/);
+  await assert.rejects(readSourceVerification(sha, async () => { throw new Error("API unavailable"); }), /API unavailable/);
+});
+
+test("a missing or pending source proof waits and has a bounded deadline", async () => {
+  let time = 0;
+  let polls = 0;
+  const { api } = fixture({ runs: [] });
+  await assert.rejects(waitForSourceVerification(sha, {
+    api: async (path) => { if (path.endsWith(".yml")) polls += 1; return api(path); },
+    now: () => time, sleep: async (ms) => { time += ms; }, timeoutMs: 50, intervalMs: 30, log: () => {},
+  }), /timed out/);
+  assert.equal(time, 50);
+  assert.equal(polls, 2);
+});
+
+test("pending verification succeeds when its exact job completes", async () => {
+  let time = 0;
+  const pending = fixture({ jobs: [{ ...baseJob, status: "in_progress", conclusion: null }] });
+  const passed = fixture();
+  const proof = await waitForSourceVerification(sha, {
+    api: (path) => (time ? passed.api : pending.api)(path), now: () => time,
+    sleep: async (ms) => { time += ms; }, timeoutMs: 100, intervalMs: 30, log: () => {},
+  });
+  assert.equal(proof.sha, sha);
+  assert.equal(time, 30);
+});
+
+test("malformed source refs are rejected before any request", async () => {
+  for (const ref of ["master", "a".repeat(7), "A".repeat(40), undefined]) {
+    await assert.rejects(readSourceVerification(ref, () => assert.fail("must not request")), /full lowercase/);
+  }
+});


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Cloud deploys images from verified master commits.
> - Cloud readiness starts outside the npm release queue so images can ship sooner.
> - The npm canary workflow repeats the same source checks on the same commit.
> - Those duplicate jobs compete for the runners that verify newer cloud images.
> - This pull request lets npm canary publication reuse a versioned source-verification result for its exact commit.
> - The benefit is fewer duplicate jobs while keeping the same source checks before publication.

## Linked Issues or Issue Description

Refs #13192 and #13227. A search found no open PR for this source-verification reuse change.

**What existing behavior does this improve?**

Master-push verification for cloud images and npm canary releases.

**Current behavior**

Cloud readiness and the npm canary release each run the complete Release Verify workflow for the same source commit. They compete for standard hosted runners.

**Proposed behavior**

Cloud readiness publishes `Cloud source verified v1` after all source checks pass. The npm canary release requires that result for its exact master push. This result does not wait for image or migrator publication.

**Reason and benefit**

Remove a duplicate verification matrix from each canary release. This reduces runner demand and queue pressure. The wall-clock gain depends on queue contention; the change does not shorten Docker compilation itself.

## What Changed

- Add the versioned source-verification job, separate from the existing cloud artifact readiness gate.
- Replace npm canary's duplicate verification matrix with a read-only check of that exact source result.
- Check workflow identity, repository, master push event, full SHA, run attempt, and successful job identity.
- Recheck the run after reading jobs so a concurrent rerun cannot reuse an earlier attempt.
- Bound waiting and pagination. Fail closed on API failures or invalid proof.
- Keep full stable and candidate-beta verification, and existing canary publish and smoke dependencies.
- Add regression tests to PR checks and to the source-verification producer. Document recovery and timing limits.

## Verification

- 39 focused source-verification, workflow, and artifact tests passed.
- `actionlint` passed for changed workflows, excluding existing SC2016 and SC2129 shell style diagnostics.
- `git diff --check` passed.
- Full local build and `pnpm -r typecheck` passed. The worktree required the local Rust toolchain and binary staging paths to be configured before typecheck.
- The full local Vitest command reached 10,546 passing server tests, 65 skipped, and 15 failures in four unchanged files. Thirteen failures involve macOS runtime-cache rename permissions; one is a legacy plugin-worker timeout, and one is a native-session expected error mismatch. The server and runner source trees are unchanged from the base commit. Additional local runs finished: all 2,375 serialized tests passed across 144 invocations; the UI group had 5,447 passes and 480 timeout/assertion failures in unchanged files, and the shared group had 726 passes and one unchanged lock-timing failure. The stable runner stops each group at its first failing project, so later projects within those groups were not run locally. Their equivalent Linux CI jobs passed.
- Latest-head GitHub CI: 29 successful checks, two intentional skips, and no failing or pending checks. All Linux release-verification test jobs passed.
- Greptile: 5/5 on `a31ae304131b71bbafff4c66b92850d3b6990744`, with zero open review threads and no actionable findings.
- Live post-merge verification passed on newer master `1d26ae965ee2bf935f9510ca2cc1a42b6acc09b4`: [Cloud readiness](https://github.com/paperclipai/paperclip/actions/runs/34622809202) completed successfully, including `Cloud source verified v1` and `Cloud deployable v1`. The unchanged consumer accepted the real run/attempt/job proof through the GitHub API.
- The first post-merge run on `4fde92107e53dbdf7f6ab80a56417b58dc96c776` failed an unchanged heartbeat-recovery teardown wait. The consumer correctly rejected it. A full retry passed that test but ran long on another unchanged server shard; it was cancelled after the newer master passed every source check and the older canary release was superseded.
- The new npm canary workflow is waiting behind an older publication run. The producer and real API consumer are verified; an automated canary consumer job has not yet been observed completing.

## Risks

A missing or failed source result now stops npm canary publication instead of starting another full test matrix. The wait is bounded at 45 minutes. Rerun Cloud readiness before retrying the release. Use Re-run all jobs if the latest attempt did not rerun the source proof.

Docker and migrator failures do not prevent npm publication after successful source verification. The source result adds one small job; it is not an added dependency of the cloud deployable job. Stable and candidate-beta verification retain their existing workflow.

Revert this PR to restore duplicate canary verification. No database or application behavior changes are required.

## Model Used

OpenAI GPT-6 / Codex, with reasoning, tool use, and code execution. The exact serving model identifier and context-window size are not exposed by this session.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass for the changed paths (39 focused tests); full-suite macOS limitations are documented above
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
