### PR TITLE
fix(watchdog): prevent self-recovery guard lockout and recognize armed monitors

### DIFF
--- a/server/src/__tests__/task-watchdogs-classifier.test.ts
+++ b/server/src/__tests__/task-watchdogs-classifier.test.ts
@@ -387,4 +387,79 @@ describe("task watchdog subtree classifier", () => {
 
     expect(result.state).toBe("not_applicable");
   });
+
+  // HAU-423: an armed monitor counts as a live path
+  it("classifies a subtree as live when a leaf has a future monitorNextCheckAt (HAU-423)", () => {
+    const evaluatedAt = new Date("2026-09-01T13:00:00.000Z");
+    const monitorNextCheckAt = new Date("2026-09-06T21:00:00.000Z");
+    const result = classify({
+      issues: [
+        issue({ status: "in_progress" }),
+        issue({ id: childId, parentId: sourceId, status: "in_progress", monitorNextCheckAt }),
+      ],
+      evaluatedAt,
+    });
+
+    expect(result).toMatchObject({
+      state: "live",
+      liveIssueIds: [childId],
+    });
+  });
+
+  it("does not count a past monitorNextCheckAt as a live path", () => {
+    const evaluatedAt = new Date("2026-09-01T13:00:00.000Z");
+    const monitorNextCheckAt = new Date("2026-08-30T09:00:00.000Z");
+    const result = classify({
+      issues: [
+        issue({ status: "in_progress" }),
+        issue({ id: childId, parentId: sourceId, status: "in_progress", monitorNextCheckAt }),
+      ],
+      evaluatedAt,
+    });
+
+    expect(result.state).toBe("stopped");
+  });
+
+  it("treats a recovery child with an armed monitor as live, preventing spurious re-fire (HAU-423)", () => {
+    // Simulate: watched subtree was stopped, watchdog created a child and armed
+    // its monitor. The next evaluation should see the subtree as live (the armed
+    // monitor is a wake path), not stopped — which would cause a spurious re-fire.
+    const evaluatedAt = new Date("2026-09-01T13:00:00.000Z");
+    const monitorArmedAt = new Date("2026-09-01T12:58:35.000Z"); // before evaluatedAt
+    const monitorNextCheckAt = new Date("2026-09-06T21:00:00.000Z"); // future
+    const result = classify({
+      issues: [
+        issue({ status: "in_progress" }),
+        issue({
+          id: childId,
+          parentId: sourceId,
+          status: "in_progress",
+          monitorNextCheckAt,
+          // createdAt is before evaluatedAt — not in the grace window
+          createdAt: monitorArmedAt,
+        }),
+      ],
+      // No active runs or queued wakes — only the monitor wake path
+      activeRuns: [],
+      queuedWakeRequests: [],
+      evaluatedAt,
+      firstRunGraceMs: 15_000,
+    });
+
+    expect(result).toMatchObject({
+      state: "live",
+      liveIssueIds: [childId],
+    });
+  });
+
+  it("still classifies as stopped when monitorNextCheckAt is absent and evaluatedAt is not provided", () => {
+    const result = classify({
+      issues: [
+        issue({ status: "in_progress" }),
+        issue({ id: childId, parentId: sourceId, status: "blocked" }),
+      ],
+    });
+
+    expect(result.state).toBe("stopped");
+  });
 });

--- a/server/src/services/task-watchdog-scope.ts
+++ b/server/src/services/task-watchdog-scope.ts
@@ -28,6 +28,9 @@ export type TaskWatchdogMutationScope =
       watchedIssueId: string;
       watchdogIssueId: string | null;
       stopFingerprint: string | null;
+      // The heartbeat run ID of the watchdog run that holds this scope. Used by
+      // the staleness guard to exempt live paths this run itself created. (HAU-417)
+      runId: string | null;
     };
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
@@ -118,6 +121,7 @@ export async function resolveTaskWatchdogMutationScope(
     watchedIssueId: watchdog.issueId,
     watchdogIssueId: watchdog.watchdogIssueId ?? null,
     stopFingerprint: taskWatchdog.stopFingerprint,
+    runId,
   };
 }
 

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -1422,6 +1422,11 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         originKind: TASK_WATCHDOG_ORIGIN_KIND,
         originId: input.sourceIssue.id,
         originFingerprint: input.classification.stopFingerprint,
+        // Stamp the run that created this child so the staleness-guard exemption
+        // in revalidateMutationScope can tell liveness THIS run caused from
+        // external liveness. Without it that exemption is an ALL-quantifier over
+        // a column nothing writes, so it can never fire. (HAU-725)
+        originRunId: input.runId ?? null,
         billingCode: input.sourceIssue.billingCode,
         inheritExecutionWorkspaceFromIssueId: input.sourceIssue.id,
       })

--- a/server/src/services/task-watchdogs.ts
+++ b/server/src/services/task-watchdogs.ts
@@ -74,6 +74,10 @@ export type TaskWatchdogClassifierIssue = Pick<
   latestCommentAt?: Date | string | null;
   latestDocumentAt?: Date | string | null;
   latestWorkProductAt?: Date | string | null;
+  // An armed monitor means a future scheduled wake exists — the issue has a
+  // live path even without an active run or queued wake request. Optional so
+  // existing callers/tests that omit it keep the pre-existing semantics.
+  monitorNextCheckAt?: Date | string | null;
 };
 
 export type TaskWatchdogClassifierPath = {
@@ -408,15 +412,28 @@ export function classifyTaskWatchdogSubtree(input: TaskWatchdogClassifierInput):
 
   const includedIds = included.map((issue) => issue.id);
   const includedIdSet = new Set(includedIds);
+  // Compute now for both the monitor-armed check and the first-run grace guard.
+  const evaluatedAtMs = toEpochMs(input.evaluatedAt);
+  // An issue with a future monitorNextCheckAt has a scheduled wake — it is a
+  // live path even if no run is currently queued or active (HAU-423).
+  const monitoredIssueIds = evaluatedAtMs != null
+    ? included
+      .filter((issue) => {
+        const nextCheck = toEpochMs(issue.monitorNextCheckAt);
+        return nextCheck != null && nextCheck > evaluatedAtMs;
+      })
+      .map((issue) => issue.id)
+    : [];
   const liveIssueIds = [
     ...pathIssueIds(input.activeRuns, input.watchdog.companyId),
     ...pathIssueIds(input.queuedWakeRequests, input.watchdog.companyId),
+    ...monitoredIssueIds,
   ].filter((issueId) => includedIdSet.has(issueId));
   const uniqueLiveIssueIds = [...new Set(liveIssueIds)].sort();
   if (uniqueLiveIssueIds.length > 0) {
     return {
       state: "live",
-      reason: "At least one issue in the watched subtree has a live run, queued wake, or scheduled retry.",
+      reason: "At least one issue in the watched subtree has a live run, queued wake, scheduled retry, or armed monitor.",
       includedIssueIds: includedIds,
       liveIssueIds: uniqueLiveIssueIds,
     };
@@ -427,7 +444,6 @@ export function classifyTaskWatchdogSubtree(input: TaskWatchdogClassifierInput):
   // assignment run/wake is committed/visible, making an actively-starting
   // subtree look idle. Suppress the stopped verdict for non-terminal issues
   // created within the first-run grace window that have never completed a run.
-  const evaluatedAtMs = toEpochMs(input.evaluatedAt);
   const graceMs = input.firstRunGraceMs ?? 0;
   if (evaluatedAtMs != null && graceMs > 0) {
     const completedRunIssueIds = new Set(input.completedRunIssueIds ?? []);
@@ -875,6 +891,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           origin_kind,
           updated_at,
           created_at,
+          monitor_next_check_at,
           0 AS depth
         FROM issues
         WHERE company_id = ${companyId}
@@ -894,6 +911,7 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
           child.origin_kind,
           child.updated_at,
           child.created_at,
+          child.monitor_next_check_at,
           watched_issues.depth + 1
         FROM issues child
         JOIN watched_issues ON child.parent_id = watched_issues.id
@@ -914,7 +932,8 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
         assignee_user_id AS "assigneeUserId",
         origin_kind AS "originKind",
         updated_at AS "updatedAt",
-        created_at AS "createdAt"
+        created_at AS "createdAt",
+        monitor_next_check_at AS "monitorNextCheckAt"
       FROM watched_issues
     `);
 
@@ -1617,6 +1636,13 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
     companyId: string;
     watchedIssueId: string;
     stopFingerprint: string | null;
+    // The current run ID, used to exempt live paths this run itself created.
+    // When present and the subtree is "live" only because of issues whose
+    // originRunId matches this run, further mutations are still allowed — the
+    // guard is meant to block writes after an *external* actor has restored
+    // the path, not to block the watchdog's own follow-up configuration writes
+    // (e.g. arming a monitor on a child it just created). (HAU-417)
+    runId?: string | null;
   }) {
     if (!scope.stopFingerprint) {
       return {
@@ -1646,6 +1672,31 @@ export function taskWatchdogService(db: Db, deps: TaskWatchdogServiceDeps = {}) 
     const classification = classifyTaskWatchdogSubtree(input);
     if (classification.state === "stopped" && classification.stopFingerprint === scope.stopFingerprint) {
       return { allowed: true as const, classification };
+    }
+
+    // Allow mutations when the subtree became live exclusively because this run
+    // created the live issues. The guard fires too early otherwise: creating an
+    // in_progress child (the most common recovery action) immediately flips the
+    // subtree to "live", locking out the next arm/comment writes that are part
+    // of the same recovery. The guard must block external liveness, not the
+    // watchdog's own multi-write recovery sequence. (HAU-417)
+    if (
+      classification.state === "live" &&
+      scope.runId &&
+      classification.liveIssueIds.length > 0
+    ) {
+      const selfCreatedCount = await db
+        .select({ id: issues.id })
+        .from(issues)
+        .where(and(
+          eq(issues.companyId, scope.companyId),
+          inArray(issues.id, classification.liveIssueIds),
+          eq(issues.originRunId, scope.runId),
+        ))
+        .then((rows) => rows.length);
+      if (selfCreatedCount === classification.liveIssueIds.length) {
+        return { allowed: true as const, classification };
+      }
     }
 
     return {


### PR DESCRIPTION
## Thinking Path

> - Paperclip is an open source app for teams that manage AI agents.
> - Task watchdogs detect issue trees that have no valid path to continue.
> - A watchdog recovery can create a review child and then make follow-up writes.
> - The old guard treated a child created by that same run as external liveness.
> - The classifier also did not treat a future monitor check as a live path.
> - This pull request records the creating run and adds future monitor checks to the live-path set.
> - The result is that a watchdog can finish its safe recovery sequence without a false second review.

## Linked Issues or Issue Description

Related pull requests found during the duplicate search:

- #12172 adds monitor liveness with a different scheduler-eligibility implementation.
- #10857 excludes the requesting run and its wakeups through a broader persistence change.
- #10331 uses per-target-leaf freshness checks for a related self-write problem.

**What happened?**

A task watchdog recovery could create a review child and then receive a stale-review error on its next write. The guard treated that child as an external live path. A future monitor check also did not count as a live path.

**Expected behavior**

The guard must allow follow-up writes when every live issue was created by the same watchdog run. A future monitor check must keep its issue tree live.

**Steps to reproduce**

1. Start a task watchdog for a stopped issue tree.
2. Let it create a review child.
3. Make the next guarded watchdog write in the same run.
4. Before this change, the server returns a stale-review error.
5. Add a future monitor check with no queued run or wake request.
6. Before this change, the classifier reports the tree as stopped.

**Paperclip version or commit**

The branch contains commits 5f4f5f16d494f6ae28a955a1eafab89397f4c6d1 and 4786cd8210760d46626515d55ad669ee4cf40030.

**Deployment mode**

The defect is in the core server. It affects source and packaged deployments that contain the old classifier and guard.

## What Changed

- Count a future monitor check as a watchdog live path.
- Allow a guarded follow-up write when all live issues have the current watchdog run as their origin.
- Store the current run identifier when the watchdog creates its review child.

## Verification

- git diff --check master..4786cd821 passed.
- The focused classifier test started but could not load because the local installed Zod does not provide string().guid(). No test assertion ran. GitHub CI is the canonical dependency check.

## Risks

The change alters watchdog liveness and stale-guard behavior. It is limited to task-watchdog execution. Existing review children keep a null origin run identifier, so their old behavior remains until a new recovery child is created.

## Model Used

OpenAI Codex, gpt-5.6-terra, with tool use and local code execution.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used with version and capability details
- [x] I have checked ROADMAP.md and confirmed this PR matches the watchdog outcome work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have described the issue in this PR with bug-report labels
- [x] I have not referenced internal or instance-local issues or links in this PR body
- [ ] The pre-existing branch name contains an internal ticket tag
- [ ] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] No user-facing documentation changes are needed
- [x] I have considered and documented risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open recommendations or follow-ups
- [x] I will address all reviewer comments before requesting merge