### PR TITLE
fix(ui): improve mobile entity picker sheets

### DIFF
--- a/ui/src/components/InlineEntitySelector.test.tsx
+++ b/ui/src/components/InlineEntitySelector.test.tsx
@@ -129,6 +129,8 @@ describe("InlineEntitySelector", () => {
 
     const searchInput = document.querySelector('input[placeholder="Search responsible..."]') as HTMLInputElement | null;
     expect(searchInput).not.toBeNull();
+    expect(searchInput?.className).toContain("text-base");
+    expect(document.querySelector("[data-mobile-entity-picker]")).not.toBeNull();
     expect(document.activeElement).toBe(searchInput);
 
     act(() => {

--- a/ui/src/components/InlineEntitySelector.tsx
+++ b/ui/src/components/InlineEntitySelector.tsx
@@ -142,6 +142,7 @@ export const InlineEntitySelector = forwardRef<HTMLButtonElement, InlineEntitySe
           </button>
         </PopoverTrigger>
         <PopoverContent
+          data-mobile-entity-picker=""
           align="start"
           side="bottom"
           collisionPadding={16}
@@ -159,7 +160,7 @@ export const InlineEntitySelector = forwardRef<HTMLButtonElement, InlineEntitySe
         >
           <input
             ref={inputRef}
-            className="w-full border-b border-border bg-transparent px-2 py-1.5 text-sm outline-none placeholder:text-muted-foreground/60"
+            className="w-full border-b border-border bg-transparent px-2 py-1.5 text-base outline-none placeholder:text-muted-foreground/60 md:text-sm"
             placeholder={searchPlaceholder}
             value={query}
             onChange={(event) => {

--- a/ui/src/components/SearchableSelect.test.tsx
+++ b/ui/src/components/SearchableSelect.test.tsx
@@ -130,6 +130,7 @@ describe("SearchableSelect", () => {
 
     expect(container.querySelector("[data-option-key='recent:alpha']")).not.toBeNull();
     expect(container.querySelector("[data-option-key='all:alpha']")).not.toBeNull();
+    expect(container.querySelector("[data-mobile-entity-picker]")).not.toBeNull();
   });
 
   it("filters options and returns the selected option object", async () => {

--- a/ui/src/components/SearchableSelect.tsx
+++ b/ui/src/components/SearchableSelect.tsx
@@ -225,6 +225,7 @@ export function SearchableSelect<
         </Button>
       </PopoverTrigger>
       <PopoverContent
+        data-mobile-entity-picker=""
         align={align}
         collisionPadding={16}
         disablePortal={disablePortal}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -2999,3 +2999,23 @@ span.paperclip-mention-chip[data-mention-kind="external-object"] {
   .runner-activity-roll-in { animation: none; }
   .runner-activity-roll-out { display: none; }
 }
+
+/* Keep entity-picker search controls visible when a narrow viewport opens its
+   software keyboard. The fixed sheet also avoids scale motion during mobile
+   viewport resizing. */
+@media (max-width: 40rem) {
+  [data-mobile-entity-picker] {
+    position: fixed !important;
+    inset: auto calc(var(--spacing) * 4) max(calc(var(--spacing) * 4), env(safe-area-inset-bottom)) !important;
+    width: auto !important;
+    max-width: none !important;
+    max-height: calc(100dvh - calc(var(--spacing) * 8)) !important;
+    transform: none !important;
+    transform-origin: bottom center !important;
+    animation: none !important;
+  }
+
+  [data-mobile-entity-picker] [data-slot="command-list"] {
+    max-height: min(var(--sz-300px), calc(100dvh - calc(var(--spacing) * 24))) !important;
+  }
+}

--- a/ui/storybook/stories/mobile-entity-pickers.stories.tsx
+++ b/ui/storybook/stories/mobile-entity-pickers.stories.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useRef, useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { InlineEntitySelector, type InlineEntityOption } from "@/components/InlineEntitySelector";
+
+const assignees: InlineEntityOption[] = [
+  { id: "agent-product", label: "Product Lead", searchText: "planning product" },
+  { id: "agent-engineer", label: "Frontend Engineer", searchText: "ui implementation" },
+  { id: "agent-qa", label: "QA Engineer", searchText: "testing review" },
+];
+
+const projects: InlineEntityOption[] = [
+  { id: "project-control-plane", label: "Control Plane" },
+  { id: "project-mobile", label: "Mobile Experience" },
+  { id: "project-connectors", label: "Apps and Connectors" },
+];
+
+function OpenPicker({ kind, options }: { kind: "Assignee" | "Project"; options: InlineEntityOption[] }) {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [value, setValue] = useState("");
+
+  useEffect(() => {
+    triggerRef.current?.click();
+  }, []);
+
+  return (
+    <div className="flex min-h-screen items-end p-4">
+      <InlineEntitySelector
+        ref={triggerRef}
+        value={value}
+        options={options}
+        placeholder={`Choose ${kind.toLowerCase()}`}
+        noneLabel={`No ${kind.toLowerCase()}`}
+        searchPlaceholder={`Search ${kind.toLowerCase()}s...`}
+        emptyMessage={`No matching ${kind.toLowerCase()}.`}
+        onChange={setValue}
+      />
+    </div>
+  );
+}
+
+const meta = {
+  title: "Components/Entity pickers/Mobile",
+  parameters: {
+    layout: "fullscreen",
+    viewport: { defaultViewport: "mobile1" },
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const AssigneePicker: Story = {
+  render: () => <OpenPicker kind="Assignee" options={assignees} />,
+};
+
+export const ProjectPicker: Story = {
+  render: () => <OpenPicker kind="Project" options={projects} />,
+};


### PR DESCRIPTION
## Thinking Path

> - Paperclip is the open source app people use to manage AI agents for work.
> - The issue editor lets operators select an assignee and a project.
> - The mobile picker could extend above the screen and hide its search field.
> - Mobile Safari could also zoom the search input.
> - This pull request changes the mobile picker to use a stable bottom sheet.
> - It also adds mobile Storybook examples for both entity picker types.
> - The benefit is a visible and stable picker on small screens.

## Linked Issues or Issue Description

**What happened?**

The assignee and project pickers can extend above a mobile screen. The search field is then not visible. Mobile Safari can zoom the page when the user selects the search field.

**Steps to reproduce**

1. Open an assignee or project picker on a narrow mobile screen.
2. Observe the picker position.
3. Select the search field.

**Expected behavior**

The picker must stay inside the screen. The search field must remain visible. The page must not zoom when the user selects the search field.

**Paperclip version or commit**

The problem reproduces on `master` before this change.

**Deployment mode**

Local development mode.

**Installation method**

Built from source with pnpm.

## What Changed

- Use the mobile viewport height for the entity picker sheet.
- Remove the mobile scale animation and keep the sheet at the bottom edge.
- Set the mobile search input size to prevent iOS input zoom.
- Add Storybook examples for the mobile assignee and project pickers.

## Verification

- `pnpm exec vitest run ui/src/components/SearchableSelect.test.tsx ui/src/components/InlineEntitySelector.test.tsx`
- `pnpm --filter @paperclipai/ui typecheck`
- `pnpm check:token-gates`
- `pnpm build-storybook`
- `git diff origin/master...HEAD --check`

## Risks

- Low risk. The layout changes apply only to mobile entity picker content.
- The Storybook build reports existing CSS and bundle-size warnings.

> For core feature work, check [`ROADMAP.md`](ROADMAP.md) first and discuss it in `#dev` before opening the PR. Feature PRs that overlap with planned core work may need to be redirected — check the roadmap first. See `CONTRIBUTING.md`.

## Model Used

- OpenAI Codex, GPT-5.6, with reasoning and code execution tools.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub `#NNN` / `github.com/paperclipai/paperclip` URLs)
- [x] My branch name describes the change (e.g. `docs/...`, `fix/...`) and contains no internal Paperclip ticket id or instance-derived details
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge


