### PR TITLE
fix(ui): hide task chat attribution badge

### DIFF
--- a/ui/src/components/task-chat/TaskChatBubble.test.tsx
+++ b/ui/src/components/task-chat/TaskChatBubble.test.tsx
@@ -272,6 +272,29 @@ describe("TaskChatBubble accent-bubble text color", () => {
 });
 
 describe("TaskChatBubble agent page-surface treatment", () => {
+  it("does not show an on-behalf-of badge in the new task view", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    flushSync(() =>
+      root.render(
+        <ThemeProvider>
+          <TaskChatBubble
+            item={{ id: "attributed", kind: "message", author: "agent", authorName: "Fable", onBehalfOfUserName: "Dotta", text: "Done." }}
+          />
+        </ThemeProvider>,
+      ),
+    );
+
+    expect(container.textContent).toContain("Fable");
+    expect(container.textContent).not.toContain("for Dotta");
+    expect(container.querySelector('[data-testid="comment-attribution-chip"]')).toBeNull();
+
+    flushSync(() => root.unmount());
+    container.remove();
+  });
+
   it("renders agent prose without a card background or constrained width", () => {
     const container = document.createElement("div");
     document.body.appendChild(container);

--- a/ui/src/components/task-chat/TaskChatBubble.tsx
+++ b/ui/src/components/task-chat/TaskChatBubble.tsx
@@ -10,7 +10,6 @@ import {
 } from "@/components/ImageGalleryModal";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { AgentIcon } from "@/components/AgentIconPicker";
-import { CommentAttributionChip } from "@/components/CommentAttributionChip";
 import {
   Attachment,
   AttachmentContent,
@@ -74,11 +73,9 @@ function initialsForName(name: string) {
 export function TaskChatAgentIdentity({
   agentName,
   agentIcon,
-  onBehalfOfUserName,
 }: {
   agentName: string;
   agentIcon?: string | null;
-  onBehalfOfUserName?: string;
 }) {
   return (
     <span
@@ -99,12 +96,6 @@ export function TaskChatAgentIdentity({
         )}
       </Avatar>
       <span className="text-sm font-semibold text-foreground">{agentName}</span>
-      {onBehalfOfUserName ? (
-        <CommentAttributionChip
-          agentName={agentName}
-          userName={onBehalfOfUserName}
-        />
-      ) : null}
     </span>
   );
 }
@@ -235,7 +226,6 @@ export function TaskChatBubble({
         <TaskChatAgentIdentity
           agentName={item.authorName}
           agentIcon={item.agentIcon}
-          onBehalfOfUserName={item.onBehalfOfUserName}
         />
       ) : null}
       {bodyText.length > 0 ? (


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The task chat shows messages from agents and users.
> - An agent message can contain an internal on-behalf-of user value.
> - The new task view showed this value as a badge next to the agent name.
> - This badge added unwanted identity text to the task chat.
> - This pull request removes the badge from the new task view.
> - The benefit is a simpler agent identity row in the task chat.

## Linked Issues or Issue Description

**What happened?**

The new task view shows a `for <user>` badge next to an agent name when a message has an on-behalf-of user value.

**Expected behavior**

The task chat shows the agent name without the on-behalf-of badge.

**Steps to reproduce**

1. Open the new task view.
2. Show an agent message that has an on-behalf-of user value.
3. See the attribution badge next to the agent name.

**Paperclip version or commit**

The issue occurs on `master` at commit `d0b7ba419`.

**Deployment mode**

Local dev and all other modes that use the web UI.

## What Changed

- Removed the attribution chip from the task chat agent identity.
- Added a regression test that supplies an on-behalf-of value and confirms that the badge is absent.

## Verification

- `pnpm --filter @paperclipai/ui exec vitest run src/components/task-chat/TaskChatBubble.test.tsx` passed with 21 tests.
- `pnpm check:token-gates` passed.
- `pnpm --filter @paperclipai/ui typecheck` passed.

## Risks

- Low risk. The change only removes one badge from the new task chat view.
- The message data remains unchanged.

> This is a small UI fix. It does not add roadmap scope.

## Model Used

- OpenAI Codex, GPT-5.4, with reasoning and tool use. The provider did not expose the context window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/no-internal-issue-references`, `fix/sandbox-secret-resolution`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge

