### PR TITLE
fix(codex): pass MCP bearer tokens through env

### DIFF
--- a/packages/adapters/codex-local/src/server/codex-home.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.test.ts
@@ -1023,7 +1023,8 @@ describe("evaluateCodexCredentialReadiness", () => {
       const alpha = await fs.readFile(path.join(alphaHome, "config.toml"), "utf8");
       const zero = await fs.readFile(path.join(zeroHome, "config.toml"), "utf8");
       expect(alpha).toContain('[mcp_servers."alpha"]');
-      expect(alpha).toContain('Authorization = "Bearer alpha-token"');
+      expect(alpha).toContain('bearer_token_env_var = "PAPERCLIP_MANAGED_MCP_BEARER_TOKEN_1"');
+      expect(alpha).not.toContain("alpha-token");
       expect(zero).not.toContain("mcp_servers.");
       expect(zero).not.toContain("stale-token");
       expect(alphaHome).not.toBe(zeroHome);
@@ -1142,7 +1143,7 @@ describe("stageCodexHomeForSync", () => {
     }
   });
 
-  // config.toml carries the managed MCP `Authorization: Bearer …` header and is
+  // config.toml carries only the managed MCP bearer-token environment variable name and is
   // secret-bearing; the staged copy must be 0600, not the world-readable default.
   it("writes the staged config.toml (managed MCP bearer header) with mode 0600", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-stage-toml-mode-"));
@@ -1154,7 +1155,7 @@ describe("stageCodexHomeForSync", () => {
       // and is persisted 0600 on disk.
       await fs.writeFile(
         path.join(home, "config.toml"),
-        "[mcp_servers.paperclip]\nheaders = { Authorization = \"Bearer secret-token\" }\n",
+        "[mcp_servers.paperclip]\nbearer_token_env_var = \"PAPERCLIP_MANAGED_MCP_BEARER_TOKEN_1\"\n",
         { mode: 0o600 },
       );
       staged = await stageCodexHomeForSync(home, { runId: "run-toml-mode" });

--- a/packages/adapters/codex-local/src/server/codex-home.test.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.test.ts
@@ -1143,16 +1143,16 @@ describe("stageCodexHomeForSync", () => {
     }
   });
 
-  // config.toml carries only the managed MCP bearer-token environment variable name and is
-  // secret-bearing; the staged copy must be 0600, not the world-readable default.
-  it("writes the staged config.toml (managed MCP bearer header) with mode 0600", async () => {
+  // Preserve the source config's restrictive mode when staging it, even though managed MCP
+  // bearer tokens are now referenced by environment-variable name instead of stored here.
+  it("writes the staged config.toml with mode 0600", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "paperclip-codex-stage-toml-mode-"));
     let staged: string | null = null;
     try {
       const home = path.join(root, "codex-home");
       await fs.mkdir(home, { recursive: true });
-      // Mirror the source writer: config.toml holds an MCP gateway bearer token
-      // and is persisted 0600 on disk.
+      // Mirror the source writer: config.toml names the environment variable that supplies
+      // the MCP gateway bearer token and is persisted 0600 on disk.
       await fs.writeFile(
         path.join(home, "config.toml"),
         "[mcp_servers.paperclip]\nbearer_token_env_var = \"PAPERCLIP_MANAGED_MCP_BEARER_TOKEN_1\"\n",

--- a/packages/adapters/codex-local/src/server/codex-home.ts
+++ b/packages/adapters/codex-local/src/server/codex-home.ts
@@ -10,6 +10,7 @@ const COPIED_SHARED_FILES = ["config.json", "config.toml", "instructions.md"] as
 const SYMLINKED_SHARED_FILES = ["auth.json"] as const;
 const MANAGED_MCP_BLOCK_START = "# BEGIN PAPERCLIP MANAGED MCP";
 const MANAGED_MCP_BLOCK_END = "# END PAPERCLIP MANAGED MCP";
+const MANAGED_MCP_BEARER_TOKEN_ENV_PREFIX = "PAPERCLIP_MANAGED_MCP_BEARER_TOKEN_";
 
 /**
  * The allowlist of managed `CODEX_HOME` entries that the codex-local adapter
@@ -32,6 +33,17 @@ export type ManagedCodexMcpGateway = {
   endpointPath: string;
   bearerToken: string;
 };
+
+export function managedCodexMcpBearerTokenEnv(
+  gateways: ManagedCodexMcpGateway[],
+): Record<string, string> {
+  return Object.fromEntries(
+    gateways.map((gateway, index) => [
+      `${MANAGED_MCP_BEARER_TOKEN_ENV_PREFIX}${index + 1}`,
+      gateway.bearerToken,
+    ]),
+  );
+}
 
 export function mergeManagedCodexMcpGateways(
   primary: ManagedCodexMcpGateway[],
@@ -316,7 +328,7 @@ function buildManagedMcpBlock(input: {
       "",
       `[mcp_servers.${tomlString(managedName)}]`,
       `url = ${tomlString(url)}`,
-      `headers = { Authorization = ${tomlString(`Bearer ${gateway.bearerToken}`)} }`,
+      `bearer_token_env_var = ${tomlString(`${MANAGED_MCP_BEARER_TOKEN_ENV_PREFIX}${index + 1}`)}`,
     );
   });
   lines.push(MANAGED_MCP_BLOCK_END);

--- a/packages/adapters/codex-local/src/server/execute.ts
+++ b/packages/adapters/codex-local/src/server/execute.ts
@@ -78,6 +78,7 @@ import {
   resolveSharedCodexHomeDir,
   seedManagedCodexHome,
   stageCodexHomeForSync,
+  managedCodexMcpBearerTokenEnv,
   mergeManagedCodexMcpGateways,
   writeManagedCodexMcpConfig,
   type ManagedCodexMcpGateway,
@@ -891,6 +892,7 @@ export async function execute(ctx: AdapterExecutionContext): Promise<AdapterExec
       onEvent,
     });
     const env: Record<string, string> = { ...paperclipBaseEnv };
+    Object.assign(env, managedCodexMcpBearerTokenEnv(managedMcpGateways));
     env.PAPERCLIP_RUN_ID = runId;
     const wakeTaskId =
       (typeof context.taskId === "string" && context.taskId.trim().length > 0 && context.taskId.trim()) ||

--- a/server/src/__tests__/codex-local-execute.test.ts
+++ b/server/src/__tests__/codex-local-execute.test.ts
@@ -23,6 +23,7 @@ const payload = {
   paperclipApiUrl: process.env.PAPERCLIP_API_URL || null,
   paperclipApiKey: process.env.PAPERCLIP_API_KEY || null,
   paperclipApiBridgeMode: process.env.PAPERCLIP_API_BRIDGE_MODE || null,
+  managedMcpBearerToken: process.env.PAPERCLIP_MANAGED_MCP_BEARER_TOKEN_1 || null,
   paperclipEnvKeys: Object.keys(process.env)
     .filter((key) => key.startsWith("PAPERCLIP_"))
     .sort(),
@@ -56,6 +57,7 @@ type CapturePayload = {
   paperclipApiUrl?: string | null;
   paperclipApiKey?: string | null;
   paperclipApiBridgeMode?: string | null;
+  managedMcpBearerToken?: string | null;
   paperclipEnvKeys: string[];
 };
 
@@ -313,7 +315,9 @@ describe("codex execute", () => {
       expect(configText).toContain("[mcp_servers.github]");
       expect(configText).toContain("[mcp_servers.\"paperclip-github\"]");
       expect(configText).toContain('url = "http://paperclip.local:3100/api/tool-gateway/gateways/gateway-1/mcp"');
-      expect(configText).toContain('Authorization = "Bearer pcgw_secret-managed-token"');
+      expect(configText).toContain('bearer_token_env_var = "PAPERCLIP_MANAGED_MCP_BEARER_TOKEN_1"');
+      expect(configText).not.toContain("pcgw_secret-managed-token");
+      expect(capture.managedMcpBearerToken).toBe("pcgw_secret-managed-token");
       expect(logs).toEqual(
         expect.arrayContaining([
           expect.objectContaining({


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - Paperclip gives agents governed MCP tools through adapter-managed gateway entries
> - The Codex adapter wrote bearer credentials with a config key that current Codex releases ignore
> - Codex then called the gateway without a bearer token and received HTTP 401
> - The supported Codex contract reads the bearer token from a named environment variable
> - This pull request writes that contract and injects the token only into the child process environment
> - The benefit is that governed MCP tools load in current Codex runtimes without storing tokens in `config.toml`

## Linked Issues or Issue Description

**What happened?**

The `codex_local` adapter wrote managed HTTP MCP credentials as `headers.Authorization` in `config.toml`. Codex 0.153.4 ignored that entry. Each managed gateway failed startup with HTTP 401 before tool discovery.

**Expected behavior**

Managed MCP gateways must receive their run-scoped bearer token and expose their tools to the Codex runtime.

**Steps to reproduce**

1. Configure a `codex_local` agent with a governed MCP connection.
2. Start a fresh run with Codex 0.153.4.
3. Observe an HTTP 401 from the gateway during MCP startup.

**Paperclip version or commit**

`44dde2dec42a22746a2f36b595acacc9ccfa1df6`

**Deployment mode**

Self-hosted server with the local Codex adapter.

## What Changed

- Write `bearer_token_env_var` for each managed Codex HTTP MCP server.
- Inject each run-scoped gateway token into the matching child-process environment variable.
- Remove bearer-token values from the generated Codex configuration.
- Update focused unit and adapter-execution tests.

## Verification

- `pnpm exec vitest run packages/adapters/codex-local/src/server/codex-home.test.ts server/src/__tests__/codex-local-execute.test.ts` (74 tests passed)
- `pnpm --filter @paperclipai/adapter-codex-local typecheck` (passed)
- `codex mcp add probe --url https://example.invalid/mcp --bearer-token-env-var PAPERCLIP_MCP_PROBE_TOKEN` generated the same `bearer_token_env_var` configuration shape with Codex 0.153.4.

## Risks

- Low risk. The change affects only adapter-managed Codex HTTP MCP entries.
- Token environment variable names depend on gateway order within one run. The config and environment use the same ordered gateway array.

> This is a focused bug fix in the existing governed MCP roadmap area. It does not add a new roadmap capability.

## Model Used

- OpenAI GPT-5 Codex with reasoning and local code execution tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [ ] I will address all Greptile and reviewer comments before requesting merge
