### PR TITLE
fix(recovery): stop routine disposition recovery from starting work

### DIFF
--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -5838,12 +5838,14 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     expect(runs).toHaveLength(1);
   });
 
-  it("preserves productive continuation for a routine execution after fresh owner work", async () => {
-    const { agentId, runId, issueId } = await seedStrandedIssueFixture({
-      status: "in_progress",
-      runStatus: "succeeded",
-      livenessState: "advanced",
-    });
+  it("preserves productive continuation when fresh owner direction precedes its asynchronous wake", async () => {
+    const { companyId, agentId, runId, issueId } =
+      await seedStrandedIssueFixture({
+        status: "in_progress",
+        runStatus: "succeeded",
+        livenessState: "advanced",
+      });
+    const recoveryRunAt = new Date(Date.now() - 1_000);
     await db
       .update(issues)
       .set({
@@ -5857,11 +5859,25 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
         contextSnapshot: {
           issueId,
           taskId: issueId,
-          wakeReason: "issue_commented",
-          source: "issue.comment",
+          wakeReason: "source_scoped_recovery_action",
+          recoveryActionId: randomUUID(),
+          recoveryCause: SUCCESSFUL_RUN_MISSING_STATE_REASON,
+          recoveryIntent: "status_only",
+          allowDeliverableWork: false,
+          allowDocumentUpdates: false,
+          resumeRequiresNormalModel: true,
         },
+        createdAt: recoveryRunAt,
       })
       .where(eq(heartbeatRuns.id, runId));
+    await db.insert(issueComments).values({
+      companyId,
+      issueId,
+      authorType: "user",
+      authorUserId: "local-board",
+      body: "Continue with this new owner instruction.",
+      createdAt: new Date(recoveryRunAt.getTime() + 500),
+    });
 
     const result =
       await heartbeatService(db).reconcileStrandedAssignedIssues();

--- a/server/src/__tests__/heartbeat-process-recovery.test.ts
+++ b/server/src/__tests__/heartbeat-process-recovery.test.ts
@@ -5775,6 +5775,112 @@ describeEmbeddedPostgres("heartbeat orphaned process recovery", () => {
     });
   });
 
+  it("blocks routine execution after successful missing-disposition recovery instead of starting productive continuation", async () => {
+    const { companyId, agentId, runId, issueId } =
+      await seedStrandedIssueFixture({
+        status: "in_progress",
+        runStatus: "succeeded",
+        livenessState: "advanced",
+      });
+    const sourceRunId = randomUUID();
+    await db
+      .update(issues)
+      .set({
+        originKind: "routine_execution",
+        originId: randomUUID(),
+      })
+      .where(eq(issues.id, issueId));
+    await db
+      .update(heartbeatRuns)
+      .set({
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "source_scoped_recovery_action",
+          recoveryActionId: randomUUID(),
+          recoveryCause: SUCCESSFUL_RUN_MISSING_STATE_REASON,
+          sourceRunId,
+          recoveryIntent: "status_only",
+          allowDeliverableWork: false,
+          allowDocumentUpdates: false,
+          resumeRequiresNormalModel: true,
+        },
+      })
+      .where(eq(heartbeatRuns.id, runId));
+
+    const result =
+      await heartbeatService(db).reconcileStrandedAssignedIssues();
+
+    expect(result.continuationRequeued).toBe(0);
+    expect(result.successfulRunHandoffEscalated).toBe(1);
+    expect(result.issueIds).toEqual([issueId]);
+    expect(
+      await db
+        .select()
+        .from(issues)
+        .where(eq(issues.id, issueId))
+        .then((rows) => rows[0]?.status),
+    ).toBe("blocked");
+    await expectSourceScopedStrandedRecoveryAction({
+      companyId,
+      agentId,
+      issueId,
+      runId,
+      previousStatus: "in_progress",
+      retryReason: null,
+      cause: SUCCESSFUL_RUN_MISSING_STATE_REASON,
+      kind: "missing_disposition",
+    });
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(1);
+  });
+
+  it("preserves productive continuation for a routine execution after fresh owner work", async () => {
+    const { agentId, runId, issueId } = await seedStrandedIssueFixture({
+      status: "in_progress",
+      runStatus: "succeeded",
+      livenessState: "advanced",
+    });
+    await db
+      .update(issues)
+      .set({
+        originKind: "routine_execution",
+        originId: randomUUID(),
+      })
+      .where(eq(issues.id, issueId));
+    await db
+      .update(heartbeatRuns)
+      .set({
+        contextSnapshot: {
+          issueId,
+          taskId: issueId,
+          wakeReason: "issue_commented",
+          source: "issue.comment",
+        },
+      })
+      .where(eq(heartbeatRuns.id, runId));
+
+    const result =
+      await heartbeatService(db).reconcileStrandedAssignedIssues();
+
+    expect(result.continuationRequeued).toBe(1);
+    expect(result.successfulRunHandoffEscalated).toBe(0);
+    const runs = await db
+      .select()
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.agentId, agentId));
+    expect(runs).toHaveLength(2);
+    expect(
+      runs.find((run) => run.id !== runId)?.contextSnapshot,
+    ).toMatchObject({
+      issueId,
+      source: "issue.productive_terminal_continuation_recovery",
+    });
+  });
+
   it("converts a continuation parked for review into a dependency wait on its open sub-tasks", async () => {
     const { companyId, agentId, issueId } = await seedStrandedIssueFixture({
       status: "in_progress",

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -752,6 +752,55 @@ function isExhaustedSuccessfulRunHandoff(latestRun: LatestIssueRun) {
   return { ...evidence, exhausted: true };
 }
 
+function routineMissingDispositionRecoveryEvidence(
+  issue: Pick<typeof issues.$inferSelect, "originKind">,
+  latestRun: LatestIssueRun,
+) {
+  // A status-only recovery may succeed without resolving the routine item.
+  // Treat that lineage as exhausted so it cannot become productive work.
+  if (
+    issue.originKind !== "routine_execution" ||
+    latestRun?.status !== "succeeded"
+  )
+    return null;
+
+  const context = parseObject(latestRun.contextSnapshot);
+  const paperclipWake = parseObject(context.paperclipWake);
+  const recovery = parseObject(paperclipWake.recovery);
+  const wakeReason =
+    readNonEmptyString(context.wakeReason) ??
+    readNonEmptyString(paperclipWake.reason);
+  const recoveryCause =
+    readNonEmptyString(context.recoveryCause) ??
+    readNonEmptyString(recovery.cause);
+  const isRecoveryActionRun =
+    wakeReason === "source_scoped_recovery_action" ||
+    readNonEmptyString(context.recoveryActionId) !== null;
+  const isMissingDispositionRecovery =
+    recoveryCause === SUCCESSFUL_RUN_MISSING_STATE_REASON ||
+    recoveryCause === "successful_run_missing_issue_disposition";
+  if (!isRecoveryActionRun || !isMissingDispositionRecovery) return null;
+
+  return {
+    sourceRunId:
+      readNonEmptyString(context.sourceRunId) ??
+      readNonEmptyString(context.resumeFromRunId) ??
+      readNonEmptyString(context.retryOfRunId),
+    correctiveRunId: latestRun.id,
+    missingDisposition:
+      readNonEmptyString(context.missingDisposition) ?? "clear_next_step",
+    handoffAttempt: Math.max(1, asNumber(context.handoffAttempt, 1)),
+    maxHandoffAttempts: Math.max(
+      1,
+      asNumber(
+        context.maxHandoffAttempts,
+        DEFAULT_MAX_SUCCESSFUL_RUN_HANDOFF_ATTEMPTS,
+      ),
+    ),
+    exhausted: true,
+  };
+}
+
 function issueIdFromRunContext(contextSnapshot: unknown) {
   const context = parseObject(contextSnapshot);
   return (
@@ -4938,7 +4987,9 @@ export function recoveryService(
         }
         continue;
       }
-      const handoffEvidence = isExhaustedSuccessfulRunHandoff(latestRun);
+      const handoffEvidence =
+        isExhaustedSuccessfulRunHandoff(latestRun) ??
+        routineMissingDispositionRecoveryEvidence(issue, latestRun);
       if (handoffEvidence) {
         if (isPluginManagedIssueLifecycle(issue)) {
           result.skipped += 1;

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -6,6 +6,7 @@ import {
   gt,
   gte,
   inArray,
+  isNotNull,
   isNull,
   not,
   notInArray,
@@ -1020,6 +1021,28 @@ export function recoveryService(
       .orderBy(desc(heartbeatRuns.createdAt), desc(heartbeatRuns.id))
       .limit(1)
       .then((rows) => rows[0] ?? null);
+  }
+
+  async function hasFreshUserDirectionAfterRun(
+    issue: Pick<typeof issues.$inferSelect, "companyId" | "id">,
+    latestRun: NonNullable<LatestIssueRun>,
+  ) {
+    return db
+      .select({ id: issueComments.id })
+      .from(issueComments)
+      .where(
+        and(
+          eq(issueComments.companyId, issue.companyId),
+          eq(issueComments.issueId, issue.id),
+          isNotNull(issueComments.authorUserId),
+          isNull(issueComments.authorAgentId),
+          isNull(issueComments.createdByRunId),
+          isNull(issueComments.deletedAt),
+          gt(issueComments.createdAt, latestRun.createdAt),
+        ),
+      )
+      .limit(1)
+      .then((rows) => Boolean(rows[0]));
   }
 
   async function summarizeRecentContinuationRetries(
@@ -4987,9 +5010,17 @@ export function recoveryService(
         }
         continue;
       }
-      const handoffEvidence =
-        isExhaustedSuccessfulRunHandoff(latestRun) ??
+      const exhaustedHandoffEvidence =
+        isExhaustedSuccessfulRunHandoff(latestRun);
+      const routineRecoveryEvidence =
         routineMissingDispositionRecoveryEvidence(issue, latestRun);
+      const hasFreshUserDirection =
+        routineRecoveryEvidence && latestRun
+          ? await hasFreshUserDirectionAfterRun(issue, latestRun)
+          : false;
+      const handoffEvidence =
+        exhaustedHandoffEvidence ??
+        (hasFreshUserDirection ? null : routineRecoveryEvidence);
       if (handoffEvidence) {
         if (isPluginManagedIssueLifecycle(issue)) {
           result.skipped += 1;


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Recovery keeps assigned issues aligned with completed agent runs.
> - A successful routine run can finish without a required issue disposition.
> - Paperclip then uses a source-scoped recovery action to request only that disposition.
> - A successful status-only recovery can still leave the routine issue in progress.
> - The stranded-issue classifier then starts a normal productive continuation from that recovery run.
> - This pull request treats that exact lineage as an exhausted handoff.
> - The benefit is that routine recovery stops for an owner decision instead of starting unrelated agent work.

## Linked Issues or Issue Description

- Refs #7496
- Refs #11141
- Refs #9010
- Related open approaches: #6398, #8434, and #12216

## What Changed

- Detect a successful source-scoped missing-disposition recovery for a `routine_execution` issue.
- Route that lineage through the existing exhausted-handoff escalation.
- Keep fresh owner work eligible for normal productive continuation.
- Add integration tests for the blocked recovery path and the fresh-owner boundary.

## Verification

- Reproduced the bug before the fix. The focused test received one productive continuation instead of zero.
- Ran `corepack pnpm --filter @paperclipai/server exec vitest run src/__tests__/heartbeat-process-recovery.test.ts`. All 286 tests passed.
- Ran `corepack pnpm --filter @paperclipai/server exec vitest run src/services/recovery/successful-run-handoff.test.ts`. All 33 tests passed.
- Built `@paperclipai/plugin-sdk` dependencies and ran `server/node_modules/.bin/tsc --noEmit`. The type check passed.
- The standard server type-check wrapper reached the unchanged Rust runner build. It could not continue because this environment has no `cargo` binary.

## Risks

- Risk is low. The classifier requires a routine origin, a successful recovery-action run, and a missing-disposition recovery cause.
- Ordinary issues and fresh owner comments keep the existing continuation behavior.
- This change has no schema, API, or configuration migration.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex with GPT-5. The exact deployment revision was not available in the session metadata. The model used agentic tool use, repository search, code execution, and test execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes (No documentation change is required.)
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
