### PR TITLE
fix(security): enforce final expiry guard for approved tool calls

### DIFF
--- a/server/src/__tests__/remote-http-rebinding.test.ts
+++ b/server/src/__tests__/remote-http-rebinding.test.ts
@@ -1,7 +1,7 @@
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import { connect as netConnect, createServer as netCreateServer, type AddressInfo, type Socket } from "node:net";
 import { gzipSync } from "node:zlib";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { guardedRemoteHttpFetch, type RemoteHttpSocketFactory } from "../services/remote-http-fetch.js";
 
@@ -116,6 +116,31 @@ function rebindingLookup(): { lookup: () => Promise<Array<{ address: string; fam
 }
 
 describe("guarded remote HTTP fetch (PAP-17098 DNS rebinding)", () => {
+  it("runs final authorization after socket verification and before request dispatch", async () => {
+    const upstream = await startServer();
+    const network = routingSocketFactory({ [PUBLIC_ADDRESS]: upstream.port });
+    const finalAuthorization = vi.fn(async () => {
+      expect(network.dialled).toEqual([PUBLIC_ADDRESS]);
+      expect(upstream.requests).toHaveLength(0);
+    });
+
+    const response = await guardedRemoteHttpFetch(
+      `http://${REBIND_HOST}/mcp`,
+      { method: "POST", body: "{}" },
+      {
+        allowPrivateNetwork: false,
+        lookup: async () => [{ address: PUBLIC_ADDRESS, family: 4 }],
+        socketFactory: network.factory,
+        error: guardError,
+        beforeProviderOperation: finalAuthorization,
+      },
+    );
+
+    expect(response.status).toBe(200);
+    expect(finalAuthorization).toHaveBeenCalledTimes(1);
+    expect(upstream.requests).toHaveLength(1);
+  });
+
   it("sends a stable default User-Agent and preserves an explicit caller value", async () => {
     const seen: Array<string | undefined> = [];
     const upstream = await startServer((req, res) => {

--- a/server/src/__tests__/tool-content-guards.test.ts
+++ b/server/src/__tests__/tool-content-guards.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   canonicalToolArguments,
+  readSignedToolArgumentsPayload,
   readSignedToolArguments,
   resolveToolActionSigningSecret,
   signToolArguments,
@@ -58,6 +59,42 @@ describe("tool content guards", () => {
     expect(() =>
       resolveToolActionSigningSecret({}),
     ).toThrow("PAPERCLIP_TOOL_ACTION_SIGNING_SECRET");
+  });
+
+  it("binds the authorization contract version into the signed envelope", () => {
+    const canonicalArguments = canonicalToolArguments({});
+    const signedArguments = signToolArguments({
+      invocationId: "invocation-versioned",
+      toolName: "mcp.example:run",
+      canonicalArguments,
+      executionOnApprove: true,
+      authorizationVersion: 2,
+      signingSecret,
+    });
+
+    expect(
+      readSignedToolArgumentsPayload({
+        signedArguments,
+        invocationId: "invocation-versioned",
+        toolName: "mcp.example:run",
+        signingSecret,
+      }),
+    ).toMatchObject({
+      arguments: {},
+      executionOnApprove: true,
+      authorizationVersion: 2,
+    });
+    expect(
+      verifyToolArgumentsSignature({
+        signedArguments,
+        invocationId: "invocation-versioned",
+        toolName: "mcp.example:run",
+        canonicalArguments,
+        executionOnApprove: true,
+        authorizationVersion: 1,
+        signingSecret,
+      }),
+    ).toBe(false);
   });
 
   it("redacts sensitive argument values before summarizing them", () => {

--- a/server/src/__tests__/tool-gateway-service.test.ts
+++ b/server/src/__tests__/tool-gateway-service.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { and, eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   activityLog,
@@ -203,6 +203,290 @@ describeEmbeddedPostgres("tool gateway service", () => {
     await tempDb?.cleanup();
   });
 
+  async function createRemoteApprovalFixture(options: ToolGatewayServiceOptions = {}) {
+    const { company, agent, issue, run } = await createRunFixture(db);
+    const remote = await createRemoteMcpToolFixture(db, company.id);
+    await db.insert(toolPolicies).values({
+      companyId: company.id,
+      name: "Review remote reads",
+      policyType: "require_approval",
+      selectors: { riskLevel: "read" },
+    });
+    const providerCalls = vi.fn(async (_url: string, init: RequestInit) => {
+      const request = JSON.parse(String(init.body)) as { id: string };
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: request.id,
+          result: { content: [{ type: "text", text: "remote ok" }] },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+    const gateway = createTestToolGatewayService(db, {
+      remoteHttpRequest: providerCalls,
+      ...options,
+    });
+    const session = await gateway.createSession({
+      companyId: company.id,
+      agentId: agent.id,
+      runId: run.id,
+    });
+    const tool = (await gateway.listToolsForSession(session.token)).find(
+      (candidate) => candidate.providerType === "mcp_remote_http",
+    )!;
+    await expect(
+      gateway.executeTool({
+        sessionToken: session.token,
+        tool: tool.name,
+        parameters: {},
+      }),
+    ).rejects.toMatchObject({ reasonCode: "approval_required" });
+    const [actionRequest] = await db
+      .select()
+      .from(toolActionRequests)
+      .where(eq(toolActionRequests.companyId, company.id));
+    const [invocation] = await db
+      .select()
+      .from(toolInvocations)
+      .where(eq(toolInvocations.companyId, company.id));
+    return {
+      company,
+      agent,
+      issue,
+      run,
+      gateway,
+      session,
+      tool,
+      remote,
+      actionRequest,
+      invocation,
+      providerCalls,
+    };
+  }
+
+  it("uses PostgreSQL time for the final expiry permit and keeps terminal audit cardinality aligned", async () => {
+    let beforeExpiryId = "";
+    const beforeExpiry = await createRemoteApprovalFixture({
+      afterApprovedActionPreparationStage: async (stage) => {
+        if (stage !== "provider_prepared") return;
+        await db
+          .update(toolActionRequests)
+          .set({ expiresAt: sql`clock_timestamp() + interval '100 milliseconds'` })
+          .where(eq(toolActionRequests.id, beforeExpiryId));
+      },
+    });
+    beforeExpiryId = beforeExpiry.actionRequest.id;
+    const executed = await beforeExpiry.gateway.approveActionRequest({
+      companyId: beforeExpiry.company.id,
+      actionRequestId: beforeExpiry.actionRequest.id,
+      actor: { userId: "board-user" },
+    });
+    expect(executed.status).toBe("executed");
+    expect(beforeExpiry.providerCalls).toHaveBeenCalledTimes(1);
+    const winningEvents = await db
+      .select()
+      .from(toolCallEvents)
+      .where(eq(toolCallEvents.actionRequestId, beforeExpiry.actionRequest.id));
+    expect(
+      winningEvents.filter((event) =>
+        ["approved_action_permitted", "approved_action_executed"].includes(
+          event.reasonCode ?? "",
+        ),
+      ),
+    ).toHaveLength(2);
+
+    const atExpiry = await createRemoteApprovalFixture();
+    await db
+      .update(toolActionRequests)
+      .set({ expiresAt: sql`clock_timestamp()` })
+      .where(eq(toolActionRequests.id, atExpiry.actionRequest.id));
+    const expired = await atExpiry.gateway.approveActionRequest({
+      companyId: atExpiry.company.id,
+      actionRequestId: atExpiry.actionRequest.id,
+      actor: { userId: "board-user" },
+    });
+    expect(expired.status).toBe("expired");
+    expect(atExpiry.providerCalls).not.toHaveBeenCalled();
+    const [expiredInvocation] = await db
+      .select()
+      .from(toolInvocations)
+      .where(eq(toolInvocations.id, atExpiry.invocation.id));
+    expect(expiredInvocation).toMatchObject({
+      status: "failed",
+      approvalState: "expired",
+      errorCode: "action_expired",
+    });
+    const expiryEvents = await db
+      .select()
+      .from(toolCallEvents)
+      .where(eq(toolCallEvents.actionRequestId, atExpiry.actionRequest.id));
+    expect(
+      expiryEvents.filter((event) => event.reasonCode === "action_expired"),
+    ).toHaveLength(1);
+    expect(
+      expiryEvents.filter(
+        (event) => event.reasonCode === "approved_action_permitted",
+      ),
+    ).toHaveLength(0);
+  });
+
+  it.each([
+    "identity",
+    "tool_discovery",
+    "approval_snapshot",
+    "policy",
+    "managed_arguments",
+    "provider_prepared",
+  ])("denies when expiry crosses during awaited %s preparation", async (stage) => {
+    let actionRequestId = "";
+    const fixture = await createRemoteApprovalFixture({
+      afterApprovedActionPreparationStage: async (currentStage) => {
+        if (currentStage !== stage) return;
+        await db
+          .update(toolActionRequests)
+          .set({ expiresAt: sql`clock_timestamp() - interval '1 millisecond'` })
+          .where(eq(toolActionRequests.id, actionRequestId));
+      },
+    });
+    actionRequestId = fixture.actionRequest.id;
+    const result = await fixture.gateway.approveActionRequest({
+      companyId: fixture.company.id,
+      actionRequestId,
+      actor: { userId: "board-user" },
+    });
+    expect(result.status).toBe("expired");
+    expect(fixture.providerCalls).not.toHaveBeenCalled();
+  });
+
+  it("makes the permit winner deterministic when expiry loses the race", async () => {
+    let observeProvider!: () => void;
+    const providerObserved = new Promise<void>((resolve) => {
+      observeProvider = resolve;
+    });
+    let releaseProvider!: () => void;
+    const providerBlocked = new Promise<void>((resolve) => {
+      releaseProvider = resolve;
+    });
+    const providerCalls = vi.fn(async (_url: string, init: RequestInit) => {
+      observeProvider();
+      await providerBlocked;
+      const request = JSON.parse(String(init.body)) as { id: string };
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: request.id,
+          result: { content: [{ type: "text", text: "won" }] },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+    const fixture = await createRemoteApprovalFixture({
+      remoteHttpRequest: providerCalls,
+    });
+    await db
+      .update(toolActionRequests)
+      .set({ expiresAt: sql`clock_timestamp() + interval '5 seconds'` })
+      .where(eq(toolActionRequests.id, fixture.actionRequest.id));
+    const approval = fixture.gateway.approveActionRequest({
+      companyId: fixture.company.id,
+      actionRequestId: fixture.actionRequest.id,
+      actor: { userId: "board-user" },
+    });
+    await providerObserved;
+    await db
+      .update(toolActionRequests)
+      .set({ expiresAt: sql`clock_timestamp() - interval '1 millisecond'` })
+      .where(eq(toolActionRequests.id, fixture.actionRequest.id));
+    releaseProvider();
+    expect((await approval).status).toBe("executed");
+    expect(providerCalls).toHaveBeenCalledTimes(1);
+  });
+
+  it("replays the single winner and denies alternate dispatch entry points", async () => {
+    const fixture = await createRemoteApprovalFixture();
+    const first = await fixture.gateway.approveActionRequest({
+      companyId: fixture.company.id,
+      actionRequestId: fixture.actionRequest.id,
+      actor: { userId: "board-user" },
+    });
+    const duplicate = await fixture.gateway.approveActionRequest({
+      companyId: fixture.company.id,
+      actionRequestId: fixture.actionRequest.id,
+      actor: { userId: "board-user" },
+    });
+    expect(first.status).toBe("executed");
+    expect(duplicate.status).toBe("executed");
+    expect(fixture.providerCalls).toHaveBeenCalledTimes(1);
+    const replay = await fixture.gateway.executeTool({
+      sessionToken: fixture.session.token,
+      tool: fixture.tool.name,
+      parameters: {},
+    });
+    expect(replay.status).toBe("replayed");
+    expect(fixture.providerCalls).toHaveBeenCalledTimes(1);
+    await expect(
+      fixture.gateway.executeTool({
+        sessionToken: fixture.session.token,
+        tool: fixture.tool.name,
+        parameters: {},
+        approvedActionRequestId: fixture.actionRequest.id,
+      }),
+    ).rejects.toMatchObject({
+      reasonCode: "approved_action_explicit_retry_unsupported",
+    });
+    await expect(
+      fixture.gateway.executeTestCall({
+        companyId: fixture.company.id,
+        connectionId: fixture.remote.connection.id,
+        agentId: fixture.agent.id,
+        userId: "board-user",
+        toolName: fixture.tool.name,
+        parameters: {},
+      }),
+    ).rejects.toMatchObject({
+      reasonCode: "approval_governed_test_call_unsupported",
+    });
+    expect(fixture.providerCalls).toHaveBeenCalledTimes(1);
+
+    const failedProviderCalls = vi.fn(
+      async (_url: string, init: RequestInit) => {
+        const request = JSON.parse(String(init.body)) as { id: string };
+        return new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: request.id,
+            result: {
+              isError: true,
+              content: [{ type: "text", text: "provider rejected" }],
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      },
+    );
+    const failedFixture = await createRemoteApprovalFixture({
+      remoteHttpRequest: failedProviderCalls,
+    });
+    expect(
+      (
+        await failedFixture.gateway.approveActionRequest({
+          companyId: failedFixture.company.id,
+          actionRequestId: failedFixture.actionRequest.id,
+          actor: { userId: "board-user" },
+        })
+      ).status,
+    ).toBe("failed");
+    await expect(
+      failedFixture.gateway.executeTool({
+        sessionToken: failedFixture.session.token,
+        tool: failedFixture.tool.name,
+        parameters: {},
+      }),
+    ).rejects.toMatchObject({ reasonCode: "tool_execution_failed" });
+    expect(failedProviderCalls).toHaveBeenCalledTimes(1);
+  });
+
   it("gates write tools with an action request and executes only stored reviewed arguments once", async () => {
     const { company, agent, run } = await createRunFixture(db);
     await db.insert(toolPolicies).values({
@@ -274,28 +558,30 @@ describeEmbeddedPostgres("tool gateway service", () => {
       resultSummary: null,
     });
 
-    await db.update(issueThreadInteractions).set({
-      status: "accepted",
-      resolvedByUserId: "board-user",
-      resolvedAt: new Date(),
-      updatedAt: new Date(),
-    }).where(eq(issueThreadInteractions.id, interaction.id));
-
-    const result = await gateway.executeTool({
-      sessionToken: session.token,
-      tool: "mcp-remote-fixture:update_note",
-      approvedActionRequestId: actionRequest.id,
-      parameters: { noteId: "n1", body: "this tampered body must not execute" },
+    const approved = await gateway.approveActionRequest({
+      companyId: company.id,
+      actionRequestId: actionRequest.id,
+      actor: { userId: "board-user" },
     });
-    expect(result.status).toBe("completed");
-    expect((result.result as { data?: { bodyLength?: number } }).data?.bodyLength).toBe("short".length);
+    expect(approved.status).toBe("executed");
 
     await expect(gateway.executeTool({
       sessionToken: session.token,
       tool: "mcp-remote-fixture:update_note",
       approvedActionRequestId: actionRequest.id,
+      parameters: { noteId: "n1", body: "this tampered body must not execute" },
+    })).rejects.toMatchObject({
+      reasonCode: "approved_action_explicit_retry_unsupported",
+    });
+    const result = await gateway.executeTool({
+      sessionToken: session.token,
+      tool: "mcp-remote-fixture:update_note",
       parameters: { noteId: "n1", body: "short" },
-    })).rejects.toMatchObject({ reasonCode: "action_not_approved" });
+    });
+    expect(result.status).toBe("replayed");
+    expect((result.result as { data?: { bodyLength?: number } }).data?.bodyLength).toBe("short".length);
+
+    expect((await db.select().from(toolActionRequests))).toHaveLength(1);
   });
 
   it("approves a pending action request directly from the review queue and preserves signed arguments", async () => {
@@ -478,14 +764,22 @@ describeEmbeddedPostgres("tool gateway service", () => {
     const session = await gateway.createSession({ companyId: company.id, agentId: agent.id, runId: run.id });
     await expect(gateway.executeTool({ sessionToken: session.token, tool: "mcp-remote-fixture:update_note", parameters: { noteId: "expire" } })).rejects.toMatchObject({ reasonCode: "approval_required" });
     const [request] = await db.select().from(toolActionRequests);
+    const [invocation] = await db.select().from(toolInvocations);
     await db.update(toolActionRequests).set({ expiresAt: new Date(Date.now() - 1000) }).where(eq(toolActionRequests.id, request.id));
+    const duplicateInvocations = Array.from({ length: 100 }, (_, i) => ({
+      ...invocation,
+      id: `10000000-0000-4000-8000-${String(i).padStart(12, "0")}`,
+      idempotencyKey: null,
+    }));
+    await db.insert(toolInvocations).values(duplicateInvocations);
     await db.insert(toolActionRequests).values(Array.from({ length: 100 }, (_, i) => ({
       ...request, id: `00000000-0000-4000-8000-${String(i).padStart(12, "0")}`,
+      invocationId: duplicateInvocations[i]!.id,
       interactionId: null, status: "approved" as const,
+      updatedAt: new Date(Date.now() - 11 * 60_000),
     })));
-    const recover = vi.spyOn(gateway, "approveActionRequest").mockRejectedValue(new Error("Unavailable approval dependency"));
     expect(await gateway.sweepActionReviews()).toEqual({ scanned: 101 });
-    expect(recover).toHaveBeenCalledTimes(100);
+    expect((await db.select().from(toolActionRequests)).filter((row) => row.status === "failed")).toHaveLength(100);
     const [settled] = await db.select().from(issueThreadInteractions).where(eq(issueThreadInteractions.id, request.interactionId!));
     expect(settled.status).toBe("expired");
   });
@@ -651,7 +945,9 @@ describeEmbeddedPostgres("tool gateway service", () => {
       tool: "mcp-remote-fixture:update_note",
       parameters: { noteId: "n1", body: "reviewed body" },
       approvedActionRequestId: actionRequest.id,
-    })).rejects.toMatchObject({ reasonCode: "action_scope_mismatch" });
+    })).rejects.toMatchObject({
+      reasonCode: "approved_action_explicit_retry_unsupported",
+    });
 
     const [stillApproved] = await db.select().from(toolActionRequests);
     expect(stillApproved.status).toBe("approved");
@@ -752,20 +1048,13 @@ describeEmbeddedPostgres("tool gateway service", () => {
     });
     await db.update(toolActionRequests).set({ signedArguments: legacySignature }).where(eq(toolActionRequests.id, actionRequest.id));
 
-    const approved = await gateway.approveActionRequest({
+    await expect(gateway.approveActionRequest({
       companyId: company.id,
       actionRequestId: actionRequest.id,
       actor: { userId: "board-user" },
+    })).rejects.toMatchObject({
+      reasonCode: "approved_action_authorization_unsupported",
     });
-    expect(approved.status).toBe("approved");
-    const [parkedInvocation] = await db.select().from(toolInvocations).where(eq(toolInvocations.id, invocation.id));
-    expect(parkedInvocation.status).toBe("awaiting_approval");
-
-    await expect(gateway.executeTool({
-      sessionToken: session.token,
-      tool: "mcp-remote-fixture:update_note",
-      parameters,
-    })).rejects.toMatchObject({ reasonCode: "legacy_approved_action_inert" });
 
     const [settledRequest] = await db
       .select()
@@ -775,20 +1064,26 @@ describeEmbeddedPostgres("tool gateway service", () => {
       .select()
       .from(toolInvocations)
       .where(eq(toolInvocations.id, invocation.id));
-    expect(settledRequest.status).toBe("failed");
+    expect(settledRequest.status).toBe("cancelled");
     expect(settledInvocation.status).toBe("failed");
-    expect(settledInvocation.errorCode).toBe("legacy_approved_action_inert");
+    expect(settledInvocation.errorCode).toBe(
+      "approved_action_authorization_unsupported",
+    );
     expect(settledInvocation.idempotencyKey).toBeNull();
 
-    await expect(gateway.executeTool({
-      sessionToken: session.token,
-      tool: "mcp-remote-fixture:update_note",
-      parameters,
-    })).rejects.toMatchObject({ reasonCode: "approval_required" });
-    expect(await db.select().from(toolActionRequests)).toHaveLength(2);
+    const failures = await db
+      .select()
+      .from(toolCallEvents)
+      .where(
+        eq(
+          toolCallEvents.reasonCode,
+          "approved_action_authorization_unsupported",
+        ),
+      );
+    expect(failures).toHaveLength(1);
   });
 
-  it("does not let a stale legacy consumer overwrite the winning approved execution", async () => {
+  it("invalidates a legacy approval exactly once under duplicate delivery", async () => {
     const { company, agent, run } = await createRunFixture(db);
     await db.insert(toolPolicies).values({
       companyId: company.id,
@@ -796,20 +1091,9 @@ describeEmbeddedPostgres("tool gateway service", () => {
       policyType: "require_approval",
       selectors: { toolName: "mcp-remote-fixture:update_note" },
     });
-
-    let observeLegacyClaim!: () => void;
-    const legacyClaimObserved = new Promise<void>((resolve) => {
-      observeLegacyClaim = resolve;
-    });
-    let releaseLegacyClaim!: () => void;
-    const legacyClaimBlocked = new Promise<void>((resolve) => {
-      releaseLegacyClaim = resolve;
-    });
+    const legacyClaim = vi.fn();
     const gateway = createTestToolGatewayService(db, {
-      beforeLegacyApprovedActionClaim: async () => {
-        observeLegacyClaim();
-        await legacyClaimBlocked;
-      },
+      beforeLegacyApprovedActionClaim: legacyClaim,
     });
     const session = await gateway.createSession({
       companyId: company.id,
@@ -817,82 +1101,57 @@ describeEmbeddedPostgres("tool gateway service", () => {
       runId: run.id,
     });
     const parameters = { noteId: "n1", body: "legacy race" };
-
-    await expect(gateway.executeTool({
-      sessionToken: session.token,
-      tool: "mcp-remote-fixture:update_note",
-      parameters,
-    })).rejects.toMatchObject({ reasonCode: "approval_required" });
+    await expect(
+      gateway.executeTool({
+        sessionToken: session.token,
+        tool: "mcp-remote-fixture:update_note",
+        parameters,
+      }),
+    ).rejects.toMatchObject({ reasonCode: "approval_required" });
     const [actionRequest] = await db.select().from(toolActionRequests);
     const [invocation] = await db.select().from(toolInvocations);
-    const currentSignature = actionRequest.signedArguments!;
-    const legacySignature = signToolArguments({
-      invocationId: invocation.id,
-      toolName: invocation.toolName,
-      canonicalArguments: canonicalToolArguments(parameters),
-      signingSecret: testToolActionSigningSecret,
-    });
     await db
       .update(toolActionRequests)
-      .set({ signedArguments: legacySignature })
+      .set({
+        signedArguments: signToolArguments({
+          invocationId: invocation.id,
+          toolName: invocation.toolName,
+          canonicalArguments: canonicalToolArguments(parameters),
+          signingSecret: testToolActionSigningSecret,
+        }),
+      })
       .where(eq(toolActionRequests.id, actionRequest.id));
-    await gateway.approveActionRequest({
-      companyId: company.id,
-      actionRequestId: actionRequest.id,
-      actor: { userId: "board-user" },
-    });
 
-    const staleAttempt = gateway.executeTool({
-      sessionToken: session.token,
-      tool: "mcp-remote-fixture:update_note",
-      approvedActionRequestId: actionRequest.id,
-      parameters,
-    }).then(
-      (value) => ({ status: "fulfilled" as const, value }),
-      (error: unknown) => ({ status: "rejected" as const, error }),
+    const results = await Promise.allSettled([
+      gateway.approveActionRequest({
+        companyId: company.id,
+        actionRequestId: actionRequest.id,
+        actor: { userId: "board-user" },
+      }),
+      gateway.approveActionRequest({
+        companyId: company.id,
+        actionRequestId: actionRequest.id,
+        actor: { userId: "board-user" },
+      }),
+    ]);
+    expect(results.every((result) => result.status === "rejected")).toBe(true);
+    expect(legacyClaim).not.toHaveBeenCalled();
+    expect((await db.select().from(toolActionRequests))[0]?.status).toBe(
+      "cancelled",
     );
-    await legacyClaimObserved;
-
-    // Simulate a concurrent repair that restores the current signed envelope
-    // after the stale consumer has read the legacy envelope but before it owns
-    // the approved -> executing claim.
-    await db
-      .update(toolActionRequests)
-      .set({ signedArguments: currentSignature, updatedAt: new Date() })
-      .where(and(
-        eq(toolActionRequests.id, actionRequest.id),
-        eq(toolActionRequests.status, "approved"),
-      ));
-    const winner = await gateway.executeTool({
-      sessionToken: session.token,
-      tool: "mcp-remote-fixture:update_note",
-      approvedActionRequestId: actionRequest.id,
-      parameters,
-    });
-    expect(winner.status).toBe("completed");
-
-    releaseLegacyClaim();
-    const stale = await staleAttempt;
-    expect(stale).toMatchObject({
-      status: "rejected",
-      error: { reasonCode: "action_already_consumed" },
-    });
-
-    const [settledRequest] = await db
-      .select()
-      .from(toolActionRequests)
-      .where(eq(toolActionRequests.id, actionRequest.id));
-    const [settledInvocation] = await db
-      .select()
-      .from(toolInvocations)
-      .where(eq(toolInvocations.id, invocation.id));
-    expect(settledRequest.status).toBe("executed");
-    expect(settledInvocation).toMatchObject({
-      status: "succeeded",
-      errorCode: null,
-      errorMessage: null,
-    });
-    expect(settledInvocation.idempotencyKey).not.toBeNull();
+    expect(
+      (
+        await db
+          .select()
+          .from(toolCallEvents)
+          .where(
+            eq(
+              toolCallEvents.reasonCode,
+              "approved_action_authorization_unsupported",
+            ),
+          )
+      ).length,
+    ).toBe(1);
   });
 
   it("does not leave unsigned action requests pending when signing is unavailable", async () => {
@@ -1086,7 +1345,7 @@ describeEmbeddedPostgres("tool gateway service", () => {
     expect(requests[1]?.status).toBe("pending");
   });
 
-  it("adds formal board approval for destructive tool actions and fails closed until approved", async () => {
+  it("fails closed for approval-governed plugin actions", async () => {
     const { company, agent, run } = await createRunFixture(db);
     await db.insert(toolPolicies).values({
       companyId: company.id,
@@ -1101,61 +1360,23 @@ describeEmbeddedPostgres("tool gateway service", () => {
       runId: run.id,
     });
 
-    let approvalRequired: ToolGatewayHttpError | null = null;
-    try {
-      await gateway.executeTool({
+    await expect(
+      gateway.executeTool({
         sessionToken: session.token,
         tool: "fixture:delete_everything",
         parameters: { target: "repo" },
-      });
-    } catch (err) {
-      approvalRequired = err as ToolGatewayHttpError;
-    }
-    expect(approvalRequired).toMatchObject({ reasonCode: "approval_required" });
+      }),
+    ).rejects.toMatchObject({
+      reasonCode: "approval_governed_provider_unsupported",
+    });
 
     const [actionRequest] = await db.select().from(toolActionRequests);
-    expect(actionRequest.approvalId).toEqual(expect.any(String));
-    const [approval] = await db.select().from(approvals).where(eq(approvals.id, actionRequest.approvalId!));
-    expect(approval).toMatchObject({
-      type: "request_board_approval",
-      status: "pending",
-      requestedByAgentId: agent.id,
+    const [invocation] = await db.select().from(toolInvocations);
+    expect(actionRequest.status).toBe("cancelled");
+    expect(invocation).toMatchObject({
+      status: "denied",
+      errorCode: "approval_governed_provider_unsupported",
     });
-    const [link] = await db.select().from(issueApprovals).where(and(
-      eq(issueApprovals.issueId, session.issueId!),
-      eq(issueApprovals.approvalId, approval.id),
-    ));
-    expect(link).toBeTruthy();
-
-    await db.update(issueThreadInteractions).set({
-      status: "accepted",
-      resolvedByUserId: "board-user",
-      resolvedAt: new Date(),
-      updatedAt: new Date(),
-    }).where(eq(issueThreadInteractions.id, actionRequest.interactionId!));
-
-    await expect(gateway.executeTool({
-      sessionToken: session.token,
-      tool: "fixture:delete_everything",
-      approvedActionRequestId: actionRequest.id,
-      parameters: { target: "tampered" },
-    })).rejects.toMatchObject({ reasonCode: "formal_approval_required" });
-
-    await db.update(approvals).set({
-      status: "approved",
-      decidedByUserId: "board-user",
-      decidedAt: new Date(),
-      updatedAt: new Date(),
-    }).where(eq(approvals.id, approval.id));
-
-    const result = await gateway.executeTool({
-      sessionToken: session.token,
-      tool: "fixture:delete_everything",
-      approvedActionRequestId: actionRequest.id,
-      parameters: { target: "tampered" },
-    });
-    expect(result.status).toBe("completed");
-    expect((result.result as { result?: { data?: { target?: string } } }).result?.data?.target).toBe("repo");
   });
 
   it("maps remote MCP elicitation to a durable issue interaction", async () => {

--- a/server/src/__tests__/tool-gateway-service.test.ts
+++ b/server/src/__tests__/tool-gateway-service.test.ts
@@ -203,9 +203,21 @@ describeEmbeddedPostgres("tool gateway service", () => {
     await tempDb?.cleanup();
   });
 
-  async function createRemoteApprovalFixture(options: ToolGatewayServiceOptions = {}) {
+  async function createRemoteApprovalFixture(
+    options: ToolGatewayServiceOptions = {},
+    prepareRemote?: (input: {
+      companyId: string;
+      agentId: string;
+      connectionId: string;
+    }) => Promise<void>,
+  ) {
     const { company, agent, issue, run } = await createRunFixture(db);
     const remote = await createRemoteMcpToolFixture(db, company.id);
+    await prepareRemote?.({
+      companyId: company.id,
+      agentId: agent.id,
+      connectionId: remote.connection.id,
+    });
     await db.insert(toolPolicies).values({
       companyId: company.id,
       name: "Review remote reads",
@@ -401,6 +413,108 @@ describeEmbeddedPostgres("tool gateway service", () => {
     releaseProvider();
     expect((await approval).status).toBe("executed");
     expect(providerCalls).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not refresh credentials or redispatch after an approved remote call returns 401", async () => {
+    const getToken = vi.fn<VercelConnectClient["getToken"]>(
+      async (_request, options) => ({
+        token: options?.forceRefresh
+          ? "fresh-provider-bearer"
+          : "stale-provider-bearer",
+        tokenId: options?.forceRefresh ? "stk_fresh" : "stk_stale",
+        expiresAt: Date.now() + 60_000,
+        connector: {
+          id: "scl_fixture",
+          uid: "fixture-paperclip",
+          type: "api-key",
+        },
+      }),
+    );
+    const evict = vi.fn<VercelConnectClient["evict"]>();
+    const providerCalls = vi.fn(async () =>
+      new Response(null, { status: 401 }),
+    );
+    const fixture = await createRemoteApprovalFixture(
+      {
+        vercelConnectClient: {
+          getConnectorMetadata: vi.fn(),
+          getToken,
+          startAuthorization: vi.fn(),
+          revoke: vi.fn(),
+          evict,
+        },
+        remoteHttpRequest: providerCalls,
+      },
+      async ({ connectionId }) => {
+        await db
+          .update(toolConnections)
+          .set({
+            credentialSource: "vercel_connect",
+            externalCredential: {
+              provider: "vercel_connect",
+              connectorId: "scl_fixture",
+              connectorUid: "fixture-paperclip",
+              service: "fixture",
+              connectorType: "api-key",
+              principalMode: "app",
+              headerName: "Authorization",
+              headerPrefix: "Bearer ",
+              scopes: ["*"],
+            },
+            credentialRefs: [],
+            credentialSecretRefs: [],
+          })
+          .where(eq(toolConnections.id, connectionId));
+        await db
+          .update(connectionGrants)
+          .set({
+            externalCredential: {
+              provider: "vercel_connect",
+              subjectType: "app",
+            },
+            credentialSecretRefs: [],
+          })
+          .where(eq(connectionGrants.connectionId, connectionId));
+      },
+    );
+
+    const result = await fixture.gateway.approveActionRequest({
+      companyId: fixture.company.id,
+      actionRequestId: fixture.actionRequest.id,
+      actor: { userId: "board-user" },
+    });
+
+    expect(result.status).toBe("failed");
+    expect(providerCalls).toHaveBeenCalledTimes(1);
+    expect(getToken).toHaveBeenCalledTimes(1);
+    expect(getToken.mock.calls[0]?.[1]).not.toMatchObject({
+      forceRefresh: true,
+    });
+    expect(evict).not.toHaveBeenCalled();
+
+    const [request] = await db
+      .select()
+      .from(toolActionRequests)
+      .where(eq(toolActionRequests.id, fixture.actionRequest.id));
+    const [invocation] = await db
+      .select()
+      .from(toolInvocations)
+      .where(eq(toolInvocations.id, fixture.invocation.id));
+    const events = await db
+      .select()
+      .from(toolCallEvents)
+      .where(eq(toolCallEvents.actionRequestId, fixture.actionRequest.id));
+    expect(request).toMatchObject({ status: "failed" });
+    expect(invocation).toMatchObject({
+      status: "failed",
+      approvalState: "approved",
+      errorCode: "mcp_remote_status",
+    });
+    expect(events.map((event) => event.reasonCode)).toEqual([
+      "requires_approval_policy",
+      "approved_action_permitted",
+      "mcp_remote_status",
+    ]);
   });
 
   it("replays the single winner and denies alternate dispatch entry points", async () => {

--- a/server/src/services/remote-http-fetch.ts
+++ b/server/src/services/remote-http-fetch.ts
@@ -60,6 +60,8 @@ export type GuardedRemoteHttpFetchOptions = RemoteHttpEndpointGuardOptions & {
    * Platform `fetch`, used only for IP literals, which cannot be rebound.
    */
   unpinnedFetch?: typeof fetch;
+  /** Runs after transport verification, immediately before request dispatch. */
+  beforeProviderOperation?: () => Promise<void>;
 };
 
 /**
@@ -101,6 +103,7 @@ export async function guardedRemoteHttpFetch(
   const platformFetch = options.unpinnedFetch ?? fetch;
   if (literalHost) {
     try {
+      await options.beforeProviderOperation?.();
       return await platformFetch(endpoint.toString(), { ...init, redirect: "manual" });
     } catch (error) {
       if (isDnsResolutionError(error)) {
@@ -155,6 +158,7 @@ async function pinnedRequest(
       signal,
       responseTimeoutMs: options.responseTimeoutMs ?? DEFAULT_RESPONSE_TIMEOUT_MS,
       error: options.error,
+      beforeProviderOperation: options.beforeProviderOperation,
     });
   } catch (error) {
     socket.destroy();
@@ -275,8 +279,20 @@ async function sendRequest(input: {
   signal: AbortSignal | null;
   responseTimeoutMs: number;
   error: RemoteHttpEndpointErrorFactory;
+  beforeProviderOperation?: () => Promise<void>;
 }): Promise<Response> {
-  const { endpoint, hostname, port, useTls, socket, init, signal, responseTimeoutMs, error } = input;
+  const {
+    endpoint,
+    hostname,
+    port,
+    useTls,
+    socket,
+    init,
+    signal,
+    responseTimeoutMs,
+    error,
+    beforeProviderOperation,
+  } = input;
   const headers = new Headers(init.headers);
   const body = readRequestBody(init.body);
   const method = (init.method ?? "GET").toUpperCase();
@@ -298,6 +314,7 @@ async function sendRequest(input: {
   headers.set("host", endpoint.host);
 
   const requestFn = useTls ? httpsRequest : httpRequest;
+  await beforeProviderOperation?.();
   const message = await new Promise<IncomingMessage>((resolve, reject) => {
     const req = requestFn({
       method,

--- a/server/src/services/tool-action-review.ts
+++ b/server/src/services/tool-action-review.ts
@@ -1,8 +1,9 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, gt, isNotNull, lte, sql } from "drizzle-orm";
 import {
   issues,
   issueThreadInteractions,
   toolActionRequests,
+  toolCallEvents,
   toolInvocations,
   toolActionDeliveries,
   type Db,
@@ -116,8 +117,6 @@ export async function commitToolActionReview(
         invocation.agentId !== current.requestedByAgentId)
     )
       throw conflict("Tool invocation context does not match");
-    if (current.expiresAt && current.expiresAt <= new Date())
-      throw conflict("This review has expired");
     if (current.interactionId) {
       const payload = interaction?.payload as {
         toolAction?: { actionRequestId?: string; invocationId?: string };
@@ -137,19 +136,92 @@ export async function commitToolActionReview(
       if (interaction.status !== "pending")
         throw conflict("This review has already been resolved");
     }
-    const now = new Date();
     const [updated] = await tx
       .update(toolActionRequests)
       .set({
         status: input.decision,
         resolvedByUserId: input.actor.userId ?? "board",
         decidedByUserId: input.actor.userId ?? "board",
-        decidedAt: now,
-        resolvedAt: now,
-        updatedAt: now,
+        decidedAt: sql`clock_timestamp()`,
+        resolvedAt: sql`clock_timestamp()`,
+        updatedAt: sql`clock_timestamp()`,
       })
-      .where(eq(toolActionRequests.id, current.id))
+      .where(
+        and(
+          eq(toolActionRequests.id, current.id),
+          input.decision === "approved"
+            ? and(
+                isNotNull(toolActionRequests.expiresAt),
+                gt(toolActionRequests.expiresAt, sql`clock_timestamp()`),
+              )
+            : undefined,
+        ),
+      )
       .returning();
+    if (!updated && input.decision === "approved") {
+      const [expired] = await tx
+        .update(toolActionRequests)
+        .set({
+          status: "expired",
+          resolvedAt: sql`clock_timestamp()`,
+          updatedAt: sql`clock_timestamp()`,
+        })
+        .where(
+          and(
+            eq(toolActionRequests.id, current.id),
+            eq(toolActionRequests.status, "pending"),
+            isNotNull(toolActionRequests.expiresAt),
+            lte(toolActionRequests.expiresAt, sql`clock_timestamp()`),
+          ),
+        )
+        .returning();
+      if (!expired) throw conflict("This review has already been resolved");
+      await tx
+        .update(toolInvocations)
+        .set({
+          status: "failed",
+          approvalState: "expired",
+          idempotencyKey: null,
+          errorCode: "action_expired",
+          errorMessage: "The approval request expired before authorization.",
+          completedAt: expired.resolvedAt ?? expired.updatedAt,
+          updatedAt: expired.resolvedAt ?? expired.updatedAt,
+        })
+        .where(eq(toolInvocations.id, current.invocationId));
+      await tx.insert(toolCallEvents).values({
+        companyId: input.companyId,
+        eventType: "approval_resolved",
+        actorType: "user",
+        actorId: input.actor.userId ?? "board",
+        agentId: invocation.agentId,
+        runId: invocation.runId,
+        issueId: invocation.issueId,
+        gatewayId: invocation.gatewayId,
+        gatewayTokenId: invocation.gatewayTokenId,
+        gatewayPublicId: invocation.gatewayPublicId,
+        clientSubjectType: invocation.clientSubjectType,
+        clientSubjectId: invocation.clientSubjectId,
+        clientName: invocation.clientName,
+        mcpSessionId: invocation.mcpSessionId,
+        correlationId: invocation.correlationId,
+        applicationId: invocation.applicationId,
+        connectionId: invocation.connectionId,
+        catalogEntryId: invocation.catalogEntryId,
+        invocationId: invocation.id,
+        actionRequestId: expired.id,
+        toolName: invocation.toolName,
+        decision: "require_approval",
+        outcome: "timeout",
+        reasonCode: "action_expired",
+        metadata: {
+          expiresAt: expired.expiresAt?.toISOString() ?? null,
+          expiredAt: expired.resolvedAt?.toISOString() ?? null,
+        },
+      });
+      return expired;
+    }
+    if (!updated) throw conflict("This review has already been resolved");
+    const now = updated.resolvedAt ?? new Date();
     if (input.rememberAction) {
       if (input.decision !== "approved")
         throw conflict("Only an approval can remember permission");

--- a/server/src/services/tool-content-guards.ts
+++ b/server/src/services/tool-content-guards.ts
@@ -86,6 +86,7 @@ export function signToolArguments(args: {
   canonicalArguments: string;
   approvalSnapshot?: unknown;
   executionOnApprove?: boolean;
+  authorizationVersion?: number;
   identityContextId?: string;
   signingSecret?: string;
 }) {
@@ -97,6 +98,9 @@ export function signToolArguments(args: {
   if (args.identityContextId) payloadValue.identityContextId = args.identityContextId;
   if (args.executionOnApprove === true) {
     payloadValue.executionOnApprove = true;
+  }
+  if (args.authorizationVersion !== undefined) {
+    payloadValue.authorizationVersion = args.authorizationVersion;
   }
   if (args.approvalSnapshot !== undefined) {
     payloadValue.approvalSnapshot = args.approvalSnapshot;
@@ -113,6 +117,7 @@ export function verifyToolArgumentsSignature(input: {
   canonicalArguments: string;
   approvalSnapshot?: unknown;
   executionOnApprove?: boolean;
+  authorizationVersion?: number;
   identityContextId?: string;
   signingSecret?: string;
 }) {
@@ -134,6 +139,9 @@ export function verifyToolArgumentsSignature(input: {
   if (input.executionOnApprove !== undefined) {
     expectedPayloadValue.executionOnApprove = input.executionOnApprove;
   }
+  if (input.authorizationVersion !== undefined) {
+    expectedPayloadValue.authorizationVersion = input.authorizationVersion;
+  }
   if (input.approvalSnapshot !== undefined) {
     expectedPayloadValue.approvalSnapshot = input.approvalSnapshot;
   }
@@ -150,7 +158,7 @@ export function readSignedToolArgumentsPayload(input: {
   invocationId: string;
   toolName: string;
   signingSecret?: string;
-}): { arguments: unknown; approvalSnapshot?: unknown; executionOnApprove?: boolean; identityContextId?: string } | null {
+}): { arguments: unknown; approvalSnapshot?: unknown; executionOnApprove?: boolean; authorizationVersion?: number; identityContextId?: string } | null {
   if (!input.signedArguments) return null;
   let parsed: { payload?: unknown };
   try {
@@ -165,6 +173,7 @@ export function readSignedToolArgumentsPayload(input: {
     canonicalArguments?: unknown;
     approvalSnapshot?: unknown;
     executionOnApprove?: unknown;
+    authorizationVersion?: unknown;
     identityContextId?: unknown;
   };
   try {
@@ -181,6 +190,10 @@ export function readSignedToolArgumentsPayload(input: {
     canonicalArguments: payload.canonicalArguments,
     approvalSnapshot: payload.approvalSnapshot,
     executionOnApprove: payload.executionOnApprove === true ? true : undefined,
+    authorizationVersion:
+      typeof payload.authorizationVersion === "number"
+        ? payload.authorizationVersion
+        : undefined,
     identityContextId: typeof payload.identityContextId === "string" ? payload.identityContextId : undefined,
     signingSecret: input.signingSecret,
   })) {
@@ -191,6 +204,9 @@ export function readSignedToolArgumentsPayload(input: {
       arguments: JSON.parse(payload.canonicalArguments) as unknown,
       ...(payload.approvalSnapshot !== undefined ? { approvalSnapshot: payload.approvalSnapshot } : {}),
       ...(payload.executionOnApprove === true ? { executionOnApprove: true } : {}),
+      ...(typeof payload.authorizationVersion === "number"
+        ? { authorizationVersion: payload.authorizationVersion }
+        : {}),
       ...(typeof payload.identityContextId === "string" ? { identityContextId: payload.identityContextId } : {}),
     };
   } catch {

--- a/server/src/services/tool-gateway.ts
+++ b/server/src/services/tool-gateway.ts
@@ -5913,7 +5913,11 @@ export function createToolGatewayService(
       // and TLS setup before it invokes the final authorization callback. The
       // request call follows that callback without another awaited step.
       let response = await dispatchRemote(endpoint, requestInit, beforeDispatch);
-      if (response.status === 401 && composioChild) {
+      // Approval-governed calls are single-attempt after their final permit.
+      // A provider may complete a side effect and still return 401, so any
+      // credential refresh and retry here could dispatch the approved action
+      // twice under one request/audit record.
+      if (!beforeDispatch && response.status === 401 && composioChild) {
         composioSession = await composioSessions.ensureSession(connection.id, {
           tools: [entry.toolName],
           scopeRevision: composioScopeRevision,
@@ -5937,6 +5941,7 @@ export function createToolGatewayService(
       }
       const oauth = asRecord(asRecord(connection.config)?.oauth);
       if (
+        !beforeDispatch &&
         response.status === 401 &&
         connection.authKind === "oauth" &&
         connection.credentialSource === "paperclip_vault" &&
@@ -5976,6 +5981,7 @@ export function createToolGatewayService(
         }
       }
       if (
+        !beforeDispatch &&
         response.status === 401 &&
         connection.authKind === "oauth" &&
         connection.credentialSource === "paperclip_vault" &&
@@ -6002,6 +6008,7 @@ export function createToolGatewayService(
         });
       }
       if (
+        !beforeDispatch &&
         response.status === 401 &&
         connection.credentialSource === "vercel_connect"
       ) {

--- a/server/src/services/tool-gateway.ts
+++ b/server/src/services/tool-gateway.ts
@@ -11,6 +11,7 @@ import {
   eq,
   gt,
   inArray,
+  isNotNull,
   isNull,
   lte,
   ne,
@@ -189,6 +190,9 @@ const ACTION_REQUEST_PREPARATION_WAIT_MS = 2 * 60 * 1000;
 // they are joining. The extra grace lets the owner persist the terminal request
 // state after the provider timeout/result settles.
 const ACTION_REQUEST_EXECUTION_WAIT_MS = APPROVED_EXECUTION_TIMEOUT_MS + 5_000;
+const APPROVED_ACTION_AUTHORIZATION_VERSION = 2;
+const isApprovalGovernedRemoteProvider = (providerType: string | null) =>
+  providerType === "mcp_remote_http" || providerType === "mcp_http_fixture";
 // The gateway creates an ask-first request in two steps: it inserts the row
 // with a null signature, then it signs the row and sets the expiry. A concurrent
 // matching call can observe the row in this window. A null signature alone does
@@ -384,7 +388,7 @@ type RemoteHttpExecutionAudit = {
     mcpMethod: "tools/call";
     requestId: string;
     upstreamToolName: string;
-    dispatched: true;
+    dispatched: boolean;
   };
   response?: {
     httpStatus: number;
@@ -1038,6 +1042,8 @@ export function createToolGatewayService(
     beforeManagedArgumentDriftExpiry?: () => Promise<void>;
     /** Test seam for pausing a legacy approved request before its execution claim. */
     beforeLegacyApprovedActionClaim?: () => Promise<void>;
+    /** Test seam for pausing each awaited approved-action preparation stage. */
+    afterApprovedActionPreparationStage?: (stage: string) => Promise<void>;
     mcpGatewayProtocolLimits?: Partial<{
       authFailures: Partial<McpGatewayRateLimitConfig>;
       gatewayRequests: Partial<McpGatewayRateLimitConfig>;
@@ -2164,6 +2170,37 @@ export function createToolGatewayService(
     argumentsSummary: ReturnType<typeof summarizeToolValue>;
     policyDecision: ToolAccessDecision;
   }): Promise<never> {
+    if (!isApprovalGovernedRemoteProvider(input.tool.providerType)) {
+      const now = new Date();
+      if (input.actionRequest) {
+        await db
+          .update(toolActionRequests)
+          .set({ status: "cancelled", resolvedAt: now, updatedAt: now })
+          .where(
+            and(
+              eq(toolActionRequests.id, input.actionRequest.id),
+              eq(toolActionRequests.status, "pending"),
+            ),
+          );
+      }
+      await db
+        .update(toolInvocations)
+        .set({
+          status: "denied",
+          idempotencyKey: null,
+          errorCode: "approval_governed_provider_unsupported",
+          errorMessage:
+            "Approval-governed execution is supported only for remote HTTP MCP tools.",
+          completedAt: now,
+          updatedAt: now,
+        })
+        .where(eq(toolInvocations.id, input.invocation.id));
+      throw new ToolGatewayHttpError(
+        409,
+        "Approval-governed execution is supported only for remote HTTP MCP tools",
+        "approval_governed_provider_unsupported",
+      );
+    }
     const canonicalArguments = canonicalToolArguments(input.parameters);
     const canonicalArgumentsHash = input.argumentsSummary.sha256 ?? "";
     const approvalSnapshot = await connectedRemoteApprovalSnapshot(
@@ -2245,6 +2282,7 @@ export function createToolGatewayService(
         canonicalArguments,
         approvalSnapshot: approvalSnapshot ?? undefined,
         executionOnApprove: true,
+        authorizationVersion: APPROVED_ACTION_AUTHORIZATION_VERSION,
         identityContextId: input.session.identityContextId ?? undefined,
         signingSecret: options.toolActionSigningSecret,
       });
@@ -5741,6 +5779,7 @@ export function createToolGatewayService(
     ms: number,
     invocationId: string,
     callerHeaders?: ExecuteGatewayToolInput["callerHeaders"],
+    beforeDispatch?: () => Promise<void>,
   ): Promise<RemoteHttpExecutionResult> {
     const { entry, connection } = await resolveConnectedRemoteTool(
       session,
@@ -5749,6 +5788,13 @@ export function createToolGatewayService(
     const grant = await resolveConnectionGrant(session, connection);
     const composioScopeRevision = `${grant.id}:${grant.status}:${grant.updatedAt.toISOString()}`;
     const composioChild = composioChildConfig(connection);
+    if (beforeDispatch && composioChild) {
+      throw new ToolGatewayHttpError(
+        409,
+        "Approval-governed Composio child sessions are not supported",
+        "approved_remote_session_unsupported",
+      );
+    }
     let composioSession = composioChild
       ? await composioSessions.ensureSession(connection.id, {
           tools: [entry.toolName],
@@ -5785,25 +5831,47 @@ export function createToolGatewayService(
         mcpMethod: "tools/call",
         requestId,
         upstreamToolName: entry.toolName,
-        dispatched: true,
+        dispatched: false,
       },
     };
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), ms);
     timer.unref?.();
     try {
-      const dispatchRemote = (target: string, init: RequestInit) =>
-        options.remoteHttpRequest
-          ? options.remoteHttpRequest(target, init)
-          : guardedRemoteHttpFetch(target, init, {
+      const dispatchRemote = async (
+        target: string,
+        init: RequestInit,
+        finalAuthorization?: () => Promise<void>,
+      ) => {
+        const authorize = finalAuthorization
+          ? async () => {
+              await finalAuthorization();
+              execution.request.dispatched = true;
+            }
+          : undefined;
+        if (!finalAuthorization) execution.request.dispatched = true;
+        if (options.remoteHttpRequest) {
+          await authorize?.();
+          return options.remoteHttpRequest(target, init);
+        }
+        return guardedRemoteHttpFetch(target, init, {
               ...remoteHttpFetchOptions(),
               // This call site owns a caller-set budget that can exceed the
               // transport's default response deadline, so hand it down rather than
               // letting the tighter default cut a legitimately slow tool short.
               responseTimeoutMs: ms,
+              beforeProviderOperation: authorize,
             });
+      };
       let requestHeaders = headers;
       if (connection.config.mcpSessionRequired === true) {
+        if (beforeDispatch) {
+          throw new ToolGatewayHttpError(
+            409,
+            "Approval-governed stateful MCP sessions are not supported",
+            "approved_remote_session_unsupported",
+          );
+        }
         requestHeaders = await initializeMcpHttpSession({
           send: (init) =>
             dispatchRemote(endpoint, {
@@ -5836,7 +5904,15 @@ export function createToolGatewayService(
           },
         }),
       };
-      let response = await dispatchRemote(endpoint, requestInit);
+      if (beforeDispatch) {
+        await options.afterApprovedActionPreparationStage?.(
+          "provider_prepared",
+        );
+      }
+      // The guarded transport performs DNS resolution, socket verification,
+      // and TLS setup before it invokes the final authorization callback. The
+      // request call follows that callback without another awaited step.
+      let response = await dispatchRemote(endpoint, requestInit, beforeDispatch);
       if (response.status === 401 && composioChild) {
         composioSession = await composioSessions.ensureSession(connection.id, {
           tools: [entry.toolName],
@@ -7534,6 +7610,408 @@ export function createToolGatewayService(
       origin.cause === "company_default" ? null : origin.responsibleUserId;
   }
 
+  function approvedActionEventValues(input: {
+    invocation: typeof toolInvocations.$inferSelect;
+    actionRequestId: string;
+    eventType: "call_started" | "call_completed" | "call_failed";
+    outcome: "pending" | "success" | "failure";
+    reasonCode: string;
+    argumentsSummary?: ReturnType<typeof summarizeToolValue> | null;
+    resultSummary?: ReturnType<typeof summarizeToolValue> | null;
+    error?: { code: string; message: string } | null;
+    metadata?: Record<string, unknown>;
+    decision?: "allow" | "deny";
+  }): typeof toolCallEvents.$inferInsert {
+    const { invocation } = input;
+    return {
+      companyId: invocation.companyId,
+      eventType: input.eventType,
+      outcome: input.outcome,
+      actorType: "agent",
+      actorId: invocation.agentId,
+      agentId: invocation.agentId,
+      runId: invocation.runId,
+      issueId: invocation.issueId,
+      gatewayId: invocation.gatewayId,
+      gatewayTokenId: invocation.gatewayTokenId,
+      gatewayPublicId: invocation.gatewayPublicId,
+      clientSubjectType: invocation.clientSubjectType,
+      clientSubjectId: invocation.clientSubjectId,
+      clientName: invocation.clientName,
+      mcpSessionId: invocation.mcpSessionId,
+      correlationId: invocation.correlationId,
+      applicationId: invocation.applicationId,
+      connectionId: invocation.connectionId,
+      catalogEntryId: invocation.catalogEntryId,
+      invocationId: invocation.id,
+      actionRequestId: input.actionRequestId,
+      toolName: invocation.toolName,
+      decision: input.decision ?? "allow",
+      reasonCode: input.reasonCode,
+      requestHash: input.argumentsSummary?.sha256 ?? invocation.argumentsHash,
+      requestSummary: input.argumentsSummary ?? invocation.argumentsSummary,
+      resultHash: input.resultSummary?.sha256 ?? null,
+      resultSummary: input.resultSummary ?? null,
+      resultSizeBytes: input.resultSummary?.sizeBytes ?? null,
+      errorCode: input.error?.code ?? null,
+      errorMessage: input.error?.message ?? null,
+      metadata: {
+        authorizationVersion: APPROVED_ACTION_AUTHORIZATION_VERSION,
+        ...input.metadata,
+      },
+    };
+  }
+
+  async function failPreparedApprovedAction(input: {
+    actionRequestId: string;
+    invocation: typeof toolInvocations.$inferSelect;
+    error: unknown;
+  }) {
+    const reasonCode =
+      input.error instanceof ToolGatewayHttpError
+        ? input.error.reasonCode
+        : "tool_execution_failed";
+    const message =
+      input.error instanceof Error ? input.error.message : String(input.error);
+    const failed = await db.transaction(async (tx) => {
+      const [request] = await tx
+        .update(toolActionRequests)
+        .set({
+          status: "failed",
+          resolvedAt: sql`clock_timestamp()`,
+          updatedAt: sql`clock_timestamp()`,
+        })
+        .where(
+          and(
+            eq(toolActionRequests.id, input.actionRequestId),
+            eq(toolActionRequests.status, "approved"),
+          ),
+        )
+        .returning();
+      if (!request) return false;
+      const [invocation] = await tx
+        .update(toolInvocations)
+        .set({
+          status: "failed",
+          idempotencyKey: null,
+          errorCode: reasonCode,
+          errorMessage: message,
+          completedAt: request.resolvedAt ?? request.updatedAt,
+          updatedAt: request.resolvedAt ?? request.updatedAt,
+        })
+        .where(
+          and(
+            eq(toolInvocations.id, input.invocation.id),
+            eq(toolInvocations.status, "awaiting_approval"),
+          ),
+        )
+        .returning({ id: toolInvocations.id });
+      if (!invocation) throw new Error("Approved invocation state changed");
+      await tx.insert(toolCallEvents).values(
+        approvedActionEventValues({
+          invocation: input.invocation,
+          actionRequestId: input.actionRequestId,
+          eventType: "call_failed",
+          outcome: "failure",
+          reasonCode,
+          error: { code: reasonCode, message },
+          decision: "deny",
+        }),
+      );
+      return true;
+    });
+    if (failed) {
+      await reflectToolActionInteractionLifecycle({
+        actionRequestId: input.actionRequestId,
+        status: "failed",
+        errorCode: reasonCode,
+        errorMessage: message,
+      });
+    }
+    return failed;
+  }
+
+  async function permitApprovedRemoteDispatch(input: {
+    actionRequestId: string;
+    invocation: typeof toolInvocations.$inferSelect;
+    argumentsSummary: ReturnType<typeof summarizeToolValue>;
+  }) {
+    const outcome = await db.transaction(async (tx) => {
+      const [issue] = await tx
+        .select({ status: issues.status })
+        .from(issues)
+        .where(
+          and(
+            eq(issues.id, input.invocation.issueId!),
+            eq(issues.companyId, input.invocation.companyId),
+          ),
+        )
+        .for("share")
+        .limit(1);
+      if (!issue || issue.status === "done" || issue.status === "cancelled") {
+        const [expired] = await tx
+          .update(toolActionRequests)
+          .set({
+            status: "expired",
+            resolvedAt: sql`clock_timestamp()`,
+            updatedAt: sql`clock_timestamp()`,
+          })
+          .where(
+            and(
+              eq(toolActionRequests.id, input.actionRequestId),
+              eq(toolActionRequests.status, "approved"),
+            ),
+          )
+          .returning();
+        if (expired) {
+          const message = "The issue for this tool action is closed.";
+          await tx
+            .update(toolInvocations)
+            .set({
+              status: "failed",
+              approvalState: "expired",
+              idempotencyKey: null,
+              errorCode: "action_issue_closed",
+              errorMessage: message,
+              completedAt: expired.resolvedAt ?? expired.updatedAt,
+              updatedAt: expired.resolvedAt ?? expired.updatedAt,
+            })
+            .where(eq(toolInvocations.id, input.invocation.id));
+          await tx.insert(toolCallEvents).values(
+            approvedActionEventValues({
+              invocation: input.invocation,
+              actionRequestId: input.actionRequestId,
+              eventType: "call_failed",
+              outcome: "failure",
+              reasonCode: "action_issue_closed",
+              argumentsSummary: input.argumentsSummary,
+              error: { code: "action_issue_closed", message },
+              decision: "deny",
+            }),
+          );
+        }
+        return { kind: "issue_closed" as const };
+      }
+
+      const [claimed] = await tx
+        .update(toolActionRequests)
+        .set({ status: "executing", updatedAt: sql`clock_timestamp()` })
+        .where(
+          and(
+            eq(toolActionRequests.id, input.actionRequestId),
+            eq(toolActionRequests.status, "approved"),
+            isNotNull(toolActionRequests.expiresAt),
+            gt(toolActionRequests.expiresAt, sql`clock_timestamp()`),
+          ),
+        )
+        .returning();
+      if (claimed) {
+        const [started] = await tx
+          .update(toolInvocations)
+          .set({
+            status: "executing",
+            approvalState: "approved",
+            startedAt: claimed.updatedAt,
+            updatedAt: claimed.updatedAt,
+          })
+          .where(
+            and(
+              eq(toolInvocations.id, input.invocation.id),
+              eq(toolInvocations.status, "awaiting_approval"),
+            ),
+          )
+          .returning({ id: toolInvocations.id });
+        if (!started) throw new Error("Approved invocation state changed");
+        await tx.insert(toolCallEvents).values(
+          approvedActionEventValues({
+            invocation: input.invocation,
+            actionRequestId: input.actionRequestId,
+            eventType: "call_started",
+            outcome: "pending",
+            reasonCode: "approved_action_permitted",
+            argumentsSummary: input.argumentsSummary,
+          }),
+        );
+        return { kind: "permitted" as const, claimed };
+      }
+
+      const [expired] = await tx
+        .update(toolActionRequests)
+        .set({
+          status: "expired",
+          resolvedAt: sql`clock_timestamp()`,
+          updatedAt: sql`clock_timestamp()`,
+        })
+        .where(
+          and(
+            eq(toolActionRequests.id, input.actionRequestId),
+            eq(toolActionRequests.status, "approved"),
+            isNotNull(toolActionRequests.expiresAt),
+            lte(toolActionRequests.expiresAt, sql`clock_timestamp()`),
+          ),
+        )
+        .returning();
+      if (expired) {
+        const message = "The approval expired before provider dispatch.";
+        await tx
+          .update(toolInvocations)
+          .set({
+            status: "failed",
+            approvalState: "expired",
+            idempotencyKey: null,
+            errorCode: "action_expired",
+            errorMessage: message,
+            completedAt: expired.resolvedAt ?? expired.updatedAt,
+            updatedAt: expired.resolvedAt ?? expired.updatedAt,
+          })
+          .where(eq(toolInvocations.id, input.invocation.id));
+        await tx.insert(toolCallEvents).values(
+          approvedActionEventValues({
+            invocation: input.invocation,
+            actionRequestId: input.actionRequestId,
+            eventType: "call_failed",
+            outcome: "failure",
+            reasonCode: "action_expired",
+            argumentsSummary: input.argumentsSummary,
+            error: { code: "action_expired", message },
+            decision: "deny",
+          }),
+        );
+        return { kind: "expired" as const };
+      }
+      return { kind: "consumed" as const };
+    });
+
+    if (outcome.kind === "permitted") return outcome.claimed;
+    if (outcome.kind === "expired") {
+      await reflectToolActionInteractionLifecycle({
+        actionRequestId: input.actionRequestId,
+        status: "expired",
+        errorCode: "action_expired",
+        errorMessage: "The approval expired before provider dispatch.",
+      });
+      throw new ToolGatewayHttpError(
+        409,
+        "The approval expired before provider dispatch",
+        "action_expired",
+      );
+    }
+    if (outcome.kind === "issue_closed") {
+      await reflectToolActionInteractionLifecycle({
+        actionRequestId: input.actionRequestId,
+        status: "expired",
+        errorCode: "action_issue_closed",
+        errorMessage: "The issue for this tool action is closed.",
+      });
+      throw new ToolGatewayHttpError(
+        409,
+        "The issue for this tool action is closed",
+        "action_issue_closed",
+      );
+    }
+    throw new ToolGatewayHttpError(
+      409,
+      "Tool action request was already consumed",
+      "action_already_consumed",
+    );
+  }
+
+  async function settleApprovedRemoteDispatch(input: {
+    claimed: typeof toolActionRequests.$inferSelect;
+    invocation: typeof toolInvocations.$inferSelect;
+    argumentsSummary: ReturnType<typeof summarizeToolValue>;
+    resultSummary?: ReturnType<typeof summarizeToolValue>;
+    error?: unknown;
+    timeoutMs?: number;
+  }) {
+    const failed = input.error !== undefined;
+    const reasonCode = failed
+      ? input.error instanceof ToolGatewayHttpError
+        ? input.error.reasonCode
+        : "tool_execution_failed"
+      : "approved_action_executed";
+    const message = failed
+      ? input.error instanceof Error
+        ? input.error.message
+        : String(input.error)
+      : null;
+    const status = failed ? "failed" : "executed";
+    const settled = await db.transaction(async (tx) => {
+      const [request] = await tx
+        .update(toolActionRequests)
+        .set({
+          status,
+          resolvedAt: sql`clock_timestamp()`,
+          updatedAt: sql`clock_timestamp()`,
+        })
+        .where(
+          and(
+            eq(toolActionRequests.id, input.claimed.id),
+            eq(toolActionRequests.status, "executing"),
+          ),
+        )
+        .returning();
+      if (!request) return false;
+      const [invocation] = await tx
+        .update(toolInvocations)
+        .set(
+          failed
+            ? {
+                status: "failed",
+                errorCode: reasonCode,
+                errorMessage: message,
+                completedAt: request.resolvedAt ?? request.updatedAt,
+                updatedAt: request.resolvedAt ?? request.updatedAt,
+              }
+            : {
+                status: "succeeded",
+                resultHash: input.resultSummary?.sha256 ?? null,
+                resultSummary: input.resultSummary,
+                resultSizeBytes: input.resultSummary?.sizeBytes ?? null,
+                completedAt: request.resolvedAt ?? request.updatedAt,
+                updatedAt: request.resolvedAt ?? request.updatedAt,
+              },
+        )
+        .where(
+          and(
+            eq(toolInvocations.id, input.invocation.id),
+            eq(toolInvocations.status, "executing"),
+          ),
+        )
+        .returning({ id: toolInvocations.id });
+      if (!invocation) throw new Error("Executing invocation state changed");
+      await tx.insert(toolCallEvents).values(
+        approvedActionEventValues({
+          invocation: input.invocation,
+          actionRequestId: input.claimed.id,
+          eventType: failed ? "call_failed" : "call_completed",
+          outcome: failed ? "failure" : "success",
+          reasonCode,
+          argumentsSummary: input.argumentsSummary,
+          resultSummary: input.resultSummary,
+          error: failed ? { code: reasonCode, message: message! } : null,
+          metadata: input.timeoutMs
+            ? {
+                timeoutMs: input.timeoutMs,
+                durationMs: Date.now() - input.claimed.updatedAt.getTime(),
+              }
+            : undefined,
+        }),
+      );
+      return true;
+    });
+    if (settled) {
+      await reflectToolActionInteractionLifecycle({
+        actionRequestId: input.claimed.id,
+        status,
+        errorCode: failed ? reasonCode : null,
+        errorMessage: message,
+        resultSummary: input.resultSummary?.summary ?? null,
+      });
+    }
+    return settled;
+  }
+
   async function executeApprovedAgentInvocation(input: {
     actionRequest: typeof toolActionRequests.$inferSelect;
     invocation: typeof toolInvocations.$inferSelect;
@@ -7551,89 +8029,58 @@ export function createToolGatewayService(
       );
     }
 
-    const [claimed] = await db
-      .update(toolActionRequests)
-      .set({ status: "executing", updatedAt: new Date() })
-      .where(
-        and(
-          eq(toolActionRequests.id, actionRequest.id),
-          eq(toolActionRequests.status, "approved"),
-        ),
-      )
-      .returning();
-    if (!claimed) {
-      const settled = await waitForActionRequestExecution(actionRequest.id);
-      const [settledInvocation] = await db
-        .select()
-        .from(toolInvocations)
-        .where(eq(toolInvocations.id, invocation.id))
-        .limit(1);
-      if (settled?.status === "executed" && settledInvocation) {
-        return storedInvocationResult(settledInvocation);
-      }
-      if (settled?.status === "failed") {
-        throw new ToolGatewayHttpError(
-          502,
-          settledInvocation?.errorMessage ?? "Approved tool action failed",
-          settledInvocation?.errorCode ?? "tool_execution_failed",
-          { actionRequestId: actionRequest.id, invocationId: invocation.id },
-        );
-      }
-      throw new ToolGatewayHttpError(
-        409,
-        "Tool action request was already consumed",
-        "action_already_consumed",
-      );
-    }
-
-    // Terminal-issue expiry revokes pending/approved requests, but a claim that
-    // committed just before the issue closed slips past that revocation. Recheck
-    // the issue after winning the claim so a governed action never runs external
-    // side effects for an issue that is already done or cancelled.
-    const issue = await assertIssueOpenForApprovedAction({
-      claimed,
-      invocation,
-    });
-
     const signedPayload = readSignedToolArgumentsPayload({
-      signedArguments: claimed.signedArguments,
+      signedArguments: actionRequest.signedArguments,
       invocationId: invocation.id,
       toolName: invocation.toolName,
       signingSecret: options.toolActionSigningSecret,
     });
-    if (!signedPayload) {
+    if (
+      !signedPayload ||
+      signedPayload.executionOnApprove !== true ||
+      signedPayload.authorizationVersion !==
+        APPROVED_ACTION_AUTHORIZATION_VERSION
+    ) {
       const error = new ToolGatewayHttpError(
         409,
-        "Approved tool action arguments signature is invalid",
-        "signed_arguments_invalid",
+        "This approval is not valid for the current execution authorization contract",
+        "approved_action_authorization_unsupported",
       );
-      await markApprovedActionFailed({
-        actionRequestId: claimed.id,
-        invocationId: invocation.id,
-        claimUpdatedAt: claimed.updatedAt,
-        expectedInvocationStatus: "awaiting_approval",
-        error,
-      });
-      throw error;
-    }
-    if (signedPayload.executionOnApprove !== true) {
-      const error = new ToolGatewayHttpError(
-        409,
-        "This approval predates execute-on-approve and must remain inert",
-        "legacy_approved_action_inert",
-      );
-      await markApprovedActionFailed({
-        actionRequestId: claimed.id,
-        invocationId: invocation.id,
-        claimUpdatedAt: claimed.updatedAt,
-        expectedInvocationStatus: "awaiting_approval",
+      await failPreparedApprovedAction({
+        actionRequestId: actionRequest.id,
+        invocation,
         error,
       });
       throw error;
     }
 
+    if (!isApprovalGovernedRemoteProvider(invocation.providerType)) {
+      const error = new ToolGatewayHttpError(
+        409,
+        "Approval-governed execution is supported only for remote HTTP MCP tools",
+        "approved_provider_unsupported",
+      );
+      await failPreparedApprovedAction({
+        actionRequestId: actionRequest.id,
+        invocation,
+        error,
+      });
+      throw error;
+    }
+
+    const [issue] = await db
+      .select({ status: issues.status, projectId: issues.projectId })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.id, invocation.issueId),
+          eq(issues.companyId, invocation.companyId),
+        ),
+      )
+      .limit(1);
+
     const session: ToolGatewaySession = {
-      id: `approved-action:${claimed.id}`,
+      id: `approved-action:${actionRequest.id}`,
       token: "",
       companyId: invocation.companyId,
       agentId: invocation.agentId,
@@ -7657,11 +8104,21 @@ export function createToolGatewayService(
         session,
         signedPayload.identityContextId,
       );
+      await options.afterApprovedActionPreparationStage?.("identity");
       tool = await findToolForSession(session, invocation.toolName);
+      await options.afterApprovedActionPreparationStage?.("tool_discovery");
+      if (!isApprovalGovernedRemoteProvider(tool.providerType)) {
+        throw new ToolGatewayHttpError(
+          409,
+          "Approval-governed execution is supported only for remote HTTP MCP tools",
+          "approved_provider_unsupported",
+        );
+      }
       liveApprovalSnapshot = await connectedRemoteApprovalSnapshot(
         session,
         tool,
       );
+      await options.afterApprovedActionPreparationStage?.("approval_snapshot");
       const currentAccess = await policyService.decide(
         policyInputForTool({
           session,
@@ -7678,12 +8135,11 @@ export function createToolGatewayService(
           currentAccess.explanation,
           currentAccess.reasonCode,
         );
+      await options.afterApprovedActionPreparationStage?.("policy");
     } catch (error) {
-      await markApprovedActionFailed({
-        actionRequestId: claimed.id,
-        invocationId: invocation.id,
-        claimUpdatedAt: claimed.updatedAt,
-        expectedInvocationStatus: "awaiting_approval",
+      await failPreparedApprovedAction({
+        actionRequestId: actionRequest.id,
+        invocation,
         error,
       });
       throw error;
@@ -7699,11 +8155,9 @@ export function createToolGatewayService(
         "Approved tool action target changed after review",
         "approved_tool_target_changed",
       );
-      await markApprovedActionFailed({
-        actionRequestId: claimed.id,
-        invocationId: invocation.id,
-        claimUpdatedAt: claimed.updatedAt,
-        expectedInvocationStatus: "awaiting_approval",
+      await failPreparedApprovedAction({
+        actionRequestId: actionRequest.id,
+        invocation,
         error,
       });
       throw error;
@@ -7711,15 +8165,16 @@ export function createToolGatewayService(
     const parameters = signedPayload.arguments;
     const canonicalArguments = canonicalToolArguments(parameters);
     if (
-      claimed.canonicalArgumentsHash !==
+      actionRequest.canonicalArgumentsHash !==
         summarizeToolValue(parameters).sha256 ||
       !verifyToolArgumentsSignature({
-        signedArguments: claimed.signedArguments,
+        signedArguments: actionRequest.signedArguments,
         invocationId: invocation.id,
         toolName: invocation.toolName,
         canonicalArguments,
         approvalSnapshot: signedPayload.approvalSnapshot,
         executionOnApprove: true,
+        authorizationVersion: APPROVED_ACTION_AUTHORIZATION_VERSION,
         identityContextId: signedPayload.identityContextId,
         signingSecret: options.toolActionSigningSecret,
       })
@@ -7729,11 +8184,9 @@ export function createToolGatewayService(
         "Approved tool action arguments do not match reviewed hash",
         "signed_arguments_mismatch",
       );
-      await markApprovedActionFailed({
-        actionRequestId: claimed.id,
-        invocationId: invocation.id,
-        claimUpdatedAt: claimed.updatedAt,
-        expectedInvocationStatus: "awaiting_approval",
+      await failPreparedApprovedAction({
+        actionRequestId: actionRequest.id,
+        invocation,
         error,
       });
       throw error;
@@ -7743,23 +8196,27 @@ export function createToolGatewayService(
       managedArgumentsRemainCurrent =
         await approvedManagedArgumentsRemainCurrent(session, tool, parameters);
     } catch (error) {
-      await markApprovedActionFailed({
-        actionRequestId: claimed.id,
-        invocationId: invocation.id,
-        claimUpdatedAt: claimed.updatedAt,
-        expectedInvocationStatus: "awaiting_approval",
+      await failPreparedApprovedAction({
+        actionRequestId: actionRequest.id,
+        invocation,
         error,
       });
       throw error;
     }
     if (!managedArgumentsRemainCurrent) {
-      throw await expireApprovedActionForManagedArgumentDrift({
-        actionRequestId: claimed.id,
-        invocationId: invocation.id,
-        toolName: invocation.toolName,
-        ownsExecutingClaim: true,
+      const error = new ToolGatewayHttpError(
+        409,
+        "Approved tool action managed arguments changed after review",
+        "approved_tool_managed_arguments_changed",
+      );
+      await failPreparedApprovedAction({
+        actionRequestId: actionRequest.id,
+        invocation,
+        error,
       });
+      throw error;
     }
+    await options.afterApprovedActionPreparationStage?.("managed_arguments");
 
     const argumentsSummary = validateToolContent({
       value: parameters,
@@ -7767,66 +8224,37 @@ export function createToolGatewayService(
       sensitiveMode: "redact",
       promptInjectionMode: "ignore",
     }).summary;
-    // Final recheck at the last DB write before dispatch: tool and snapshot
-    // resolution above involve network calls, so re-verify the issue is still
-    // open now that only the provider call remains. A close that commits after
-    // this read has raced an execution that was approved, claimed, and verified
-    // while the issue was open; that instant is irreducible for an external
-    // side effect gated by DB state (holding a DB lock across a remote provider
-    // call is not an option), and the accepted linearization is that the
-    // execution wins — its result still lands on the expired card via
-    // reflectToolActionInteractionLifecycle.
-    await assertIssueOpenForApprovedAction({ claimed, invocation });
-
-    const startedAt = Date.now();
-    await db
-      .update(toolInvocations)
-      .set({
-        status: "executing",
-        approvalState: "approved",
-        startedAt: new Date(),
-        updatedAt: new Date(),
-      })
-      .where(eq(toolInvocations.id, invocation.id));
-    await reflectToolActionInteractionLifecycle({
-      actionRequestId: claimed.id,
-      status: "executing",
-    });
-
+    let claimed: typeof toolActionRequests.$inferSelect | null = null;
+    const executionTimeoutMs = timeoutMs(APPROVED_EXECUTION_TIMEOUT_MS);
     try {
-      const executionTimeoutMs = timeoutMs(APPROVED_EXECUTION_TIMEOUT_MS);
-      const result =
-        tool.providerType === "mcp_remote_http"
-          ? (
-              await executeRemoteHttpTool(
-                session,
-                tool,
-                parameters,
-                executionTimeoutMs,
-                invocation.id,
-              )
-            ).result
-          : tool.providerType === "mcp_local_stdio"
-            ? (
-                await executeLocalStdioTool(
-                  session,
-                  tool,
-                  parameters,
-                  executionTimeoutMs,
-                )
-              ).result
-            : tool.providerType !== "paperclip_plugin"
-              ? await runWithTimeout(
-                  executeBuiltinTool(session, tool, parameters),
-                  executionTimeoutMs,
-                )
-              : (() => {
-                  throw new ToolGatewayHttpError(
-                    409,
-                    "Plugin actions cannot execute outside their originating run",
-                    "approved_execution_unsupported",
-                  );
-                })();
+      const finalPermit = async () => {
+        claimed = await permitApprovedRemoteDispatch({
+          actionRequestId: actionRequest.id,
+          invocation,
+          argumentsSummary,
+        });
+      };
+      let result: unknown;
+      if (tool.providerType === "mcp_remote_http") {
+        result = (
+          await executeRemoteHttpTool(
+            session,
+            tool,
+            parameters,
+            executionTimeoutMs,
+            invocation.id,
+            undefined,
+            finalPermit,
+          )
+        ).result;
+      } else {
+        await options.afterApprovedActionPreparationStage?.(
+          "provider_prepared",
+        );
+        await finalPermit();
+        const providerOperation = executeBuiltinTool(session, tool, parameters);
+        result = await providerOperation;
+      }
       const resultRecord = asRecord(result);
       if (resultRecord?.error)
         throw new ToolGatewayHttpError(
@@ -7840,66 +8268,55 @@ export function createToolGatewayService(
         sensitiveMode: "redact",
         promptInjectionMode: "block",
       });
-      const now = new Date();
-      await db
-        .update(toolInvocations)
-        .set({
-          status: "succeeded",
-          resultHash: resultValidation.summary.sha256 ?? null,
-          resultSummary: resultValidation.summary,
-          resultSizeBytes: resultValidation.summary.sizeBytes ?? null,
-          completedAt: now,
-          updatedAt: now,
-        })
-        .where(eq(toolInvocations.id, invocation.id));
-      await db
-        .update(toolActionRequests)
-        .set({ status: "executed", resolvedAt: now, updatedAt: now })
-        .where(eq(toolActionRequests.id, claimed.id));
-      await reflectToolActionInteractionLifecycle({
-        actionRequestId: claimed.id,
-        status: "executed",
-        resultSummary: resultValidation.summary.summary,
-      });
-      await writeToolCallEvent({
-        invocationId: invocation.id,
-        actionRequestId: claimed.id,
-        session,
-        eventType: "call_completed",
-        outcome: "success",
-        toolName: tool.name,
-        policyDecision: "allow",
-        reasonCode: "approved_action_executed",
+      if (!claimed) throw new Error("Provider dispatched without authorization");
+      await settleApprovedRemoteDispatch({
+        claimed,
+        invocation,
         argumentsSummary,
         resultSummary: resultValidation.summary,
-        metadata: {
-          durationMs: Date.now() - startedAt,
-          timeoutMs: executionTimeoutMs,
-        },
-        tool,
+        timeoutMs: executionTimeoutMs,
       });
       return resultValidation.value;
     } catch (error) {
-      const { reasonCode } = await markApprovedActionFailed({
-        actionRequestId: claimed.id,
-        invocationId: invocation.id,
-        claimUpdatedAt: claimed.updatedAt,
-        expectedInvocationStatus: "executing",
-        error,
-      });
-      await writeToolCallEvent({
-        invocationId: invocation.id,
-        actionRequestId: claimed.id,
-        session,
-        eventType: "call_failed",
-        outcome: "failure",
-        toolName: tool.name,
-        policyDecision: "deny",
-        reasonCode,
-        argumentsSummary,
-        metadata: { durationMs: Date.now() - startedAt },
-        tool,
-      });
+      if (claimed) {
+        await settleApprovedRemoteDispatch({
+          claimed,
+          invocation,
+          argumentsSummary,
+          error,
+          timeoutMs: executionTimeoutMs,
+        });
+      } else if (
+        error instanceof ToolGatewayHttpError &&
+        error.reasonCode === "action_already_consumed"
+      ) {
+        const settled = await waitForActionRequestExecution(actionRequest.id);
+        const [settledInvocation] = await db
+          .select()
+          .from(toolInvocations)
+          .where(eq(toolInvocations.id, invocation.id))
+          .limit(1);
+        if (settled?.status === "executed" && settledInvocation) {
+          return storedInvocationResult(settledInvocation);
+        }
+        if (settled?.status === "failed" && settledInvocation) {
+          throw new ToolGatewayHttpError(
+            502,
+            settledInvocation.errorMessage ?? "Approved tool action failed",
+            settledInvocation.errorCode ?? "tool_execution_failed",
+            {
+              actionRequestId: actionRequest.id,
+              invocationId: invocation.id,
+            },
+          );
+        }
+      } else {
+        await failPreparedApprovedAction({
+          actionRequestId: actionRequest.id,
+          invocation,
+          error,
+        });
+      }
       throw error;
     }
   }
@@ -7933,6 +8350,7 @@ export function createToolGatewayService(
             "executing",
             "rejected",
             "executed",
+            "failed",
           ]),
         ),
       )
@@ -8026,6 +8444,18 @@ export function createToolGatewayService(
         result: storedInvocationResult(invocation),
         invocationId: invocation.id,
       };
+    }
+    if (actionRequest.status === "failed") {
+      if (!invocation.startedAt) return null;
+      throw new ToolGatewayHttpError(
+        502,
+        invocation.errorMessage ?? "Approved tool action failed",
+        invocation.errorCode ?? "tool_execution_failed",
+        {
+          invocationId: invocation.id,
+          actionRequestId: actionRequest.id,
+        },
+      );
     }
     if (actionRequest.status === "executing") {
       const settled = await waitForActionRequestExecution(actionRequest.id);
@@ -8847,6 +9277,13 @@ export function createToolGatewayService(
         consumeRateLimit: true,
       });
       const accessDecision = await policyService.decide(decisionInput);
+      if ((accessDecision.decision as string) === "require_approval") {
+        throw new ToolGatewayHttpError(
+          409,
+          "Approval-governed Test-tab calls are not supported",
+          "approval_governed_test_call_unsupported",
+        );
+      }
       const recorded = await policyService.recordInvocation(
         decisionInput,
         accessDecision,
@@ -9125,7 +9562,10 @@ export function createToolGatewayService(
                   eq(toolActionRequests.status, "pending"),
                   lte(toolActionRequests.expiresAt, now),
                 ),
-                eq(toolActionRequests.status, "approved"),
+                and(
+                  eq(toolActionRequests.status, "approved"),
+                  lte(toolActionRequests.updatedAt, staleAt),
+                ),
                 and(
                   eq(toolActionRequests.status, "executing"),
                   lte(toolActionRequests.updatedAt, staleAt),
@@ -9138,16 +9578,22 @@ export function createToolGatewayService(
           .limit(100);
         for (const row of rows) {
           if (row.status === "approved") {
-            await this.approveActionRequest({
-              companyId: row.companyId,
-              actionRequestId: row.id,
-              actor: { userId: row.decidedByUserId ?? row.resolvedByUserId },
-            }).catch((error) =>
-              logger.warn(
-                { err: error, actionRequestId: row.id },
-                "Could not recover approved tool action",
-              ),
-            );
+            const [invocation] = await db
+              .select()
+              .from(toolInvocations)
+              .where(eq(toolInvocations.id, row.invocationId))
+              .limit(1);
+            if (invocation) {
+              await failPreparedApprovedAction({
+                actionRequestId: row.id,
+                invocation,
+                error: new ToolGatewayHttpError(
+                  409,
+                  "Automatic recovery of approved tool actions is not supported",
+                  "approved_action_recovery_unsupported",
+                ),
+              });
+            }
             continue;
           }
           const status = row.status === "pending" ? "expired" : "failed";
@@ -9321,6 +9767,82 @@ export function createToolGatewayService(
           "action_request_invalidated",
         );
       }
+      if (
+        isTestOriginInvocation(invocation) ||
+        signedPayload.executionOnApprove !== true ||
+        signedPayload.authorizationVersion !==
+          APPROVED_ACTION_AUTHORIZATION_VERSION ||
+        !isApprovalGovernedRemoteProvider(invocation.providerType)
+      ) {
+        if (actionRequest.status === "pending") {
+          await db.transaction(async (tx) => {
+            const [cancelled] = await tx
+              .update(toolActionRequests)
+              .set({
+                status: "cancelled",
+                resolvedAt: sql`clock_timestamp()`,
+                updatedAt: sql`clock_timestamp()`,
+              })
+              .where(
+                and(
+                  eq(toolActionRequests.id, actionRequest.id),
+                  eq(toolActionRequests.status, "pending"),
+                ),
+              )
+              .returning();
+            if (!cancelled) return;
+            await tx
+              .update(toolInvocations)
+              .set({
+                status: "failed",
+                idempotencyKey: null,
+                errorCode: "approved_action_authorization_unsupported",
+                errorMessage:
+                  "This approval path is not supported by the current authorization contract.",
+                completedAt: cancelled.resolvedAt ?? cancelled.updatedAt,
+                updatedAt: cancelled.resolvedAt ?? cancelled.updatedAt,
+              })
+              .where(eq(toolInvocations.id, invocation.id));
+            await tx.insert(toolCallEvents).values(
+              approvedActionEventValues({
+                invocation,
+                actionRequestId: actionRequest.id,
+                eventType: "call_failed",
+                outcome: "failure",
+                reasonCode: "approved_action_authorization_unsupported",
+                error: {
+                  code: "approved_action_authorization_unsupported",
+                  message:
+                    "This approval path is not supported by the current authorization contract.",
+                },
+                decision: "deny",
+              }),
+            );
+          });
+        } else {
+          await failPreparedApprovedAction({
+            actionRequestId: actionRequest.id,
+            invocation,
+            error: new ToolGatewayHttpError(
+              409,
+              "This approval path is not supported by the current authorization contract",
+              "approved_action_authorization_unsupported",
+            ),
+          });
+        }
+        await reflectToolActionInteractionLifecycle({
+          actionRequestId: actionRequest.id,
+          status: actionRequest.status === "pending" ? "cancelled" : "failed",
+          errorCode: "approved_action_authorization_unsupported",
+          errorMessage:
+            "This approval path is not supported by the current authorization contract.",
+        });
+        throw new ToolGatewayHttpError(
+          409,
+          "This approval path is not supported by the current authorization contract",
+          "approved_action_authorization_unsupported",
+        );
+      }
       if (actionRequest.approvalId) {
         const [formalApproval] = await db
           .select({ status: approvals.status })
@@ -9365,12 +9887,6 @@ export function createToolGatewayService(
         }
         return actionRequest;
       }
-      if (actionRequest.expiresAt && actionRequest.expiresAt <= new Date())
-        throw new ToolGatewayHttpError(
-          409,
-          "Tool review has expired",
-          "action_expired",
-        );
       if (
         !isTestOriginInvocation(invocation) &&
         signedPayload.executionOnApprove === true
@@ -9436,20 +9952,20 @@ export function createToolGatewayService(
         ...input,
         decision: "approved",
       });
+      if (updated.status === "expired") {
+        await reflectToolActionInteractionLifecycle({
+          actionRequestId: updated.id,
+          status: "expired",
+          errorCode: "action_expired",
+          errorMessage: "The approval request expired before authorization.",
+        });
+        return actionRequestResolution(updated);
+      }
       await reflectToolActionInteractionLifecycle({
         actionRequestId: updated.id,
         status: "approved",
       });
-      // A test-tab ask-first request has no agent run to carry out the parked
-      // call, so approving it is what runs it. Execute against the signed
-      // arguments and record the result on the invocation for the live panel.
-      if (isTestOriginInvocation(invocation)) {
-        await runApprovedTestInvocation(
-          { ...invocation, approvalState: "approved" },
-          signedPayload.arguments,
-          updated.id,
-        );
-      } else if (signedPayload.executionOnApprove === true) {
+      if (signedPayload.executionOnApprove === true) {
         try {
           await executeApprovedAgentInvocation({
             actionRequest: updated,
@@ -9499,6 +10015,13 @@ export function createToolGatewayService(
         callerHeaders: input.callerHeaders,
       });
       await assertGatewayTokenAction(session, "tools/call");
+      if (input.approvedActionRequestId) {
+        throw new ToolGatewayHttpError(
+          409,
+          "Explicit approval-request execution is not supported; approve the original review card",
+          "approved_action_explicit_retry_unsupported",
+        );
+      }
       let invocationId = String(randomUUID());
       const startedAt = Date.now();
 


### PR DESCRIPTION
## Summary

- make the approval-governed remote HTTP MCP path perform its final authorization with PostgreSQL time after all awaited preparation and immediately before the first provider operation
- deny at the expiry boundary (`db_now >= expires_at`), atomically consume the winning request/invocation/audit disposition, and fail closed for unsupported alternate dispatch paths and legacy request envelopes
- prevent every credential-refresh/retry family from redispatching after an approved provider call returns HTTP 401

This is a fresh replacement for #13167. It preserves a deliberately narrow supported path: newly created, immutable, stateless remote HTTP actions approved through the normal human review flow. Existing outstanding approval-governed requests are not migrated and must be recreated.

## Safety properties

- all discovery, credential, argument, target, DNS, socket, and TLS preparation completes before the final permit
- no await occurs between a successful permit and HTTP request creation/write
- one approved request can produce at most one provider operation, including duplicate delivery and 401 responses
- provider completion followed by a lost/error response remains outcome-uncertain and is never automatically replayed

## Verification

- disposable real PostgreSQL: 3 focused files, 71 tests passed, 0 skipped
- covers just-before/equal/after expiry, both race winner orders, every awaited preparation seam, duplicate success/failure delivery, alternate-entry fail-closure, terminal/audit cardinality, and approved-401 single dispatch
- direct server TypeScript `tsc --noEmit` passed
- `git diff --check` passed

Exact reviewed head: `c6f521bdb10f8c8624c6eec0d9d90f223b15edf7`.
