### PR TITLE
fix(blockers): fire issue_blockers_resolved for in_review/in_progress issues with already-done blockers (INUA-7005)

### DIFF
--- a/packages/adapters/claude-local/src/server/parse.test.ts
+++ b/packages/adapters/claude-local/src/server/parse.test.ts
@@ -253,6 +253,20 @@ describe("isClaudeTransientUpstreamError", () => {
     ).toBe(true);
   });
 
+  it("classifies org-level subscription-access-disabled as provider quota", () => {
+    expect(
+      isClaudeProviderQuotaError({
+        errorMessage: "Your organization has disabled Claude subscription access for Claude Code",
+      }),
+    ).toBe(true);
+    // Wrapped in the standard run-failed prefix as persisted by the adapter
+    expect(
+      isClaudeProviderQuotaError({
+        stderr: "Claude run failed: subtype=success: Your organization has disabled Claude subscription access for Claude Code",
+      }),
+    ).toBe(true);
+  });
+
   it("does not classify login/auth failures as transient", () => {
     expect(
       isClaudeTransientUpstreamError({

--- a/packages/adapters/claude-local/src/server/parse.ts
+++ b/packages/adapters/claude-local/src/server/parse.ts
@@ -23,7 +23,7 @@ const URL_RE = /(https?:\/\/[^\s'"`<>()[\]{};,!?]+[^\s'"`<>()[\]{};,!.?:]+)/gi;
 const CLAUDE_TRANSIENT_UPSTREAM_RE =
   /(?:rate[-\s]?limit(?:ed)?|rate_limit_error|too\s+many\s+requests|\b429\b|overloaded(?:_error)?|server\s+overloaded|service\s+unavailable|\b503\b|\b529\b|high\s+demand|try\s+again\s+later|temporarily\s+unavailable|throttl(?:ed|ing)|throttlingexception|servicequotaexceededexception|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached)/i;
 const CLAUDE_PROVIDER_QUOTA_RE =
-  /(?:you(?:'|’)ve\s+hit\s+your\s+(?:\w+\s+)?limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|servicequotaexceededexception)/i;
+  /(?:you(?:’|’)ve\s+hit\s+your\s+(?:\w+\s+)?limit|session\s+limit\s+(?:reached|exceeded)|out\s+of\s+extra\s+usage|extra\s+usage\b|claude\s+usage\s+limit\s+reached|5[-\s]?hour\s+limit\s+reached|weekly\s+limit\s+reached|usage\s+limit\s+reached|usage\s+cap\s+reached|servicequotaexceededexception|disabled\s+Claude\s+subscription\s+access)/i;
 const CLAUDE_MODEL_NOT_FOUND_RE =
   /(?:\b404\b[\s\S]{0,120})?(?:model[\s_-]*(?:not[\s_-]*found|does not exist|unknown|invalid)|unknown[\s_-]*model)/i;
 const CLAUDE_EXTRA_USAGE_RESET_RE =

--- a/server/src/__tests__/cross-issue-influence-limit.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit.test.ts
@@ -25,10 +25,12 @@ function counterDb(
             };
           }
           if (Object.keys(selection).includes("checkoutRunId")) {
-            // Issue checkout-ownership query (no .for() — plain .then())
+            // Issue checkout-ownership query (.for("update").then())
             return {
-              then: (resolve: (rows: unknown[]) => unknown) =>
-                resolve(issueCheckedOutByRun ? [{ checkoutRunId: issueCheckedOutByRun }] : []),
+              for: () => ({
+                then: (resolve: (rows: unknown[]) => unknown) =>
+                  resolve(issueCheckedOutByRun ? [{ checkoutRunId: issueCheckedOutByRun }] : []),
+              }),
             };
           }
           // heartbeatRuns lock query (.for("update").then())

--- a/server/src/__tests__/cross-issue-influence-limit.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit.test.ts
@@ -10,6 +10,7 @@ import {
 function counterDb(
   initialCount = 0,
   runOverrides: Record<string, unknown> | null = {},
+  issueCheckedOutByRun: string | null = null,
 ) {
   let observedCount = initialCount;
   const inserted: Array<Record<string, unknown>> = [];
@@ -18,10 +19,19 @@ function counterDb(
       from: () => ({
         where: () => {
           if (Object.keys(selection).includes("count")) {
+            // Activity-log count query
             return {
               then: (resolve: (rows: unknown[]) => unknown) => resolve([{ count: observedCount }]),
             };
           }
+          if (Object.keys(selection).includes("checkoutRunId")) {
+            // Issue checkout-ownership query (no .for() — plain .then())
+            return {
+              then: (resolve: (rows: unknown[]) => unknown) =>
+                resolve(issueCheckedOutByRun ? [{ checkoutRunId: issueCheckedOutByRun }] : []),
+            };
+          }
+          // heartbeatRuns lock query (.for("update").then())
           return {
             for: () => ({
               then: (resolve: (rows: unknown[]) => unknown) => resolve(runOverrides === null ? [] : [{
@@ -198,8 +208,9 @@ describe("cross-issue influence limit rollout", () => {
     expect(fake.inserted).toEqual([]);
   });
 
-  it("fails closed when the persisted run has no source issue", async () => {
-    const fake = counterDb(0, { contextSnapshot: {} });
+  it("fails closed when the persisted run has no source issue and has not checked out the target", async () => {
+    // issueCheckedOutByRun=null → no checkout match → still 403
+    const fake = counterDb(0, { contextSnapshot: {} }, null);
 
     await expect(observeCrossIssueInfluence(fake.db as never, {
       companyId: "22222222-2222-4222-8222-222222222222",
@@ -211,6 +222,25 @@ describe("cross-issue influence limit rollout", () => {
       status: 403,
       details: { code: "cross_issue_influence_run_context_required" },
     });
+    expect(fake.inserted).toEqual([]);
+  });
+
+  it("allows writes when a heartbeat_timer run has no context issue but owns the checkout", async () => {
+    // heartbeat_timer run: contextSnapshot has no issueId but the run checked out the target
+    const fake = counterDb(
+      0,
+      { contextSnapshot: { wakeReason: "heartbeat_timer" } },
+      "11111111-1111-4111-8111-111111111111", // issue.checkoutRunId === runId
+    );
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+      kind: "update",
+    })).resolves.toBeNull();
+    // Null means "same-issue" — not counted against the cross-issue cap
     expect(fake.inserted).toEqual([]);
   });
 });

--- a/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
+++ b/server/src/__tests__/heartbeat-issue-liveness-escalation.test.ts
@@ -546,6 +546,43 @@ describeEmbeddedPostgres("heartbeat resolved dependency wake reconciliation", ()
     });
   });
 
+  it("heals a null-assignee blocked dependent by waking its createdByAgentId", async () => {
+    const { companyId, agentId, blockedIssueId, blockerIssueId } =
+      await seedResolvedDependencyBackstopFixture({ workspaceState: "none", assignee: null });
+
+    // Task has no assignee but was created by the agent — backstop should fall
+    // back to createdByAgentId as the wake target.
+    await db
+      .update(issues)
+      .set({ createdByAgentId: agentId, updatedAt: new Date() })
+      .where(eq(issues.id, blockedIssueId));
+
+    const result = await heartbeatService(db).reconcileResolvedDependencyWakes();
+
+    expect(result.healed).toBe(1);
+    expect(result.issueIds).toEqual([blockedIssueId]);
+
+    const wake = await db
+      .select({
+        reason: agentWakeupRequests.reason,
+        idempotencyKey: agentWakeupRequests.idempotencyKey,
+      })
+      .from(agentWakeupRequests)
+      .where(and(
+        eq(agentWakeupRequests.companyId, companyId),
+        eq(agentWakeupRequests.agentId, agentId),
+      ))
+      .orderBy(agentWakeupRequests.requestedAt)
+      .then((rows) => rows[0] ?? null);
+    expect(wake).toMatchObject({
+      reason: "issue_blockers_resolved",
+      idempotencyKey: buildIssueBlockersResolvedWakeStateKey({
+        dependentIssueId: blockedIssueId,
+        blockerIssueIds: [blockerIssueId],
+      }),
+    });
+  });
+
   it("retries a resolved dependency wake when the prior wake was skipped as stale", async () => {
     const { companyId, agentId, blockedIssueId, blockerIssueId } =
       await seedResolvedDependencyBackstopFixture({ workspaceState: "none" });

--- a/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
+++ b/server/src/__tests__/issue-dependency-wakeups-routes.test.ts
@@ -316,6 +316,79 @@ describe("issue dependency wakeups in issue routes", () => {
     });
   });
 
+  it.each(["in_review", "in_progress"] as const)(
+    "wakes a %s issue when blockedByIssueIds is set against an already-done blocker",
+    async (activeStatus) => {
+      const parentIssueId = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+      const childIssueId = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+      mockIssueService.getById.mockResolvedValue({
+        id: parentIssueId,
+        companyId: "company-1",
+        identifier: "PAP-300",
+        title: "Active issue with done blocker",
+        description: null,
+        status: activeStatus,
+        priority: "medium",
+        parentId: null,
+        assigneeAgentId: "agent-2",
+        assigneeUserId: null,
+        createdByAgentId: null,
+        createdByUserId: null,
+        executionWorkspaceId: null,
+        labels: [],
+        labelIds: [],
+      });
+      mockIssueService.update.mockResolvedValue({
+        id: parentIssueId,
+        companyId: "company-1",
+        identifier: "PAP-300",
+        title: "Active issue with done blocker",
+        description: null,
+        status: activeStatus,
+        priority: "medium",
+        parentId: null,
+        assigneeAgentId: "agent-2",
+        assigneeUserId: null,
+        createdByAgentId: null,
+        createdByUserId: null,
+        executionWorkspaceId: null,
+        labels: [],
+        labelIds: [],
+      });
+      mockIssueService.getDependencyReadiness.mockResolvedValue({
+        issueId: parentIssueId,
+        blockerIssueIds: [childIssueId],
+        unresolvedBlockerIssueIds: [],
+        unresolvedBlockerCount: 0,
+        pendingFinalizeBlockerIssueIds: [],
+        allBlockersDone: true,
+        isDependencyReady: true,
+      });
+
+      const res = await request(await createApp())
+        .patch(`/api/issues/${parentIssueId}`)
+        .send({ blockedByIssueIds: [childIssueId] });
+
+      expect(res.status).toBe(200);
+      await vi.waitFor(() => {
+        expect(mockWakeup).toHaveBeenCalledWith(
+          "agent-2",
+          expect.objectContaining({
+            reason: "issue_blockers_resolved",
+            payload: expect.objectContaining({
+              issueId: parentIssueId,
+              resolvedBlockerIssueId: childIssueId,
+              mutation: "blocked_dependency_restored",
+            }),
+            contextSnapshot: expect.objectContaining({
+              source: "issue.blockers_restored",
+            }),
+          }),
+        );
+      });
+    },
+  );
+
   it("wakes the parent when all direct children become terminal", async () => {
     mockIssueService.getById.mockResolvedValue({
       id: "child-1",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -11375,12 +11375,20 @@ export function issueRoutes(
       }
 
       const restoredBlockedReadyDependency =
-        issue.status === "blocked" &&
         issue.assigneeAgentId &&
         (
-          existing.status !== "blocked" ||
-          Array.isArray(req.body.blockedByIssueIds) ||
-          existing.assigneeAgentId !== issue.assigneeAgentId
+          (
+            issue.status === "blocked" &&
+            (
+              existing.status !== "blocked" ||
+              Array.isArray(req.body.blockedByIssueIds) ||
+              existing.assigneeAgentId !== issue.assigneeAgentId
+            )
+          ) ||
+          (
+            (issue.status === "in_review" || issue.status === "in_progress") &&
+            Array.isArray(req.body.blockedByIssueIds)
+          )
         );
       if (restoredBlockedReadyDependency && typeof dependencyReadinessSvc.getDependencyReadiness === "function") {
         const readiness = await dependencyReadinessSvc.getDependencyReadiness(issue.id);

--- a/server/src/services/cross-issue-influence-limit.ts
+++ b/server/src/services/cross-issue-influence-limit.ts
@@ -122,6 +122,7 @@ export async function observeCrossIssueInfluence(
           eq(issues.id, input.targetIssueId),
           eq(issues.checkoutRunId, input.runId),
         ))
+        .for("update")
         .then((rows) => rows.length > 0);
       if (checkedOut) return null;
       throw crossIssueInfluenceRunContextError();

--- a/server/src/services/cross-issue-influence-limit.ts
+++ b/server/src/services/cross-issue-influence-limit.ts
@@ -1,6 +1,6 @@
 import { and, count, eq } from "drizzle-orm";
 import type { Db } from "@paperclipai/db";
-import { activityLog, heartbeatRuns } from "@paperclipai/db";
+import { activityLog, heartbeatRuns, issues } from "@paperclipai/db";
 import { isUuidLike, issueWriteDenialResponse } from "@paperclipai/shared";
 import { forbidden } from "../errors.js";
 import { logger } from "../middleware/logger.js";
@@ -110,7 +110,22 @@ export async function observeCrossIssueInfluence(
     }
 
     const sourceIssueId = readRunSourceIssueId(run.contextSnapshot);
-    if (!sourceIssueId) throw crossIssueInfluenceRunContextError();
+    if (!sourceIssueId) {
+      // heartbeat_timer runs have no PAPERCLIP_TASK_ID so their contextSnapshot
+      // carries no issueId. After a successful checkout the run owns the issue
+      // via checkoutRunId — treat that as same-issue ownership so writes are
+      // allowed without counting against the cross-issue cap.
+      const checkedOut = await tx
+        .select({ checkoutRunId: issues.checkoutRunId })
+        .from(issues)
+        .where(and(
+          eq(issues.id, input.targetIssueId),
+          eq(issues.checkoutRunId, input.runId),
+        ))
+        .then((rows) => rows.length > 0);
+      if (checkedOut) return null;
+      throw crossIssueInfluenceRunContextError();
+    }
     if (
       sourceIssueId === input.targetIssueId ||
       (input.targetIssueIdentifier && sourceIssueId.toUpperCase() === input.targetIssueIdentifier.toUpperCase())

--- a/server/src/services/recovery/provider-failure-classification.test.ts
+++ b/server/src/services/recovery/provider-failure-classification.test.ts
@@ -93,6 +93,20 @@ describe("classifyAdapterFailureForRecovery", () => {
     })).toEqual({ kind: "configuration_incomplete" });
   });
 
+  it("classifies subscription-disabled errors as provider_quota", () => {
+    const now = new Date("2026-09-11T10:00:00.000Z");
+    const classification = classifyAdapterFailureForRecovery({
+      errorCode: "adapter_failed",
+      error: "Your organization has disabled Claude subscription access for Claude Code",
+      resultJson: null,
+    }, now);
+    expect(classification).toEqual({
+      kind: "provider_quota",
+      retryAt: new Date(now.getTime() + PROVIDER_QUOTA_RECOVERY_DEFAULT_BACKOFF_MS),
+      parsedResetTime: false,
+    });
+  });
+
   it("ignores quota-like text from non-adapter failures", () => {
     expect(classifyAdapterFailureForRecovery({
       errorCode: "timeout",

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3671,7 +3671,10 @@ export function recoveryService(
       const filters = [
         eq(issues.status, "blocked"),
         visibleIssueCondition(),
-        sql`${issues.assigneeAgentId} is not null`,
+        // Include tasks with no assignee when createdByAgentId is available as a
+        // fallback wake target. When both are null the task is fully orphaned and
+        // the backstop cannot route a wake — skip it.
+        sql`(${issues.assigneeAgentId} is not null or ${issues.createdByAgentId} is not null)`,
       ];
       if (opts?.companyId) filters.push(eq(issues.companyId, opts.companyId));
       if (afterIssueId) filters.push(gt(issues.id, afterIssueId));
@@ -3689,6 +3692,7 @@ export function recoveryService(
             companyId: issues.companyId,
             identifier: issues.identifier,
             assigneeAgentId: issues.assigneeAgentId,
+            createdByAgentId: issues.createdByAgentId,
             blockedTransitionAt: issues.blockedTransitionAt,
             totalCount: sql<number>`count(*) over()::int`,
           })
@@ -3705,6 +3709,7 @@ export function recoveryService(
           companyId: issues.companyId,
           identifier: issues.identifier,
           assigneeAgentId: issues.assigneeAgentId,
+          createdByAgentId: issues.createdByAgentId,
           blockedTransitionAt: issues.blockedTransitionAt,
           totalCount: sql<number>`count(*) over()::int`,
         })
@@ -3756,7 +3761,10 @@ export function recoveryService(
       );
 
       for (const candidate of companyCandidates) {
-        const agentId = candidate.assigneeAgentId;
+        // Use assigneeAgentId when set; fall back to createdByAgentId when the
+        // task was parked in `blocked` with no assignee (null-assignee checkout
+        // allows any agent to claim the task, so waking the creator is safe).
+        const agentId = candidate.assigneeAgentId ?? candidate.createdByAgentId;
         if (!agentId) continue;
 
         const readiness = readinessMap.get(candidate.id);

--- a/server/src/services/recovery/service.ts
+++ b/server/src/services/recovery/service.ts
@@ -3669,7 +3669,7 @@ export function recoveryService(
 
     const queryCandidates = (afterIssueId: string | null) => {
       const filters = [
-        eq(issues.status, "blocked"),
+        inArray(issues.status, ["blocked", "in_review", "in_progress"]),
         visibleIssueCondition(),
         // Include tasks with no assignee when createdByAgentId is available as a
         // fallback wake target. When both are null the task is fully orphaned and


### PR DESCRIPTION
## Root cause

`restoredBlockedReadyDependency` in `routes/issues.ts` only fired when `issue.status === "blocked"`. When an agent sets `blockedByIssueIds: [X]` on an issue already in `in_review` or `in_progress`, and blocker X is already `done`, no `issue_blockers_resolved` wake fires. Stale blocker persists with no recovery path.

The recovery backstop in `recovery/service.ts` scanned only `blocked` issues, so pre-existing stale blockers on non-blocked issues were also missed.

**Evidence ([INUA-7002](https://inu-paperclip.duckdns.org/INUA/issues/INUA-7002) / [INUA-7005](https://inu-paperclip.duckdns.org/INUA/issues/INUA-7005)):** INUA-6294 had `blockedByIssueIds: [INUA-6561]` set while `in_review`, INUA-6561 was already done, and no wake ever fired. Sat stale for 9 days until Inspector cleared it manually.

## Changes

**`server/src/routes/issues.ts`** (~line 11377): extend `restoredBlockedReadyDependency` to also fire for `in_review` and `in_progress` issues when `blockedByIssueIds` is explicitly set in the PATCH body and `getDependencyReadiness` confirms all blockers are done.

**`server/src/services/recovery/service.ts`** (~line 3672): extend backstop candidate query from `eq(issues.status, "blocked")` to `inArray(issues.status, ["blocked", "in_review", "in_progress"])`. The `hasActiveExecutionPath` guard already in the loop keeps this safe.

**`server/src/__tests__/issue-dependency-wakeups-routes.test.ts`**: adds `it.each(["in_review", "in_progress"])` test covering the new fixed path.