### PR TITLE
fix: keep execution recovery holds atomic across cancelled wakes

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2758,7 +2758,11 @@ export { ACCOUNT_HANDLE_MAX_LENGTH, toAccountHandle } from "./account-handle.js"
 export type { ExecutionContinuationEnvelope } from "./types/execution-continuation.js";
 export type { ExecutionProjection, ExecutionReconciliation, ExecutionBlocker } from "./types/execution-projection.js";
 
-export { EXECUTION_RECONCILIATION_CAUSES, requiresExecutionReconciliation } from "./types/execution-projection.js";
+export {
+  EXECUTION_RECONCILIATION_CAUSES,
+  EXECUTION_RECOVERY_OPERATOR_CAPABILITY,
+  requiresExecutionReconciliation,
+} from "./types/execution-projection.js";
 
 export * from "./types/email.js";
 export * from "./validators/email.js";

--- a/packages/shared/src/types/execution-projection.ts
+++ b/packages/shared/src/types/execution-projection.ts
@@ -59,6 +59,11 @@ export function requiresExecutionReconciliation(
   return EXECUTION_RECONCILIATION_CAUSES.some((value) => value === cause);
 }
 
+/** Narrow agent-token capability that may reconcile an assigned execution hold. */
+export const EXECUTION_RECOVERY_OPERATOR_CAPABILITY = "execution_recovery_operator" as const;
+export type ExecutionRecoveryOperatorCapability =
+  typeof EXECUTION_RECOVERY_OPERATOR_CAPABILITY;
+
 export interface ExecutionReconciliation {
   runId: string;
   providerStopped: true;

--- a/packages/shared/src/types/issue.ts
+++ b/packages/shared/src/types/issue.ts
@@ -836,6 +836,8 @@ export interface Issue {
   blockedTransitionAt?: Date | null;
   blockedOwnerNotifiedAt?: Date | null;
   activeRecoveryAction?: IssueRecoveryAction | null;
+  /** Settled no-replay hold that still blocks dispatch, when it is not `active`. */
+  effectiveRecoveryAction?: IssueRecoveryAction | null;
   successfulRunHandoff?: SuccessfulRunHandoffState | null;
   executionBlocker?: ExecutionBlocker | null;
   watchdog?: IssueWatchdogSummary | null;

--- a/packages/shared/src/validators/agent.ts
+++ b/packages/shared/src/validators/agent.ts
@@ -16,6 +16,7 @@ export const agentPermissionsSchema = z.object({
   // permissions record marks the agent low-trust) when the field is omitted.
   canCreateAgents: z.boolean().optional(),
   canCreateSkills: z.boolean().optional().default(true),
+  execution_recovery_operator: z.boolean().optional(),
   trustPreset: trustPresetSchema.optional(),
   authorizationPolicy: trustAuthorizationPolicySchema.optional(),
 }).catchall(z.unknown());
@@ -174,6 +175,7 @@ export const taskBridgeAgentKeyScopeSchema = z.object({
 
 export const standardAgentKeyScopeSchema = z.object({
   kind: z.literal("standard"),
+  capabilities: z.array(z.literal("execution_recovery_operator")).max(8).optional(),
 }).strict();
 
 export const skillTestAgentKeyScopeSchema = z.object({

--- a/server/src/__tests__/agent-auth-jwt.test.ts
+++ b/server/src/__tests__/agent-auth-jwt.test.ts
@@ -79,6 +79,19 @@ describe("agent local JWT", () => {
     expect(claims?.key_scope).toEqual({ kind: "skill_test", issueId });
   });
 
+  it("round-trips an execution recovery operator capability on a standard key", () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    const token = createLocalAgentJwt("agent-1", "company-1", "claude_local", "run-1", "user-1", {
+      kind: "standard",
+      capabilities: ["execution_recovery_operator"],
+    });
+    const claims = verifyLocalAgentJwt(token!);
+    expect(claims?.key_scope).toEqual({
+      kind: "standard",
+      capabilities: ["execution_recovery_operator"],
+    });
+  });
+
   it("returns null when secret is missing", () => {
     process.env[secretEnv] = "";
     const token = createLocalAgentJwt("agent-1", "company-1", "claude_local", "run-1");

--- a/server/src/__tests__/agent-permissions-service.test.ts
+++ b/server/src/__tests__/agent-permissions-service.test.ts
@@ -77,6 +77,13 @@ describe("agent permissions service", () => {
     expect(defaultAgentPermissions({ lowTrust: true, context: "create" }).canCreateSkills).toBe(true);
   });
 
+  it("withholds execution recovery operator authority unless explicitly granted", () => {
+    expect(defaultAgentPermissions().execution_recovery_operator).toBe(false);
+    expect(normalizeAgentPermissions({}).execution_recovery_operator).toBe(false);
+    expect(normalizeAgentPermissions({ execution_recovery_operator: true }).execution_recovery_operator).toBe(true);
+    expect(normalizeAgentPermissions({ execution_recovery_operator: "true" }).execution_recovery_operator).toBe(false);
+  });
+
   it("preserves explicit canCreateAgents overrides in both contexts", () => {
     expect(normalizeAgentPermissions({ canCreateAgents: false }, { context: "create" }).canCreateAgents).toBe(false);
     expect(normalizeAgentPermissions({ canCreateAgents: true }).canCreateAgents).toBe(true);

--- a/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
+++ b/server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts
@@ -9,9 +9,11 @@ import {
   createDb,
   documentRevisions,
   documents,
+  heartbeatRunEvents,
   heartbeatRuns,
   issueComments,
   issueDocuments,
+  issueRecoveryActions,
   issueThreadInteractions,
   issues,
 } from "@paperclipai/db";
@@ -97,6 +99,7 @@ async function cleanupHeartbeatInvalidationFixture(db: ReturnType<typeof createD
           "documents",
           "issue_relations",
           "issue_tree_holds",
+          "issue_recovery_actions",
           "issues",
           "heartbeat_run_events",
           "cost_events",
@@ -310,6 +313,78 @@ describeEmbeddedPostgres("heartbeat stale queued-run invalidation", () => {
       key: ISSUE_CONTINUATION_SUMMARY_DOCUMENT_KEY,
     });
   }
+
+  it("cancels three heartbeat wakes against a root hold without opening new recovery or invoking the adapter", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent({ maxConcurrentRuns: 3 });
+    const issueId = randomUUID();
+    const rootRunId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Root execution hold",
+      status: "blocked",
+      priority: "medium",
+      assigneeAgentId: agentId,
+    });
+    await db.insert(issueRecoveryActions).values({
+      companyId,
+      sourceIssueId: issueId,
+      kind: "active_run_watchdog",
+      ownerType: "board",
+      cause: "uncertain_external_action",
+      status: "resolved",
+      evidence: { runId: rootRunId, automaticRecovery: { replay: "blocked" } },
+      fingerprint: rootRunId,
+      nextAction: "Verify whether the action ran.",
+    });
+
+    const queued = [];
+    for (let i = 0; i < 3; i += 1) {
+      queued.push(await seedQueuedRun({
+        companyId,
+        agentId,
+        issueId,
+        wakeReason: "issue_commented",
+        invocationSource: "automation",
+      }));
+    }
+
+    await heartbeat.resumeQueuedRuns();
+    expect(await waitForCondition(async () => {
+      const runs = await db.select({
+        status: heartbeatRuns.status,
+        startedAt: heartbeatRuns.startedAt,
+        errorCode: heartbeatRuns.errorCode,
+      }).from(heartbeatRuns);
+      return runs.length === 3 && runs.every((run) =>
+        run.status === "cancelled" && run.startedAt == null && run.errorCode === "execution_reconciliation_required"
+      );
+    }, 10_000)).toBe(true);
+
+    const liveWakes = [];
+    for (let i = 0; i < 3; i += 1) {
+      liveWakes.push(await heartbeat.wakeup(agentId, {
+        source: "automation",
+        triggerDetail: "system",
+        reason: "issue_commented",
+        payload: { issueId },
+        contextSnapshot: { issueId, wakeReason: "issue_commented" },
+      }));
+    }
+    expect(liveWakes.every((run) => run == null || run.status === "cancelled")).toBe(true);
+
+    const cancelled = await db.select().from(heartbeatRuns);
+    const queuedIds = new Set(queued.map((wake) => wake.runId));
+    const cancelledQueued = cancelled.filter((run) => queuedIds.has(run.id));
+    expect(cancelledQueued).toHaveLength(3);
+    expect(cancelledQueued.every((run) =>
+      run.status === "cancelled" && run.startedAt == null && run.errorCode === "execution_reconciliation_required",
+    )).toBe(true);
+    expect(cancelled.every((run) => run.status !== "running" && run.startedAt == null)).toBe(true);
+    expect(mockAdapterExecute).not.toHaveBeenCalled();
+    expect(await db.select().from(heartbeatRunEvents).where(eq(heartbeatRunEvents.eventType, "adapter.invoke"))).toHaveLength(0);
+    expect(await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.sourceIssueId, issueId))).toHaveLength(1);
+  });
 
   it("skips generic timer wakes with no actionable assigned work before adapter execution", async () => {
     const { agentId } = await seedCompanyAndAgent({

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -10,6 +10,7 @@ import {
   agentWakeupRequests,
   activityLog,
   companies,
+  companyMemberships,
   createDb,
   environmentLeases,
   environments,
@@ -24,6 +25,8 @@ import {
   getEmbeddedPostgresTestSupport,
   startEmbeddedPostgresTestDatabase,
 } from "./helpers/embedded-postgres.js";
+import { createLocalAgentJwt } from "../agent-auth-jwt.js";
+import { actorMiddleware } from "../middleware/auth.js";
 import { errorHandler } from "../middleware/index.js";
 import { issueRoutes } from "../routes/issues.js";
 import { buildPaperclipWakePayload, heartbeatService } from "../services/heartbeat.js";
@@ -132,8 +135,10 @@ if (!embeddedPostgresSupport.supported) {
 describeEmbeddedPostgres("issue recovery actions", () => {
   let tempDb: Awaited<ReturnType<typeof startEmbeddedPostgresTestDatabase>> | null = null;
   let db: ReturnType<typeof createDb>;
+  const previousAgentJwtSecret = process.env.PAPERCLIP_AGENT_JWT_SECRET;
 
   beforeAll(async () => {
+    process.env.PAPERCLIP_AGENT_JWT_SECRET = "issue-recovery-actions-jwt-test-secret";
     tempDb = await startEmbeddedPostgresTestDatabase("paperclip-issue-recovery-actions-");
     db = createDb(tempDb.connectionString);
   }, 30_000);
@@ -150,12 +155,15 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     await db.delete(issues);
     await db.delete(agentRuntimeState);
     await db.delete(agents);
+    await db.delete(companyMemberships);
     await db.delete(companies);
     await db.delete(authUsers);
   });
 
   afterAll(async () => {
     await tempDb?.cleanup();
+    if (previousAgentJwtSecret === undefined) delete process.env.PAPERCLIP_AGENT_JWT_SECRET;
+    else process.env.PAPERCLIP_AGENT_JWT_SECRET = previousAgentJwtSecret;
   });
 
   async function seedCompany() {
@@ -240,6 +248,36 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     app.use("/api", issueRoutes(db, {} as any, opts));
     app.use(errorHandler);
     return app;
+  }
+
+  function authenticatedApp(opts: Parameters<typeof issueRoutes>[2] = {}) {
+    const app = express();
+    app.use(express.json());
+    app.use(actorMiddleware(db, { deploymentMode: "authenticated" }));
+    app.use("/api", issueRoutes(db, {} as any, opts));
+    app.use(errorHandler);
+    return app;
+  }
+
+  function agentBearer(
+    agentId: string,
+    companyId: string,
+    runId: string,
+    responsibleUserId: string,
+    capabilities: Array<"execution_recovery_operator"> = [],
+  ) {
+    const token = createLocalAgentJwt(
+      agentId,
+      companyId,
+      "codex_local",
+      runId,
+      responsibleUserId,
+      capabilities.length
+        ? { kind: "standard", capabilities }
+        : { kind: "standard" },
+    );
+    expect(token).toBeTruthy();
+    return token!;
   }
 
   it("upserts one active source-scoped action per issue and keeps company scoping explicit", async () => {
@@ -2718,7 +2756,7 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     expect(detail.body.effectiveRecoveryAction).toMatchObject({ id: action!.id });
   });
 
-  it("lets an assigned execution-recovery operator reconcile atomically and refuses ordinary agent tokens", async () => {
+  async function seedOperatorReconciliation() {
     const { companyId, managerId, prefix, sourceIssueId } = await seedCompany();
     const infraId = randomUUID();
     const backendId = randomUUID();
@@ -2747,6 +2785,36 @@ describeEmbeddedPostgres("issue recovery actions", () => {
         adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {},
       },
     ]);
+    await db.insert(companyMemberships).values([
+      {
+        companyId,
+        principalType: "user",
+        principalId: responsibleUserId,
+        status: "active",
+        membershipRole: "operator",
+      },
+      {
+        companyId,
+        principalType: "agent",
+        principalId: infraId,
+        status: "active",
+        membershipRole: "member",
+      },
+      {
+        companyId,
+        principalType: "agent",
+        principalId: backendId,
+        status: "active",
+        membershipRole: "member",
+      },
+      {
+        companyId,
+        principalType: "agent",
+        principalId: managerId,
+        status: "active",
+        membershipRole: "member",
+      },
+    ]);
     const rootRunId = randomUUID();
     await seedHeartbeatRun({ companyId, agentId: infraId, runId: rootRunId, issueId: sourceIssueId, status: "failed" });
     await seedHeartbeatRun({ companyId, agentId: infraId, runId: randomUUID(), status: "running" });
@@ -2766,8 +2834,13 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     await db.insert(heartbeatRuns).values({
       id: childRunId, companyId, agentId: infraId, invocationSource: "manual", status: "cancelled",
       errorCode: "execution_reconciliation_required",
-      resultJson: { executionRecovery: { kind: "bootstrap", providerWorkStarted: false } },
-      contextSnapshot: { issueId: childIssueId },
+      retryOfRunId: rootRunId,
+      startedAt: null,
+      resultJson: {
+        executionRecovery: { kind: "bootstrap", providerWorkStarted: false },
+        executionWait: { recoveryActionId: rootAction!.id },
+      },
+      contextSnapshot: { issueId: childIssueId, previousRunId: rootRunId },
     });
     const [childAction] = await db.insert(issueRecoveryActions).values({
       companyId, sourceIssueId: childIssueId, kind: "active_run_watchdog", status: "resolved", outcome: "blocked",
@@ -2775,6 +2848,24 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       fingerprint: `legacy-execution:${childRunId}`,
       nextAction: "Inspect the stopped provider.",
       evidence: { runId: childRunId, automaticRecovery: { replay: "blocked", actionOutcome: "unknown" } },
+    }).returning();
+    const unrelatedIssueId = randomUUID();
+    const unrelatedRunId = randomUUID();
+    await db.insert(issues).values({
+      id: unrelatedIssueId, companyId, title: "Backend child", status: "blocked", priority: "medium",
+      parentId: sourceIssueId, assigneeAgentId: backendId, issueNumber: 3, identifier: `${prefix}-3`,
+    });
+    await db.insert(heartbeatRuns).values({
+      id: unrelatedRunId, companyId, agentId: backendId, invocationSource: "manual", status: "failed",
+      startedAt: new Date("2026-05-13T18:00:00.000Z"),
+      contextSnapshot: { issueId: unrelatedIssueId },
+    });
+    const [unrelatedAction] = await db.insert(issueRecoveryActions).values({
+      companyId, sourceIssueId: unrelatedIssueId, kind: "active_run_watchdog", status: "resolved", outcome: "blocked",
+      ownerType: "board", returnOwnerAgentId: backendId, cause: "uncertain_external_action",
+      fingerprint: unrelatedRunId,
+      nextAction: "Inspect the stopped provider.",
+      evidence: { runId: unrelatedRunId, automaticRecovery: { replay: "blocked", actionOutcome: "unknown" } },
     }).returning();
     const actorRunId = randomUUID();
     await seedHeartbeatRun({ companyId, agentId: infraId, runId: actorRunId, issueId: sourceIssueId, status: "succeeded" });
@@ -2789,52 +2880,119 @@ describeEmbeddedPostgres("issue recovery actions", () => {
         outcomeEvidence: "The provider never started; queued successor runs were cancelled before start.",
       },
     };
-    const operatorActor = {
-      type: "agent" as const,
-      agentId: infraId,
-      companyId,
-      runId: actorRunId,
-      keyScope: { kind: "standard" as const, capabilities: ["execution_recovery_operator" as const] },
-      source: "agent_jwt",
+    return {
+      companyId, managerId, infraId, backendId, responsibleUserId, sourceIssueId,
+      rootRunId, rootAction: rootAction!, childIssueId, childAction: childAction!,
+      unrelatedIssueId, unrelatedAction: unrelatedAction!, unrelatedRunId,
+      actorRunId, ctoRunId, backendRunId, proof,
     };
-    expect((await request(createApp({
-      type: "agent", agentId: managerId, companyId, runId: ctoRunId,
-      keyScope: { kind: "standard" }, source: "agent_jwt",
-    })).post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`).send(proof)).status).toBe(403);
-    expect((await request(createApp({
-      type: "agent", agentId: backendId, companyId, runId: backendRunId,
-      keyScope: { kind: "standard" }, source: "agent_jwt",
-    })).post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`).send(proof)).status).toBe(403);
-    expect((await request(createApp({
-      ...operatorActor, keyScope: { kind: "standard" },
-    })).post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`).send(proof)).status).toBe(403);
-    const incomplete = await request(createApp(operatorActor))
-      .post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`)
-      .send({ ...proof, executionReconciliation: undefined });
+  }
+
+  function postResolve(
+    issueId: string,
+    body: Record<string, unknown>,
+    token: string,
+    runId: string,
+  ) {
+    return request(authenticatedApp())
+      .post(`/api/issues/${issueId}/recovery-actions/resolve`)
+      .set("Authorization", `Bearer ${token}`)
+      .set("X-Paperclip-Run-Id", runId)
+      .send(body);
+  }
+
+  it("lets an assigned execution-recovery operator reconcile atomically and refuses ordinary agent tokens", async () => {
+    const fixture = await seedOperatorReconciliation();
+    const {
+      companyId, managerId, infraId, backendId, responsibleUserId, sourceIssueId,
+      rootRunId, rootAction, childIssueId, childAction,
+      unrelatedIssueId, unrelatedAction, unrelatedRunId,
+      actorRunId, ctoRunId, backendRunId, proof,
+    } = fixture;
+    const operatorToken = agentBearer(
+      infraId, companyId, actorRunId, responsibleUserId, ["execution_recovery_operator"],
+    );
+    const infraWithoutCapability = agentBearer(infraId, companyId, actorRunId, responsibleUserId);
+    const ctoToken = agentBearer(managerId, companyId, ctoRunId, responsibleUserId);
+    const backendToken = agentBearer(backendId, companyId, backendRunId, responsibleUserId);
+
+    expect((await postResolve(sourceIssueId, proof, ctoToken, ctoRunId)).status).toBe(403);
+    expect((await postResolve(sourceIssueId, proof, backendToken, backendRunId)).status).toBe(403);
+    expect((await postResolve(sourceIssueId, proof, infraWithoutCapability, actorRunId)).status).toBe(403);
+    const incomplete = await postResolve(
+      sourceIssueId, { ...proof, executionReconciliation: undefined }, operatorToken, actorRunId,
+    );
     expect(incomplete.status).toBe(422);
     expect((await db.select().from(issues).where(eq(issues.id, sourceIssueId)))[0]!.status).toBe("blocked");
     expect(await getExecutionBlocker(db, companyId, sourceIssueId)).toMatchObject({
-      recoveryActionId: rootAction!.id,
+      recoveryActionId: rootAction.id,
       runId: rootRunId,
     });
-    const resolved = await request(createApp(operatorActor))
-      .post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`)
-      .send(proof)
-      .expect(200);
+    const resolved = await postResolve(sourceIssueId, proof, operatorToken, actorRunId).expect(200);
     expect(resolved.body.issue.status).toBe("todo");
     expect(resolved.body.issue.executionBlocker).toBeNull();
     expect(resolved.body.issue.effectiveRecoveryAction).toBeNull();
-    const [child] = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.id, childAction!.id));
+    const [child] = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.id, childAction.id));
     expect(child).toMatchObject({ status: "cancelled", outcome: "cancelled" });
     expect(child!.evidence).not.toHaveProperty("automaticRecovery");
     expect(await getExecutionBlocker(db, companyId, sourceIssueId)).toBeNull();
     expect(await getExecutionBlocker(db, companyId, childIssueId)).toBeNull();
+    const [unrelated] = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.id, unrelatedAction.id));
+    expect(unrelated).toMatchObject({ status: "resolved", outcome: "blocked" });
+    expect(unrelated!.evidence.automaticRecovery).toMatchObject({ replay: "blocked" });
+    expect(await getExecutionBlocker(db, companyId, unrelatedIssueId)).toMatchObject({
+      recoveryActionId: unrelatedAction.id,
+      runId: unrelatedRunId,
+    });
     const successors = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.retryOfRunId, rootRunId));
-    expect(successors).toHaveLength(1);
+    const successorWakes = successors.filter((run) => run.id !== childAction.evidence.runId && run.status !== "cancelled");
+    expect(successorWakes).toHaveLength(1);
     const wakes = await db.select().from(agentWakeupRequests).where(
-      eq(agentWakeupRequests.idempotencyKey, `execution-reconciliation:${rootAction!.id}`),
+      eq(agentWakeupRequests.idempotencyKey, `execution-reconciliation:${rootAction.id}`),
     );
     expect(wakes).toHaveLength(1);
-    expect(wakes[0]!.runId).toBe(successors[0]!.id);
+    expect(wakes[0]!.runId).toBe(successorWakes[0]!.id);
+  });
+
+  it.each([
+    {
+      name: "missing outcomeEvidence",
+      patch: { outcomeEvidence: undefined },
+    },
+    {
+      name: "providerStopped false",
+      patch: { providerStopped: false },
+    },
+    {
+      name: "wrong runId",
+      patch: { runId: randomUUID() },
+    },
+  ])("rejects partial execution reconciliation proof ($name) without mutation", async ({ patch }) => {
+    const fixture = await seedOperatorReconciliation();
+    const {
+      companyId, infraId, responsibleUserId, sourceIssueId,
+      rootAction, childAction, unrelatedAction,
+      actorRunId, proof,
+    } = fixture;
+    const operatorToken = agentBearer(
+      infraId, companyId, actorRunId, responsibleUserId, ["execution_recovery_operator"],
+    );
+    const rejected = await postResolve(sourceIssueId, {
+      ...proof,
+      executionReconciliation: { ...proof.executionReconciliation, ...patch },
+    }, operatorToken, actorRunId);
+    expect(rejected.status).toBeGreaterThanOrEqual(400);
+    expect(rejected.status).toBeLessThan(500);
+    expect((await db.select().from(issues).where(eq(issues.id, sourceIssueId)))[0]!.status).toBe("blocked");
+    const [root] = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.id, rootAction.id));
+    expect(root).toMatchObject({ status: "resolved", outcome: "blocked" });
+    expect(root!.evidence.automaticRecovery).toMatchObject({ replay: "blocked" });
+    const [child] = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.id, childAction.id));
+    expect(child).toMatchObject({ status: "resolved", outcome: "blocked" });
+    const [unrelated] = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.id, unrelatedAction.id));
+    expect(unrelated).toMatchObject({ status: "resolved", outcome: "blocked" });
+    expect(await db.select().from(agentWakeupRequests).where(
+      eq(agentWakeupRequests.idempotencyKey, `execution-reconciliation:${rootAction.id}`),
+    )).toHaveLength(0);
   });
 });

--- a/server/src/__tests__/issue-recovery-actions.test.ts
+++ b/server/src/__tests__/issue-recovery-actions.test.ts
@@ -28,6 +28,7 @@ import { errorHandler } from "../middleware/index.js";
 import { issueRoutes } from "../routes/issues.js";
 import { buildPaperclipWakePayload, heartbeatService } from "../services/heartbeat.js";
 import { deliverReconciledExecutions } from "../services/execution-recovery-resolution.js";
+import { getExecutionBlocker } from "../services/execution-blocker.js";
 import { issueRecoveryActionService } from "../services/issue-recovery-actions.js";
 import { recoveryService } from "../services/recovery/service.js";
 import { noticeMetadataReferencesRecoveryAction } from "../services/recovery/successful-run-handoff.js";
@@ -1648,8 +1649,8 @@ describeEmbeddedPostgres("issue recovery actions", () => {
     const body = { actionId: action!.id, outcome: "restored", sourceIssueStatus: "todo",
       executionReconciliation: { runId, providerStopped: true, actionOutcome: "not_performed",
         outcomeEvidence: "Provider receipts confirm the action was never submitted; the stopped process has no remaining effects." } };
-    // A retry without new evidence cannot clear the hold or reopen the task.
-    await request(app).post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`).send({ ...body, executionReconciliation: undefined }).expect(200);
+    // A restore without proof must not reopen the hold.
+    await request(app).post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`).send({ ...body, executionReconciliation: undefined }).expect(422);
     expect((await db.select().from(issues).where(eq(issues.id, sourceIssueId)))[0]!.status).toBe("blocked");
     const resolved = await request(app).post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`).send(body).expect(200);
     expect(resolved.body.issue.status).toBe("todo");
@@ -2691,5 +2692,149 @@ describeEmbeddedPostgres("issue recovery actions", () => {
       .from(issueRecoveryActions)
       .where(eq(issueRecoveryActions.id, action.id));
     expect(actionRow?.status).toBe("active");
+  });
+
+  it("exposes a settled no-replay hold as the effective recovery action", async () => {
+    const { companyId, coderId, sourceIssueId } = await seedCompany();
+    const runId = randomUUID();
+    await seedHeartbeatRun({ companyId, agentId: coderId, runId, issueId: sourceIssueId, status: "failed" });
+    const [action] = await db.insert(issueRecoveryActions).values({
+      companyId, sourceIssueId, kind: "active_run_watchdog", status: "resolved", outcome: "blocked",
+      ownerType: "board", returnOwnerAgentId: coderId, cause: "uncertain_external_action", fingerprint: runId,
+      nextAction: "Preserve recorded work without replay.",
+      evidence: { runId, automaticRecovery: { replay: "blocked", actionOutcome: "unknown" } },
+    }).returning();
+    const app = createApp();
+    const list = await request(app).get(`/api/issues/${sourceIssueId}/recovery-actions`).expect(200);
+    expect(list.body.active).toBeNull();
+    expect(list.body.effective).toMatchObject({ id: action!.id, status: "resolved" });
+    expect(list.body.actions).toHaveLength(1);
+    const detail = await request(app).get(`/api/issues/${sourceIssueId}`).expect(200);
+    expect(detail.body.activeRecoveryAction).toBeNull();
+    expect(detail.body.executionBlocker).toMatchObject({
+      recoveryActionId: action!.id,
+      runId,
+    });
+    expect(detail.body.effectiveRecoveryAction).toMatchObject({ id: action!.id });
+  });
+
+  it("lets an assigned execution-recovery operator reconcile atomically and refuses ordinary agent tokens", async () => {
+    const { companyId, managerId, prefix, sourceIssueId } = await seedCompany();
+    const infraId = randomUUID();
+    const backendId = randomUUID();
+    const responsibleUserId = randomUUID();
+    await db.insert(authUsers).values({
+      id: responsibleUserId,
+      name: "Recovery operator",
+      email: `${responsibleUserId}@example.test`,
+      emailVerified: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    await db
+      .update(companies)
+      .set({ defaultResponsibleUserId: responsibleUserId })
+      .where(eq(companies.id, companyId));
+    await db.insert(agents).values([
+      {
+        id: infraId, companyId, name: "Infra", role: "engineer", status: "idle",
+        adapterType: "codex_local", adapterConfig: {},
+        runtimeConfig: { heartbeat: { maxConcurrentRuns: 1 } },
+        permissions: { execution_recovery_operator: true },
+      },
+      {
+        id: backendId, companyId, name: "Backend", role: "engineer", status: "idle",
+        adapterType: "codex_local", adapterConfig: {}, runtimeConfig: {}, permissions: {},
+      },
+    ]);
+    const rootRunId = randomUUID();
+    await seedHeartbeatRun({ companyId, agentId: infraId, runId: rootRunId, issueId: sourceIssueId, status: "failed" });
+    await seedHeartbeatRun({ companyId, agentId: infraId, runId: randomUUID(), status: "running" });
+    await db.update(issues).set({ status: "blocked", assigneeAgentId: infraId }).where(eq(issues.id, sourceIssueId));
+    const [rootAction] = await db.insert(issueRecoveryActions).values({
+      companyId, sourceIssueId, kind: "active_run_watchdog", status: "resolved", outcome: "blocked",
+      ownerType: "board", returnOwnerAgentId: infraId, cause: "uncertain_external_action", fingerprint: rootRunId,
+      nextAction: "Preserve recorded work without replay.",
+      evidence: { runId: rootRunId, automaticRecovery: { replay: "blocked", actionOutcome: "unknown" } },
+    }).returning();
+    const childIssueId = randomUUID();
+    await db.insert(issues).values({
+      id: childIssueId, companyId, title: "Child", status: "blocked", priority: "medium",
+      parentId: sourceIssueId, assigneeAgentId: infraId, issueNumber: 2, identifier: `${prefix}-2`,
+    });
+    const childRunId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: childRunId, companyId, agentId: infraId, invocationSource: "manual", status: "cancelled",
+      errorCode: "execution_reconciliation_required",
+      resultJson: { executionRecovery: { kind: "bootstrap", providerWorkStarted: false } },
+      contextSnapshot: { issueId: childIssueId },
+    });
+    const [childAction] = await db.insert(issueRecoveryActions).values({
+      companyId, sourceIssueId: childIssueId, kind: "active_run_watchdog", status: "resolved", outcome: "blocked",
+      ownerType: "board", returnOwnerAgentId: infraId, cause: "legacy_execution_requires_reconciliation",
+      fingerprint: `legacy-execution:${childRunId}`,
+      nextAction: "Inspect the stopped provider.",
+      evidence: { runId: childRunId, automaticRecovery: { replay: "blocked", actionOutcome: "unknown" } },
+    }).returning();
+    const actorRunId = randomUUID();
+    await seedHeartbeatRun({ companyId, agentId: infraId, runId: actorRunId, issueId: sourceIssueId, status: "succeeded" });
+    const ctoRunId = randomUUID();
+    await seedHeartbeatRun({ companyId, agentId: managerId, runId: ctoRunId, issueId: sourceIssueId, status: "succeeded" });
+    const backendRunId = randomUUID();
+    await seedHeartbeatRun({ companyId, agentId: backendId, runId: backendRunId, issueId: sourceIssueId, status: "succeeded" });
+    const proof = {
+      actionId: rootAction!.id, outcome: "restored", sourceIssueStatus: "todo",
+      executionReconciliation: {
+        runId: rootRunId, providerStopped: true, actionOutcome: "not_performed",
+        outcomeEvidence: "The provider never started; queued successor runs were cancelled before start.",
+      },
+    };
+    const operatorActor = {
+      type: "agent" as const,
+      agentId: infraId,
+      companyId,
+      runId: actorRunId,
+      keyScope: { kind: "standard" as const, capabilities: ["execution_recovery_operator" as const] },
+      source: "agent_jwt",
+    };
+    expect((await request(createApp({
+      type: "agent", agentId: managerId, companyId, runId: ctoRunId,
+      keyScope: { kind: "standard" }, source: "agent_jwt",
+    })).post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`).send(proof)).status).toBe(403);
+    expect((await request(createApp({
+      type: "agent", agentId: backendId, companyId, runId: backendRunId,
+      keyScope: { kind: "standard" }, source: "agent_jwt",
+    })).post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`).send(proof)).status).toBe(403);
+    expect((await request(createApp({
+      ...operatorActor, keyScope: { kind: "standard" },
+    })).post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`).send(proof)).status).toBe(403);
+    const incomplete = await request(createApp(operatorActor))
+      .post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`)
+      .send({ ...proof, executionReconciliation: undefined });
+    expect(incomplete.status).toBe(422);
+    expect((await db.select().from(issues).where(eq(issues.id, sourceIssueId)))[0]!.status).toBe("blocked");
+    expect(await getExecutionBlocker(db, companyId, sourceIssueId)).toMatchObject({
+      recoveryActionId: rootAction!.id,
+      runId: rootRunId,
+    });
+    const resolved = await request(createApp(operatorActor))
+      .post(`/api/issues/${sourceIssueId}/recovery-actions/resolve`)
+      .send(proof)
+      .expect(200);
+    expect(resolved.body.issue.status).toBe("todo");
+    expect(resolved.body.issue.executionBlocker).toBeNull();
+    expect(resolved.body.issue.effectiveRecoveryAction).toBeNull();
+    const [child] = await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.id, childAction!.id));
+    expect(child).toMatchObject({ status: "cancelled", outcome: "cancelled" });
+    expect(child!.evidence).not.toHaveProperty("automaticRecovery");
+    expect(await getExecutionBlocker(db, companyId, sourceIssueId)).toBeNull();
+    expect(await getExecutionBlocker(db, companyId, childIssueId)).toBeNull();
+    const successors = await db.select().from(heartbeatRuns).where(eq(heartbeatRuns.retryOfRunId, rootRunId));
+    expect(successors).toHaveLength(1);
+    const wakes = await db.select().from(agentWakeupRequests).where(
+      eq(agentWakeupRequests.idempotencyKey, `execution-reconciliation:${rootAction!.id}`),
+    );
+    expect(wakes).toHaveLength(1);
+    expect(wakes[0]!.runId).toBe(successors[0]!.id);
   });
 });

--- a/server/src/agent-auth-jwt.ts
+++ b/server/src/agent-auth-jwt.ts
@@ -137,7 +137,9 @@ export function createLocalAgentJwt(
     adapter_type: adapterType,
     run_id: runId,
     responsible_user_id: responsibleUserId?.trim() || null,
-    ...(keyScope.kind === "standard" ? {} : { key_scope: keyScope }),
+    ...(keyScope.kind === "standard" && !keyScope.capabilities?.length
+      ? {}
+      : { key_scope: keyScope }),
     iat: now,
     exp: now + config.ttlSeconds,
     iss: config.issuer,

--- a/server/src/modules/run-dispatch/adapters/postgres.test.ts
+++ b/server/src/modules/run-dispatch/adapters/postgres.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { eq, sql } from "drizzle-orm";
+import { eq, inArray, sql } from "drizzle-orm";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   activityLog,
@@ -24,6 +24,10 @@ import {
 import { createPostgresRunDispatchAdapter } from "./postgres.js";
 import { settleUnrecoverableExecutions } from "../../../services/execution-recovery-resolution.js";
 import { getExecutionBlocker } from "../../../services/execution-blocker.js";
+import {
+  legacyExecutionNeedsReconciliation,
+  terminalizeLegacyExecution,
+} from "../../../services/legacy-execution-recovery.js";
 
 // Proves the DB-to-facts mapping this adapter owns for each state the two
 // run-dispatch gates decide on. `application/use-cases.test.ts` and
@@ -57,6 +61,7 @@ describeEmbeddedPostgres("run-dispatch postgres adapter", () => {
     await db.delete(documents);
     await db.delete(issueTreeHolds);
     await db.delete(issueRelations);
+    await db.delete(issueRecoveryActions);
     await db.delete(issues);
     await db.delete(heartbeatRunEvents);
     await db.delete(heartbeatRuns);
@@ -763,6 +768,46 @@ describeEmbeddedPostgres("run-dispatch postgres adapter", () => {
       15_000,
     );
   });
+  it("cancels three pre-start wakes against a root hold without opening new recovery", async () => {
+    const { companyId, agentId } = await seedCompanyAndAgent();
+    const issueId = randomUUID();
+    const rootRunId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId, companyId, title: "Root hold", status: "blocked", assigneeAgentId: agentId,
+    });
+    await db.insert(issueRecoveryActions).values({
+      companyId, sourceIssueId: issueId, kind: "active_run_watchdog", ownerType: "board",
+      cause: "uncertain_external_action", status: "resolved",
+      evidence: { runId: rootRunId, automaticRecovery: { replay: "blocked" } },
+      fingerprint: rootRunId, nextAction: "Verify whether the action ran.",
+    });
+    const adapter = createPostgresRunDispatchAdapter(db);
+    const wakeIds = [randomUUID(), randomUUID(), randomUUID()];
+    for (const runId of wakeIds) {
+      await db.insert(heartbeatRuns).values({
+        id: runId, companyId, agentId, status: "queued",
+        contextSnapshot: { issueId, wakeReason: "issue_commented" },
+      });
+      await expect(adapter.cancelStaleQueuedRun({
+        companyId, runId, expectedStatus: "queued", now: new Date(),
+      })).resolves.toMatchObject({ outcome: "cancelled", errorCode: "execution_reconciliation_required" });
+    }
+    const cancelled = await db.select().from(heartbeatRuns).where(inArray(heartbeatRuns.id, wakeIds));
+    expect(cancelled).toHaveLength(3);
+    expect(cancelled.every((run) => run.status === "cancelled" && run.startedAt == null)).toBe(true);
+    expect(cancelled.every((run) =>
+      (run.resultJson as { executionRecovery?: { kind?: string; providerWorkStarted?: boolean } } | null)
+        ?.executionRecovery?.kind === "bootstrap" &&
+      (run.resultJson as { executionRecovery?: { providerWorkStarted?: boolean } }).executionRecovery?.providerWorkStarted === false,
+    )).toBe(true);
+    expect(cancelled.every((run) => !legacyExecutionNeedsReconciliation(run))).toBe(true);
+    for (const run of cancelled) {
+      await terminalizeLegacyExecution({ db, run, status: "cancelled" });
+    }
+    expect(await db.select().from(issueRecoveryActions).where(eq(issueRecoveryActions.sourceIssueId, issueId))).toHaveLength(1);
+    expect(await db.select().from(heartbeatRunEvents).where(eq(heartbeatRunEvents.eventType, "adapter.invoke"))).toHaveLength(0);
+  });
+
   it.each(["active", "resolved"])("blocks a generic retry after %s no-replay disposition", async status => {
     const { companyId, agentId } = await seedCompanyAndAgent();
     const issueId = randomUUID(), runId = randomUUID();

--- a/server/src/modules/run-dispatch/adapters/postgres.ts
+++ b/server/src/modules/run-dispatch/adapters/postgres.ts
@@ -825,7 +825,17 @@ export function createPostgresRunDispatchAdapter(
             ...parseObject(run.resultJson),
             stopReason: decision.errorCode,
             ...(decision.errorCode === "execution_reconciliation_required"
-              ? { executionWait: decision.details }
+              ? {
+                  executionWait: decision.details,
+                  ...(!run.startedAt
+                    ? {
+                        executionRecovery: {
+                          kind: "bootstrap",
+                          providerWorkStarted: false,
+                        },
+                      }
+                    : {}),
+                }
               : {}),
             effectiveTimeoutSec: 0,
             timeoutConfigured: false,

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1,11 +1,16 @@
 import { deliverConversationComments, isConversation } from "../services/agent-conversations.js";
 import { issueRecoveryActionReadModel } from "../services/issue-recovery-actions.js";
-import { getExecutionBlocker } from "../services/execution-blocker.js";
+import { findExecutionBlockerAction, getExecutionBlocker } from "../services/execution-blocker.js";
 import { requiresExecutionReconciliation } from "@paperclipai/shared";
 import {
   validateExecutionReconciliation,
   markExecutionReconciliation,
+  deliverReconciledExecutions,
 } from "../services/execution-recovery-resolution.js";
+import {
+  assertExecutionReconciliationAuthorized,
+  requireExecutionReconciliationProof,
+} from "../services/execution-recovery-operator.js";
 import {
   storedSteeringAcknowledgement,
   reconcileSteeredIdentity,
@@ -8765,6 +8770,13 @@ export function issueRoutes(
       ? await executionWorkspacesSvc.getById(issue.executionWorkspaceId)
       : null;
     const workProducts = await workProductsSvc.listForIssue(issue.id);
+    const executionBlocker = await getExecutionBlocker(db, issue.companyId, issue.id);
+    const blockerAction = executionBlocker?.recoveryActionId
+      ? await findExecutionBlockerAction(db, issue.companyId, issue.id)
+      : null;
+    const effectiveRecoveryAction = blockerAction
+      ? issueRecoveryActionReadModel(blockerAction)
+      : revalidatedActiveRecoveryAction;
     res.setHeader(
       "Server-Timing",
       `paperclip_issue;dur=${(performance.now() - requestStartedAt).toFixed(1)}`,
@@ -8777,9 +8789,10 @@ export function issueRoutes(
       ...(blockerAttention ? { blockerAttention } : {}),
       ...(reviewAttention ? { reviewAttention } : {}),
       successfulRunHandoff: successfulRunHandoffStates.get(issue.id) ?? null,
-      executionBlocker: await getExecutionBlocker(db, issue.companyId, issue.id),
+      executionBlocker,
       scheduledRetry,
       activeRecoveryAction: revalidatedActiveRecoveryAction,
+      effectiveRecoveryAction: effectiveRecoveryAction ?? null,
       blockedBy: relationsWithRecoveryActions.blockedBy,
       blocks: relationsWithRecoveryActions.blocks,
       relatedWork: referenceSummary,
@@ -8940,9 +8953,17 @@ export function issueRoutes(
       trigger: "read_projection",
       actor: getActorInfo(req),
     });
+    const blockerAction = await findExecutionBlockerAction(db, issue.companyId, issue.id);
+    const effective = blockerAction
+      ? issueRecoveryActionReadModel(blockerAction)
+      : active;
+    const actions = [active, effective].filter((action, index, list) =>
+      Boolean(action) && list.findIndex((candidate) => candidate?.id === action?.id) === index,
+    );
     res.json({
       active,
-      actions: active ? [active] : [],
+      effective: effective ?? null,
+      actions,
     });
   });
 
@@ -9053,10 +9074,9 @@ export function issueRoutes(
             );
             const automatic = settled.evidence.automaticRecovery as
               { replay?: string } | undefined;
-            if (automatic?.replay === "blocked" && executionReconciliation) {
-              // An automatic no-replay disposition is final until new evidence
-              // arrives. Keep the supported evidence API usable without a dialog.
-              assertBoard(req);
+            if (automatic?.replay === "blocked") {
+              requireExecutionReconciliationProof(executionReconciliation);
+              assertExecutionReconciliationAuthorized(req, lockedIssue);
               if (
                 activeRecoveryAction ||
                 sourceIssueStatus !== "todo" ||
@@ -9098,7 +9118,8 @@ export function issueRoutes(
           sourceIssueStatus === "todo" &&
           requiresExecutionReconciliation(activeRecoveryAction.cause)
         ) {
-          assertBoard(req);
+          requireExecutionReconciliationProof(executionReconciliation);
+          assertExecutionReconciliationAuthorized(req, lockedIssue);
           await validateExecutionReconciliation({
             db: tx as unknown as Db,
             companyId: lockedIssue.companyId,
@@ -9403,6 +9424,8 @@ export function issueRoutes(
             "chat recovery retry dispatch deferred to durable worker",
           );
         }
+      } else if (executionReconciliation) {
+        await deliverReconciledExecutions(db, enqueueRecoveryActionWakeup);
       } else if (
         !executionReconciliation &&
         sourceIssueStatus === "todo" &&
@@ -9446,6 +9469,8 @@ export function issueRoutes(
         issue: {
           ...result.issue,
           activeRecoveryAction: null,
+          effectiveRecoveryAction: null,
+          executionBlocker: null,
         },
         recoveryAction: result.recoveryAction,
       });

--- a/server/src/services/agent-permissions.ts
+++ b/server/src/services/agent-permissions.ts
@@ -3,6 +3,7 @@ import { LOW_TRUST_REVIEW_PRESET } from "@paperclipai/shared";
 export type NormalizedAgentPermissions = Record<string, unknown> & {
   canCreateAgents: boolean;
   canCreateSkills: boolean;
+  execution_recovery_operator: boolean;
 };
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -45,6 +46,7 @@ export function defaultAgentPermissions(
   return {
     canCreateAgents: options?.context === "create" && options?.lowTrust !== true,
     canCreateSkills: true,
+    execution_recovery_operator: false,
   };
 }
 
@@ -71,5 +73,7 @@ export function normalizeAgentPermissions(
       typeof record.canCreateSkills === "boolean"
         ? record.canCreateSkills
         : defaults.canCreateSkills,
+    execution_recovery_operator:
+      record.execution_recovery_operator === true,
   };
 }

--- a/server/src/services/agents.ts
+++ b/server/src/services/agents.ts
@@ -1174,7 +1174,8 @@ export function agentService(db: Db) {
           name,
           keyHash,
           responsibleUserId: options?.responsibleUserId?.trim() || null,
-          scopeConfig: scope.kind === "standard" ? null : scope,
+          scopeConfig:
+            scope.kind === "standard" && !scope.capabilities?.length ? null : scope,
         })
         .returning()
         .then((rows) => rows[0]);

--- a/server/src/services/execution-blocker.ts
+++ b/server/src/services/execution-blocker.ts
@@ -36,12 +36,9 @@ export async function getExecutionBlocker(db: Db, companyId: string, issueId: st
 
   const ownership = await getConversationOwnershipBlocker(db, companyId, issueId);
   if (ownership) return { ...ownership, recoveryActionId: null };
-  const [action] = await db.select().from(issueRecoveryActions).where(and(
-    eq(issueRecoveryActions.companyId, companyId),
-    eq(issueRecoveryActions.sourceIssueId, issueId),
-    executionBlockerPredicate(),
-    boundary ? gt(issueRecoveryActions.createdAt, boundary.createdAt) : undefined,
-  )).orderBy(desc(issueRecoveryActions.updatedAt), desc(issueRecoveryActions.id)).limit(1);
+  const action = await findExecutionBlockerAction(db, companyId, issueId, {
+    createdAfter: boundary?.createdAt ?? null,
+  });
   if (!action) return null;
   const parsedRunId = z.string().guid().safeParse(action.evidence.runId ?? action.evidence.sourceRunId);
   const runId = parsedRunId.success ? parsedRunId.data : null;
@@ -57,4 +54,19 @@ export async function getExecutionBlocker(db: Db, companyId: string, issueId: st
     cause: action.cause,
     nextAction: action.nextAction,
   };
+}
+
+export async function findExecutionBlockerAction(
+  db: Db,
+  companyId: string,
+  issueId: string,
+  options?: { createdAfter?: Date | null },
+) {
+  const [action] = await db.select().from(issueRecoveryActions).where(and(
+    eq(issueRecoveryActions.companyId, companyId),
+    eq(issueRecoveryActions.sourceIssueId, issueId),
+    executionBlockerPredicate(),
+    options?.createdAfter ? gt(issueRecoveryActions.createdAt, options.createdAfter) : undefined,
+  )).orderBy(desc(issueRecoveryActions.updatedAt), desc(issueRecoveryActions.id)).limit(1);
+  return action ?? null;
 }

--- a/server/src/services/execution-recovery-operator.ts
+++ b/server/src/services/execution-recovery-operator.ts
@@ -1,0 +1,65 @@
+import type { AgentApiKeyScope } from "@paperclipai/shared";
+import { EXECUTION_RECOVERY_OPERATOR_CAPABILITY } from "@paperclipai/shared";
+import type { Request } from "express";
+import { forbidden, unprocessable } from "../errors.js";
+import { normalizeAgentPermissions } from "./agent-permissions.js";
+
+export function actorHasExecutionRecoveryOperatorCapability(actor: {
+  keyScope?: AgentApiKeyScope | null;
+}): boolean {
+  const scope = actor.keyScope;
+  return (
+    scope?.kind === "standard" &&
+    Array.isArray(scope.capabilities) &&
+    scope.capabilities.includes(EXECUTION_RECOVERY_OPERATOR_CAPABILITY)
+  );
+}
+
+export function agentGrantExecutionRecoveryOperator(permissions: unknown): boolean {
+  return normalizeAgentPermissions(permissions).execution_recovery_operator === true;
+}
+
+export function localAgentJwtScopeForExecutionRecovery(input: {
+  workMode?: string | null;
+  issueId?: string | null;
+  permissions: unknown;
+}): AgentApiKeyScope {
+  if (input.workMode === "skill_test" && input.issueId) {
+    return { kind: "skill_test", issueId: input.issueId };
+  }
+  if (agentGrantExecutionRecoveryOperator(input.permissions)) {
+    return {
+      kind: "standard",
+      capabilities: [EXECUTION_RECOVERY_OPERATOR_CAPABILITY],
+    };
+  }
+  return { kind: "standard" };
+}
+
+/** Board actors keep the existing path. Assigned agents need the narrow token capability. */
+export function assertExecutionReconciliationAuthorized(
+  req: Request,
+  issue: { assigneeAgentId: string | null },
+) {
+  if (req.actor.type === "board") return;
+  if (
+    req.actor.type === "agent" &&
+    req.actor.agentId &&
+    issue.assigneeAgentId === req.actor.agentId &&
+    actorHasExecutionRecoveryOperatorCapability(req.actor)
+  ) {
+    return;
+  }
+  throw forbidden("Execution recovery operator capability required", {
+    code: "execution_recovery_operator_required",
+  });
+}
+
+export function requireExecutionReconciliationProof(decision: unknown) {
+  if (!decision || typeof decision !== "object") {
+    throw unprocessable(
+      "Reconcile the recorded execution and its action outcomes before continuing this task.",
+      { code: "execution_reconciliation_required" },
+    );
+  }
+}

--- a/server/src/services/execution-recovery-operator.ts
+++ b/server/src/services/execution-recovery-operator.ts
@@ -1,8 +1,18 @@
-import type { AgentApiKeyScope } from "@paperclipai/shared";
+import type { AgentApiKeyScope, ExecutionReconciliation } from "@paperclipai/shared";
 import { EXECUTION_RECOVERY_OPERATOR_CAPABILITY } from "@paperclipai/shared";
 import type { Request } from "express";
+import { z } from "zod";
 import { forbidden, unprocessable } from "../errors.js";
 import { normalizeAgentPermissions } from "./agent-permissions.js";
+
+const executionReconciliationProofSchema = z
+  .object({
+    runId: z.string().guid(),
+    providerStopped: z.literal(true),
+    actionOutcome: z.enum(["completed", "not_performed", "mixed"]),
+    outcomeEvidence: z.string().trim().min(20).max(12000),
+  })
+  .strict();
 
 export function actorHasExecutionRecoveryOperatorCapability(actor: {
   keyScope?: AgentApiKeyScope | null;
@@ -55,11 +65,15 @@ export function assertExecutionReconciliationAuthorized(
   });
 }
 
-export function requireExecutionReconciliationProof(decision: unknown) {
-  if (!decision || typeof decision !== "object") {
+export function requireExecutionReconciliationProof(
+  decision: unknown,
+): ExecutionReconciliation {
+  const parsed = executionReconciliationProofSchema.safeParse(decision);
+  if (!parsed.success) {
     throw unprocessable(
       "Reconcile the recorded execution and its action outcomes before continuing this task.",
       { code: "execution_reconciliation_required" },
     );
   }
+  return parsed.data;
 }

--- a/server/src/services/execution-recovery-resolution.ts
+++ b/server/src/services/execution-recovery-resolution.ts
@@ -195,39 +195,98 @@ export async function markExecutionReconciliation(
     );
   await supersedeDescendantExecutionHolds(db, {
     companyId: action.companyId,
-    rootIssueId: action.sourceIssueId,
     rootActionId: action.id,
+    rootRunId: decision.runId,
     now: new Date(),
   });
 }
 
-/** Cancel leftover execution holds on this issue and its descendants. */
+function isPreStartCancelledHoldRun(run: {
+  startedAt: Date | null;
+  resultJson: Record<string, unknown> | null;
+}): boolean {
+  if (run.startedAt) return false;
+  const recovery = run.resultJson?.executionRecovery as
+    | { providerWorkStarted?: unknown }
+    | undefined;
+  return recovery?.providerWorkStarted !== true;
+}
+
+/** Holds whose source run descends from the reconciled run and never started provider work. */
+async function findPreStartDescendantRunIds(
+  db: Db,
+  input: { companyId: string; rootRunId: string; rootActionId: string },
+): Promise<string[]> {
+  const eligible = new Set<string>();
+  const seen = new Set<string>([input.rootRunId]);
+  let frontier = [input.rootRunId];
+  for (let depth = 0; depth < 64 && frontier.length > 0; depth += 1) {
+    const children = await db
+      .select({
+        id: heartbeatRuns.id,
+        startedAt: heartbeatRuns.startedAt,
+        resultJson: heartbeatRuns.resultJson,
+      })
+      .from(heartbeatRuns)
+      .where(
+        and(
+          eq(heartbeatRuns.companyId, input.companyId),
+          or(
+            inArray(heartbeatRuns.retryOfRunId, frontier),
+            sql`${heartbeatRuns.contextSnapshot}->>'previousRunId' in (${sql.join(
+              frontier.map((id) => sql`${id}`),
+              sql`, `,
+            )})`,
+            sql`${heartbeatRuns.contextSnapshot}->>'retryOfRunId' in (${sql.join(
+              frontier.map((id) => sql`${id}`),
+              sql`, `,
+            )})`,
+          ),
+        ),
+      );
+    const next: string[] = [];
+    for (const child of children) {
+      if (seen.has(child.id)) continue;
+      seen.add(child.id);
+      next.push(child.id);
+      if (isPreStartCancelledHoldRun(child)) eligible.add(child.id);
+    }
+    frontier = next;
+  }
+  const cancelledByHold = await db
+    .select({
+      id: heartbeatRuns.id,
+      startedAt: heartbeatRuns.startedAt,
+      resultJson: heartbeatRuns.resultJson,
+    })
+    .from(heartbeatRuns)
+    .where(
+      and(
+        eq(heartbeatRuns.companyId, input.companyId),
+        eq(heartbeatRuns.errorCode, "execution_reconciliation_required"),
+        isNull(heartbeatRuns.startedAt),
+        sql`${heartbeatRuns.resultJson}->'executionWait'->>'recoveryActionId' = ${input.rootActionId}`,
+      ),
+    );
+  for (const run of cancelledByHold) {
+    if (run.id === input.rootRunId) continue;
+    if (isPreStartCancelledHoldRun(run)) eligible.add(run.id);
+  }
+  return [...eligible];
+}
+
+/** Cancel leftover pre-start execution holds that descend from the reconciled run. */
 export async function supersedeDescendantExecutionHolds(
   db: Db,
   input: {
     companyId: string;
-    rootIssueId: string;
     rootActionId: string;
+    rootRunId: string;
     now: Date;
   },
 ) {
-  const issueIds = [input.rootIssueId];
-  let frontier = [input.rootIssueId];
-  for (let depth = 0; depth < 8 && frontier.length > 0; depth += 1) {
-    const children = await db
-      .select({ id: issues.id })
-      .from(issues)
-      .where(
-        and(
-          eq(issues.companyId, input.companyId),
-          inArray(issues.parentId, frontier),
-        ),
-      );
-    frontier = children
-      .map((child) => child.id)
-      .filter((id) => !issueIds.includes(id));
-    issueIds.push(...frontier);
-  }
+  const descendantRunIds = await findPreStartDescendantRunIds(db, input);
+  if (descendantRunIds.length === 0) return;
   const supersededNote = "Superseded by root execution reconciliation.";
   await db
     .update(issueRecoveryActions)
@@ -246,9 +305,12 @@ export async function supersedeDescendantExecutionHolds(
     .where(
       and(
         eq(issueRecoveryActions.companyId, input.companyId),
-        inArray(issueRecoveryActions.sourceIssueId, issueIds),
         ne(issueRecoveryActions.id, input.rootActionId),
         executionBlockerPredicate(),
+        sql`coalesce(${issueRecoveryActions.evidence}->>'runId', ${issueRecoveryActions.evidence}->>'sourceRunId') in (${sql.join(
+          descendantRunIds.map((id) => sql`${id}`),
+          sql`, `,
+        )})`,
       ),
     );
 }

--- a/server/src/services/execution-recovery-resolution.ts
+++ b/server/src/services/execution-recovery-resolution.ts
@@ -3,7 +3,7 @@ import { conversationRecoveryActionPredicate, getConversationOwnershipBlocker } 
 import { persistActivity } from "./activity-log.js";
 import { appendHeartbeatRunEvent } from "./heartbeat-run-events.js";
 import { logger } from "../middleware/logger.js";
-import { and, eq, inArray, isNull, not, or, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, ne, not, or, sql } from "drizzle-orm";
 import {
   chatActions,
   environmentLeases,
@@ -14,6 +14,7 @@ import {
   type Db,
 } from "@paperclipai/db";
 import { conflict } from "../errors.js";
+import { executionBlockerPredicate } from "./execution-blocker.js";
 import { buildExecutionContinuation } from "./execution-continuation.js";
 import {
   EXECUTION_RECONCILIATION_CAUSES,
@@ -190,6 +191,64 @@ export async function markExecutionReconciliation(
       and(
         eq(issueRecoveryActions.companyId, action.companyId),
         eq(issueRecoveryActions.id, action.id),
+      ),
+    );
+  await supersedeDescendantExecutionHolds(db, {
+    companyId: action.companyId,
+    rootIssueId: action.sourceIssueId,
+    rootActionId: action.id,
+    now: new Date(),
+  });
+}
+
+/** Cancel leftover execution holds on this issue and its descendants. */
+export async function supersedeDescendantExecutionHolds(
+  db: Db,
+  input: {
+    companyId: string;
+    rootIssueId: string;
+    rootActionId: string;
+    now: Date;
+  },
+) {
+  const issueIds = [input.rootIssueId];
+  let frontier = [input.rootIssueId];
+  for (let depth = 0; depth < 8 && frontier.length > 0; depth += 1) {
+    const children = await db
+      .select({ id: issues.id })
+      .from(issues)
+      .where(
+        and(
+          eq(issues.companyId, input.companyId),
+          inArray(issues.parentId, frontier),
+        ),
+      );
+    frontier = children
+      .map((child) => child.id)
+      .filter((id) => !issueIds.includes(id));
+    issueIds.push(...frontier);
+  }
+  const supersededNote = "Superseded by root execution reconciliation.";
+  await db
+    .update(issueRecoveryActions)
+    .set({
+      status: "cancelled",
+      outcome: "cancelled",
+      resolvedAt: input.now,
+      updatedAt: input.now,
+      resolutionNote: supersededNote,
+      nextAction: supersededNote,
+      evidence: sql`(${issueRecoveryActions.evidence} - 'automaticRecovery') || ${JSON.stringify({
+        supersededByRecoveryActionId: input.rootActionId,
+        supersededAt: input.now.toISOString(),
+      })}::jsonb`,
+    })
+    .where(
+      and(
+        eq(issueRecoveryActions.companyId, input.companyId),
+        inArray(issueRecoveryActions.sourceIssueId, issueIds),
+        ne(issueRecoveryActions.id, input.rootActionId),
+        executionBlockerPredicate(),
       ),
     );
 }

--- a/server/src/services/heartbeat.ts
+++ b/server/src/services/heartbeat.ts
@@ -251,6 +251,7 @@ import type {
   UsageSummary,
 } from "../adapters/index.js";
 import { createLocalAgentJwt } from "../agent-auth-jwt.js";
+import { localAgentJwtScopeForExecutionRecovery } from "./execution-recovery-operator.js";
 import { createRuntimeToolsToken } from "../runtime-tools-token.js";
 import {
   parseObject,
@@ -22838,10 +22839,11 @@ export function heartbeatService(
             })
             .where(eq(heartbeatRuns.id, run.id));
         }
-        const localAgentJwtScope =
-          issueRef?.workMode === "skill_test"
-            ? { kind: "skill_test" as const, issueId: issueRef.id }
-            : { kind: "standard" as const };
+        const localAgentJwtScope = localAgentJwtScopeForExecutionRecovery({
+          workMode: issueRef?.workMode,
+          issueId: issueRef?.id,
+          permissions: agent.permissions,
+        });
         const authToken =
           nativeRuntimeResolution.kind === "legacy" &&
           adapter.supportsLocalAgentJwt

--- a/server/src/services/legacy-execution-recovery.test.ts
+++ b/server/src/services/legacy-execution-recovery.test.ts
@@ -30,6 +30,16 @@ it("retains the hold until the provider actually acknowledges cancellation", () 
   } })).toBe(true);
 });
 
+it("does not open recovery for a pre-start cancel caused by an existing execution hold", () => {
+  expect(legacyExecutionNeedsReconciliation({
+    runtimeMode: "legacy",
+    status: "cancelled",
+    errorCode: "execution_reconciliation_required",
+    startedAt: null,
+    resultJson: { timeoutSource: "stale_queued_run_gate" },
+  })).toBe(false);
+});
+
  it("continues a conversation without requiring receipts, even after automatic attempts are exhausted", () => {
   for (const status of ["failed", "timed_out", "interrupted", "cancelled"]) {
     expect(legacyExecutionNeedsReconciliation({

--- a/server/src/services/legacy-execution-recovery.ts
+++ b/server/src/services/legacy-execution-recovery.ts
@@ -13,11 +13,19 @@ export const LEGACY_RECOVERY_CAUSE = "legacy_execution_requires_reconciliation";
 
 /** Error families describe availability, not whether earlier actions happened. */
 export function legacyExecutionNeedsReconciliation(
-  run: Pick<Run, "runtimeMode" | "status" | "errorCode" | "resultJson"> & Partial<Pick<Run, "scheduledRetryAttempt" | "scheduledRetryReason" | "contextSnapshot">>,
+  run: Pick<Run, "runtimeMode" | "status" | "errorCode" | "resultJson"> & Partial<Pick<Run, "scheduledRetryAttempt" | "scheduledRetryReason" | "contextSnapshot" | "startedAt">>,
 ): boolean {
   if (
     run.runtimeMode === "native" ||
     !["failed", "timed_out", "interrupted", "cancelled"].includes(run.status)
+  )
+    return false;
+  // A queued run cancelled by an existing hold never started provider work.
+  // Keep the source blocker; do not open a second recovery incident.
+  if (
+    run.status === "cancelled" &&
+    run.errorCode === "execution_reconciliation_required" &&
+    !run.startedAt
   )
     return false;
   // A fresh conversation turn lets the agent decide what remains. The retry
@@ -106,7 +114,8 @@ export async function terminalizeLegacyExecution(input: {
       task &&
       !isSupersededConversationRun(task, updated) &&
       (task.assigneeAgentId === run.agentId || isCurrentReviewer) &&
-      !["done", "cancelled"].includes(task.status)
+      !["done", "cancelled"].includes(task.status) &&
+      legacyExecutionNeedsReconciliation(updated)
     ) {
       // Periodic stranded-work checks may revisit this terminal run before its
       // reconciled continuation is dispatched. Preserve the recorded decision.

--- a/ui/src/components/ExecutionBlockerNotice.tsx
+++ b/ui/src/components/ExecutionBlockerNotice.tsx
@@ -32,6 +32,16 @@ export function ExecutionBlockerNotice({ companyId, issueId, blocker, onRetried 
   return (
     <div role="status" className="px-(--sz-execution-blocker-inline) py-(--sz-execution-blocker-block) text-sm text-muted-foreground">
       <span>Work cannot start. {blocker.nextAction}</span>{" "}
+      {blocker.recoveryActionId && (
+        <code data-testid="execution-blocker-action-id" className="rounded bg-background/80 px-1.5 py-0.5 font-mono text-(length:--text-micro)">
+          action {blocker.recoveryActionId.slice(0, 8)}
+        </code>
+      )}{" "}
+      {blocker.runId && (
+        <code data-testid="execution-blocker-run-id" className="rounded bg-background/80 px-1.5 py-0.5 font-mono text-(length:--text-micro)">
+          run {blocker.runId.slice(0, 8)}
+        </code>
+      )}{" "}
       {failedRun && (
         <Button variant="outline" size="sm" disabled={retry.isPending} onClick={() => retry.mutate()}>
           {retry.isPending ? "Retrying…" : "Retry"}

--- a/ui/src/components/IssueChatThread.tsx
+++ b/ui/src/components/IssueChatThread.tsx
@@ -557,6 +557,10 @@ interface IssueChatThreadProps {
   scheduledRetry?: IssueScheduledRetry | null;
   recoveryAction?: IssueRecoveryAction | null;
   onResolveRecoveryAction?: (outcome: RecoveryResolveOutcome) => void;
+  onReconcileExecutionRecoveryAction?: (
+    decision: import("@paperclipai/shared").ExecutionReconciliation,
+  ) => void;
+  reconcileExecutionRecoveryActionPending?: boolean;
   onReissueIsolatedRecoveryAction?: (request: RecoveryReissueRequest) => void;
   reissueIsolatedRecoveryActionPending?: boolean;
   onReconcileForwardRecoveryAction?: () => void;
@@ -5727,6 +5731,8 @@ export function IssueChatThread({
   scheduledRetry = null,
   recoveryAction = null,
   onResolveRecoveryAction,
+  onReconcileExecutionRecoveryAction,
+  reconcileExecutionRecoveryActionPending = false,
   onReissueIsolatedRecoveryAction,
   reissueIsolatedRecoveryActionPending = false,
   onReconcileForwardRecoveryAction,
@@ -6599,6 +6605,10 @@ export function IssueChatThread({
                         agentMap={agentMap}
                         scheduledRetry={scheduledRetry}
                         onResolve={onResolveRecoveryAction}
+                        onReconcileExecution={onReconcileExecutionRecoveryAction}
+                        reconcileExecutionPending={
+                          reconcileExecutionRecoveryActionPending
+                        }
                         onReissueIsolated={onReissueIsolatedRecoveryAction}
                         reissuePending={reissueIsolatedRecoveryActionPending}
                         onReconcileForward={onReconcileForwardRecoveryAction}

--- a/ui/src/components/IssueRecoveryActionCard.test.tsx
+++ b/ui/src/components/IssueRecoveryActionCard.test.tsx
@@ -168,12 +168,16 @@ describe("IssueRecoveryActionCard", () => {
     );
   });
 
-  it.each(["active", "escalated", "resolved"] as const)("keeps %s runner recovery in the run log without a card", status => {
+  it.each(["active", "escalated"] as const)("exposes %s execution-reconciliation holds on the operator card", status => {
     const node = render(<IssueRecoveryActionCard action={buildAction({
       kind: "active_run_watchdog", cause: "uncertain_external_action", status, ownerType: "board",
     })} />);
-    expect(node.textContent).toBe("");
-    expect(node.querySelector("section")).toBeNull();
+    expect(node.querySelector("section")?.getAttribute("data-recovery-state")).toBe(
+      status === "escalated" ? "escalated" : "needed",
+    );
+    expect(node.querySelector("[data-testid='recovery-action-id']")?.textContent).toBe(
+      "00000000-0000-0000-0000-0000000000aa",
+    );
   });
 
   it.each(["active", "escalated"] as const)(
@@ -311,6 +315,60 @@ describe("IssueRecoveryActionCard", () => {
     );
     expect(code).toBeTruthy();
     expect(code?.className).toContain("font-mono");
+  });
+
+  it("renders execution reconciliation form for a settled no-replay hold", () => {
+    const onReconcileExecution = vi.fn();
+    const node = render(
+      <IssueRecoveryActionCard
+        action={buildAction({
+          kind: "active_run_watchdog",
+          status: "resolved",
+          outcome: "blocked",
+          cause: "uncertain_external_action",
+          evidence: {
+            runId: "7accd7a4-c9ca-4db2-9233-3228a037cc09",
+            automaticRecovery: { replay: "blocked" },
+          },
+        })}
+        onReconcileExecution={onReconcileExecution}
+      />,
+    );
+    expect(node.querySelector("[data-testid='execution-reconciliation-form']")).toBeTruthy();
+    expect(node.querySelector("[data-testid='execution-reconciliation-run-id']")?.textContent).toContain(
+      "7accd7a4-c9ca-4db2-9233-3228a037cc09",
+    );
+    expect(node.querySelector("[data-testid='recovery-action-id']")?.textContent).toBe(
+      "00000000-0000-0000-0000-0000000000aa",
+    );
+    expect(
+      (node.querySelector("[data-testid='execution-reconciliation-submit']") as HTMLButtonElement).disabled,
+    ).toBe(true);
+    expect(onReconcileExecution).not.toHaveBeenCalled();
+
+    const evidence = node.querySelector("[data-testid='execution-reconciliation-evidence']") as HTMLTextAreaElement;
+    act(() => {
+      const assign = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value")?.set;
+      assign?.call(
+        evidence,
+        "The provider never started; queued successor runs were cancelled before start.",
+      );
+      evidence.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    expect(
+      (node.querySelector("[data-testid='execution-reconciliation-submit']") as HTMLButtonElement).disabled,
+    ).toBe(false);
+    act(() => {
+      node.querySelector("[data-testid='execution-reconciliation-form']")!.dispatchEvent(
+        new Event("submit", { bubbles: true, cancelable: true }),
+      );
+    });
+    expect(onReconcileExecution).toHaveBeenCalledWith({
+      runId: "7accd7a4-c9ca-4db2-9233-3228a037cc09",
+      providerStopped: true,
+      actionOutcome: "not_performed",
+      outcomeEvidence: "The provider never started; queued successor runs were cancelled before start.",
+    });
   });
 
   it("renders the resolved state and outcome when resolved", () => {

--- a/ui/src/components/IssueRecoveryActionCard.tsx
+++ b/ui/src/components/IssueRecoveryActionCard.tsx
@@ -2,6 +2,7 @@ import { requiresExecutionReconciliation } from "@paperclipai/shared";
 import { useMemo, useState } from "react";
 import type {
   Agent,
+  ExecutionReconciliation,
   GitWorktreeBranchAncestryVerdict,
   IssueRecoveryAction,
   IssueRecoveryActionKind,
@@ -79,6 +80,9 @@ export interface IssueRecoveryActionCardProps {
   forcedState?: RecoveryCardCardState;
   /** Optional click handler for resolve menu actions. If omitted, the buttons are not rendered. */
   onResolve?: (outcome: RecoveryResolveOutcome) => void;
+  /** Record observed execution outcomes and continue the assigned task. */
+  onReconcileExecution?: (decision: ExecutionReconciliation) => void;
+  reconcileExecutionPending?: boolean;
   /**
    * Optional handler for the workspace_validation "Re-issue on isolated workspace" action.
    * Rendered only for a git-worktree branch-incoherence divergence with a resolvable live ref.
@@ -975,12 +979,84 @@ const RESOLVE_OPTIONS: Array<{
   },
 ];
 
+function ExecutionReconciliationForm({
+  action,
+  pending,
+  onSubmit,
+}: {
+  action: IssueRecoveryAction;
+  pending: boolean;
+  onSubmit: (decision: ExecutionReconciliation) => void;
+}) {
+  const runId =
+    asNonEmptyString(action.evidence?.runId) ??
+    asNonEmptyString(action.evidence?.sourceRunId) ??
+    "";
+  const [outcomeEvidence, setOutcomeEvidence] = useState("");
+  const [actionOutcome, setActionOutcome] =
+    useState<ExecutionReconciliation["actionOutcome"]>("not_performed");
+  const canSubmit = runId.length > 0 && outcomeEvidence.trim().length > 0 && !pending;
+  return (
+    <form
+      className="flex w-full flex-col gap-2"
+      data-testid="execution-reconciliation-form"
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (!canSubmit) return;
+        onSubmit({
+          runId,
+          providerStopped: true,
+          actionOutcome,
+          outcomeEvidence: outcomeEvidence.trim(),
+        });
+      }}
+    >
+      <p className="text-(length:--text-micro) text-muted-foreground">
+        Record the stopped run outcome before continuing. Generic retry is not allowed.
+      </p>
+      <div className="flex flex-wrap items-center gap-2 text-(length:--text-micro)">
+        <span>
+          Run <code data-testid="execution-reconciliation-run-id">{runId || "unknown"}</code>
+        </span>
+        <label className="inline-flex items-center gap-1">
+          Outcome
+          <select
+            className="rounded-md border border-border bg-background px-1.5 py-1"
+            value={actionOutcome}
+            onChange={(event) =>
+              setActionOutcome(event.target.value as ExecutionReconciliation["actionOutcome"])
+            }
+          >
+            <option value="not_performed">not performed</option>
+            <option value="completed">completed</option>
+            <option value="mixed">mixed</option>
+          </select>
+        </label>
+      </div>
+      <Label htmlFor={`execution-reconciliation-evidence-${action.id}`}>Outcome evidence</Label>
+      <Textarea
+        id={`execution-reconciliation-evidence-${action.id}`}
+        data-testid="execution-reconciliation-evidence"
+        value={outcomeEvidence}
+        onChange={(event) => setOutcomeEvidence(event.target.value)}
+        placeholder="What proves the provider action did not run, completed, or mixed?"
+        rows={3}
+      />
+      <Button type="submit" size="sm" disabled={!canSubmit} data-testid="execution-reconciliation-submit">
+        {pending ? "Reconciling…" : "Reconcile and continue"}
+      </Button>
+    </form>
+  );
+}
+
 export function IssueRecoveryActionCard({
   action,
   agentMap,
   scheduledRetry = null,
   forcedState,
   onResolve,
+  onReconcileExecution,
+  reconcileExecutionPending = false,
   onReissueIsolated,
   reissuePending = false,
   onReconcileForward,
@@ -1057,7 +1133,12 @@ export function IssueRecoveryActionCard({
     resolved: "resolved",
   } satisfies Record<RecoveryCardCardState, string>)[cardState];
 
-  const showResolveActions = onResolve !== undefined && cardState !== "resolved";
+  const showResolveActions = onResolve !== undefined && cardState !== "resolved"
+    && !requiresExecutionReconciliation(action.cause);
+  const showExecutionReconciliation =
+    onReconcileExecution !== undefined &&
+    requiresExecutionReconciliation(action.cause) &&
+    cardState !== "resolved";
   const visibleResolveOptions = RESOLVE_OPTIONS.filter((option) => {
     if (option.outcome === "todo" && requiresExecutionReconciliation(action.cause)) return false;
     if (option.boardOnly && !canFalsePositive) return false;
@@ -1103,12 +1184,11 @@ export function IssueRecoveryActionCard({
   const reissueRecommended = showRepairAction && repairContention !== null;
   const showFooter =
     showResolveActions ||
+    showExecutionReconciliation ||
     showReissueAction ||
     showReconcileForward ||
     showBreakGlass ||
     showRepairAction;
-
-  if (requiresExecutionReconciliation(action.cause)) return null;
 
   return (
     <section
@@ -1280,6 +1360,11 @@ export function IssueRecoveryActionCard({
             <RunChip runId={correctiveRunId} agentId={action.previousOwnerAgentId} />
           </MetadataRow>
         ) : null}
+        <MetadataRow label="Action">
+          <code data-testid="recovery-action-id" className="rounded bg-background/80 px-1.5 py-0.5 font-mono text-(length:--text-micro)">
+            {action.id}
+          </code>
+        </MetadataRow>
         <MetadataRow label="Evidence">
           {evidenceSummary ? (
             evidenceSummary.isCode ? (
@@ -1324,6 +1409,13 @@ export function IssueRecoveryActionCard({
       {divergence ? <DivergenceDiagnosis divergence={divergence} dividerClass={tone.divider} /> : null}
       {showFooter ? (
         <div className={cn("flex flex-wrap items-center gap-2 border-t px-3 py-2.5 sm:px-4", tone.divider)}>
+          {showExecutionReconciliation ? (
+            <ExecutionReconciliationForm
+              action={action}
+              pending={reconcileExecutionPending}
+              onSubmit={onReconcileExecution!}
+            />
+          ) : null}
           {showResolveActions ? (
             <Popover>
               <PopoverTrigger asChild>

--- a/ui/src/lib/recovery-display.test.ts
+++ b/ui/src/lib/recovery-display.test.ts
@@ -62,6 +62,15 @@ describe("deriveRecoveryDisplayState", () => {
     outcome: null,
   };
 
+  it("keeps a settled no-replay hold visible as recovery needed", () => {
+    expect(deriveRecoveryDisplayState({
+      status: "resolved",
+      kind: "active_run_watchdog",
+      outcome: "blocked",
+      evidence: { automaticRecovery: { replay: "blocked" } },
+    })).toBe("needed");
+  });
+
   it("classifies workspace_validation active as needed", () => {
     expect(deriveRecoveryDisplayState({ ...base, kind: "workspace_validation" })).toBe(
       "needed",

--- a/ui/src/lib/recovery-display.ts
+++ b/ui/src/lib/recovery-display.ts
@@ -68,6 +68,13 @@ export function deriveRecoveryDisplayState(
   action: RecoveryDisplayInput,
   context?: RecoveryLivenessContext,
 ): RecoveryDisplayState {
+  const automaticReplay =
+    action.evidence &&
+    typeof action.evidence === "object" &&
+    !Array.isArray(action.evidence)
+      ? (action.evidence.automaticRecovery as { replay?: string } | undefined)?.replay
+      : undefined;
+  if (action.status === "resolved" && automaticReplay === "blocked") return "needed";
   if (action.status === "resolved") return "resolved";
   if (action.status === "escalated") return "escalated";
   if (action.status === "cancelled") return "resolved";

--- a/ui/src/pages/IssueDetail.tsx
+++ b/ui/src/pages/IssueDetail.tsx
@@ -1197,6 +1197,10 @@ type IssueDetailChatTabProps = {
   onResolveRecoveryAction?: (
     outcome: import("../components/IssueRecoveryActionCard").RecoveryResolveOutcome,
   ) => void;
+  onReconcileExecutionRecoveryAction?: (
+    decision: import("@paperclipai/shared").ExecutionReconciliation,
+  ) => void;
+  reconcileExecutionRecoveryActionPending?: boolean;
   onReissueIsolatedRecoveryAction?: (
     request: import("../components/IssueRecoveryActionCard").RecoveryReissueRequest,
   ) => void;
@@ -1340,6 +1344,8 @@ const IssueDetailChatTab = memo(function IssueDetailChatTab({
   scheduledRetry,
   recoveryAction,
   onResolveRecoveryAction,
+  onReconcileExecutionRecoveryAction,
+  reconcileExecutionRecoveryActionPending = false,
   onReissueIsolatedRecoveryAction,
   reissueIsolatedRecoveryActionPending,
   onReconcileForwardRecoveryAction,
@@ -2368,6 +2374,10 @@ const IssueDetailChatTab = memo(function IssueDetailChatTab({
             scheduledRetry={scheduledRetry}
             recoveryAction={recoveryAction ?? null}
             onResolveRecoveryAction={onResolveRecoveryAction}
+            onReconcileExecutionRecoveryAction={onReconcileExecutionRecoveryAction}
+            reconcileExecutionRecoveryActionPending={
+              reconcileExecutionRecoveryActionPending
+            }
             onReissueIsolatedRecoveryAction={onReissueIsolatedRecoveryAction}
             reissueIsolatedRecoveryActionPending={
               reissueIsolatedRecoveryActionPending
@@ -4019,6 +4029,7 @@ export function TaskDetailSurface({ conversation, tasksTab }: { tasksTab?: TaskS
       outcome: ResolveRecoveryActionOutcome;
       sourceIssueStatus: "todo" | "done" | "in_review" | "blocked";
       resolutionNote?: string | null;
+      executionReconciliation?: import("@paperclipai/shared").ExecutionReconciliation;
     }) => issuesApi.resolveRecoveryAction(issueId!, data),
     onSuccess: ({ issue: nextIssue }) => {
       const issueRefs = new Set<string>([issueId!, nextIssue.id]);
@@ -6312,7 +6323,8 @@ export function TaskDetailSurface({ conversation, tasksTab }: { tasksTab?: TaskS
   const handleResumeAssignee = useCallback(async () => {
     await resumeAssigneeAgent.mutateAsync();
   }, [resumeAssigneeAgent.mutateAsync]);
-  const activeRecoveryActionId = issue?.activeRecoveryAction?.id;
+  const activeRecoveryActionId =
+    issue?.activeRecoveryAction?.id ?? issue?.effectiveRecoveryAction?.id;
   const handleResolveRecoveryAction = useCallback(
     (
       outcome: import("../components/IssueRecoveryActionCard").RecoveryResolveOutcome,
@@ -6356,6 +6368,19 @@ export function TaskDetailSurface({ conversation, tasksTab }: { tasksTab?: TaskS
           });
           return;
       }
+    },
+    [activeRecoveryActionId, resolveRecoveryAction.mutateAsync],
+  );
+  const handleReconcileExecutionRecoveryAction = useCallback(
+    (decision: import("@paperclipai/shared").ExecutionReconciliation) => {
+      const actionId = activeRecoveryActionId;
+      if (!actionId) return;
+      void resolveRecoveryAction.mutateAsync({
+        actionId,
+        outcome: "restored",
+        sourceIssueStatus: "todo",
+        executionReconciliation: decision,
+      });
     },
     [activeRecoveryActionId, resolveRecoveryAction.mutateAsync],
   );
@@ -7669,8 +7694,18 @@ export function TaskDetailSurface({ conversation, tasksTab }: { tasksTab?: TaskS
                   blockerAttention={issue.blockerAttention ?? null}
                   successfulRunHandoff={issue.successfulRunHandoff ?? null}
                   scheduledRetry={issue.scheduledRetry ?? null}
-                  recoveryAction={issue.activeRecoveryAction ?? null}
+                  recoveryAction={
+                    issue.activeRecoveryAction ??
+                    issue.effectiveRecoveryAction ??
+                    null
+                  }
                   onResolveRecoveryAction={handleResolveRecoveryAction}
+                  onReconcileExecutionRecoveryAction={
+                    handleReconcileExecutionRecoveryAction
+                  }
+                  reconcileExecutionRecoveryActionPending={
+                    resolveRecoveryAction.isPending
+                  }
                   onReissueIsolatedRecoveryAction={
                     handleReissueIsolatedRecoveryAction
                   }


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - Heartbeat dispatch and issue recovery together decide whether a stopped run may continue.
> - A settled no-replay hold cancelled later queued wakes before start, but root reconciliation then cancelled every execution hold on the issue tree.
> - That lift could clear another agent's hold after provider work had already started.
> - This pull request scopes supersession to pre-start descendant runs of the reconciled root run.
> - Assigned operators still reconcile with a narrow JWT capability and a complete proof payload.
> - The benefit is one successor wake without silently bypassing a no-replay gate on an unrelated card.

## Linked Issues or Issue Description

**Describe the bug**
A settled execution hold cancelled later queued wakes before start. Root reconciliation then cancelled every execution-blocker action on the issue and its `parentId` descendants. A child card with a genuine hold from a run that started provider work could lose that hold without proof.

**Expected behavior**
Pre-start cancelled wakes do not open a second recovery action and do not invoke a provider. GET/UI expose the settled hold. One assigned operator POST with complete proof clears the root hold, supersedes only pre-start descendant holds, and emits exactly one successor wake. Unrelated child holds with provider work started stay blocked.

**Steps to reproduce**
1. Create a root hold with `replay: blocked`.
2. Queue three wakes for that issue and dispatch them.
3. Observe three `cancelled` runs with `startedAt: null` and one recovery row.
4. Place an unrelated child hold whose run has `startedAt` set.
5. Reconcile the root hold with operator proof.

**Refs** related recovery work: #13270, #13150, #12157.

## What Changed

- Scope `supersedeDescendantExecutionHolds` to run lineage (`retryOfRunId` / previous-run snapshot / cancelled-by-this-hold) and to pre-start runs only.
- Reject incomplete `executionReconciliation` proof before mutation (`runId`, `providerStopped: true`, `actionOutcome`, `outcomeEvidence`).
- Drive three queued wakes through heartbeat `resumeQueuedRuns` with a mocked adapter and assert zero `execute` calls.
- Mint real run JWTs through `actorMiddleware` for Infra operator 2xx and CTO/Backend 403.
- Prove partial proof (`missing outcomeEvidence`, `providerStopped: false`, wrong `runId`) returns 4xx with no mutation.

## Verification

```sh
pnpm exec vitest run \
  server/src/__tests__/agent-auth-jwt.test.ts \
  server/src/__tests__/agent-permissions-service.test.ts \
  server/src/services/legacy-execution-recovery.test.ts \
  server/src/__tests__/issue-recovery-actions.test.ts \
  server/src/modules/run-dispatch/adapters/postgres.test.ts \
  server/src/__tests__/heartbeat-stale-queue-invalidation.test.ts \
  ui/src/components/IssueRecoveryActionCard.test.tsx \
  ui/src/lib/recovery-display.test.ts
```

Expect: `Test Files  8 passed (8)` · `Tests  236 passed (236)`.

The three-wake test logs `claimQueuedRun: cancelled stale queued run` with `errorCode: execution_reconciliation_required` three times and `mockAdapterExecute` is not called.

## Risks

- A descendant hold whose run started provider work is no longer cleared by a parent reconciliation. That is the intended safety change. The operator must reconcile that hold on its own card.
- Live agents still need `permissions.execution_recovery_operator: true` before run JWTs carry the capability. This PR does not grant that permission.
- `postgres.test.ts` still logs a duplicate `heartbeat_run_events_run_seq_uq` from `settleUnrecoverableExecutions` on an existing conversation-hold path. Tests pass. This PR does not change that insert.

## Model Used

- Provider: xAI
- Model: Grok 4.6
- Tool use and local test execution were used
- Reasoning: chain-of-thought over review findings, then a bounded implementation

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
