### PR TITLE
fix(sandbox): keep reusable sandbox leases when a task closes

### DIFF
--- a/server/src/__tests__/issue-activity-events-routes.test.ts
+++ b/server/src/__tests__/issue-activity-events-routes.test.ts
@@ -1,3 +1,4 @@
+import { readFile } from "node:fs/promises";
 import express from "express";
 import request from "supertest";
 import { getTableName } from "drizzle-orm";
@@ -544,6 +545,19 @@ describe("issue activity event routes", () => {
         }),
       );
     });
+  });
+
+  it("defers reusable sandbox cleanup when an issue transitions to done", async () => {
+    const source = await readFile(
+      new URL("../routes/issues.ts", import.meta.url),
+      "utf8",
+    );
+    const helperCall = "destroyReusableSandboxLeasesForTerminalIssue(";
+    const callSites = source.split(helperCall).length - 1;
+
+    // Terminal issue transitions must not tear down a reusable lease immediately.
+    // The terminal-workspace reaper destroys it after the configured cooldown.
+    expect(callSites).toBe(0);
   });
 
   it("logs successful_run_handoff_resolved when an in_progress issue transitions to done with a pending required handoff", async () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -277,7 +277,6 @@ import {
 import { authorizationDeniedDetails } from "../services/authorization.js";
 import { stalledReviewDecisionService } from "../services/stalled-review-decisions.js";
 import { environmentService } from "../services/environments.js";
-import { environmentRuntimeService } from "../services/environment-runtime.js";
 import { redactSensitiveText } from "../redaction.js";
 import { createRunSecretRedactionRegistry } from "../services/run-secret-redaction.js";
 import {
@@ -3703,9 +3702,6 @@ export function issueRoutes(
     syncCommentExternalObjectsSafely: (commentId, tx) => externalObjectsSvc.syncCommentSafely(commentId, tx),
   });
   const routinesSvc = routineService(db, {
-    pluginWorkerManager: opts.pluginWorkerManager,
-  });
-  const environmentRuntime = environmentRuntimeService(db, {
     pluginWorkerManager: opts.pluginWorkerManager,
   });
   const issueTreeControlFactory = Object.prototype.hasOwnProperty.call(
@@ -7380,31 +7376,6 @@ export function issueRoutes(
         );
         await new Promise((resolve) => setTimeout(resolve, attempt * 250));
       }
-    }
-  }
-
-  async function destroyReusableSandboxLeasesForTerminalIssue(issue: {
-    id: string;
-    companyId: string;
-    status: string;
-    executionWorkspaceId?: string | null;
-  }) {
-    try {
-      await environmentRuntime.destroyReusableSandboxLeases({
-        companyId: issue.companyId,
-        issueId: issue.id,
-        executionWorkspaceId: issue.executionWorkspaceId ?? null,
-        failureReason: `issue_terminal_${issue.status}`,
-      });
-    } catch (err) {
-      logger.warn(
-        {
-          err,
-          issueId: issue.id,
-          executionWorkspaceId: issue.executionWorkspaceId ?? null,
-        },
-        "failed to destroy reusable sandbox leases for terminal issue",
-      );
     }
   }
 
@@ -14666,7 +14637,6 @@ export function issueRoutes(
             actor,
             source: "issue.status_transition.issue_closed",
           });
-          await destroyReusableSandboxLeasesForTerminalIssue(issue);
         }
         if (becameTerminal && issue.parentId) {
           const parent = await svc.getWakeableParentAfterChildCompletion(
@@ -17858,7 +17828,6 @@ export function issueRoutes(
             actor,
             source: "issue.status_transition.issue_closed",
           });
-          await destroyReusableSandboxLeasesForTerminalIssue(currentIssue);
         }
         if (becameTerminal && currentIssue.parentId) {
           const parent = await svc.getWakeableParentAfterChildCompletion(


### PR DESCRIPTION
<!-- Written in Simplified Technical English. -->

## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Sandbox provider environments can retain one reusable provider lease per execution workspace (`reuseLease`)
> - A reusable lease exists so the next run on that workspace starts warm, with its dependencies and build caches intact
> - Paperclip already owns the teardown policy for that state: the terminal-workspace reaper waits `PAPERCLIP_WORKSPACE_REAPER_COOLDOWN_DAYS` after a task tree goes terminal, then archives the execution workspace and destroys the reusable lease inside the workspace lifecycle fence
> - The task close handlers also destroyed the same lease immediately, before that cooldown window started, so a reopened task lost the warm sandbox the reaper was still holding for it
> - This pull request removes the two eager destroy calls and leaves the reaper as the single owner of that teardown
> - The benefit is that a reopened task resumes its own sandbox, and an abandoned task is still reclaimed on the existing schedule

## Linked Issues or Issue Description

**What happened**

Closing a task destroyed its reusable sandbox lease at once. Reopening the task then cold-started a new sandbox. The workspace state, installed dependencies, and build caches were already gone.

**What I expected to happen**

A closed task keeps its sandbox for the reaper cooldown window. A reopen inside that window resumes the same sandbox.

**Steps to reproduce**

1. Configure a sandbox environment with `reuseLease: true`.
2. Run a task to completion, so the task holds a reusable lease on its execution workspace.
3. Set the task status to `done`.
4. Reopen the task and run it again.
5. The second run provisions a new sandbox. `sandboxLeaseAcquisition.outcome` is `created`, not `resumed`.

**Additional context**

The execution workspace row stays archivable during the cooldown, so the eager destroy removed only the provider sandbox. It did not advance any other part of the lifecycle.

## What Changed

- Remove the `destroyReusableSandboxLeasesForTerminalIssue` call from the task update close path in `server/src/routes/issues.ts`.
- Remove the same call from the comment-driven close path in `server/src/routes/issues.ts`.
- Remove the now unused helper and its `environmentRuntimeService` construction from the task routes.
- Add a regression test that fails if either eager call site returns.

## Verification

```sh
pnpm --filter @paperclipai/server exec vitest run src/__tests__/issue-activity-events-routes.test.ts
pnpm --filter @paperclipai/server typecheck
```

The test file passes with 11 tests. Typecheck passes.

Manual check on a self-hosted instance with a sandbox provider and `reuseLease: true`:

1. Run a task, then close it.
2. Confirm the lease row for its execution workspace is still present and not `expired`.
3. Reopen the task and run it again.
4. Confirm the new lease reports `sandboxLeaseAcquisition.outcome` as `resumed` and keeps the same provider lease id.

## Risks

Low risk for correctness, and the change is a deletion of an early teardown call.

- A closed task now holds its provider sandbox until the reaper archives its execution workspace. This increases idle sandbox retention for the length of `PAPERCLIP_WORKSPACE_REAPER_COOLDOWN_DAYS`, which defaults to 7 days. Operators who want the previous timing can set that variable to a smaller value.
- Environment delete and execution workspace close are unchanged. Both still destroy reusable leases directly.
- No schema change. No API change.

## Model Used

Anthropic Claude Sonnet 4.5 (`claude-sonnet-4-5`), 200K context window, tool-use and code-editing capabilities. The model made the code change and wrote the test. A human reviewed the runtime behaviour on a self-hosted instance.

## Checklist

- [x] I read `CONTRIBUTING.md`
- [x] The change keeps company-scoped behaviour
- [x] Contracts stay synchronized across db/shared/server/ui
- [x] Tests pass
- [x] Docs updated when behaviour or commands change
