### PR TITLE
fix(issues): allow blocked ticket cancellation

### DIFF
--- a/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
+++ b/server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts
@@ -1681,6 +1681,197 @@ describe("agent issue mutation checkout ownership", () => {
     },
   );
 
+  it("allows an authorized agent to cancel an unassigned blocked issue without changing ownership or dependencies", async () => {
+    const blockedBy = [
+      {
+        id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        identifier: "PAP-1650",
+        title: "Upstream blocker",
+        status: "todo",
+        priority: "high",
+        assigneeAgentId: ownerAgentId,
+        assigneeUserId: null,
+      },
+    ];
+    const blockedIssue = makeIssue({
+      status: "blocked",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+      blockedBy,
+    });
+    mockIssueService.getById.mockResolvedValue(blockedIssue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...blockedIssue,
+      ...patch,
+    }));
+    mockIssueService.getDependencyReadiness.mockResolvedValue({
+      blockerIssueIds: blockedBy.map((blocker) => blocker.id),
+      isDependencyReady: false,
+      unresolvedBlockerCount: 1,
+      unresolvedBlockerIssueIds: blockedBy.map((blocker) => blocker.id),
+      pendingFinalizeBlockerIssueIds: [],
+    });
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({
+        status: "cancelled",
+        comment: "Cancel obsolete work without changing its routing metadata.",
+      });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toMatchObject({
+      id: issueId,
+      status: "cancelled",
+      assigneeAgentId: null,
+      assigneeUserId: null,
+      blockedBy,
+    });
+    expect(mockIssueService.update).toHaveBeenCalledWith(
+      issueId,
+      expect.objectContaining({ status: "cancelled" }),
+      expect.anything(),
+      undefined,
+      expect.any(Array),
+    );
+    const updatePatch = mockIssueService.update.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(updatePatch).not.toHaveProperty("assigneeAgentId");
+    expect(updatePatch).not.toHaveProperty("assigneeUserId");
+    expect(updatePatch).not.toHaveProperty("blockedByIssueIds");
+    expect(mockIssueService.getDependencyReadiness).not.toHaveBeenCalled();
+  });
+
+  it("allows an authorized peer agent to cancel an assigned blocked issue without taking ownership", async () => {
+    const blockedIssue = makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId });
+    mockIssueService.getById.mockResolvedValue(blockedIssue);
+    mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({
+      ...blockedIssue,
+      ...patch,
+    }));
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "cancelled" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    expect(res.body).toMatchObject({
+      id: issueId,
+      status: "cancelled",
+      assigneeAgentId: ownerAgentId,
+    });
+    const updatePatch = mockIssueService.update.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(updatePatch).not.toHaveProperty("assigneeAgentId");
+    expect(updatePatch).not.toHaveProperty("assigneeUserId");
+  });
+
+  it.each(["todo", "in_progress"] as const)(
+    "keeps a blocked-to-%s transition behind unresolved dependency checks",
+    async (status) => {
+      mockIssueService.getById.mockResolvedValue(
+        makeIssue({ status: "blocked", assigneeAgentId: ownerAgentId }),
+      );
+      mockIssueService.getDependencyReadiness.mockResolvedValue({
+        blockerIssueIds: ["aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"],
+        isDependencyReady: false,
+        unresolvedBlockerCount: 1,
+        unresolvedBlockerIssueIds: ["aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"],
+        pendingFinalizeBlockerIssueIds: [],
+      });
+
+      const res = await request(await createApp(ownerActor()))
+        .patch(`/api/issues/${issueId}`)
+        .send({ status });
+
+      expect(res.status, JSON.stringify(res.body)).toBe(409);
+      expect(res.body.error).toBe("Issue follow-up blocked by unresolved blockers");
+      expect(mockIssueService.update).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps company boundaries enforced for blocked issue cancellation", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "blocked", assigneeAgentId: null }),
+    );
+
+    const res = await request(
+      await createApp(
+        peerActor({ companyId: "99999999-9999-4999-8999-999999999999" }),
+      ),
+    )
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "cancelled" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(404);
+    expect(res.body.error).toBe("Issue not found");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("keeps active checkout ownership enforced for issue cancellation", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "in_progress", assigneeAgentId: ownerAgentId }),
+    );
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "cancelled" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body.details.code).toBe("issue_write_assignee_run_lock");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("keeps human-only review authorization enforced for issue cancellation", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({
+        status: "in_review",
+        assigneeAgentId: ownerAgentId,
+        reviewPolicy: "human_only",
+      }),
+    );
+
+    const res = await request(await createApp(ownerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "cancelled" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.details.code).toBe("review_policy_denied");
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
+  it("keeps low-trust agents from cancelling blocked issues", async () => {
+    mockIssueService.getById.mockResolvedValue(
+      makeIssue({ status: "blocked", assigneeAgentId: null }),
+    );
+    mockAgentService.getById.mockImplementation(async (id: string) => {
+      if (id === peerAgentId) {
+        return makeAgent(peerAgentId, {
+          permissions: {
+            trustPreset: "low_trust_review",
+            authorizationPolicy: {
+              managedBy: "core-trust-preset",
+              trustBoundary: {
+                mode: "low_trust_review",
+                companyId,
+                issueIds: [issueId],
+              },
+            },
+          },
+        });
+      }
+      return id === ownerAgentId ? makeAgent(ownerAgentId) : null;
+    });
+
+    const res = await request(await createApp(peerActor()))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "cancelled" });
+
+    expect(res.status, JSON.stringify(res.body)).toBe(403);
+    expect(res.body.error).toBe(
+      "Low-trust actors cannot use this control-plane surface",
+    );
+    expect(mockIssueService.update).not.toHaveBeenCalled();
+  });
+
   it("allows same-company agent mutations on unassigned in-progress issues", async () => {
     mockIssueService.getById.mockResolvedValue(makeIssue({ assigneeAgentId: null }));
     mockIssueService.update.mockImplementation(async (_id: string, patch: Record<string, unknown>) => ({

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -12699,6 +12699,8 @@ export function issueRoutes(
       }
       const shouldCancelActiveRunForCancelledStatus =
         existing.status !== "cancelled" && updateFields.status === "cancelled";
+      const agentCancellationRequested =
+        req.actor.type === "agent" && shouldCancelActiveRunForCancelledStatus;
       if (resumeRequested === true && !commentBody) {
         res.status(400).json({ error: "Follow-up intent requires a comment" });
         return;
@@ -12706,7 +12708,8 @@ export function issueRoutes(
       if (
         (reopenRequested === true ||
           resumeRequested === true ||
-          Array.isArray(req.body.blockedByIssueIds)) &&
+          Array.isArray(req.body.blockedByIssueIds) ||
+          agentCancellationRequested) &&
         (await assertLowTrustControlPlaneDenied(
           req,
           res,
@@ -12727,6 +12730,10 @@ export function issueRoutes(
         req.actor.type === "agent" &&
         typeof updateFields.status === "string" &&
         updateFields.status !== existing.status &&
+        // Cancellation stops work; it does not resume it. The ordinary
+        // mutation, checkout, recovery, review, and low-trust gates still
+        // authorize this terminal disposition.
+        updateFields.status !== "cancelled" &&
         (isBlocked || (isClosed && !isClosedIssueStatus(updateFields.status)));
       if (
         resumeRequested !== true &&


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Issue lifecycle rules control when agents may move work between states.
> - A blocked issue uses resume checks for transitions that restart work.
> - The same checks also reject cancellation when the issue has no assignee or has unresolved blockers.
> - Cancellation stops work and must not require authority to resume work.
> - This pull request exempts cancellation from resume checks and keeps the other authorization gates.
> - The benefit is a supported terminal action that preserves assignment and dependency data.

## Linked Issues or Issue Description

Refs #8531

Related prior attempts: #11350 and #11412.

This change applies the narrow cancellation repair to the current default branch. It does not change the rules for reopening or resuming work.

## What Changed

- Skip blocked and closed resume checks only when an agent changes an issue to `cancelled`.
- Keep the low-trust control-plane check on agent cancellation.
- Add route tests for unassigned and assigned blocked issues.
- Verify that assignment fields and dependency links stay unchanged.
- Verify that dependency, company, checkout, review, and low-trust gates still apply.

## Verification

- `pnpm exec vitest run server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts` — 116 tests passed.
- `pnpm --filter @paperclipai/server exec tsc --noEmit` — passed after the JavaScript SDK build dependencies were prepared.
- The full server typecheck wrapper reached its Rust runner build and stopped because this host does not have `cargo`. CI must run that host-dependent gate.

## Risks

- Low risk. The change affects only agent transitions whose target status is `cancelled`.
- Existing mutation, company, checkout, recovery, review, and low-trust checks remain in the route.
- No database migration or API shape change is required.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI GPT-5 through Codex, with reasoning, repository tools, code execution, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
