### PR TITLE
fix(server): stop reporting expected managed-cloud transients to Sentry

### DIFF
--- a/server/src/__tests__/cloud-tenant-transient-db-retry.test.ts
+++ b/server/src/__tests__/cloud-tenant-transient-db-retry.test.ts
@@ -33,7 +33,7 @@ describe("isTransientDbConnectionError", () => {
 });
 
 describe("retryOnTransientDbConnectionError", () => {
-  it("retries exactly once after a transient closed connection", async () => {
+  it("retries after a transient closed connection", async () => {
     let calls = 0;
     const result = await retryOnTransientDbConnectionError(async () => {
       calls += 1;
@@ -42,6 +42,19 @@ describe("retryOnTransientDbConnectionError", () => {
     });
     expect(result).toBe("ok");
     expect(calls).toBe(2);
+  });
+
+  it("survives a pool-wide recycle where the first replay draws another dead socket", async () => {
+    // A suspending pooled endpoint kills every pooled socket at once, so
+    // the first replay can fail identically to the original attempt.
+    let calls = 0;
+    const result = await retryOnTransientDbConnectionError(async () => {
+      calls += 1;
+      if (calls <= 2) throw driverClosedError("CONNECTION_CLOSED");
+      return "ok";
+    });
+    expect(result).toBe("ok");
+    expect(calls).toBe(3);
   });
 
   it("propagates a non-transient failure without retrying", async () => {
@@ -55,7 +68,7 @@ describe("retryOnTransientDbConnectionError", () => {
     expect(calls).toBe(1);
   });
 
-  it("propagates the second failure when the retry also dies", async () => {
+  it("propagates the failure once the replay budget is spent", async () => {
     let calls = 0;
     await expect(
       retryOnTransientDbConnectionError(async () => {
@@ -63,6 +76,6 @@ describe("retryOnTransientDbConnectionError", () => {
         throw driverClosedError("CONNECTION_CLOSED");
       }),
     ).rejects.toThrow("Failed query");
-    expect(calls).toBe(2);
+    expect(calls).toBe(3);
   });
 });

--- a/server/src/__tests__/error-handler.test.ts
+++ b/server/src/__tests__/error-handler.test.ts
@@ -64,6 +64,24 @@ describe("errorHandler", () => {
     expect(res.__errorContext?.error?.message).toBe("boom");
   });
 
+  it("ends aborted client requests without reporting a crash", () => {
+    // A closed tab or dropped network surfaces as `Error: aborted` with
+    // ECONNRESET; there is no server fault and nobody left to answer.
+    const req = makeReq();
+    const res = { ...makeRes(), end: vi.fn(), headersSent: false } as any;
+    (res.status as ReturnType<typeof vi.fn>).mockReturnValue(res);
+    const next = vi.fn() as unknown as NextFunction;
+    const err = Object.assign(new Error("aborted"), { code: "ECONNRESET" });
+
+    errorHandler(err, req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(499);
+    expect(res.end).toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+    expect(telemetryMocks.trackErrorHandlerCrash).not.toHaveBeenCalled();
+  });
+
   it("exposes raw 500 messages for trusted Cloud tenant imports", () => {
     const req = {
       ...makeReq(),

--- a/server/src/__tests__/startup-refusals.test.ts
+++ b/server/src/__tests__/startup-refusals.test.ts
@@ -16,13 +16,16 @@ describe("migrationRefusalError", () => {
     expect(error.message).toContain("Refusing to start");
   });
 
-  it("keeps pending migrations on a migrated database as a plain, always-reported error", () => {
+  it("classifies pending migrations on a migrated database as a supervised-transient refusal", () => {
+    // Managed fleet rolls deliver the new app image before the migration
+    // runner, so a briefly-behind schema is the routine mid-upgrade phase
+    // under a supervisor — suppressed there, still reported self-hosted.
     const error = migrationRefusalError(
       { appliedMigrations: ["0000_init.sql"], tableCount: 41 },
       message,
     );
-    expect(error).toBeInstanceOf(Error);
-    expect(error).not.toBeInstanceOf(StartupRefusalError);
+    expect(error).toBeInstanceOf(StartupRefusalError);
+    expect((error as StartupRefusalError).kind).toBe("schema-migration-pending");
   });
 
   it("treats an empty journal beside existing tables as drift, not a fresh database", () => {

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -557,16 +557,22 @@ export function isTransientDbConnectionError(error: unknown): boolean {
 }
 
 /**
- * Runs `run` and retries it exactly once when it fails on a transient
- * closed-connection error. Callers must pass an idempotent operation.
- * Exported for tests.
+ * Runs `run` and retries it up to twice when it fails on a transient
+ * closed-connection error. Two replays, not one: when a pooled endpoint
+ * suspends or recycles, EVERY pooled socket is dead at once, so the first
+ * replay can draw another stale socket from the pool and fail identically
+ * (observed 2026-09-12: retried actor resolution still surfacing
+ * CONNECTION_CLOSED). The short pause gives the driver time to notice and
+ * re-dial. Callers must pass an idempotent operation. Exported for tests.
  */
 export async function retryOnTransientDbConnectionError<T>(run: () => Promise<T>): Promise<T> {
-  try {
-    return await run();
-  } catch (error) {
-    if (!isTransientDbConnectionError(error)) throw error;
-    return run();
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await run();
+    } catch (error) {
+      if (attempt >= 2 || !isTransientDbConnectionError(error)) throw error;
+      await new Promise((resolve) => setTimeout(resolve, 50 * (attempt + 1)));
+    }
   }
 }
 

--- a/server/src/middleware/error-handler.ts
+++ b/server/src/middleware/error-handler.ts
@@ -237,6 +237,20 @@ export function errorHandler(
   }
 
   const rootError = err instanceof Error ? err : new Error(String(err));
+
+  // The client tore down the connection mid-request (closed tab, dropped
+  // mobile network, cancelled upload): Node surfaces it as `Error: aborted`
+  // with ECONNRESET. There is no server fault to report and nobody left to
+  // answer, so skip the error sinks and just close out the response.
+  if (
+    rootError.message === "aborted" &&
+    (rootError as NodeJS.ErrnoException).code === "ECONNRESET"
+  ) {
+    if (!res.headersSent) res.status(499);
+    res.end();
+    return;
+  }
+
   const reportableError = sanitizeSecretSensitiveError(req, rootError);
   attachErrorContext(
     req,

--- a/server/src/startup-refusals.ts
+++ b/server/src/startup-refusals.ts
@@ -22,6 +22,7 @@
 
 export type StartupRefusalKind =
   | "schema-not-yet-migrated"
+  | "schema-migration-pending"
   | "database-contract-unmet";
 
 /**
@@ -53,9 +54,23 @@ export function migrationRefusalError(
   message: string,
 ): Error {
   const neverMigrated = state.appliedMigrations.length === 0 && state.tableCount === 0;
-  return neverMigrated
-    ? new StartupRefusalError("schema-not-yet-migrated", message)
-    : new Error(message);
+  if (neverMigrated) return new StartupRefusalError("schema-not-yet-migrated", message);
+  // A database with applied HISTORY and newer pending files is normal
+  // mid-upgrade under a supervisor: managed fleet rolls deliver the new
+  // app image before the migration runner, so every upgraded stack
+  // briefly boots ahead of its schema and crash-loops until the
+  // supervisor migrates and restarts it (observed: ~11 events per
+  // container, hundreds per fleet roll). It still refuses, logs, and
+  // exits nonzero; only the Sentry capture is skipped — and only when
+  // `PAPERCLIP_CLOUD_API_ORIGIN` marks the deployment as supervised
+  // (`shouldReportStartupFailure`). Self-hosted deployments keep
+  // reporting.
+  if (state.appliedMigrations.length > 0) {
+    return new StartupRefusalError("schema-migration-pending", message);
+  }
+  // An empty or wiped migration journal beside real tables is genuine
+  // drift with no supervisor remedy on the way; it must keep reporting.
+  return new Error(message);
 }
 
 /**


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work
> - The server reports crashes to Sentry so operators can find real faults
> - Three expected conditions report as crashes: a client that closes the connection mid-request, one stale pooled database socket after a pooled endpoint recycles, and the short boot window where a supervised cloud stack runs a new app image before its migration runner has caught up
> - These events arrive in the hundreds and bury real errors
> - This pull request classifies each condition as expected and stops the Sentry capture for exactly that condition, with behavior unchanged everywhere else
> - The benefit is a Sentry feed where each event is a real fault

## Linked Issues or Issue Description

**What happened?**

Three noise classes fill the backend Sentry project on managed cloud fleets:

1. `Error: aborted` (ECONNRESET) reports as a 500 crash when a client closes the tab or loses its network mid-request. Observed 18 times in one week from routine client disconnects.
2. `Error: write CONNECTION_CLOSED ...` reports from many query paths after a pooled Postgres endpoint suspends. The existing single retry in cloud actor resolution still fails, because a suspended endpoint kills every pooled socket at once and the one replay draws another dead socket.
3. `Error: PostgreSQL has pending migrations (...). Refusing to start` reports from every supervised stack during a fleet upgrade. The supervisor delivers the new app image before it runs the migration runner, so each stack crash-loops briefly by design. One fleet roll produced 329 events (11 per container).

**Expected behavior**

A client disconnect ends the request quietly. A transient dead socket is replayed until a live socket answers. A supervised mid-upgrade boot refusal logs and exits nonzero without a Sentry capture, while the same refusal on a self-hosted deployment keeps reporting.

**Steps to reproduce**

1. Abort an HTTP request mid-flight: the error handler reports a crash to Sentry.
2. Suspend a pooled Postgres endpoint under an idle server, then issue two quick requests: the first replay can draw a second dead socket and surface `CONNECTION_CLOSED`.
3. On a deployment with `PAPERCLIP_CLOUD_API_ORIGIN` set, add a migration file without running the migration runner and boot: the refusal reports to Sentry.

**Paperclip version or commit**

master (0e14c61da)

## What Changed

- `server/src/middleware/error-handler.ts`: a request abort (`Error: aborted` with `ECONNRESET`) ends the response with status 499 and skips crash reporting and telemetry.
- `server/src/middleware/auth.ts`: `retryOnTransientDbConnectionError` replays up to twice with a short pause, so a pool-wide recycle does not defeat the retry.
- `server/src/startup-refusals.ts`: pending migrations on a database with applied history classify as a supervised-transient refusal (`schema-migration-pending`). The capture skip applies only when `PAPERCLIP_CLOUD_API_ORIGIN` is set. A wiped journal beside real tables keeps reporting. Self-hosted behavior is unchanged.
- Tests updated and added for all three behaviors.

## Verification

- `pnpm vitest run src/__tests__/startup-refusals.test.ts src/__tests__/cloud-tenant-transient-db-retry.test.ts src/__tests__/error-handler.test.ts` in `server/` — 25 tests, all pass.
- The abort test asserts no `captureException` and no telemetry crash track.
- The refusal tests pin all three classifications: never-migrated, pending-with-history, wiped journal.

## Risks

- Low risk. The abort path only triggers on the exact `aborted` + `ECONNRESET` pair; every other error keeps reporting.
- The refusal reclassification suppresses a capture only under a cloud supervisor. If an operator breaks a migration runner, the supervisor's own deploy gates surface it; self-hosted deployments still report.
- The retry widening adds at most ~150 ms before a genuine connection fault surfaces.

## Model Used

Claude (Anthropic) — claude-fable-5 (Claude Fable 5), Claude Code harness, extended thinking with tool use.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge