### PR TITLE
docs: explain quota-bound AWS runner burst capacity

### DIFF
--- a/doc/cloud-build-readiness.md
+++ b/doc/cloud-build-readiness.md
@@ -129,9 +129,14 @@ When reverting this workflow, restore the master push trigger in
 waiting, readiness signals, and exact-master migrator preparation to the
 `paperclip-post-merge` runner group. The separate Fleet label is
 `runs-on/fleet=paperclip-post-merge-x64/env=public-ci`. Its 36 reserved slots use
-the same four-vCPU, 16-GiB machines as approved PR jobs. PR capacity is reduced
-to 64; image capacity stays at eight. The total ceiling remains 108 runners.
-This keeps PR bursts from consuming every post-merge verification slot.
+the same four-vCPU, 16-GiB machines as approved PR jobs. Image capacity stays
+at eight. The initial split allocated 64 PR slots and 108 total slots. The PR
+ceiling can increase independently, subject to the applied regional EC2
+Standard On-Demand vCPU quota and the reviewed infrastructure configuration.
+For example, 100 PR, 36 post-merge, and eight image workers require 576 vCPUs.
+A pending quota increase does not supply that capacity. These are limits for
+ephemeral workers, with no idle worker pool or Reserved Instance commitment.
+The separate post-merge allocation keeps PR bursts from consuming its slots.
 
 Every selector checks the canonical repository name and ID, master ref, and a
 push or manual event. Reusable verification also requires `inputs.ref` to equal


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Cloud deployment waits for image and source verification.
> - Separate AWS capacity keeps approved PR bursts from consuming all post-merge slots.
> - The public guide describes the initial PR ceiling as a permanent limit.
> - PR capacity can change after infrastructure review and applied AWS quota approval.
> - This PR explains that boundary and the difference between concurrency limits and idle workers.

## Linked Issues or Issue Description

Refs #13257. This follows the same post-merge routing work.

**Current behavior**

The guide states that the initial 64 PR slots and 108 total workers remain the current limits.

**Proposed behavior**

Identify those values as the initial split. Explain that the PR ceiling is independently configured and bounded by the applied EC2 quota. Show the CPU demand of a 100/36/8 split without claiming that a pending quota request is already available.

**Reason and benefit**

Operators can increase burst capacity without confusing a concurrency ceiling with an idle worker pool or a Reserved Instance purchase.

## What Changed

- Explain the quota and infrastructure review requirements for capacity increases.
- Keep the original split as historical context.
- Clarify the ephemeral worker lifecycle and independent post-merge allocation.

## Verification

- Checked the arithmetic: (100 + 36 + 8) × 4 = 576 vCPUs.
- Compared the guide with the current four-vCPU profiles and separate fleet limits.
- `git diff --check` passes.
- No code or workflow changes. Local typecheck, tests, and build were not rerun for this documentation-only change; GitHub CI must pass before merge.

## Risks

Low risk. This changes documentation only. The example is not an instruction to deploy before AWS applies the required quota. The infrastructure plan remains the source of truth for live ceilings.

## Model Used

OpenAI GPT-6 through Codex, with reasoning, repository tools, and code execution. The exact serving model ID and context window are not exposed by this environment.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] Local verification passes: checked capacity arithmetic, Markdown diff, and the related infrastructure configuration. No executable files changed.
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
