### PR TITLE
fix(health): flag empty .sql.gz database backups (REVIP-8079)

### DIFF
--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -79,6 +79,7 @@ function hasWorkspaceReadinessToken(providedToken: string | undefined) {
 function redactedDatabaseBackupWarning(warning: DatabaseBackupHealthWarning): DatabaseBackupHealthWarning {
   const messages: Record<DatabaseBackupHealthWarning["code"], string> = {
     database_backup_check_failed: "Database backup health check failed.",
+    database_backup_empty: "Latest database backup is empty.",
     database_backup_last_failure: "Database backup failure marker is present.",
     database_backup_missing: "No recent database backup was found.",
     database_backup_stale: "Latest database backup is stale.",

--- a/server/src/routes/openapi.ts
+++ b/server/src/routes/openapi.ts
@@ -1749,6 +1749,7 @@ registry.registerPath({
                 mtime: z.string().datetime(),
                 ageHours: z.number(),
                 sizeBytes: z.number(),
+                empty: z.boolean(),
               })
               .nullable()
               .optional(),
@@ -1764,6 +1765,7 @@ registry.registerPath({
               z.object({
                 code: z.enum([
                   "database_backup_check_failed",
+                  "database_backup_empty",
                   "database_backup_last_failure",
                   "database_backup_missing",
                   "database_backup_stale",

--- a/server/src/services/database-backup-health.test.ts
+++ b/server/src/services/database-backup-health.test.ts
@@ -1,0 +1,50 @@
+import { gzipSync } from "node:zlib";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { inspectDatabaseBackupHealth } from "./database-backup-health.js";
+
+describe("inspectDatabaseBackupHealth", () => {
+  let dir: string | undefined;
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+    dir = undefined;
+  });
+
+  // Regression for REVIP-8079: an aborted backup run left a valid but
+  // empty .sql.gz (gzip of zero bytes) that passed every existing check.
+  it("warns and reports non-ok status for an empty .sql.gz", () => {
+    dir = mkdtempSync(join(tmpdir(), "db-backup-health-"));
+    writeFileSync(join(dir, "paperclip-20260911-135047.sql.gz"), gzipSync(Buffer.from("")));
+
+    const result = inspectDatabaseBackupHealth({
+      enabled: true,
+      backupDir: dir,
+      maxAgeHours: 26,
+    });
+
+    expect(result.status).toBe("warning");
+    expect(result.warnings.map((w) => w.code)).toContain("database_backup_empty");
+    expect(result.latestBackup?.uncompressedSizeBytes).toBe(0);
+  });
+
+  it("reports ok for a complete, non-empty archive", () => {
+    dir = mkdtempSync(join(tmpdir(), "db-backup-health-"));
+    writeFileSync(
+      join(dir, "paperclip-20260911-125024.sql.gz"),
+      gzipSync(Buffer.from("CREATE TABLE example (id integer);")),
+    );
+
+    const result = inspectDatabaseBackupHealth({
+      enabled: true,
+      backupDir: dir,
+      maxAgeHours: 26,
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.warnings).toEqual([]);
+    expect(result.latestBackup?.uncompressedSizeBytes).toBe(34);
+  });
+});

--- a/server/src/services/database-backup-health.test.ts
+++ b/server/src/services/database-backup-health.test.ts
@@ -27,7 +27,7 @@ describe("inspectDatabaseBackupHealth", () => {
 
     expect(result.status).toBe("warning");
     expect(result.warnings.map((w) => w.code)).toContain("database_backup_empty");
-    expect(result.latestBackup?.uncompressedSizeBytes).toBe(0);
+    expect(result.latestBackup?.empty).toBe(true);
   });
 
   it("reports ok for a complete, non-empty archive", () => {
@@ -45,6 +45,6 @@ describe("inspectDatabaseBackupHealth", () => {
 
     expect(result.status).toBe("ok");
     expect(result.warnings).toEqual([]);
-    expect(result.latestBackup?.uncompressedSizeBytes).toBe(34);
+    expect(result.latestBackup?.empty).toBe(false);
   });
 });

--- a/server/src/services/database-backup-health.ts
+++ b/server/src/services/database-backup-health.ts
@@ -1,8 +1,9 @@
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { closeSync, existsSync, openSync, readdirSync, readFileSync, readSync, statSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
 
 export type DatabaseBackupHealthWarningCode =
   | "database_backup_check_failed"
+  | "database_backup_empty"
   | "database_backup_last_failure"
   | "database_backup_missing"
   | "database_backup_stale";
@@ -23,6 +24,7 @@ export type DatabaseBackupHealthStatus = {
     mtime: string;
     ageHours: number;
     sizeBytes: number;
+    uncompressedSizeBytes: number;
   } | null;
   lastFailure: {
     path: string;
@@ -78,6 +80,23 @@ function readLastFailure(alertFiles: string[]) {
   };
 }
 
+// gzip stores the uncompressed size mod 2^32 in the last 4 bytes of the
+// stream (RFC 1952 ISIZE). A backup that never received real content
+// (e.g. an aborted run) is a valid, small gzip stream whose ISIZE is 0 -
+// that case is otherwise indistinguishable from a healthy backup by
+// looking only at the compressed file size.
+function readGzipUncompressedSize(filePath: string, compressedSizeBytes: number): number {
+  if (compressedSizeBytes < 18) return -1;
+  const fd = openSync(filePath, "r");
+  try {
+    const trailer = Buffer.alloc(4);
+    readSync(fd, trailer, 0, 4, compressedSizeBytes - 4);
+    return trailer.readUInt32LE(0);
+  } finally {
+    closeSync(fd);
+  }
+}
+
 function findLatestBackup(backupDir: string, nowMs: number) {
   if (!existsSync(backupDir)) return null;
 
@@ -99,6 +118,7 @@ function findLatestBackup(backupDir: string, nowMs: number) {
     mtime: new Date(latest.stat.mtimeMs).toISOString(),
     ageHours: roundHours((nowMs - latest.stat.mtimeMs) / 3_600_000),
     sizeBytes: latest.stat.size,
+    uncompressedSizeBytes: readGzipUncompressedSize(latest.fullPath, latest.stat.size),
   };
 }
 
@@ -121,11 +141,21 @@ export function inspectDatabaseBackupHealth(
         code: "database_backup_missing",
         message: `No .sql.gz database backups found in ${opts.backupDir}.`,
       });
-    } else if (latestBackup.ageHours > maxAgeHours) {
-      warnings.push({
-        code: "database_backup_stale",
-        message: `Latest database backup is ${latestBackup.ageHours}h old, exceeding ${maxAgeHours}h.`,
-      });
+    } else {
+      if (latestBackup.uncompressedSizeBytes <= 0) {
+        warnings.push({
+          code: "database_backup_empty",
+          message:
+            `Latest database backup ${latestBackup.name} decompresses to ` +
+            `${latestBackup.uncompressedSizeBytes} bytes; expected a non-empty SQL dump.`,
+        });
+      }
+      if (latestBackup.ageHours > maxAgeHours) {
+        warnings.push({
+          code: "database_backup_stale",
+          message: `Latest database backup is ${latestBackup.ageHours}h old, exceeding ${maxAgeHours}h.`,
+        });
+      }
     }
 
     if (lastFailure) {

--- a/server/src/services/database-backup-health.ts
+++ b/server/src/services/database-backup-health.ts
@@ -1,5 +1,6 @@
 import { closeSync, existsSync, openSync, readdirSync, readFileSync, readSync, statSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
+import { gunzipSync } from "node:zlib";
 
 export type DatabaseBackupHealthWarningCode =
   | "database_backup_check_failed"
@@ -24,7 +25,7 @@ export type DatabaseBackupHealthStatus = {
     mtime: string;
     ageHours: number;
     sizeBytes: number;
-    uncompressedSizeBytes: number;
+    empty: boolean;
   } | null;
   lastFailure: {
     path: string;
@@ -85,15 +86,25 @@ function readLastFailure(alertFiles: string[]) {
 // (e.g. an aborted run) is a valid, small gzip stream whose ISIZE is 0 -
 // that case is otherwise indistinguishable from a healthy backup by
 // looking only at the compressed file size.
-function readGzipUncompressedSize(filePath: string, compressedSizeBytes: number): number {
-  if (compressedSizeBytes < 18) return -1;
+function readGzipIsEmpty(filePath: string, compressedSizeBytes: number): boolean {
+  if (compressedSizeBytes < 18) return false;
   const fd = openSync(filePath, "r");
   try {
     const trailer = Buffer.alloc(4);
     readSync(fd, trailer, 0, 4, compressedSizeBytes - 4);
-    return trailer.readUInt32LE(0);
+    if (trailer.readUInt32LE(0) !== 0) return false;
   } finally {
     closeSync(fd);
+  }
+
+  // ISIZE is stored modulo 2^32. Confirm a zero trailer by inflating at most
+  // one byte so a non-empty archive whose size wraps to zero is not reported
+  // as empty. zlib stops as soon as the output limit is exceeded.
+  try {
+    return gunzipSync(readFileSync(filePath), { maxOutputLength: 1 }).length === 0;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ERR_BUFFER_TOO_LARGE") return false;
+    throw error;
   }
 }
 
@@ -118,7 +129,7 @@ function findLatestBackup(backupDir: string, nowMs: number) {
     mtime: new Date(latest.stat.mtimeMs).toISOString(),
     ageHours: roundHours((nowMs - latest.stat.mtimeMs) / 3_600_000),
     sizeBytes: latest.stat.size,
-    uncompressedSizeBytes: readGzipUncompressedSize(latest.fullPath, latest.stat.size),
+    empty: readGzipIsEmpty(latest.fullPath, latest.stat.size),
   };
 }
 
@@ -142,12 +153,10 @@ export function inspectDatabaseBackupHealth(
         message: `No .sql.gz database backups found in ${opts.backupDir}.`,
       });
     } else {
-      if (latestBackup.uncompressedSizeBytes <= 0) {
+      if (latestBackup.empty) {
         warnings.push({
           code: "database_backup_empty",
-          message:
-            `Latest database backup ${latestBackup.name} decompresses to ` +
-            `${latestBackup.uncompressedSizeBytes} bytes; expected a non-empty SQL dump.`,
+          message: `Latest database backup ${latestBackup.name} contains no uncompressed data.`,
         });
       }
       if (latestBackup.ageHours > maxAgeHours) {


### PR DESCRIPTION
## Summary
- Backup health gate previously reported a 0-byte-decompressed `.sql.gz` as OK; this flags it as a failure.
- Prepared fast-forward commit d280e28f5b9623db885268259576483ae35c237e on top of remote master 30aa3740babaa442dd4d507e08a9d58aa8b6bddb.

Opened from a fork because the pushing account (rendedennis6-byte) has fork-push access but not direct write access to paperclipai/paperclip.

Source issue: REVIP-8079 / REVIP-8123 / REVIP-8376 (internal tracking, not GitHub-visible).