### PR TITLE
fix(ui): use full mobile width for task tree

### DIFF
--- a/ui/src/pages/IssueDetail.test.tsx
+++ b/ui/src/pages/IssueDetail.test.tsx
@@ -2136,6 +2136,8 @@ describe("IssueDetail", () => {
     );
     expect(panel).not.toBeNull();
     expect(panel?.className).toContain("max-h-(--sz-85dvh)");
+    expect(panel?.className).toContain("w-full");
+    expect(panel?.className).toContain("max-w-none");
     expect(panel?.textContent).toContain("Task side panel");
     expect(panel?.querySelector('[data-slot="sheet-close"]')).not.toBeNull();
   });

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -8060,7 +8060,7 @@ export function IssueDetail({ tasksTab }: { tasksTab?: TaskSidePanelProps["tasks
               showCloseButton={!taskChatShellEnabled}
               className={cn(
                 taskChatShellEnabled
-                  ? "h-(--sz-85dvh) max-h-(--sz-85dvh) gap-0 p-0 pb-(--sz-safe-bottom)"
+                  ? "h-(--sz-85dvh) max-h-(--sz-85dvh) w-full max-w-none gap-0 p-0 pb-(--sz-safe-bottom)"
                   : documentDeepLink?.documentKey === "plan"
                     ? "inset-0 h-dvh w-screen max-w-none gap-0 border-0 p-0 sm:max-w-none"
                     : "max-h-(--sz-85dvh) pb-(--sz-safe-bottom)",


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app that people use to manage AI agents for work.
> - The task detail page gives operators a task tree in a mobile side panel.
> - The mobile sheet did not set an explicit full width.
> - A maximum width rule could make the task tree narrower than the phone viewport.
> - This pull request makes the mobile task tree sheet use the full viewport width.
> - The benefit is a consistent and readable task tree on phones.

## Linked Issues or Issue Description

**What happened?**

The task tree sheet could use less than the full viewport width on a mobile task page.

**Expected behavior**

The task tree sheet must use the full available phone width.

**Steps to reproduce**

1. Open a task on a phone viewport.
2. Open the task side panel.
3. Select the Tasks tab.
4. Compare the sheet width with the viewport width.

**Paperclip version or commit**

`7b829efdf`

**Deployment mode**

Built from source.

## What Changed

- Set the mobile task side panel to `w-full` and `max-w-none`.
- Add regression assertions for both width classes.

## Verification

- `vitest run src/pages/IssueDetail.test.tsx --config vitest.config.ts` passes 103 tests.
- `node scripts/check-token-gates.mjs` passes all four token gates.
- `git diff --check` passes.

## Risks

- Low risk. The change only affects the mobile task side panel width.
- The desktop panel and other sheet variants do not change.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5.6, agentic coding with reasoning and tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
