### PR TITLE
test(server): pin explicit false assignment wake behavior

### DIFF
--- a/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
+++ b/server/src/__tests__/issue-update-comment-wakeup-routes.test.ts
@@ -507,6 +507,37 @@ describe("issue update comment wakeups", () => {
     expect(mockIssueService.update).not.toHaveBeenCalled();
   });
 
+  it("keeps the normal assignment wake when goal wake deferral is explicitly false", async () => {
+    const existing = makeIssue({ assigneeAgentId: null, assigneeUserId: null, status: "todo" });
+    const updated = makeIssue({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      status: "todo",
+    });
+    mockIssueService.getById.mockResolvedValue(existing);
+    mockIssueService.update.mockResolvedValue(updated);
+
+    const res = await request(await createApp()).patch(`/api/issues/${existing.id}`).send({
+      assigneeAgentId: ASSIGNEE_AGENT_ID,
+      assigneeUserId: null,
+      deferWakeForGoal: false,
+    });
+
+    expect(res.status).toBe(200);
+    await vi.waitFor(() => expect(mockHeartbeatService.wakeup).toHaveBeenCalledTimes(1));
+    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+      ASSIGNEE_AGENT_ID,
+      expect.objectContaining({
+        source: "assignment",
+        reason: "issue_assigned",
+        payload: expect.objectContaining({
+          issueId: existing.id,
+          mutation: "update",
+        }),
+      }),
+    );
+  });
+
   it("wakes the assignee on comment-only issue updates", async () => {
     const existing = makeIssue({
       assigneeAgentId: ASSIGNEE_AGENT_ID,


### PR DESCRIPTION
## Thinking Path

> - Paperclip coordinates agent work and must preserve reliable issue wake behavior.
> - Issue assignment can wake the assigned agent.
> - A structured goal handoff can suppress that wake with `deferWakeForGoal: true`.
> - The explicit `false` value must preserve the normal assignment wake.
> - Existing tests cover `true` deferral and reject mixed assignment and status updates.
> - This pull request adds the missing explicit `false` regression case.
> - The benefit is a measurable contract for callers that send the optional field explicitly.

## Linked Issues or Issue Description

Refs #13217

## What Changed

- Added one server route test for `deferWakeForGoal: false` on an assignment-only update.
- Confirmed that the update wakes the newly assigned agent with the standard assignment payload.

## Verification

- `corepack pnpm exec vitest run server/src/__tests__/issue-update-comment-wakeup-routes.test.ts` (16 tests passed).
- `git diff --check 787f0df19541196c0378a1d96aee5cb69d155c6a^ 787f0df19541196c0378a1d96aee5cb69d155c6a`.
- Stable patch ID matches the independently reviewed source commit `5965c88ec34e18091eb0ac0860a875d907beb46d`.

## Risks

- Low risk. This pull request changes one test file and no production code.
- The test binds the existing assignment wake payload. An intentional contract change will require an explicit test update.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with GPT-5. The agent used reasoning, repository inspection, Git, and test execution. The context-window size is not exposed.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [x] All Paperclip CI gates are green
- [x] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge