### PR TITLE
fix: preserve native Goal authority during recovery

### DIFF
--- a/packages/paperclip-runner/src/contracts/harness-driver.ts
+++ b/packages/paperclip-runner/src/contracts/harness-driver.ts
@@ -415,7 +415,8 @@ export type HarnessGoalOperation =
       action: "set";
       objective: string;
       tokenBudget?: number | null;
-      status?: HarnessThreadGoal["status"];
+      /** Null preserves the provider's current lifecycle status. */
+      status?: HarnessThreadGoal["status"] | null;
       requestId?: string;
     }
   | { action: "pause" | "resume" | "clear"; requestId?: string };

--- a/packages/paperclip-runner/src/drivers/codex/codex-app-server-driver.test.ts
+++ b/packages/paperclip-runner/src/drivers/codex/codex-app-server-driver.test.ts
@@ -1871,6 +1871,34 @@ describe("Codex app-server Codex driver", () => {
     await session.close({ reason: "fixture complete" });
   });
 
+  it("omits status from a partial goal update", async () => {
+    const transport = new FakeCodexTransport();
+    const session = await makeDriver([transport]).openSession({
+      runId: "run-goal-budget-edit",
+      normalizedSessionId: "normalized-goal-budget-edit",
+      workingDirectory: TEST_WORKING_DIRECTORY,
+    });
+
+    await session.goal?.({
+      action: "set",
+      objective: "Continue after raising the budget",
+      status: null,
+      tokenBudget: 100_000,
+    });
+
+    expect(
+      transport.calls.filter(({ method }) => method === "thread/goal/set"),
+    ).toContainEqual({
+      method: "thread/goal/set",
+      params: {
+        threadId: "thread-1",
+        objective: "Continue after raising the budget",
+        tokenBudget: 100_000,
+      },
+    });
+    await session.close({ reason: "fixture complete" });
+  });
+
   it("rolls back only a definitely rejected idle goal autostart", async () => {
     const definiteTransport = new FakeCodexTransport();
     const definiteSession = await makeDriver([definiteTransport]).openSession({

--- a/packages/paperclip-runner/src/drivers/codex/codex-harness-session.ts
+++ b/packages/paperclip-runner/src/drivers/codex/codex-harness-session.ts
@@ -548,7 +548,9 @@ export class CodexHarnessSession
         params = {
           ...params,
           objective: input.objective,
-          status: input.status ?? "active",
+          ...(input.status === null
+            ? {}
+            : { status: input.status ?? "active" }),
           ...(input.tokenBudget !== undefined
             ? { tokenBudget: input.tokenBudget }
             : {}),

--- a/packages/paperclip-runner/src/native-session-runtime.test.ts
+++ b/packages/paperclip-runner/src/native-session-runtime.test.ts
@@ -1913,6 +1913,60 @@ describe("executeNativeSession recovery", () => {
     expect(openSession).not.toHaveBeenCalled();
   });
 
+  it("does not create a replacement provider session when exact Goal continuity has no checkpoint", async () => {
+    const openSession = vi.fn();
+    const loadSessionCheckpoint = vi.fn(async () => null);
+    const backend: NativeSessionBackend = {
+      async descriptor() {
+        return {
+          kind: "mock",
+          name: "missing-goal-checkpoint",
+          version: "1",
+          capabilities: {
+            resume: true,
+            typedEvents: true,
+            steering: false,
+            interruption: true,
+            structuredResult: true,
+          },
+        };
+      },
+      openSession,
+    };
+    const port: ControlPlanePort = {
+      loadSessionCheckpoint,
+      async openRun() {
+        throw new Error("a checkpoint-less Goal dispatch must not open a run");
+      },
+      async appendEvent() {
+        throw new Error("unexpected event");
+      },
+      async replayEvents() {
+        return { events: [], highestContiguousSourceSeq: 0 };
+      },
+      async completeRun() {},
+    };
+
+    await expect(
+      executeNativeSession({
+        input,
+        backend,
+        controlPlane: port,
+        runnerInstanceId: "runner-recovery",
+        controlPlaneInstanceId: "control-recovery",
+        sessionGoalControl: {
+          requestId: "goal-edit-after-failed-rotation",
+          action: "edit",
+          tokenBudget: 100_000,
+        },
+        requirePersistedSession: true,
+      }),
+    ).rejects.toThrow("native_session_required_checkpoint_missing");
+
+    expect(loadSessionCheckpoint).toHaveBeenCalledOnce();
+    expect(openSession).not.toHaveBeenCalled();
+  });
+
   it("does not admit a fresh run when provider session initialization fails", async () => {
     const providerFailure = new Error("provider initialization failed");
     const openSession = vi.fn(async () => {

--- a/packages/paperclip-runner/src/native-session-runtime.test.ts
+++ b/packages/paperclip-runner/src/native-session-runtime.test.ts
@@ -26,6 +26,7 @@ import {
   nativeRuntimePromptDigest,
 } from "./contracts/runtime-context.js";
 import {
+  applyNativeSessionGoalControl,
   executeNativeSession,
   type ExecuteNativeSessionOptions,
 } from "./native-session-runtime.js";
@@ -200,6 +201,45 @@ function highestContiguous(events: PrpEvent[]): number {
 }
 
 describe("executeNativeSession recovery", () => {
+  it("edits a budget-limited Goal without replaying its terminal status", async () => {
+    const currentGoal = {
+      threadId: "provider-recovery",
+      objective: "Old objective",
+      status: "budgetLimited" as const,
+      tokenBudget: 12_000,
+      tokensUsed: 20_283,
+      timeUsedSeconds: 23,
+      createdAt: Date.parse("2026-08-09T00:00:00.000Z"),
+      updatedAt: Date.parse("2026-08-09T00:00:23.000Z"),
+    };
+    const editedGoal = {
+      ...currentGoal,
+      objective: "Continue the fixture",
+      status: "active" as const,
+      tokenBudget: 100_000,
+    };
+    const goal = vi.fn<NativeSession["goal"]>(async (operation) =>
+      operation.action === "get" ? currentGoal : editedGoal,
+    );
+    const session = { goal } as unknown as NativeSession;
+
+    await expect(applyNativeSessionGoalControl(session, {
+      requestId: "raise-budget",
+      action: "edit",
+      objective: "Continue the fixture",
+      tokenBudget: 100_000,
+    })).resolves.toEqual(editedGoal);
+
+    expect(goal).toHaveBeenNthCalledWith(1, { action: "get" });
+    expect(goal).toHaveBeenNthCalledWith(2, {
+      action: "set",
+      objective: "Continue the fixture",
+      status: null,
+      requestId: "raise-budget",
+      tokenBudget: 100_000,
+    });
+  });
+
   it.each([false, true])("preserves a durable session failure when its stream closes (throws=%s)", async throws => {
     const capabilities = { resume: true, typedEvents: true, steering: false, interruption: true, structuredResult: true };
     const session: NativeSession = {

--- a/packages/paperclip-runner/src/native-session-runtime.ts
+++ b/packages/paperclip-runner/src/native-session-runtime.ts
@@ -1329,11 +1329,16 @@ export async function applyNativeSessionGoalControl(
   if (control.action === "replace") {
     await session.goal({ action: "clear", requestId: control.requestId });
   }
-  let status: HarnessThreadGoal["status"] = "active";
+  let status: HarnessThreadGoal["status"] | null = "active";
   if (control.action === "edit") {
     const current = await session.goal({ action: "get" });
     if (!current) throw new Error("native_session_goal_not_found");
-    status = current.status === "complete" ? "active" : current.status;
+    // An edit is a partial update. In particular, forwarding a terminal
+    // budgetLimited/usageLimited status back to Codex prevents a larger
+    // budget from reactivating the Goal. Preserve the caller's omission and
+    // let thread/goal/set derive the lifecycle transition from the edited
+    // objective or budget.
+    status = null;
   }
   return session.goal({
     action: "set",

--- a/packages/paperclip-runner/src/native-session-runtime.ts
+++ b/packages/paperclip-runner/src/native-session-runtime.ts
@@ -150,6 +150,8 @@ export interface ExecuteNativeSessionOptions {
   onSessionQuarantined?: (reason: string) => Promise<void> | void;
   existingSession?: NativeSession;
   persistedSession?: PersistedNativeSession | null;
+  /** Refuse fresh provider creation when the caller requires exact continuity. */
+  requirePersistedSession?: boolean;
   keepSessionOpen?: boolean;
   /** Apply a structured session-goal control instead of starting an ordinary turn. */
   sessionGoalControl?: NativeSessionGoalControl | null;
@@ -1766,6 +1768,13 @@ export async function executeNativeSession(
       persistedSession.identity.sessionId !== input.session.normalizedSessionId)
   )
     throw new Error("native_session_checkpoint_binding_mismatch");
+  if (
+    options.requirePersistedSession &&
+    !options.existingSession &&
+    !persistedSession
+  ) {
+    throw new Error("native_session_required_checkpoint_missing");
+  }
   const existingIdentity = options.existingSession?.identity() ?? null;
   if (
     existingIdentity &&

--- a/server/src/__tests__/native-session-resumption.test.ts
+++ b/server/src/__tests__/native-session-resumption.test.ts
@@ -6,6 +6,7 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { eq, inArray } from "drizzle-orm";
 import {
   activityLog,
+  agentTaskSessions,
   agentWakeupRequests,
   agents,
   companies,
@@ -44,6 +45,7 @@ import {
   claimNativeSessionResumptions,
   dispatchNativeSessionResumptions,
 } from "../services/native-runtime/native-finalization-reconciler.js";
+import { nativeToolContractFingerprintForTarget } from "../services/native-runtime/native-session-resume.js";
 
 const legacyAdapterExecute = vi.hoisted(() => vi.fn(async () => ({
   exitCode: 0,
@@ -1368,6 +1370,368 @@ describe.each(["unchanged", "newer_active", "stale_idle"] as const)(
           }),
         }),
       ]);
+    }, 30_000);
+  },
+);
+
+describe.each(["failed_rotation_binding", "provider_config_drift"] as const)(
+  "native Goal offline-control persisted-input guard (%s)",
+  (variant) => {
+    it("fails before the provider backend when exact Goal continuity is unavailable", async () => {
+      const temporary = await startEmbeddedPostgresTestDatabase(
+        "paperclip-native-goal-offline-control-",
+      );
+      const db = createDb(temporary.connectionString);
+      let heartbeat: ReturnType<typeof heartbeatService> | null = null;
+      try {
+        const companyId = randomUUID();
+        const agentId = randomUUID();
+        const projectId = randomUUID();
+        const projectWorkspaceId = randomUUID();
+        const executionWorkspaceId = randomUUID();
+        const issueId = randomUUID();
+        const sourceRunId = randomUUID();
+        const failedRotationRunId = randomUUID();
+        const currentRunId = randomUUID();
+        const sourceSessionId = randomUUID();
+        const failedRotationSessionId = randomUUID();
+        const runnerInstanceId = randomUUID();
+        const contractId = randomUUID();
+        const requestId = randomUUID();
+        const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
+        const contract = {
+          revision: "native-goal-offline-control-v1",
+          objective: "Keep the established Goal on its exact provider session",
+          criteria: [
+            {
+              id: "continuity",
+              requirement: "Resume without creating a replacement provider session",
+            },
+          ],
+        };
+        const contractSha = "native-goal-offline-control-contract";
+        const buildExecution = (
+          runId: string,
+          sessionId: string,
+          model: string | null,
+        ): NativeExecutionInputV1 => ({
+          schema: "paperclip.native-execution-input.v1",
+          binding: {
+            companyId,
+            runId,
+            issueId,
+            agentId,
+            executionWorkspaceId,
+          },
+          task: {
+            identifier: "NGO-1",
+            title: "Resume an offline Goal control",
+            description: null,
+            prompt: "Apply only the pending Goal control.",
+            workMode: "standard",
+          },
+          workspace: {
+            cwd: repoRoot,
+            repoUrl: null,
+            repoRef: null,
+            branchName: null,
+          },
+          session: {
+            normalizedSessionId: sessionId,
+            driverKind: "codex_app_server",
+            protocolVersion: 1,
+          },
+          provider: { kind: "codex", model },
+          completionContract: {
+            id: contractId,
+            sha256: contractSha,
+            schemaVersion: "paperclip.completion-contract.v1",
+            contract,
+          },
+          interactionResponses: [],
+          credentialBindings: [],
+        });
+        const sourceExecution = buildExecution(
+          sourceRunId,
+          sourceSessionId,
+          null,
+        );
+        const currentExecution = buildExecution(
+          currentRunId,
+          variant === "failed_rotation_binding"
+            ? failedRotationSessionId
+            : sourceSessionId,
+          variant === "provider_config_drift" ? "different-model" : null,
+        );
+        const sourceCheckpoint: PersistedNativeSession = {
+          backendKind: "mock",
+          sessionId: "driver-established-goal",
+          identity: {
+            companyId,
+            runId: sourceRunId,
+            issueId,
+            agentId,
+            sessionId: sourceSessionId,
+          },
+          providerSessionId: "provider-established-goal",
+          providerRecoveryPolicy: "same_session_only",
+          cursor: "1",
+          activeTurnId: null,
+          semanticResult: null,
+          terminal: null,
+          terminalTurns: [],
+          pendingRuntimeRequests: [],
+          goal: {
+            threadId: "provider-established-goal",
+            objective: "Complete the isolated native Goal fixture",
+            status: "budgetLimited",
+            tokenBudget: 12_000,
+            tokensUsed: 20_283,
+            timeUsedSeconds: 120,
+            createdAt: 1,
+            updatedAt: 2,
+          },
+          lineage: [],
+        };
+
+        await db.insert(companies).values({
+          id: companyId,
+          name: "Native Goal offline control",
+          issuePrefix: "NGO",
+          status: "active",
+          defaultResponsibleUserId: "responsible-user",
+        });
+        await db.insert(projects).values({
+          id: projectId,
+          companyId,
+          name: "Native Goal project",
+          status: "active",
+        });
+        await db.insert(projectWorkspaces).values({
+          id: projectWorkspaceId,
+          companyId,
+          projectId,
+          name: "Native Goal source workspace",
+          cwd: repoRoot,
+          isPrimary: true,
+        });
+        await db.insert(agents).values({
+          id: agentId,
+          companyId,
+          name: "Native Goal runner",
+          adapterType: "paperclip_runner",
+          adapterConfig: { workspaceStrategy: { type: "project_primary" } },
+          status: "active",
+          runtimeConfig: {
+            heartbeat: { wakeOnDemand: true, maxConcurrentRuns: 1 },
+            nativeRunner: {
+              mode: "native",
+              backend: "codex_app_server",
+              protocolVersion: 1,
+            },
+          },
+        });
+        await db.insert(issues).values({
+          id: issueId,
+          companyId,
+          projectId,
+          projectWorkspaceId,
+          issueNumber: 1,
+          identifier: "NGO-1",
+          title: "Resume an offline Goal control",
+          status: "in_progress",
+          assigneeAgentId: agentId,
+          workMode: "standard",
+        });
+        await db.insert(executionWorkspaces).values({
+          id: executionWorkspaceId,
+          companyId,
+          projectId,
+          projectWorkspaceId,
+          sourceIssueId: issueId,
+          mode: "shared_workspace",
+          strategyType: "project_primary",
+          name: "Established Goal workspace",
+          status: "active",
+          cwd: repoRoot,
+          providerType: "local_fs",
+        });
+        await db
+          .update(issues)
+          .set({
+            executionWorkspaceId,
+            executionWorkspacePreference: "reuse_existing",
+            executionWorkspaceSettings: { mode: "shared_workspace" },
+          })
+          .where(eq(issues.id, issueId));
+        await db.insert(completionContracts).values({
+          id: contractId,
+          companyId,
+          issueId,
+          revision: 1,
+          schemaVersion: "paperclip.completion-contract.v1",
+          policyVersion: "native-goal-offline-control-v1",
+          risk: "standard",
+          completionAuthority: "server_arbiter",
+          incompleteCriteriaPolicy: "preserve_non_terminal",
+          contractJson: contract,
+          canonicalSha256: contractSha,
+          createdByActorType: "system",
+          createdByActorId: "test",
+        });
+        await db.insert(heartbeatRuns).values([
+          {
+            id: sourceRunId,
+            companyId,
+            agentId,
+            nativeIssueId: issueId,
+            status: "succeeded",
+            invocationSource: "on_demand",
+            runtimeMode: "native",
+            runtimeModeResolvedAt: new Date("2026-09-12T00:00:00.000Z"),
+            runnerProfileJson: {
+              mode: "native",
+              backend: "codex_app_server",
+              protocolVersion: 1,
+              nativeExecutionInput: sourceExecution,
+              sessionCheckpoint: sourceCheckpoint,
+              nativeToolContractFingerprint:
+                nativeToolContractFingerprintForTarget("local"),
+            },
+            runnerInstanceId,
+            nativeSessionId: sourceSessionId,
+            completionContractId: contractId,
+            completionContractSha256: contractSha,
+            createdAt: new Date("2026-09-12T00:00:00.000Z"),
+          },
+          {
+            id: failedRotationRunId,
+            companyId,
+            agentId,
+            nativeIssueId: issueId,
+            status: "failed",
+            invocationSource: "automation",
+            runtimeMode: "native",
+            runtimeModeResolvedAt: new Date("2026-09-12T00:01:00.000Z"),
+            runnerProfileJson: {
+              mode: "native",
+              backend: "codex_app_server",
+              protocolVersion: 1,
+              nativeExecutionInput: buildExecution(
+                failedRotationRunId,
+                failedRotationSessionId,
+                null,
+              ),
+            },
+            runnerInstanceId: randomUUID(),
+            nativeSessionId: failedRotationSessionId,
+            completionContractId: contractId,
+            completionContractSha256: contractSha,
+            createdAt: new Date("2026-09-12T00:01:00.000Z"),
+          },
+          {
+            id: currentRunId,
+            companyId,
+            agentId,
+            nativeIssueId: issueId,
+            status: "queued",
+            invocationSource: "automation",
+            triggerDetail: "system",
+            runtimeMode: "native",
+            runtimeModeResolvedAt: new Date("2026-09-12T00:02:00.000Z"),
+            runnerProfileJson: {
+              mode: "native",
+              backend: "codex_app_server",
+              protocolVersion: 1,
+              nativeExecutionInput: currentExecution,
+            },
+            completionContractId: contractId,
+            completionContractSha256: contractSha,
+            contextSnapshot: {
+              issueId,
+              taskKey: issueId,
+              resumeIntent: true,
+              goalControlRequestId: requestId,
+              runnerGoalControl: {
+                requestId,
+                action: "edit",
+                tokenBudget: 100_000,
+              },
+              skipIssueComment: true,
+            },
+            createdAt: new Date("2026-09-12T00:02:00.000Z"),
+          },
+        ]);
+        await db.insert(agentTaskSessions).values({
+          companyId,
+          agentId,
+          adapterType: "paperclip_runner",
+          taskKey: issueId,
+          sessionParamsJson: {
+            sessionId: failedRotationSessionId,
+            cwd: repoRoot,
+          },
+          sessionDisplayId: "provider-failed-rotation",
+          lastRunId: failedRotationRunId,
+          goalJson: {
+            objective: "Complete the isolated native Goal fixture",
+            status: "budget_limited",
+            tokenBudget: 12_000,
+            tokensUsed: 20_283,
+            elapsedSeconds: 120,
+            iterations: 2,
+            workingNow: false,
+          },
+          goalStatus: "budget_limited",
+          goalDesiredState: "active",
+          goalRevision: 12,
+          goalSourceId: `${runnerInstanceId}:${sourceRunId}`,
+          goalSourceCursor: 4,
+        });
+        await db
+          .update(issues)
+          .set({ executionRunId: currentRunId })
+          .where(eq(issues.id, issueId));
+        await instanceSettingsService(db).updateExperimental({
+          enableNativeRunner: true,
+        });
+
+        const backendFactory = vi.fn((): NativeSessionBackend => ({
+          async descriptor() {
+            throw new Error("provider backend must not be constructed");
+          },
+          async openSession() {
+            throw new Error("replacement provider session must not open");
+          },
+        }));
+        heartbeat = heartbeatService(db, {
+          runtimeEnv: { PAPERCLIP_INSTANCE_ID: "goal-offline-control-test" },
+          nativeSessionBackendFactory: backendFactory,
+        });
+
+        await heartbeat.resumeQueuedRuns();
+        await heartbeat.drainActiveRunExecutions();
+
+        expect(backendFactory).not.toHaveBeenCalled();
+        await expect(
+          db
+            .select()
+            .from(heartbeatRuns)
+            .where(eq(heartbeatRuns.id, currentRunId)),
+        ).resolves.toEqual([
+          expect.objectContaining({
+            status: "failed",
+            errorCode: "native_goal_resume_authority_unavailable",
+            nativeSessionId: null,
+          }),
+        ]);
+        await expect(
+          db.select().from(heartbeatRuns).where(eq(heartbeatRuns.agentId, agentId)),
+        ).resolves.toHaveLength(3);
+      } finally {
+        if (heartbeat) await heartbeat.drainActiveRunExecutions();
+        await temporary.cleanup();
+      }
     }, 30_000);
   },
 );

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -193,11 +193,14 @@ import {
   materializeNativeInteractionResponses,
   nativeCompletionRequestsForComments,
   NativeCancellationPendingRecoveryError,
+  NativeGoalResumeCheckpointUnavailableError,
+  nativeExecutionMatchesGoalResumeAnchor,
   nativeToolContractFingerprintForTarget,
   prepareNativeSessionBootstrapPersistence,
   prepareNativeWorkspaceSync,
   readNativeWorkspaceSyncReference,
   recordNativeFinalizationFailure,
+  resolveNativeTaskSessionResumeSeed,
   type NativeRestartRecoveryClaim,
   rebindNativeSessionCheckpoint,
   reconcileNativeFinalizations,
@@ -749,6 +752,8 @@ const WORKSPACE_VALIDATION_FAILURE_CODE = "workspace_validation_failed";
 const WORKSPACE_VALIDATION_RECOVERY_CAUSE = "workspace_validation_failed";
 const CONFIGURATION_INCOMPLETE_FAILURE_CODE = "configuration_incomplete";
 const CONFIGURATION_INCOMPLETE_RECOVERY_CAUSE = "configuration_incomplete";
+const NATIVE_GOAL_RESUME_UNAVAILABLE_CODE =
+  "native_goal_resume_authority_unavailable";
 const EXECUTION_REVIEW_PARTICIPANT_RECOVERY_RETRY_REASON =
   "execution_review_participant_recovery";
 const EXECUTION_REVIEW_PARTICIPANT_RECOVERY_WAKE_REASON =
@@ -764,6 +769,7 @@ const NON_RETRYABLE_PREFLIGHT_FAILURE_CODES = new Set<string>([
   "low_trust_requires_sandbox_environment",
   "low_trust_runtime_services_denied",
   "chat_failed_run_retry_not_authorized",
+  NATIVE_GOAL_RESUME_UNAVAILABLE_CODE,
   CHAT_CONTROL_RECOVERY_UNRESOLVED_CODE,
 ]);
 // Error codes that mark a pre-dispatch setup failure. The adapter process never
@@ -777,6 +783,8 @@ const PRE_ADAPTER_SETUP_FAILURE_CODES = new Set<string>([
 ]);
 
 function nonRetryablePreflightFailureCode(error: unknown): string | null {
+  if (error instanceof NativeGoalResumeCheckpointUnavailableError)
+    return NATIVE_GOAL_RESUME_UNAVAILABLE_CODE;
   if (error instanceof ChatControlRecoveryUnresolvedError)
     return CHAT_CONTROL_RECOVERY_UNRESOLVED_CODE;
   if (
@@ -789,6 +797,14 @@ function nonRetryablePreflightFailureCode(error: unknown): string | null {
   if (!(error instanceof HttpError) || error.status !== 422) return null;
   const code = readNonEmptyString(parseObject(error.details).code);
   return code && NON_RETRYABLE_PREFLIGHT_FAILURE_CODES.has(code) ? code : null;
+}
+
+function nativeGoalResumeUnavailable(reason: string) {
+  return new HttpError(
+    422,
+    "The established native session Goal cannot be resumed from its exact provider checkpoint and execution workspace. No replacement provider session was started.",
+    { code: NATIVE_GOAL_RESUME_UNAVAILABLE_CODE, reason },
+  );
 }
 class ChatControlRecoveryUnresolvedError extends Error {
   constructor() {
@@ -19776,10 +19792,14 @@ export function heartbeatService(
           : null;
       const persistedNativeExecutionWorkspaceId =
         persistedNativeExecutionInput?.binding.executionWorkspaceId ?? null;
+      const nativeGoalResumeWake = Boolean(
+        readNonEmptyString(context.goalControlRequestId) ||
+          context.resumeSessionGoalHeartbeat === true,
+      );
+      const nativeGoalResumeRequired =
+        nativeGoalResumeWake && taskSession?.goalJson != null;
       const nativeGoalResumeAnchor =
-        issueRef &&
-        (readNonEmptyString(context.goalControlRequestId) ||
-          context.resumeSessionGoalHeartbeat === true)
+        issueRef && nativeGoalResumeWake
           ? await findNativeGoalResumeAnchor(db, {
               goalSourceId: taskSession?.goalSourceId,
               companyId: agent.companyId,
@@ -19788,16 +19808,38 @@ export function heartbeatService(
               currentRunId: run.id,
             })
           : null;
+      if (nativeGoalResumeRequired && !nativeGoalResumeAnchor) {
+        throw nativeGoalResumeUnavailable("goal_source_binding_invalid");
+      }
+      if (
+        nativeGoalResumeRequired &&
+        persistedNativeExecutionInput &&
+        nativeGoalResumeAnchor &&
+        !nativeExecutionMatchesGoalResumeAnchor({
+          execution: persistedNativeExecutionInput,
+          anchor: nativeGoalResumeAnchor,
+          companyId: agent.companyId,
+          agentId: agent.id,
+          issueId: issueRef!.id,
+          currentRunId: run.id,
+        })
+      ) {
+        throw nativeGoalResumeUnavailable(
+          "current_run_goal_source_binding_mismatch",
+        );
+      }
       const requestedExecutionWorkspaceId =
         persistedNativeExecutionWorkspaceId ??
-        nativeGoalResumeAnchor?.executionWorkspaceId ??
+        nativeGoalResumeAnchor?.managedExecutionWorkspaceId ??
         readNonEmptyString(issueRef?.executionWorkspaceId);
       const existingExecutionWorkspace = requestedExecutionWorkspaceId
         ? await executionWorkspacesSvc.getById(requestedExecutionWorkspaceId)
         : null;
       const nativeRecoveryExecutionWorkspaceId =
         resolveNativeRecoveryExecutionWorkspaceBinding({
-          bindingId: persistedNativeExecutionWorkspaceId,
+          bindingId:
+            persistedNativeExecutionWorkspaceId ??
+            nativeGoalResumeAnchor?.managedExecutionWorkspaceId,
           persistedWorkspaceFound: existingExecutionWorkspace !== null,
         });
       const workspaceReuseRequest =
@@ -19809,6 +19851,15 @@ export function heartbeatService(
           existingExecutionWorkspaceStatus:
             existingExecutionWorkspace?.status ?? null,
         });
+      if (
+        nativeGoalResumeRequired &&
+        nativeGoalResumeAnchor?.managedExecutionWorkspaceId &&
+        !workspaceReuseRequest.existingExecutionWorkspaceAvailable
+      ) {
+        throw nativeGoalResumeUnavailable(
+          "goal_source_execution_workspace_unavailable",
+        );
+      }
       const requestedShouldReuseExisting =
         workspaceReuseRequest.requestedShouldReuseExisting;
       const reusableExistingExecutionWorkspace =
@@ -20252,16 +20303,8 @@ export function heartbeatService(
         sessionConfigFreshness.reasons.join("; ") || null;
       const taskSessionForRun = resetTaskSession ? null : taskSession;
       const nativeGoalResumeSessionParams =
-        nativeGoalResumeAnchor && taskSessionForRun
+        nativeGoalResumeAnchor
           ? {
-              ...(normalizeResumeParamsForAdapter(
-                agent.adapterType,
-                stripPaperclipSessionMetadataFromSessionParams(
-                  sessionCodec.deserialize(
-                    taskSessionForRun.sessionParamsJson ?? null,
-                  ),
-                ),
-              ) ?? {}),
               sessionId: nativeGoalResumeAnchor.normalizedSessionId,
               cwd: nativeGoalResumeAnchor.workspaceCwd,
             }
@@ -21890,9 +21933,7 @@ export function heartbeatService(
                   })(),
                 });
           const taskNativeSessionId = readNonEmptyString(
-            nativeGoalResumeAnchor && taskSessionForRun
-              ? nativeGoalResumeAnchor.normalizedSessionId
-              : taskSessionDecodedParams?.sessionId,
+            taskSessionDecodedParams?.sessionId,
           );
           // Compatibility for native retry rows created before same-run restart
           // recovery existed. Only an entirely unused replacement row may
@@ -21957,14 +21998,14 @@ export function heartbeatService(
               : null;
           const legacyRetrySessionId =
             compatibleLegacyRetrySource?.nativeSessionId;
-          const taskResumeRunId =
-            taskSessionForRun?.lastRunId &&
-            taskSessionForRun.lastRunId !== run.id &&
-            isNativeSessionId(taskNativeSessionId)
-              ? taskSessionForRun.lastRunId
-              : null;
-          const resumableTaskSessionId = taskResumeRunId
-            ? taskNativeSessionId
+          const taskResumeSeed = resolveNativeTaskSessionResumeSeed({
+            goalResumeAnchor: nativeGoalResumeAnchor,
+            taskSessionLastRunId: taskSessionForRun?.lastRunId,
+            taskSessionNormalizedSessionId: taskNativeSessionId,
+            currentRunId: run.id,
+          });
+          const resumableTaskSessionId = taskResumeSeed
+            ? taskResumeSeed.normalizedSessionId
             : (legacyRetrySessionId ?? null);
           const requestedNativeSessionId =
             run.nativeSessionId ?? resumableTaskSessionId;
@@ -21987,6 +22028,15 @@ export function heartbeatService(
                   beforeCreatedAt: run.createdAt,
                 })
               : null;
+          if (
+            nativeGoalResumeRequired &&
+            !persistedNativeExecutionInput &&
+            !previousNativeRun
+          ) {
+            throw nativeGoalResumeUnavailable(
+              "goal_source_checkpoint_unavailable_or_superseded",
+            );
+          }
           nativeRunnerInstanceId =
             previousNativeRun?.runnerInstanceId &&
             previousNativeRun.nativeSessionId ===
@@ -22203,6 +22253,7 @@ export function heartbeatService(
                 previousRun: previousNativeRun,
                 normalizedSessionId: nativeSessionId,
                 executionTargetKind: executionTarget?.kind ?? "local",
+                requireCheckpoint: nativeGoalResumeRequired,
                 buildExecution: ({ normalizedSessionId, resumedSession }) =>
                   buildNativeExecutionInput({
                     companyId: agent.companyId,

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -183,6 +183,7 @@ import {
   ensureNativeCompletionContract,
   executePaperclipNativeSession,
   finalizeNativeRun,
+  findNativeGoalResumeAnchor,
   findNativeSessionResumeRun,
   isNativeSessionId,
   isUnusedNativeSessionBootstrap,
@@ -19775,8 +19776,21 @@ export function heartbeatService(
           : null;
       const persistedNativeExecutionWorkspaceId =
         persistedNativeExecutionInput?.binding.executionWorkspaceId ?? null;
+      const nativeGoalResumeAnchor =
+        issueRef &&
+        (readNonEmptyString(context.goalControlRequestId) ||
+          context.resumeSessionGoalHeartbeat === true)
+          ? await findNativeGoalResumeAnchor(db, {
+              goalSourceId: taskSession?.goalSourceId,
+              companyId: agent.companyId,
+              agentId: agent.id,
+              issueId: issueRef.id,
+              currentRunId: run.id,
+            })
+          : null;
       const requestedExecutionWorkspaceId =
         persistedNativeExecutionWorkspaceId ??
+        nativeGoalResumeAnchor?.executionWorkspaceId ??
         readNonEmptyString(issueRef?.executionWorkspaceId);
       const existingExecutionWorkspace = requestedExecutionWorkspaceId
         ? await executionWorkspacesSvc.getById(requestedExecutionWorkspaceId)
@@ -20237,6 +20251,21 @@ export function heartbeatService(
       const sessionResetReason =
         sessionConfigFreshness.reasons.join("; ") || null;
       const taskSessionForRun = resetTaskSession ? null : taskSession;
+      const nativeGoalResumeSessionParams =
+        nativeGoalResumeAnchor && taskSessionForRun
+          ? {
+              ...(normalizeResumeParamsForAdapter(
+                agent.adapterType,
+                stripPaperclipSessionMetadataFromSessionParams(
+                  sessionCodec.deserialize(
+                    taskSessionForRun.sessionParamsJson ?? null,
+                  ),
+                ),
+              ) ?? {}),
+              sessionId: nativeGoalResumeAnchor.normalizedSessionId,
+              cwd: nativeGoalResumeAnchor.workspaceCwd,
+            }
+          : null;
       const previousSessionParams =
         explicitResumeSessionParams ??
         (isCanonicalSessionIdForAdapter(
@@ -20245,6 +20274,7 @@ export function heartbeatService(
         )
           ? { sessionId: explicitResumeSessionDisplayId }
           : null) ??
+        nativeGoalResumeSessionParams ??
         normalizeResumeParamsForAdapter(
           agent.adapterType,
           stripPaperclipSessionMetadataFromSessionParams(
@@ -21860,7 +21890,9 @@ export function heartbeatService(
                   })(),
                 });
           const taskNativeSessionId = readNonEmptyString(
-            taskSessionDecodedParams?.sessionId,
+            nativeGoalResumeAnchor && taskSessionForRun
+              ? nativeGoalResumeAnchor.normalizedSessionId
+              : taskSessionDecodedParams?.sessionId,
           );
           // Compatibility for native retry rows created before same-run restart
           // recovery existed. Only an entirely unused replacement row may

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -194,6 +194,7 @@ import {
   nativeCompletionRequestsForComments,
   NativeCancellationPendingRecoveryError,
   NativeGoalResumeCheckpointUnavailableError,
+  nativeGoalResumeCheckpointMatchesExecution,
   nativeExecutionMatchesGoalResumeAnchor,
   nativeToolContractFingerprintForTarget,
   prepareNativeSessionBootstrapPersistence,
@@ -22028,15 +22029,6 @@ export function heartbeatService(
                   beforeCreatedAt: run.createdAt,
                 })
               : null;
-          if (
-            nativeGoalResumeRequired &&
-            !persistedNativeExecutionInput &&
-            !previousNativeRun
-          ) {
-            throw nativeGoalResumeUnavailable(
-              "goal_source_checkpoint_unavailable_or_superseded",
-            );
-          }
           nativeRunnerInstanceId =
             previousNativeRun?.runnerInstanceId &&
             previousNativeRun.nativeSessionId ===
@@ -22110,6 +22102,7 @@ export function heartbeatService(
                 previousRun: previousNativeRun,
                 currentExecution: nativeExecution,
                 executionTargetKind: executionTarget?.kind ?? "local",
+                requireSameProviderSession: nativeGoalResumeRequired,
               });
             }
             if (nativeExecution.provider.kind === "claude_managed") {
@@ -22326,6 +22319,16 @@ export function heartbeatService(
               nativeRunnerInstanceId = randomUUID();
             }
             nativeSessionId = nativeExecutionWithCheckpoint.normalizedSessionId;
+          }
+          if (
+            nativeGoalResumeRequired &&
+            !nativeGoalResumeCheckpointMatchesExecution({
+              checkpoint:
+                nativeResumeCheckpoint ?? persistedProfile.sessionCheckpoint,
+              execution: nativeExecution,
+            })
+          ) {
+            throw new NativeGoalResumeCheckpointUnavailableError();
           }
           const nativeSandboxLifecycle = resolveNativeSandboxLifecycle({
             adapterType: agent.adapterType,
@@ -22917,6 +22920,7 @@ export function heartbeatService(
                       resumeSessionGoalHeartbeat:
                         context.resumeSessionGoalHeartbeat === true ||
                         completedGoalControl,
+                      requirePersistedSession: nativeGoalResumeRequired,
                       onGoalCheckpoint: async (snapshot) => {
                         if (!taskKey) return;
                         const params =

--- a/server/src/services/native-runtime/native-session-executor.ts
+++ b/server/src/services/native-runtime/native-session-executor.ts
@@ -6633,6 +6633,8 @@ export async function executePaperclipNativeSession(input: {
   onGoalCheckpoint?: (snapshot: PersistedNativeSession) => Promise<void>;
   sessionGoalControl?: NativeSessionGoalControl | null;
   resumeSessionGoalHeartbeat?: boolean;
+  /** Defense in depth for Goal controls that may not create a new provider session. */
+  requirePersistedSession?: boolean;
   /** Internal test seam; production rolls over five minutes before runnerd's one-hour lease. */
   goalRolloverAtMs?: number;
   preparationSpans?: NativeRunHistoricalSpan[];
@@ -7660,6 +7662,7 @@ async function executePaperclipNativeSessionWithinScope(
             keepSessionOpen: warmSessionId !== null,
             sessionGoalControl: input.sessionGoalControl,
             resumeSessionGoalHeartbeat: input.resumeSessionGoalHeartbeat,
+            requirePersistedSession: input.requirePersistedSession,
             // Every durable runner must finish its bounded suspension before
             // the next run verifies and rotates the saved authority.
             requireSessionCloseBeforeReturn: runnerdBackend !== null,

--- a/server/src/services/native-runtime/native-session-resume.test.ts
+++ b/server/src/services/native-runtime/native-session-resume.test.ts
@@ -60,6 +60,7 @@ import {
 import { buildNativeExecutionInput } from "./native-execution-input.js";
 import {
   buildNativeExecutionWithCheckpoint,
+  findNativeGoalResumeAnchor,
   findNativeSessionResumeRun,
   NATIVE_TOOL_CONTRACT_FINGERPRINT,
   isUnusedLegacyNativeRetryReplacement,
@@ -68,6 +69,7 @@ import {
   nativeSessionProviderEvidence,
   prepareNativeSessionBootstrapPersistence,
   rebindNativeSessionCheckpoint,
+  resolveNativeGoalResumeAnchor,
   selectNativeSessionResumeRun,
 } from "./native-session-resume.js";
 import { nativeRuntimeContextFixture } from "./runtime-context.test-fixture.js";
@@ -416,6 +418,11 @@ it("wires exact-session recovery and guarded selected identity into heartbeat pe
     "utf8",
   );
   expect(source).toContain("await findNativeSessionResumeRun(db,");
+  expect(source).toContain("await findNativeGoalResumeAnchor(db,");
+  expect(source).toContain(
+    "nativeGoalResumeAnchor?.executionWorkspaceId",
+  );
+  expect(source).toContain("nativeGoalResumeAnchor.normalizedSessionId");
   expect(source).toContain(
     "await prepareNativeSessionBootstrapPersistence(tx,",
   );
@@ -429,6 +436,122 @@ it("wires exact-session recovery and guarded selected identity into heartbeat pe
 });
 
 const embeddedSupport = await getEmbeddedPostgresTestSupport();
+
+describe("native Goal resume authority", () => {
+  const runnerInstanceId = "80000000-0000-4000-8000-000000000008";
+  const managedWorkspaceId = "90000000-0000-4000-8000-000000000009";
+  const sourceRun = () => ({
+    ...previousRun({
+      nativeExecutionInput: execution(
+        previousRunId,
+        "/managed-workspace",
+        "standard",
+        { id: managedWorkspaceId },
+      ),
+    }),
+    runnerInstanceId,
+    nativeIssueId: issueId,
+    runtimeMode: "native",
+    status: "succeeded",
+  });
+
+  it("selects the Goal source session and workspace instead of a later failed task-session pointer", () => {
+    expect(
+      resolveNativeGoalResumeAnchor({
+        goalSourceId: `${runnerInstanceId}:${previousRunId}`,
+        companyId,
+        agentId,
+        issueId,
+        currentRunId,
+        sourceRun: sourceRun(),
+      }),
+    ).toEqual({
+      sourceRunId: previousRunId,
+      normalizedSessionId,
+      executionWorkspaceId: managedWorkspaceId,
+      workspaceCwd: "/managed-workspace",
+    });
+  });
+
+  it.each([
+    ["runner epoch", { runnerInstanceId: randomUUID() }],
+    ["task", { nativeIssueId: randomUUID() }],
+    ["agent", { agentId: randomUUID() }],
+    ["company", { companyId: randomUUID() }],
+    ["runtime", { runtimeMode: "legacy" }],
+    ["terminal state", { status: "running" }],
+    ["session", { nativeSessionId: randomUUID() }],
+    ["checkpoint", { runnerProfileJson: {} }],
+  ])("rejects a mismatched %s binding", (_label, override) => {
+    expect(
+      resolveNativeGoalResumeAnchor({
+        goalSourceId: `${runnerInstanceId}:${previousRunId}`,
+        companyId,
+        agentId,
+        issueId,
+        currentRunId,
+        sourceRun: { ...sourceRun(), ...override },
+      }),
+    ).toBeNull();
+  });
+
+  (embeddedSupport.supported ? it : it.skip)(
+    "loads only the exact server-authenticated Goal source run",
+    async () => {
+      const database = await startEmbeddedPostgresTestDatabase(
+        "paperclip-native-goal-anchor-",
+      );
+      const db = createDb(database.connectionString);
+      try {
+        await db.insert(companies).values({
+          id: companyId,
+          name: "Goal resume anchor",
+          issuePrefix: "NGA",
+        });
+        await db.insert(agents).values({
+          id: agentId,
+          companyId,
+          name: "Native goal runner",
+        });
+        await db.insert(issues).values({
+          id: issueId,
+          companyId,
+          title: "Resume exact Goal",
+        });
+        await db.insert(heartbeatRuns).values({
+          ...sourceRun(),
+          createdAt: new Date("2026-09-12T00:00:00.000Z"),
+        });
+        expect(
+          await findNativeGoalResumeAnchor(db, {
+            goalSourceId: `${runnerInstanceId}:${previousRunId}`,
+            companyId,
+            agentId,
+            issueId,
+            currentRunId,
+          }),
+        ).toEqual({
+          sourceRunId: previousRunId,
+          normalizedSessionId,
+          executionWorkspaceId: managedWorkspaceId,
+          workspaceCwd: "/managed-workspace",
+        });
+        expect(
+          await findNativeGoalResumeAnchor(db, {
+            goalSourceId: `${runnerInstanceId}:${previousRunId}`,
+            companyId,
+            agentId,
+            issueId: randomUUID(),
+            currentRunId,
+          }),
+        ).toBeNull();
+      } finally {
+        await database.cleanup();
+      }
+    },
+  );
+});
+
 const recoveryFakeCodex = resolve(
   import.meta.dirname,
   "../../../../packages/paperclip-runner/test/fixtures/fake-final-burst-codex-app-server.mjs",

--- a/server/src/services/native-runtime/native-session-resume.test.ts
+++ b/server/src/services/native-runtime/native-session-resume.test.ts
@@ -64,12 +64,15 @@ import {
   findNativeSessionResumeRun,
   NATIVE_TOOL_CONTRACT_FINGERPRINT,
   isUnusedLegacyNativeRetryReplacement,
+  NativeGoalResumeCheckpointUnavailableError,
+  nativeExecutionMatchesGoalResumeAnchor,
   nativeToolContractFingerprintForTarget,
   nativeSessionIdForBootstrapPersistence,
   nativeSessionProviderEvidence,
   prepareNativeSessionBootstrapPersistence,
   rebindNativeSessionCheckpoint,
   resolveNativeGoalResumeAnchor,
+  resolveNativeTaskSessionResumeSeed,
   selectNativeSessionResumeRun,
 } from "./native-session-resume.js";
 import { nativeRuntimeContextFixture } from "./runtime-context.test-fixture.js";
@@ -420,9 +423,15 @@ it("wires exact-session recovery and guarded selected identity into heartbeat pe
   expect(source).toContain("await findNativeSessionResumeRun(db,");
   expect(source).toContain("await findNativeGoalResumeAnchor(db,");
   expect(source).toContain(
-    "nativeGoalResumeAnchor?.executionWorkspaceId",
+    "nativeGoalResumeAnchor?.managedExecutionWorkspaceId",
   );
   expect(source).toContain("nativeGoalResumeAnchor.normalizedSessionId");
+  expect(source).toContain("resolveNativeTaskSessionResumeSeed({");
+  expect(source).toContain("goalResumeAnchor: nativeGoalResumeAnchor,");
+  expect(source).toContain("requireCheckpoint: nativeGoalResumeRequired,");
+  expect(source).toContain(
+    '"goal_source_checkpoint_unavailable_or_superseded"',
+  );
   expect(source).toContain(
     "await prepareNativeSessionBootstrapPersistence(tx,",
   );
@@ -469,8 +478,134 @@ describe("native Goal resume authority", () => {
       sourceRunId: previousRunId,
       normalizedSessionId,
       executionWorkspaceId: managedWorkspaceId,
+      managedExecutionWorkspaceId: managedWorkspaceId,
       workspaceCwd: "/managed-workspace",
+      workspaceRepoUrl: null,
+      workspaceRepoRef: null,
+      workspaceBranchName: null,
     });
+  });
+
+  it("ignores a later failed rotation in task-session metadata", () => {
+    const anchor = resolveNativeGoalResumeAnchor({
+      goalSourceId: `${runnerInstanceId}:${previousRunId}`,
+      companyId,
+      agentId,
+      issueId,
+      currentRunId,
+      sourceRun: sourceRun(),
+    });
+    const failedRotationRunId = randomUUID();
+    const failedRotationSessionId = randomUUID();
+    expect(
+      resolveNativeTaskSessionResumeSeed({
+        goalResumeAnchor: anchor,
+        taskSessionLastRunId: failedRotationRunId,
+        taskSessionNormalizedSessionId: failedRotationSessionId,
+        currentRunId,
+      }),
+    ).toEqual({
+      sourceRunId: previousRunId,
+      normalizedSessionId,
+    });
+  });
+
+  it("accepts only a same-run immutable execution input bound to that Goal authority", () => {
+    const anchor = resolveNativeGoalResumeAnchor({
+      goalSourceId: `${runnerInstanceId}:${previousRunId}`,
+      companyId,
+      agentId,
+      issueId,
+      currentRunId,
+      sourceRun: sourceRun(),
+    })!;
+    expect(
+      nativeExecutionMatchesGoalResumeAnchor({
+        execution: execution(
+          currentRunId,
+          "/managed-workspace",
+          "standard",
+          { id: managedWorkspaceId },
+        ),
+        anchor,
+        companyId,
+        agentId,
+        issueId,
+        currentRunId,
+      }),
+    ).toBe(true);
+    expect(
+      nativeExecutionMatchesGoalResumeAnchor({
+        execution: execution(currentRunId, "/rotated-workspace"),
+        anchor,
+        companyId,
+        agentId,
+        issueId,
+        currentRunId,
+      }),
+    ).toBe(false);
+  });
+
+  it("forbids a fresh provider replacement when exact Goal continuity is required", () => {
+    const source = sourceRun();
+    const profile = source.runnerProfileJson as Record<string, unknown>;
+    const checkpoint = profile.sessionCheckpoint as Record<string, unknown>;
+    checkpoint.goal = {
+      threadId: "provider-thread-123",
+      objective: "Continue only on this provider thread.",
+      status: "budget_limited",
+      tokenBudget: 12_000,
+      tokensUsed: 20_283,
+      timeUsedSeconds: 120,
+    };
+    const buildExecution = vi.fn(
+      ({ normalizedSessionId: selected }: { normalizedSessionId: string }) => {
+        const current = execution(currentRunId, "/different-workspace");
+        return {
+          ...current,
+          session: { ...current.session, normalizedSessionId: selected },
+        };
+      },
+    );
+    expect(() =>
+      buildNativeExecutionWithCheckpoint({
+        previousRun: source,
+        normalizedSessionId,
+        requireCheckpoint: true,
+        buildExecution,
+      }),
+    ).toThrow(NativeGoalResumeCheckpointUnavailableError);
+    expect(buildExecution).toHaveBeenCalledTimes(1);
+  });
+
+  it("forbids replacement after configuration drift or a newer progress barrier", () => {
+    const source = sourceRun();
+    const changedRuntime = execution(
+      currentRunId,
+      "/managed-workspace",
+      "standard",
+      { id: managedWorkspaceId },
+    );
+    changedRuntime.runtimeContext = {
+      ...changedRuntime.runtimeContext,
+      aggregateDigest: `sha256:${"f".repeat(64)}`,
+    };
+    expect(() =>
+      buildNativeExecutionWithCheckpoint({
+        previousRun: source,
+        normalizedSessionId,
+        requireCheckpoint: true,
+        buildExecution: () => changedRuntime,
+      }),
+    ).toThrow(NativeGoalResumeCheckpointUnavailableError);
+    expect(() =>
+      buildNativeExecutionWithCheckpoint({
+        previousRun: null,
+        normalizedSessionId,
+        requireCheckpoint: true,
+        buildExecution: () => changedRuntime,
+      }),
+    ).toThrow(NativeGoalResumeCheckpointUnavailableError);
   });
 
   it.each([
@@ -534,7 +669,11 @@ describe("native Goal resume authority", () => {
           sourceRunId: previousRunId,
           normalizedSessionId,
           executionWorkspaceId: managedWorkspaceId,
+          managedExecutionWorkspaceId: managedWorkspaceId,
           workspaceCwd: "/managed-workspace",
+          workspaceRepoUrl: null,
+          workspaceRepoRef: null,
+          workspaceBranchName: null,
         });
         expect(
           await findNativeGoalResumeAnchor(db, {

--- a/server/src/services/native-runtime/native-session-resume.test.ts
+++ b/server/src/services/native-runtime/native-session-resume.test.ts
@@ -39,8 +39,10 @@ import {
   defaultCapabilityRunnerdBinary,
   executeNativeSession,
   parseNativeExecutionInput,
+  type ControlPlanePort,
   type NativeExecutionInput,
   type NativeSession,
+  type NativeSessionBackend,
 } from "../../vendor/paperclip-runner/index.js";
 import {
   runnerPrpWebSocketInternals,
@@ -65,6 +67,7 @@ import {
   NATIVE_TOOL_CONTRACT_FINGERPRINT,
   isUnusedLegacyNativeRetryReplacement,
   NativeGoalResumeCheckpointUnavailableError,
+  nativeGoalResumeCheckpointMatchesExecution,
   nativeExecutionMatchesGoalResumeAnchor,
   nativeToolContractFingerprintForTarget,
   nativeSessionIdForBootstrapPersistence,
@@ -429,9 +432,8 @@ it("wires exact-session recovery and guarded selected identity into heartbeat pe
   expect(source).toContain("resolveNativeTaskSessionResumeSeed({");
   expect(source).toContain("goalResumeAnchor: nativeGoalResumeAnchor,");
   expect(source).toContain("requireCheckpoint: nativeGoalResumeRequired,");
-  expect(source).toContain(
-    '"goal_source_checkpoint_unavailable_or_superseded"',
-  );
+  expect(source).toContain("nativeGoalResumeCheckpointMatchesExecution({");
+  expect(source).toContain("requirePersistedSession: nativeGoalResumeRequired,");
   expect(source).toContain(
     "await prepareNativeSessionBootstrapPersistence(tx,",
   );
@@ -486,7 +488,7 @@ describe("native Goal resume authority", () => {
     });
   });
 
-  it("ignores a later failed rotation in task-session metadata", () => {
+  it("recovers the Goal source after a later failed rotation without provider replacement", async () => {
     const anchor = resolveNativeGoalResumeAnchor({
       goalSourceId: `${runnerInstanceId}:${previousRunId}`,
       companyId,
@@ -497,17 +499,86 @@ describe("native Goal resume authority", () => {
     });
     const failedRotationRunId = randomUUID();
     const failedRotationSessionId = randomUUID();
-    expect(
-      resolveNativeTaskSessionResumeSeed({
-        goalResumeAnchor: anchor,
-        taskSessionLastRunId: failedRotationRunId,
-        taskSessionNormalizedSessionId: failedRotationSessionId,
-        currentRunId,
-      }),
-    ).toEqual({
+    const seed = resolveNativeTaskSessionResumeSeed({
+      goalResumeAnchor: anchor,
+      taskSessionLastRunId: failedRotationRunId,
+      taskSessionNormalizedSessionId: failedRotationSessionId,
+      currentRunId,
+    });
+    expect(seed).toEqual({
       sourceRunId: previousRunId,
       normalizedSessionId,
     });
+
+    const resumed = buildNativeExecutionWithCheckpoint({
+      previousRun: sourceRun(),
+      normalizedSessionId: seed!.normalizedSessionId,
+      requireCheckpoint: true,
+      buildExecution: () =>
+        execution(currentRunId, "/managed-workspace", "standard", {
+          id: managedWorkspaceId,
+        }),
+    });
+    const openSession = vi.fn();
+    const recoverSession = vi.fn(async () => ({
+      recovered: false as const,
+      reason: "the original provider process is unavailable",
+    }));
+    const backend: NativeSessionBackend = {
+      async descriptor() {
+        return {
+          kind: "mock",
+          name: "failed-rotation-recovery",
+          version: "1",
+          capabilities: {
+            resume: true,
+            typedEvents: true,
+            steering: false,
+            interruption: true,
+            structuredResult: true,
+          },
+          runtimeContextCapabilities: {
+            instructions: "native",
+            skills: "native",
+            mcp: "native",
+          },
+        };
+      },
+      openSession,
+      recoverSession,
+    };
+    const controlPlane: ControlPlanePort = {
+      async openRun() {
+        throw new Error("a failed exact recovery must not open a new run");
+      },
+      async checkpointSession() {},
+      async appendEvent() {
+        throw new Error("unexpected event");
+      },
+      async replayEvents() {
+        return { events: [], highestContiguousSourceSeq: 0 };
+      },
+      async completeRun() {},
+    };
+
+    await expect(
+      executeNativeSession({
+        input: resumed.execution,
+        backend,
+        persistedSession: resumed.checkpoint,
+        requirePersistedSession: true,
+        sessionGoalControl: {
+          requestId: "goal-edit-after-failed-rotation",
+          action: "edit",
+          tokenBudget: 100_000,
+        },
+        controlPlane,
+        runnerInstanceId,
+        controlPlaneInstanceId: "control-plane-instance",
+      }),
+    ).rejects.toThrow("native_session_recovery_failed");
+    expect(recoverSession).toHaveBeenCalledOnce();
+    expect(openSession).not.toHaveBeenCalled();
   });
 
   it("accepts only a same-run immutable execution input bound to that Goal authority", () => {
@@ -606,6 +677,41 @@ describe("native Goal resume authority", () => {
         buildExecution: () => changedRuntime,
       }),
     ).toThrow(NativeGoalResumeCheckpointUnavailableError);
+  });
+
+  it("rejects a persisted current-run input without an exact non-replaceable checkpoint", () => {
+    const current = execution(
+      currentRunId,
+      "/managed-workspace",
+      "standard",
+      { id: managedWorkspaceId },
+    );
+    const rebound = rebindNativeSessionCheckpoint({
+      previousRun: sourceRun(),
+      currentExecution: current,
+      requireSameProviderSession: true,
+    });
+    expect(
+      nativeGoalResumeCheckpointMatchesExecution({
+        checkpoint: rebound,
+        execution: current,
+      }),
+    ).toBe(true);
+    expect(
+      nativeGoalResumeCheckpointMatchesExecution({
+        checkpoint: null,
+        execution: current,
+      }),
+    ).toBe(false);
+    expect(
+      nativeGoalResumeCheckpointMatchesExecution({
+        checkpoint: {
+          ...rebound,
+          providerRecoveryPolicy: "allow_replacement_after_resume_failure",
+        },
+        execution: current,
+      }),
+    ).toBe(false);
   });
 
   it.each([

--- a/server/src/services/native-runtime/native-session-resume.ts
+++ b/server/src/services/native-runtime/native-session-resume.ts
@@ -601,6 +601,7 @@ export function buildNativeExecutionWithCheckpoint(input: {
         previousRun: input.previousRun,
         currentExecution: execution,
         executionTargetKind: input.executionTargetKind,
+        requireSameProviderSession: input.requireCheckpoint,
       })
     : null;
   if (checkpoint)
@@ -634,6 +635,28 @@ export class NativeGoalResumeCheckpointUnavailableError extends Error {
   }
 }
 
+/** A Goal-control dispatch may use only an exact, non-replaceable checkpoint. */
+export function nativeGoalResumeCheckpointMatchesExecution(input: {
+  checkpoint: unknown;
+  execution: NativeExecutionInput;
+}): boolean {
+  const checkpoint = record(input.checkpoint);
+  const identity = record(checkpoint.identity);
+  const execution = input.execution;
+  return (
+    typeof checkpoint.sessionId === "string" &&
+    identity.runId === execution.binding.runId &&
+    identity.companyId === execution.binding.companyId &&
+    identity.issueId === execution.binding.issueId &&
+    identity.agentId === execution.binding.agentId &&
+    identity.sessionId === execution.session.normalizedSessionId &&
+    checkpoint.providerRecoveryPolicy !==
+      "allow_replacement_after_governed_wait" &&
+    checkpoint.providerRecoveryPolicy !==
+      "allow_replacement_after_resume_failure"
+  );
+}
+
 /**
  * Rebind a completed prior run's provider checkpoint to a new heartbeat run.
  * The provider/driver session identity is retained, while every per-turn and
@@ -649,6 +672,7 @@ export function rebindNativeSessionCheckpoint(input: {
   };
   currentExecution: NativeExecutionInput;
   executionTargetKind?: NativeToolExecutionTargetKind;
+  requireSameProviderSession?: boolean;
 }): PersistedNativeSession | null {
   const previousProfile = record(input.previousRun.runnerProfileJson);
   if (
@@ -716,12 +740,14 @@ export function rebindNativeSessionCheckpoint(input: {
     rawGoal !== null &&
     rawGoal !== undefined &&
     record(rawGoal).status !== "complete";
-  const providerRecoveryPolicy = hasUnfinishedGoal
+  const providerRecoveryPolicy = input.requireSameProviderSession
     ? ("same_session_only" as const)
-    : priorSemanticResult.reportedWorkDisposition === "yielded" &&
-        priorContinuation.kind === "response_wake"
-      ? ("allow_replacement_after_governed_wait" as const)
-      : ("allow_replacement_after_resume_failure" as const);
+    : hasUnfinishedGoal
+      ? ("same_session_only" as const)
+      : priorSemanticResult.reportedWorkDisposition === "yielded" &&
+          priorContinuation.kind === "response_wake"
+        ? ("allow_replacement_after_governed_wait" as const)
+        : ("allow_replacement_after_resume_failure" as const);
 
   return {
     ...(structuredClone(rawCheckpoint) as unknown as PersistedNativeSession),

--- a/server/src/services/native-runtime/native-session-resume.ts
+++ b/server/src/services/native-runtime/native-session-resume.ts
@@ -247,7 +247,16 @@ export type NativeGoalResumeAnchor = {
   sourceRunId: string;
   normalizedSessionId: string;
   executionWorkspaceId: string;
+  managedExecutionWorkspaceId: string | null;
   workspaceCwd: string;
+  workspaceRepoUrl: string | null;
+  workspaceRepoRef: string | null;
+  workspaceBranchName: string | null;
+};
+
+export type NativeTaskSessionResumeSeed = {
+  sourceRunId: string;
+  normalizedSessionId: string;
 };
 
 type NativeGoalSourceRun = {
@@ -332,8 +341,66 @@ export function resolveNativeGoalResumeAnchor(input: {
     sourceRunId: run.id,
     normalizedSessionId: run.nativeSessionId,
     executionWorkspaceId: execution.binding.executionWorkspaceId,
+    managedExecutionWorkspaceId:
+      execution.binding.executionWorkspaceId === run.id
+        ? null
+        : execution.binding.executionWorkspaceId,
     workspaceCwd: execution.workspace.cwd,
+    workspaceRepoUrl: execution.workspace.repoUrl,
+    workspaceRepoRef: execution.workspace.repoRef,
+    workspaceBranchName: execution.workspace.branchName,
   };
+}
+
+/** Validate a same-run immutable input against the earlier Goal authority. */
+export function nativeExecutionMatchesGoalResumeAnchor(input: {
+  execution: NativeExecutionInput;
+  anchor: NativeGoalResumeAnchor;
+  companyId: string;
+  agentId: string;
+  issueId: string;
+  currentRunId: string;
+}): boolean {
+  const { execution, anchor } = input;
+  const workspaceMatches = anchor.managedExecutionWorkspaceId
+    ? execution.binding.executionWorkspaceId ===
+      anchor.managedExecutionWorkspaceId
+    : execution.binding.executionWorkspaceId === input.currentRunId &&
+      execution.workspace.cwd === anchor.workspaceCwd &&
+      execution.workspace.repoUrl === anchor.workspaceRepoUrl &&
+      execution.workspace.repoRef === anchor.workspaceRepoRef &&
+      execution.workspace.branchName === anchor.workspaceBranchName;
+  return (
+    execution.binding.runId === input.currentRunId &&
+    execution.binding.companyId === input.companyId &&
+    execution.binding.agentId === input.agentId &&
+    execution.binding.issueId === input.issueId &&
+    execution.session.normalizedSessionId === anchor.normalizedSessionId &&
+    workspaceMatches
+  );
+}
+
+/** Goal authority outranks task-session pointers written by a failed rotation. */
+export function resolveNativeTaskSessionResumeSeed(input: {
+  goalResumeAnchor: NativeGoalResumeAnchor | null;
+  taskSessionLastRunId: string | null | undefined;
+  taskSessionNormalizedSessionId: string | null | undefined;
+  currentRunId: string;
+}): NativeTaskSessionResumeSeed | null {
+  if (input.goalResumeAnchor) {
+    return {
+      sourceRunId: input.goalResumeAnchor.sourceRunId,
+      normalizedSessionId: input.goalResumeAnchor.normalizedSessionId,
+    };
+  }
+  return input.taskSessionLastRunId &&
+    input.taskSessionLastRunId !== input.currentRunId &&
+    isNativeSessionId(input.taskSessionNormalizedSessionId)
+    ? {
+        sourceRunId: input.taskSessionLastRunId,
+        normalizedSessionId: input.taskSessionNormalizedSessionId,
+      }
+    : null;
 }
 
 /** Find a Goal projection's server-authenticated native resume authority. */
@@ -515,6 +582,7 @@ export function buildNativeExecutionWithCheckpoint(input: {
     Parameters<typeof rebindNativeSessionCheckpoint>[0]["previousRun"] | null;
   normalizedSessionId: string;
   executionTargetKind?: NativeToolExecutionTargetKind;
+  requireCheckpoint?: boolean;
   buildExecution: (options: {
     normalizedSessionId: string;
     resumedSession: boolean;
@@ -541,6 +609,9 @@ export function buildNativeExecutionWithCheckpoint(input: {
       checkpoint,
       normalizedSessionId: input.normalizedSessionId,
     };
+  if (input.requireCheckpoint) {
+    throw new NativeGoalResumeCheckpointUnavailableError();
+  }
   // Rebuild both task context and wake instructions. Merely rotating the ID
   // leaves a fresh provider with a compact delta and missing task context.
   const normalizedSessionId = randomUUID();
@@ -552,6 +623,15 @@ export function buildNativeExecutionWithCheckpoint(input: {
     checkpoint: null,
     normalizedSessionId,
   };
+}
+
+export class NativeGoalResumeCheckpointUnavailableError extends Error {
+  constructor() {
+    super(
+      "The established native session Goal cannot resume from its exact provider checkpoint. No replacement provider session was started.",
+    );
+    this.name = "NativeGoalResumeCheckpointUnavailableError";
+  }
 }
 
 /**

--- a/server/src/services/native-runtime/native-session-resume.ts
+++ b/server/src/services/native-runtime/native-session-resume.ts
@@ -243,6 +243,138 @@ export async function findNativeSessionResumeRun(
   });
 }
 
+export type NativeGoalResumeAnchor = {
+  sourceRunId: string;
+  normalizedSessionId: string;
+  executionWorkspaceId: string;
+  workspaceCwd: string;
+};
+
+type NativeGoalSourceRun = {
+  id: string;
+  companyId: string;
+  agentId: string;
+  runnerInstanceId: string | null;
+  nativeSessionId: string | null;
+  nativeIssueId: string | null;
+  runtimeMode: string | null;
+  status: string;
+  runnerProfileJson: unknown;
+};
+
+function parseNativeGoalSourceId(value: string | null | undefined) {
+  const sourceId = value?.trim();
+  if (!sourceId) return null;
+  const separator = sourceId.lastIndexOf(":");
+  if (separator <= 0 || separator === sourceId.length - 1) return null;
+  const runnerInstanceId = sourceId.slice(0, separator);
+  const runId = sourceId.slice(separator + 1);
+  return isNativeSessionId(runId) ? { runnerInstanceId, runId } : null;
+}
+
+/**
+ * Resolve the immutable provider/workspace authority named by the durable Goal
+ * projection. Task-session lastRunId is intentionally not consulted: a failed
+ * offline control bootstrap can rotate that pointer before the established
+ * provider Goal accepts the command.
+ */
+export function resolveNativeGoalResumeAnchor(input: {
+  goalSourceId: string | null | undefined;
+  companyId: string;
+  agentId: string;
+  issueId: string;
+  currentRunId: string;
+  sourceRun: NativeGoalSourceRun | null;
+}): NativeGoalResumeAnchor | null {
+  const source = parseNativeGoalSourceId(input.goalSourceId);
+  const run = input.sourceRun;
+  if (
+    !source ||
+    !run ||
+    run.id === input.currentRunId ||
+    run.id !== source.runId ||
+    run.runnerInstanceId !== source.runnerInstanceId ||
+    run.companyId !== input.companyId ||
+    run.agentId !== input.agentId ||
+    run.nativeIssueId !== input.issueId ||
+    run.runtimeMode !== "native" ||
+    !LEGACY_RETRY_SOURCE_TERMINAL_STATUSES.has(run.status) ||
+    !isNativeSessionId(run.nativeSessionId)
+  )
+    return null;
+
+  const profile = record(run.runnerProfileJson);
+  if (profile.sessionCheckpoint == null) return null;
+  let execution: NativeExecutionInput;
+  try {
+    execution = parseNativeExecutionInput(profile.nativeExecutionInput);
+  } catch {
+    return null;
+  }
+  const checkpoint = record(profile.sessionCheckpoint);
+  const checkpointIdentity = record(checkpoint.identity);
+  if (
+    execution.binding.runId !== run.id ||
+    execution.binding.companyId !== input.companyId ||
+    execution.binding.issueId !== input.issueId ||
+    execution.binding.agentId !== input.agentId ||
+    execution.session.normalizedSessionId !== run.nativeSessionId ||
+    checkpointIdentity.runId !== run.id ||
+    checkpointIdentity.companyId !== input.companyId ||
+    checkpointIdentity.issueId !== input.issueId ||
+    checkpointIdentity.agentId !== input.agentId ||
+    checkpointIdentity.sessionId !== run.nativeSessionId ||
+    typeof checkpoint.sessionId !== "string"
+  )
+    return null;
+
+  return {
+    sourceRunId: run.id,
+    normalizedSessionId: run.nativeSessionId,
+    executionWorkspaceId: execution.binding.executionWorkspaceId,
+    workspaceCwd: execution.workspace.cwd,
+  };
+}
+
+/** Find a Goal projection's server-authenticated native resume authority. */
+export async function findNativeGoalResumeAnchor(
+  db: Db,
+  input: {
+    goalSourceId: string | null | undefined;
+    companyId: string;
+    agentId: string;
+    issueId: string;
+    currentRunId: string;
+  },
+): Promise<NativeGoalResumeAnchor | null> {
+  const source = parseNativeGoalSourceId(input.goalSourceId);
+  if (!source) return null;
+  const sourceRun = await db
+    .select({
+      id: heartbeatRuns.id,
+      companyId: heartbeatRuns.companyId,
+      agentId: heartbeatRuns.agentId,
+      runnerInstanceId: heartbeatRuns.runnerInstanceId,
+      nativeSessionId: heartbeatRuns.nativeSessionId,
+      nativeIssueId: heartbeatRuns.nativeIssueId,
+      runtimeMode: heartbeatRuns.runtimeMode,
+      status: heartbeatRuns.status,
+      runnerProfileJson: heartbeatRuns.runnerProfileJson,
+    })
+    .from(heartbeatRuns)
+    .where(
+      and(
+        eq(heartbeatRuns.id, source.runId),
+        eq(heartbeatRuns.companyId, input.companyId),
+        eq(heartbeatRuns.agentId, input.agentId),
+        eq(heartbeatRuns.nativeIssueId, input.issueId),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null);
+  return resolveNativeGoalResumeAnchor({ ...input, sourceRun });
+}
+
 /** A preassigned session id may rotate only before immutable native admission. */
 export function nativeSessionIdForBootstrapPersistence(input: {
   run: NativeSessionBootstrapState & { nativeSessionId: string | null };


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app that people use to manage AI agents for work.
> - Paperclip Runner keeps native provider sessions across governed runs.
> - A native Goal continuation must keep the original Goal authority, provider session, and managed workspace.
> - Recovery can otherwise bind a later task session or start without the matching provider checkpoint.
> - A partial Goal edit can also replay a terminal status that the Codex provider does not accept.
> - This pull request retains the Goal source authority, requires the matching checkpoint, and omits an unchanged status during a partial edit.
> - The benefit is deterministic and fail-closed Goal recovery without a replacement provider session.

## Linked Issues or Issue Description

Related pull requests: #12669, #13239, #13254, #13261, and #13270.

**What happened?**

A stopped or restarted native Codex Goal could lose its original Goal source binding. Recovery could select a later task session or continue without the exact provider checkpoint and managed workspace. A budget-only Goal edit could also replay the terminal budget_limited status. Codex rejects that terminal status as an edit value.

**Expected behavior**

Paperclip must resume only when the stored Goal source, provider session, managed workspace, checkpoint, and provider configuration agree. Paperclip must stop before provider dispatch when it cannot prove this authority. A partial edit must omit status unless the caller changes status.

**Steps to reproduce**

1. Start a native Codex Goal and persist its task session and managed workspace.
2. Stop the server or runner after a provider checkpoint.
3. Create a later failed task session pointer or change the provider configuration.
4. Resume the Goal and observe that the beta can select the wrong binding or lack the required checkpoint guard.
5. Put a Goal in budget_limited state and edit only its token budget.
6. Observe that replay of the terminal status makes the provider reject the edit.

**Paperclip version or commit**

The reproduced base is 86c2e0ac4af0718a97bb6e44df508a95f0c5e1b1 from 2026.910.0-beta.0.

**Deployment mode**

The live reproduction used an isolated self-hosted source deployment.

**Installation method**

The deployment was built from source.

**Agent adapter(s) involved**

Paperclip Runner used the Codex App Server adapter.

**Database mode**

The live reproduction used embedded PostgreSQL. The verification did not use direct database repair.

**Node.js version**

The current local verification used Node.js 24.20.0.

**Operating system**

The live reproduction used macOS on arm64. The automated tests do not depend on that platform.

## What Changed

- Retain the native Goal source run and session authority through recovery.
- Require the original managed workspace, provider configuration, and native checkpoint before resume.
- Use same-session-only recovery for an established native Goal.
- Fail before provider dispatch with native_goal_resume_authority_unavailable when the authority is missing or incompatible.
- Require a native Goal checkpoint in the runner contract and runtime.
- Omit status from a partial Goal edit when the caller did not change status.
- Add server and runner regression tests for persisted resume guards, mismatched bindings, missing checkpoints, and partial edits.

The branch keeps these five local commits in order:

1. 1ffadcd26b4853880db93709dd466af9a7a4ea80 — fix(server): retain native goal resume authority
2. bea433a064370c91c7a6646aa572bb7a1b7237eb — fix(server): fail closed on native goal resume
3. 8fa9e1c20f0da0adbd6f96781b8c4b1df0f896fc — fix(runner): require native goal checkpoint
4. 09663a87361fb9fd8591858d6e7020a337c8e5cf — test(server): cover persisted goal resume guard
5. 51be4e8d047a42b58435b7e23a4b59f830abcc97 — fix: preserve goal status on partial edits

## Verification

- git diff --check passed for the complete diff from 86c2e0ac4af0718a97bb6e44df508a95f0c5e1b1 to 51be4e8d047a42b58435b7e23a4b59f830abcc97.
- Both Paperclip Runner TypeScript configurations passed tsc with no output.
- The server TypeScript configuration passed tsc with no output.
- The focused runner suites passed 198 tests.
- The focused server suites passed 63 tests and kept two existing tests skipped.
- Live isolated validation completed a multi-turn Goal, cleared it with the structured operation, and accepted a normal message with no active Goal.
- Live restart validation resumed the same provider thread, session, runner, and workspace. It did not create a second provider session.
- A local merge-tree check against current master reports conflicts in packages/paperclip-runner/src/native-session-runtime.test.ts and server/src/services/native-runtime/native-session-executor.ts.

## Risks

- This draft is not ready to merge. Current master has overlapping native recovery work after the beta base.
- A maintainer must reconcile the two listed conflicts and preserve the fail-closed invariants before merge.
- The exact beta-based head passed the listed tests. The branch has not passed integration tests on current master.
- The change can stop a resume that cannot prove its original authority. This is intentional, but it can expose incomplete persisted state from older executions.
- Codex 0.153.4 does not include tokens from a paused active turn in Goal usage. This provider limitation is outside this pull request.
- The change has no migration, schema, or credential changes.
- This draft has no documentation change. The behavior is an internal recovery invariant and the integration work is not complete.

> ROADMAP.md lists native execution recovery as shipped work. This pull request fixes a bounded recovery defect. It does not add a separate core feature.

## Model Used

- OpenAI Codex based on GPT-5 assisted with analysis, test execution, and pull request preparation. The exact runtime model identifier and context window are not exposed in this session. Tool use and local code execution were enabled.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with Fixes: # / Closes # / Refs # OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub #NNN / github.com/paperclipai/paperclip URLs)
- [x] My branch name describes the change and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [ ] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
