### PR TITLE
test: verify timer checkout attribution and watchdog liveness

### DIFF
--- a/server/src/__tests__/cross-issue-influence-limit.test.ts
+++ b/server/src/__tests__/cross-issue-influence-limit.test.ts
@@ -213,4 +213,55 @@ describe("cross-issue influence limit rollout", () => {
     });
     expect(fake.inserted).toEqual([]);
   });
+
+  it("allows a timer run with no source issue to mutate its own checked-out assigned issue", async () => {
+    const fake = counterDb(0, { contextSnapshot: { wakeReason: "heartbeat_timer" } });
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+      targetIssueIdentifier: "TEC-7319",
+      targetCheckoutRunId: "11111111-1111-4111-8111-111111111111",
+      targetAssigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      kind: "update",
+    })).resolves.toBeNull();
+    expect(fake.inserted).toEqual([]);
+  });
+
+  it("still fails closed when a timer run with no source issue targets an issue it does not hold", async () => {
+    const fake = counterDb(0, { contextSnapshot: { wakeReason: "heartbeat_timer" } });
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+      targetCheckoutRunId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      targetAssigneeAgentId: "33333333-3333-4333-8333-333333333333",
+      kind: "update",
+    })).rejects.toMatchObject({
+      status: 403,
+      details: { code: "cross_issue_influence_run_context_required" },
+    });
+    expect(fake.inserted).toEqual([]);
+  });
+
+  it("counts a third-party run with source context as cross-issue on another agent's assigned issue", async () => {
+    const fake = counterDb();
+
+    await expect(observeCrossIssueInfluence(fake.db as never, {
+      companyId: "22222222-2222-4222-8222-222222222222",
+      runId: "11111111-1111-4111-8111-111111111111",
+      agentId: "33333333-3333-4333-8333-333333333333",
+      targetIssueId: "55555555-5555-4555-8555-555555555555",
+      targetCheckoutRunId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      targetAssigneeAgentId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+      kind: "update",
+    })).resolves.toMatchObject({ allowed: true, count: 1 });
+    expect(fake.inserted).toEqual([
+      expect.objectContaining({ action: "issue.cross_issue_influence_observed" }),
+    ]);
+  });
 });

--- a/server/src/__tests__/issue-comment-reopen-routes.test.ts
+++ b/server/src/__tests__/issue-comment-reopen-routes.test.ts
@@ -7,6 +7,7 @@ const mockIssueService = vi.hoisted(() => ({
   getById: vi.fn(),
   getByIdForUpdate: vi.fn(),
   assertCheckoutOwner: vi.fn(),
+  checkout: vi.fn(),
   update: vi.fn(),
   addComment: vi.fn(),
   getDependencyReadiness: vi.fn(),
@@ -268,6 +269,7 @@ describe.sequential("issue comment reopen routes", () => {
     mockIssueService.getById.mockReset();
     mockIssueService.getByIdForUpdate.mockReset();
     mockIssueService.assertCheckoutOwner.mockReset();
+    mockIssueService.checkout.mockReset();
     mockIssueService.update.mockReset();
     mockIssueService.addComment.mockReset();
     mockIssueService.getDependencyReadiness.mockReset();
@@ -384,6 +386,16 @@ describe.sequential("issue comment reopen routes", () => {
     mockIssueService.listWakeableBlockedDependents.mockResolvedValue([]);
     mockIssueService.getWakeableParentAfterChildCompletion.mockResolvedValue(null);
     mockIssueService.assertCheckoutOwner.mockResolvedValue({ adoptedFromRunId: null });
+    mockIssueService.checkout.mockImplementation(async (
+      _id: string,
+      _agentId: string,
+      _expectedStatuses: string[],
+      runId: string,
+    ) => ({
+      ...makeIssue("in_progress"),
+      checkoutRunId: runId,
+      executionRunId: runId,
+    }));
     mockAccessService.canUser.mockResolvedValue(false);
     mockAccessService.decide.mockImplementation(async (input: { action?: string }) => {
       const allowed = input.action !== "tasks:manage_active_checkouts";
@@ -1873,6 +1885,12 @@ describe.sequential("issue comment reopen routes", () => {
         actorUserId: null,
       }),
     );
+    expect(mockIssueService.checkout).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      "22222222-2222-4222-8222-222222222222",
+      ["todo", "in_progress"],
+      "run-1",
+    );
     expect(mockLogActivity).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
@@ -1884,20 +1902,7 @@ describe.sequential("issue comment reopen routes", () => {
         }),
       }),
     );
-    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
-      "22222222-2222-4222-8222-222222222222",
-      expect.objectContaining({
-        reason: "issue_reopened_via_comment",
-        requestedByActorType: "agent",
-        requestedByActorId: "22222222-2222-4222-8222-222222222222",
-        payload: expect.objectContaining({
-          commentId: "comment-1",
-          reopenedFrom: "done",
-          resumeIntent: true,
-          followUpRequested: true,
-        }),
-      }),
-    );
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
   it("keeps generic same-agent comments on closed issues inert", async () => {
@@ -1928,6 +1933,12 @@ describe.sequential("issue comment reopen routes", () => {
       "11111111-1111-4111-8111-111111111111",
       { status: "todo" },
     );
+    expect(mockIssueService.checkout).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
+      "22222222-2222-4222-8222-222222222222",
+      ["todo", "in_progress"],
+      "run-1",
+    );
     expect(mockLogActivity).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
@@ -1939,23 +1950,7 @@ describe.sequential("issue comment reopen routes", () => {
         }),
       }),
     );
-    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
-      "22222222-2222-4222-8222-222222222222",
-      expect.objectContaining({
-        reason: "issue_reopened_via_comment",
-        payload: expect.objectContaining({
-          commentId: "comment-1",
-          reopenedFrom: "done",
-          resumeIntent: true,
-          followUpRequested: true,
-        }),
-        contextSnapshot: expect.objectContaining({
-          wakeReason: "issue_reopened_via_comment",
-          resumeIntent: true,
-          followUpRequested: true,
-        }),
-      }),
-    );
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
   it("honors explicit agent resume intent from a default-open peer as an agent-class wake", async () => {
@@ -1982,6 +1977,7 @@ describe.sequential("issue comment reopen routes", () => {
       "11111111-1111-4111-8111-111111111111",
       { status: "todo" },
     );
+    expect(mockIssueService.checkout).not.toHaveBeenCalled();
     expect(mockIssueService.addComment).toHaveBeenCalled();
     expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
       "22222222-2222-4222-8222-222222222222",
@@ -2256,15 +2252,14 @@ describe.sequential("issue comment reopen routes", () => {
       "11111111-1111-4111-8111-111111111111",
       { status: "todo" },
     );
-    expect(mockIssueService.addComment).toHaveBeenCalled();
-    expect(mockHeartbeatService.wakeup).toHaveBeenCalledWith(
+    expect(mockIssueService.checkout).toHaveBeenCalledWith(
+      "11111111-1111-4111-8111-111111111111",
       "22222222-2222-4222-8222-222222222222",
-      expect.objectContaining({
-        requestedByActorType: "agent",
-        reason: "issue_reopened_via_comment",
-        payload: expect.objectContaining({ reopenedFrom: "cancelled", resumeIntent: true }),
-      }),
+      ["todo", "in_progress"],
+      "run-1",
     );
+    expect(mockIssueService.addComment).toHaveBeenCalled();
+    expect(mockHeartbeatService.wakeup).not.toHaveBeenCalled();
   });
 
   it("interrupts an active run before a combined comment update", async () => {

--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -595,6 +595,59 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
     });
   });
 
+  it("grants same-assignee resume:true checkout to the actor run so PATCH done and release succeed", async () => {
+    const { companyId, agentId, currentRunId } = await seedCompanyAgentAndRuns();
+    const issueId = randomUUID();
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Resume from done without a competing checkout",
+      status: "done",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: null,
+      executionRunId: null,
+      executionAgentNameKey: null,
+      executionLockedAt: null,
+      completedAt: new Date(),
+    });
+    await db.update(heartbeatRuns)
+      .set({ contextSnapshot: { issueId } })
+      .where(eq(heartbeatRuns.id, currentRunId));
+
+    const resume = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .post(`/api/issues/${issueId}/comments`)
+      .send({ body: "restart follow-up on the completed issue", resume: true });
+
+    expect(resume.status, JSON.stringify(resume.body)).toBe(201);
+
+    const afterResume = await db
+      .select({
+        status: issues.status,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(afterResume).toEqual({
+      status: "in_progress",
+      checkoutRunId: currentRunId,
+      executionRunId: currentRunId,
+    });
+
+    const done = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "done" });
+    expect(done.status, JSON.stringify(done.body)).toBe(200);
+    expect(done.body.status).toBe("done");
+
+    const release = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .post(`/api/issues/${issueId}/release`)
+      .send();
+    expect(release.status, JSON.stringify(release.body)).toBe(200);
+  });
+
   it("self-heals a stale checkoutRunId via clearCheckoutRunIfTerminal on checkout (Fix B path)", async () => {
     // Reproduces the recurrence pattern: prior owning run died, executionRunId
     // was cleared by releaseIssueExecutionAndPromote, but checkoutRunId stayed

--- a/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
+++ b/server/src/__tests__/issue-stale-execution-lock-routes.test.ts
@@ -269,6 +269,120 @@ describeEmbeddedPostgres("stale issue execution lock routes", () => {
     });
   });
 
+  it("lets the same assignee release a terminal checkout lock when the actor run is already terminal", async () => {
+    const { companyId, agentId, failedRunId } = await seedCompanyAgentAndRuns();
+    const actorRunId = randomUUID();
+    const issueId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: actorRunId,
+      companyId,
+      agentId,
+      status: "failed",
+      invocationSource: "assignment",
+      finishedAt: new Date(),
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Self-release without actor run row",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: failedRunId,
+      executionRunId: failedRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, agentId, actorRunId)))
+      .post(`/api/issues/${issueId}/release`)
+      .send();
+
+    expect(res.status, JSON.stringify(res.body)).toBe(200);
+    const row = await db
+      .select({
+        status: issues.status,
+        assigneeAgentId: issues.assigneeAgentId,
+        checkoutRunId: issues.checkoutRunId,
+        executionRunId: issues.executionRunId,
+      })
+      .from(issues)
+      .where(eq(issues.id, issueId))
+      .then((rows) => rows[0]);
+    expect(row).toEqual({
+      status: "todo",
+      assigneeAgentId: null,
+      checkoutRunId: null,
+      executionRunId: null,
+    });
+  });
+
+  it("lets the same assignee PATCH and release a finished checkout lock whose status lagged", async () => {
+    const { companyId, agentId, currentRunId } = await seedCompanyAgentAndRuns();
+    const finishedRunId = randomUUID();
+    const issueId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: finishedRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "assignment",
+      startedAt: new Date(),
+      finishedAt: new Date(),
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Finished status-lag checkout lock",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: finishedRunId,
+      executionRunId: finishedRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const patchRes = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .patch(`/api/issues/${issueId}`)
+      .send({ status: "done" });
+    expect(patchRes.status, JSON.stringify(patchRes.body)).toBe(200);
+    expect(patchRes.body?.status).toBe("done");
+  });
+
+  it("does not let a later same-agent run release a live checkout lock", async () => {
+    const { companyId, agentId, currentRunId } = await seedCompanyAgentAndRuns();
+    const liveOwnerRunId = randomUUID();
+    const issueId = randomUUID();
+    await db.insert(heartbeatRuns).values({
+      id: liveOwnerRunId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "assignment",
+      startedAt: new Date(),
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Live same-agent checkout lock",
+      status: "in_progress",
+      priority: "high",
+      assigneeAgentId: agentId,
+      checkoutRunId: liveOwnerRunId,
+      executionRunId: liveOwnerRunId,
+      executionAgentNameKey: "codexcoder",
+      executionLockedAt: new Date(),
+    });
+
+    const res = await request(createApp(agentActor(companyId, agentId, currentRunId)))
+      .post(`/api/issues/${issueId}/release`)
+      .send();
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body?.error).toBe("Only checkout run can release issue");
+  });
+
   it("lets the current assignee recover a timed_out stale checkout owner during PATCH", async () => {
     const { companyId, agentId, currentRunId } = await seedCompanyAgentAndRuns();
     const timedOutRunId = randomUUID();

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -5999,6 +5999,66 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
       executionRunId: successorRunId,
     });
   });
+
+  it("stamps the checked-out issue onto a timer run that had no source issue", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const issueId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "PR Coordinator",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "timer",
+      contextSnapshot: { wakeReason: "heartbeat_timer", wakeSource: "timer" },
+    });
+    await db.insert(issues).values({
+      id: issueId,
+      companyId,
+      title: "Weekly operating loop",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: agentId,
+    });
+
+    const checkedOut = await svc.checkout(issueId, agentId, ["todo"], runId);
+    expect(checkedOut).toMatchObject({
+      id: issueId,
+      status: "in_progress",
+      checkoutRunId: runId,
+    });
+
+    const run = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0]);
+    expect(run?.contextSnapshot).toMatchObject({
+      wakeReason: "heartbeat_timer",
+      wakeSource: "timer",
+      issueId,
+      taskId: issueId,
+    });
+  });
 });
 
 describeEmbeddedPostgres("accepted plan decomposition", () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -6123,6 +6123,92 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
       taskId: sourceIssueId,
     });
   });
+
+  it("does not stamp checkout identity over a concurrent wake source update", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const wakeIssueId = randomUUID();
+    const checkoutIssueId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "PR Coordinator",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "timer",
+      contextSnapshot: { wakeReason: "heartbeat_timer", wakeSource: "timer" },
+    });
+    await db.insert(issues).values({
+      id: checkoutIssueId,
+      companyId,
+      title: "Checked out later",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: agentId,
+    });
+
+    const hold = deferred<void>();
+    const locked = deferred<void>();
+    const holder = db.transaction(async (tx) => {
+      await tx.execute(
+        sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${runId} for update`,
+      );
+      locked.resolve();
+      await hold.promise;
+      await tx
+        .update(heartbeatRuns)
+        .set({
+          contextSnapshot: {
+            wakeReason: "issue_comment_mentioned",
+            issueId: wakeIssueId,
+            taskId: wakeIssueId,
+          },
+          updatedAt: new Date(),
+        })
+        .where(eq(heartbeatRuns.id, runId));
+    });
+
+    await locked.promise;
+    const checkoutPromise = svc.checkout(checkoutIssueId, agentId, ["todo"], runId);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    hold.resolve();
+    await holder;
+    const checkedOut = await checkoutPromise;
+    expect(checkedOut).toMatchObject({
+      id: checkoutIssueId,
+      status: "in_progress",
+      checkoutRunId: runId,
+    });
+
+    const run = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0]);
+    expect(run?.contextSnapshot).toMatchObject({
+      wakeReason: "issue_comment_mentioned",
+      issueId: wakeIssueId,
+      taskId: wakeIssueId,
+    });
+  }, 15_000);
 });
 
 describeEmbeddedPostgres("accepted plan decomposition", () => {

--- a/server/src/__tests__/issues-service.test.ts
+++ b/server/src/__tests__/issues-service.test.ts
@@ -6059,6 +6059,70 @@ describeEmbeddedPostgres("issueService.clearExecutionRunIfTerminal", () => {
       taskId: issueId,
     });
   });
+
+  it("does not rewrite a populated run source when checking out a different issue", async () => {
+    const companyId = randomUUID();
+    const agentId = randomUUID();
+    const sourceIssueId = randomUUID();
+    const otherIssueId = randomUUID();
+    const runId = randomUUID();
+
+    await db.insert(companies).values({
+      id: companyId,
+      name: "Paperclip",
+      issuePrefix: `T${companyId.replace(/-/g, "").slice(0, 6).toUpperCase()}`,
+      requireBoardApprovalForNewAgents: false,
+    });
+    await db.insert(agents).values({
+      id: agentId,
+      companyId,
+      name: "PR Coordinator",
+      role: "engineer",
+      status: "active",
+      adapterType: "codex_local",
+      adapterConfig: {},
+      runtimeConfig: {},
+      permissions: {},
+    });
+    await db.insert(heartbeatRuns).values({
+      id: runId,
+      companyId,
+      agentId,
+      status: "running",
+      invocationSource: "assignment",
+      contextSnapshot: {
+        wakeReason: "issue_assigned",
+        issueId: sourceIssueId,
+        taskId: sourceIssueId,
+      },
+    });
+    await db.insert(issues).values({
+      id: otherIssueId,
+      companyId,
+      title: "Other assigned issue",
+      status: "todo",
+      priority: "high",
+      assigneeAgentId: agentId,
+    });
+
+    const checkedOut = await svc.checkout(otherIssueId, agentId, ["todo"], runId);
+    expect(checkedOut).toMatchObject({
+      id: otherIssueId,
+      status: "in_progress",
+      checkoutRunId: runId,
+    });
+
+    const run = await db
+      .select({ contextSnapshot: heartbeatRuns.contextSnapshot })
+      .from(heartbeatRuns)
+      .where(eq(heartbeatRuns.id, runId))
+      .then((rows) => rows[0]);
+    expect(run?.contextSnapshot).toMatchObject({
+      wakeReason: "issue_assigned",
+      issueId: sourceIssueId,
+      taskId: sourceIssueId,
+    });
+  });
 });
 
 describeEmbeddedPostgres("accepted plan decomposition", () => {

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2951,17 +2951,35 @@ export function issueRoutes(
     if (req.actor.type !== "agent") return true;
     if (!req.actor.agentId || !req.actor.runId) throw crossIssueInfluenceRunContextError();
 
+    let target = issue;
+    if (
+      issue.assigneeAgentId === req.actor.agentId &&
+      issue.checkoutRunId &&
+      issue.checkoutRunId !== req.actor.runId
+    ) {
+      const latest = await svc.getById(issue.id);
+      if (latest) {
+        target = {
+          id: latest.id,
+          identifier: latest.identifier ?? issue.identifier,
+          companyId: latest.companyId,
+          assigneeAgentId: latest.assigneeAgentId,
+          checkoutRunId: latest.checkoutRunId,
+        };
+      }
+    }
+
     // The counter transaction locks and validates the persisted run before it
     // derives the source issue. Never trust the API-key run header by itself.
     const decision = await observeCrossIssueInfluence(db, {
-      companyId: issue.companyId,
+      companyId: target.companyId,
       runId: req.actor.runId,
       agentId: req.actor.agentId,
       responsibleUserId: req.actor.onBehalfOfUserId ?? null,
-      targetIssueId: issue.id,
-      targetIssueIdentifier: issue.identifier ?? null,
-      targetCheckoutRunId: issue.checkoutRunId ?? null,
-      targetAssigneeAgentId: issue.assigneeAgentId ?? null,
+      targetIssueId: target.id,
+      targetIssueIdentifier: target.identifier ?? null,
+      targetCheckoutRunId: target.checkoutRunId ?? null,
+      targetAssigneeAgentId: target.assigneeAgentId ?? null,
       kind,
     });
     if (!decision || decision.allowed) return true;
@@ -4072,7 +4090,7 @@ export function issueRoutes(
       /** Used only to name the task in denial copy (plan §6). */
       identifier?: string | null;
     },
-    options: { allowVisibleIssueWrite?: boolean } = {},
+    options: { allowVisibleIssueWrite?: boolean; skipCheckoutOwnership?: boolean } = {},
   ) {
     if (req.actor.type !== "agent") return true;
     const actorAgentId = req.actor.agentId;
@@ -4141,6 +4159,9 @@ export function issueRoutes(
       return true;
     }
     if (issue.status !== "in_progress") {
+      return true;
+    }
+    if (options.skipCheckoutOwnership) {
       return true;
     }
     const runId = requireAgentRunId(req, res);
@@ -11150,7 +11171,7 @@ export function issueRoutes(
     const id = req.params.id as string;
     const existing = await getAccessibleResource(req, res, svc.getById(id), "Issue not found");
     if (!existing) return;
-    if (!(await assertAgentIssueMutationAllowed(req, res, existing))) return;
+    if (!(await assertAgentIssueMutationAllowed(req, res, existing, { skipCheckoutOwnership: true }))) return;
     const actorRunId = requireAgentRunId(req, res);
     if (req.actor.type === "agent" && !actorRunId) return;
 

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -1927,6 +1927,22 @@ function isAssigneeSelfCommentOnTerminalIssue(input: {
   return input.actorId === input.assigneeAgentId;
 }
 
+function shouldClaimResumeCheckoutForActorRun(input: {
+  resumeRequested: boolean;
+  actorType: "agent" | "user";
+  actorAgentId: string | null | undefined;
+  actorRunId: string | null | undefined;
+  assigneeAgentId: string | null | undefined;
+}) {
+  if (!input.resumeRequested) return false;
+  if (input.actorType !== "agent") return false;
+  const actorRunId = typeof input.actorRunId === "string" ? input.actorRunId.trim() : "";
+  const actorAgentId = typeof input.actorAgentId === "string" ? input.actorAgentId.trim() : "";
+  const assigneeAgentId = typeof input.assigneeAgentId === "string" ? input.assigneeAgentId.trim() : "";
+  if (!actorRunId || !actorAgentId || !assigneeAgentId) return false;
+  return actorAgentId === assigneeAgentId;
+}
+
 function readToolActionExecutionStatus(value: unknown) {
   return value === "approved"
     || value === "executing"
@@ -2920,6 +2936,29 @@ export function issueRoutes(
   };
   const feedbackExportService = opts?.feedbackExportService;
   const environmentsSvc = environmentService(db);
+
+  async function claimAssigneeResumeCheckout(input: {
+    resumeRequested: boolean;
+    reopened: boolean;
+    actor: ReturnType<typeof getActorInfo>;
+    issueId: string;
+    assigneeAgentId: string | null | undefined;
+  }) {
+    if (!input.reopened) return null;
+    if (!shouldClaimResumeCheckoutForActorRun({
+      resumeRequested: input.resumeRequested,
+      actorType: input.actor.actorType,
+      actorAgentId: input.actor.agentId,
+      actorRunId: input.actor.runId,
+      assigneeAgentId: input.assigneeAgentId,
+    })) {
+      return null;
+    }
+    const agentId = input.actor.agentId;
+    const runId = input.actor.runId?.trim();
+    if (!agentId || !runId) return null;
+    return svc.checkout(input.issueId, agentId, ["todo", "in_progress"], runId);
+  }
 
   async function queueTaskWatchdogEvaluation(issue: { id: string; companyId: string }, runId?: string | null) {
     await taskWatchdogsSvc
@@ -10209,6 +10248,23 @@ export function issueRoutes(
       previous.status !== undefined &&
       issue.status === "todo";
     const reopenFromStatus = reopened ? existing.status : null;
+    const claimedResumeCheckout = await claimAssigneeResumeCheckout({
+      resumeRequested: resumeRequested === true,
+      reopened,
+      actor,
+      issueId: issue.id,
+      assigneeAgentId: issue.assigneeAgentId,
+    });
+    if (claimedResumeCheckout) {
+      issueResponse = {
+        ...issueResponse,
+        status: claimedResumeCheckout.status,
+        checkoutRunId: claimedResumeCheckout.checkoutRunId,
+        executionRunId: claimedResumeCheckout.executionRunId,
+        executionLockedAt: claimedResumeCheckout.executionLockedAt,
+        startedAt: claimedResumeCheckout.startedAt,
+      };
+    }
     const scheduledRetrySupersededByComment =
       shouldResumeInProgressScheduledRetry &&
       previous.status !== undefined &&
@@ -10710,6 +10766,7 @@ export function issueRoutes(
       }
 
       if (
+        !claimedResumeCheckout &&
         !assigneeChanged &&
         (
           statusChangedFromBacklog ||
@@ -10749,7 +10806,7 @@ export function issueRoutes(
         // stale issue_commented wake for an already-completed issue.
         const skipAssigneeCommentWake = selfComment || isClosedIssueStatus(issue.status);
 
-        if (assigneeId && !assigneeChanged && (reopened || !skipAssigneeCommentWake)) {
+        if (assigneeId && !claimedResumeCheckout && !assigneeChanged && (reopened || !skipAssigneeCommentWake)) {
           addWakeup(assigneeId, {
             source: "automation",
             triggerDetail: "system",
@@ -12405,6 +12462,7 @@ export function issueRoutes(
     let reopened = false;
     let reopenFromStatus: string | null = null;
     let interruptedRunId: string | null = null;
+    let claimedResumeCheckout = false;
     let currentIssue = issue;
     // Clear the reopen-pending flag if this comment leaves the issue terminal, so
     // the rebuilt worktree does not leak. A comment reopens the workspace but only
@@ -12446,6 +12504,24 @@ export function issueRoutes(
       reopened = isClosed || (isBlocked && !hasUnresolvedFirstClassBlockers);
       reopenFromStatus = reopened ? issue.status : null;
       currentIssue = reopenedIssue;
+      const claimed = await claimAssigneeResumeCheckout({
+        resumeRequested: resumeRequested === true,
+        reopened,
+        actor,
+        issueId: id,
+        assigneeAgentId: currentIssue.assigneeAgentId,
+      });
+      if (claimed) {
+        claimedResumeCheckout = true;
+        currentIssue = {
+          ...currentIssue,
+          status: claimed.status,
+          checkoutRunId: claimed.checkoutRunId,
+          executionRunId: claimed.executionRunId,
+          executionLockedAt: claimed.executionLockedAt,
+          startedAt: claimed.startedAt,
+        };
+      }
 
       await logActivity(db, {
         companyId: currentIssue.companyId,
@@ -12835,7 +12911,7 @@ export function issueRoutes(
       // transition (in_review -> done) suppresses a stale `issue_commented` wake
       // to the returnAssignee for an already-completed issue.
       const skipWake = selfComment || isClosedIssueStatus(wakeIssueSnapshot.status);
-      if (assigneeId && (reopened || !skipWake)) {
+      if (assigneeId && !claimedResumeCheckout && (reopened || !skipWake)) {
         if (reopened) {
           addWakeup(assigneeId, {
             source: "automation",

--- a/server/src/routes/issues.ts
+++ b/server/src/routes/issues.ts
@@ -2939,7 +2939,13 @@ export function issueRoutes(
   async function assertCrossIssueInfluenceWithinRunCap(
     req: Request,
     res: Response,
-    issue: { id: string; identifier?: string | null; companyId: string },
+    issue: {
+      id: string;
+      identifier?: string | null;
+      companyId: string;
+      assigneeAgentId?: string | null;
+      checkoutRunId?: string | null;
+    },
     kind: CrossIssueInfluenceKind,
   ) {
     if (req.actor.type !== "agent") return true;
@@ -2954,6 +2960,8 @@ export function issueRoutes(
       responsibleUserId: req.actor.onBehalfOfUserId ?? null,
       targetIssueId: issue.id,
       targetIssueIdentifier: issue.identifier ?? null,
+      targetCheckoutRunId: issue.checkoutRunId ?? null,
+      targetAssigneeAgentId: issue.assigneeAgentId ?? null,
       kind,
     });
     if (!decision || decision.allowed) return true;

--- a/server/src/services/cross-issue-influence-limit.ts
+++ b/server/src/services/cross-issue-influence-limit.ts
@@ -76,6 +76,8 @@ export async function observeCrossIssueInfluence(
     responsibleUserId?: string | null;
     targetIssueId: string;
     targetIssueIdentifier?: string | null;
+    targetCheckoutRunId?: string | null;
+    targetAssigneeAgentId?: string | null;
     kind: CrossIssueInfluenceKind;
     now?: Date;
   },
@@ -110,6 +112,15 @@ export async function observeCrossIssueInfluence(
     }
 
     const sourceIssueId = readRunSourceIssueId(run.contextSnapshot);
+    // Timer wakes omit issueId. A checkout lock on this run's assigned issue is
+    // still same-issue influence, not a missing run.
+    if (
+      !sourceIssueId &&
+      input.targetCheckoutRunId === input.runId &&
+      input.targetAssigneeAgentId === input.agentId
+    ) {
+      return null;
+    }
     if (!sourceIssueId) throw crossIssueInfluenceRunContextError();
     if (
       sourceIssueId === input.targetIssueId ||

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -1216,11 +1216,12 @@ export async function heartbeatRunIsTerminalOrMissing(
   runId: string,
 ): Promise<boolean> {
   const run = await dbOrTx
-    .select({ status: heartbeatRuns.status })
+    .select({ status: heartbeatRuns.status, finishedAt: heartbeatRuns.finishedAt })
     .from(heartbeatRuns)
     .where(eq(heartbeatRuns.id, runId))
-    .then((rows: Array<{ status: string }>) => rows[0] ?? null);
+    .then((rows: Array<{ status: string; finishedAt: Date | null }>) => rows[0] ?? null);
   if (!run) return true;
+  if (run.finishedAt) return true;
   return TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status);
 }
 
@@ -5317,18 +5318,24 @@ export function issueService(db: Db) {
       ]);
       const [existingRun, actorRun] = await Promise.all([
         tx
-          .select({ status: heartbeatRuns.status })
+          .select({ status: heartbeatRuns.status, finishedAt: heartbeatRuns.finishedAt })
           .from(heartbeatRuns)
           .where(eq(heartbeatRuns.id, input.expectedCheckoutRunId))
           .then((rows) => rows[0] ?? null),
         tx
-          .select({ status: heartbeatRuns.status })
+          .select({ status: heartbeatRuns.status, finishedAt: heartbeatRuns.finishedAt })
           .from(heartbeatRuns)
           .where(eq(heartbeatRuns.id, input.actorRunId))
           .then((rows) => rows[0] ?? null),
       ]);
-      const stale = !existingRun || TERMINAL_HEARTBEAT_RUN_STATUSES.has(existingRun.status);
-      const actorLive = actorRun && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(actorRun.status);
+      const stale =
+        !existingRun ||
+        Boolean(existingRun.finishedAt) ||
+        TERMINAL_HEARTBEAT_RUN_STATUSES.has(existingRun.status);
+      const actorLive =
+        Boolean(actorRun) &&
+        !actorRun.finishedAt &&
+        !TERMINAL_HEARTBEAT_RUN_STATUSES.has(actorRun.status);
       if (!stale || !actorLive) {
         return { adopted: null, latest: lockedIssue };
       }
@@ -5387,11 +5394,17 @@ export function issueService(db: Db) {
         sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${input.actorRunId} for update`,
       );
       const actorRun = await tx
-        .select({ status: heartbeatRuns.status })
+        .select({ status: heartbeatRuns.status, finishedAt: heartbeatRuns.finishedAt })
         .from(heartbeatRuns)
         .where(eq(heartbeatRuns.id, input.actorRunId))
         .then((rows) => rows[0] ?? null);
-      if (!actorRun || TERMINAL_HEARTBEAT_RUN_STATUSES.has(actorRun.status)) return null;
+      if (
+        !actorRun ||
+        actorRun.finishedAt ||
+        TERMINAL_HEARTBEAT_RUN_STATUSES.has(actorRun.status)
+      ) {
+        return null;
+      }
 
       const now = new Date();
       const adopted = await tx
@@ -5439,12 +5452,7 @@ export function issueService(db: Db) {
       await tx.execute(
         sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${issue.executionRunId} for update`,
       );
-      const run = await tx
-        .select({ status: heartbeatRuns.status })
-        .from(heartbeatRuns)
-        .where(eq(heartbeatRuns.id, issue.executionRunId))
-        .then((rows) => rows[0] ?? null);
-      if (run && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status)) return false;
+      if (!(await isTerminalOrMissingHeartbeatRun(issue.executionRunId, tx))) return false;
 
       const updated = await tx
         .update(issues)
@@ -5487,23 +5495,13 @@ export function issueService(db: Db) {
       await tx.execute(
         sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${issue.checkoutRunId} for update`,
       );
-      const run = await tx
-        .select({ status: heartbeatRuns.status })
-        .from(heartbeatRuns)
-        .where(eq(heartbeatRuns.id, issue.checkoutRunId))
-        .then((rows) => rows[0] ?? null);
-      if (run && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(run.status)) return false;
+      if (!(await isTerminalOrMissingHeartbeatRun(issue.checkoutRunId, tx))) return false;
 
       if (issue.executionRunId && issue.executionRunId !== issue.checkoutRunId) {
         await tx.execute(
           sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${issue.executionRunId} for update`,
         );
-        const executionRun = await tx
-          .select({ status: heartbeatRuns.status })
-          .from(heartbeatRuns)
-          .where(eq(heartbeatRuns.id, issue.executionRunId))
-          .then((rows) => rows[0] ?? null);
-        if (executionRun && !TERMINAL_HEARTBEAT_RUN_STATUSES.has(executionRun.status)) return false;
+        if (!(await isTerminalOrMissingHeartbeatRun(issue.executionRunId, tx))) return false;
       }
 
       const updated = await tx

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -449,14 +449,16 @@ async function bindHeartbeatRunToCheckedOutIssue(
     : {};
   const currentIssueId = typeof context.issueId === "string" ? context.issueId.trim() : "";
   const currentTaskId = typeof context.taskId === "string" ? context.taskId.trim() : "";
-  if (currentIssueId === input.issueId && (currentTaskId === input.issueId || currentTaskId === "")) return;
+  if (currentIssueId && currentIssueId !== input.issueId) return;
+  if (currentTaskId && currentTaskId !== input.issueId) return;
+  if (currentIssueId === input.issueId && currentTaskId === input.issueId) return;
   await db
     .update(heartbeatRuns)
     .set({
       contextSnapshot: {
         ...context,
         issueId: input.issueId,
-        ...(currentTaskId ? {} : { taskId: input.issueId }),
+        taskId: input.issueId,
       },
       updatedAt: new Date(),
     })

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -425,6 +425,44 @@ type DerivedIssueCommentAttribution = {
  * Resolve a `created_by_run_id` safe for the heartbeat_runs FK; returns null for
  * missing/invalid ids so an unknown run id never 500s a comment insert.
  */
+
+async function bindHeartbeatRunToCheckedOutIssue(
+  db: Db,
+  input: { companyId: string; runId: string | null; agentId: string; issueId: string },
+) {
+  if (!input.runId) return;
+  const run = await db
+    .select({
+      id: heartbeatRuns.id,
+      contextSnapshot: heartbeatRuns.contextSnapshot,
+    })
+    .from(heartbeatRuns)
+    .where(and(
+      eq(heartbeatRuns.id, input.runId),
+      eq(heartbeatRuns.companyId, input.companyId),
+      eq(heartbeatRuns.agentId, input.agentId),
+    ))
+    .then((rows) => rows[0] ?? null);
+  if (!run) return;
+  const context = run.contextSnapshot && typeof run.contextSnapshot === "object" && !Array.isArray(run.contextSnapshot)
+    ? { ...(run.contextSnapshot as Record<string, unknown>) }
+    : {};
+  const currentIssueId = typeof context.issueId === "string" ? context.issueId.trim() : "";
+  const currentTaskId = typeof context.taskId === "string" ? context.taskId.trim() : "";
+  if (currentIssueId === input.issueId && (currentTaskId === input.issueId || currentTaskId === "")) return;
+  await db
+    .update(heartbeatRuns)
+    .set({
+      contextSnapshot: {
+        ...context,
+        issueId: input.issueId,
+        ...(currentTaskId ? {} : { taskId: input.issueId }),
+      },
+      updatedAt: new Date(),
+    })
+    .where(eq(heartbeatRuns.id, run.id));
+}
+
 async function resolveCommentCreatedByRunId(
   dbOrTx: any,
   companyId: string,
@@ -8236,6 +8274,15 @@ export function issueService(db: Db) {
       if (!issueCompany) throw notFound("Issue not found");
       await assertAssignableAgent(db, issueCompany.companyId, agentId, { kind: "work" });
 
+      const bindCheckoutRun = async () => {
+        await bindHeartbeatRunToCheckedOutIssue(db, {
+          companyId: issueCompany.companyId,
+          runId: checkoutRunId,
+          agentId,
+          issueId: id,
+        });
+      };
+
       const now = new Date();
       const activePauseHold = await treeControlSvc.getActivePauseHoldGate(issueCompany.companyId, id);
       if (
@@ -8302,6 +8349,7 @@ export function issueService(db: Db) {
         .then((rows) => rows[0] ?? null);
 
       if (updated) {
+        await bindCheckoutRun();
         const [enriched] = await withIssueLabels(db, [updated]);
         return enriched;
       }
@@ -8345,7 +8393,10 @@ export function issueService(db: Db) {
           )
           .returning()
           .then((rows) => rows[0] ?? null);
-        if (adopted) return adopted;
+        if (adopted) {
+          await bindCheckoutRun();
+          return adopted;
+        }
       }
 
       if (
@@ -8362,6 +8413,7 @@ export function issueService(db: Db) {
           expectedCheckoutRunId: current.checkoutRunId,
         });
         if (staleAdoption.adopted) {
+          await bindCheckoutRun();
           const row = await db.select().from(issues).where(eq(issues.id, id)).then((rows) => rows[0] ?? null);
           if (!row) throw notFound("Issue not found");
           const [enriched] = await withIssueLabels(db, [row]);
@@ -8407,6 +8459,7 @@ export function issueService(db: Db) {
             .returning()
             .then((rows) => rows[0] ?? null);
           if (adopted) {
+            await bindCheckoutRun();
             const [enriched] = await withIssueLabels(db, [adopted]);
             return enriched;
           }
@@ -8422,6 +8475,7 @@ export function issueService(db: Db) {
         const row = await db.select().from(issues).where(eq(issues.id, id)).then((rows) => rows[0] ?? null);
         if (!row) throw notFound("Issue not found");
         const [enriched] = await withIssueLabels(db, [row]);
+        await bindCheckoutRun();
         return enriched;
       }
 

--- a/server/src/services/issues.ts
+++ b/server/src/services/issues.ts
@@ -431,38 +431,48 @@ async function bindHeartbeatRunToCheckedOutIssue(
   input: { companyId: string; runId: string | null; agentId: string; issueId: string },
 ) {
   if (!input.runId) return;
-  const run = await db
-    .select({
-      id: heartbeatRuns.id,
-      contextSnapshot: heartbeatRuns.contextSnapshot,
-    })
-    .from(heartbeatRuns)
-    .where(and(
-      eq(heartbeatRuns.id, input.runId),
-      eq(heartbeatRuns.companyId, input.companyId),
-      eq(heartbeatRuns.agentId, input.agentId),
-    ))
-    .then((rows) => rows[0] ?? null);
-  if (!run) return;
-  const context = run.contextSnapshot && typeof run.contextSnapshot === "object" && !Array.isArray(run.contextSnapshot)
-    ? { ...(run.contextSnapshot as Record<string, unknown>) }
-    : {};
-  const currentIssueId = typeof context.issueId === "string" ? context.issueId.trim() : "";
-  const currentTaskId = typeof context.taskId === "string" ? context.taskId.trim() : "";
-  if (currentIssueId && currentIssueId !== input.issueId) return;
-  if (currentTaskId && currentTaskId !== input.issueId) return;
-  if (currentIssueId === input.issueId && currentTaskId === input.issueId) return;
-  await db
-    .update(heartbeatRuns)
-    .set({
-      contextSnapshot: {
-        ...context,
-        issueId: input.issueId,
-        taskId: input.issueId,
-      },
-      updatedAt: new Date(),
-    })
-    .where(eq(heartbeatRuns.id, run.id));
+  const runId = input.runId;
+  await db.transaction(async (tx) => {
+    await tx.execute(
+      sql`select ${heartbeatRuns.id} from ${heartbeatRuns} where ${heartbeatRuns.id} = ${runId} for update`,
+    );
+    const run = await tx
+      .select({
+        id: heartbeatRuns.id,
+        contextSnapshot: heartbeatRuns.contextSnapshot,
+      })
+      .from(heartbeatRuns)
+      .where(and(
+        eq(heartbeatRuns.id, runId),
+        eq(heartbeatRuns.companyId, input.companyId),
+        eq(heartbeatRuns.agentId, input.agentId),
+      ))
+      .then((rows) => rows[0] ?? null);
+    if (!run) return;
+    const context = run.contextSnapshot && typeof run.contextSnapshot === "object" && !Array.isArray(run.contextSnapshot)
+      ? { ...(run.contextSnapshot as Record<string, unknown>) }
+      : {};
+    const currentIssueId = typeof context.issueId === "string" ? context.issueId.trim() : "";
+    const currentTaskId = typeof context.taskId === "string" ? context.taskId.trim() : "";
+    if (currentIssueId && currentIssueId !== input.issueId) return;
+    if (currentTaskId && currentTaskId !== input.issueId) return;
+    if (currentIssueId === input.issueId && currentTaskId === input.issueId) return;
+    await tx
+      .update(heartbeatRuns)
+      .set({
+        contextSnapshot: {
+          ...context,
+          issueId: input.issueId,
+          taskId: input.issueId,
+        },
+        updatedAt: new Date(),
+      })
+      .where(sql`
+        ${heartbeatRuns.id} = ${run.id}
+        and coalesce(${heartbeatRuns.contextSnapshot}->>'issueId', '') in ('', ${input.issueId})
+        and coalesce(${heartbeatRuns.contextSnapshot}->>'taskId', '') in ('', ${input.issueId})
+      `);
+  });
 }
 
 async function resolveCommentCreatedByRunId(


### PR DESCRIPTION
## Thinking Path

> - Paperclip manages work for AI agents.
> - Timer runs can start without an issue in their context.
> - Issue checkout must connect the run to its selected work.
> - Recovery must see that live run instead of an old completed run.
> - This PR tests the repair in #12526 through real authentication, routes, and database services.
> - The tests protect comment attribution, final status, and live-work detection.

## Linked Issues or Issue Description

Refs #12526. This draft depends on that PR. Its head at the start of this work was `4bffbed0472520d0ad5ca7f4ad35458e2009595e`. The new change above that head is one test file. Do not merge this PR before #12526. The repair remains in its existing review path.

Related: #12428 covers checkout locks when a run context names a different issue, and parked-loop recovery. This PR does not add that repair.

## What Changed

- Add database tests for a signed, standard-trust timer JWT with an empty context.
- Select and check out assigned work. Persist a comment with the correct run ID. Persist both `todo` and `done` with agent and run attribution in the activity log.
- Invoke the real recovery sweep and watchdog collection with an old succeeded run in the fixture. Check both normal execution locks and stamped checkout-only locks.
- Check that an unbound legacy checkout-only row is stopped, while an execution lock makes the watchdog live. Check stopped detection after the current run ends.
- Check that a second checkout preserves the first source. Permit 20 additional same-assignee comments. Reject comment 21 with HTTP 429 and no inserted comment.

## Verification

Run with local socket access and disposable embedded PostgreSQL:

```sh
node node_modules/vitest/vitest.mjs run --project @paperclipai/server server/src/__tests__/timer-checkout-watchdog.test.ts server/src/__tests__/cross-issue-influence-limit.test.ts server/src/__tests__/issues-service.test.ts server/src/__tests__/issue-agent-mutation-ownership-routes.test.ts server/src/__tests__/agent-auth-middleware.test.ts server/src/__tests__/low-trust-red-team-routes.test.ts
```

The integrated dependency passed seven affected suites (382 tests, zero skips) and server typecheck at `4bffbed0472520d0ad5ca7f4ad35458e2009595e`. At the resulting dependent head `8ae67a22e2c4046bd04d4d5199593999eb681b27`, both timer cases passed with zero database skips. Upstream task-completion telemetry added `hashPrivateRef`; the fixture now supplies that no-op method, preserving every behavioral assertion.

The six-suite command above exited 1 on this head: 279 passed, 1 failed, zero skips (215.92s). The failure is `issue-agent-mutation-ownership-routes.test.ts` → `denies company-wide issue list routes for task bridge keys`: 15000ms timeout. Both timer cases passed in that run. The same ownership suite passed on the dependency head; a loaded-host timeout is suspected but not proven. No timeout or assertion was weakened. A bounded rerun remains required. Native [Actions run](https://github.com/paperclipai/paperclip/actions/runs/34869397642) is queued, and independent code/security review must be refreshed. Required contexts are `ci / verify` and `ci / e2e`. No previous-head green result or test-only approval establishes readiness for this head.

## Risks

- The new file requires embedded PostgreSQL. It fails if the database cannot start; it does not silently skip.
- Each case uses its own disposable database. No production database is used.
- The source stamp covers successful checkout of the first selected issue. It does not repair old unbound rows or make one source represent all issues held by a run.
- The terminal-run assertion checks the watchdog collector and classifier. It does not claim that every terminal recovery branch was tested.
- No production code changes are added above #12526.

## Model Used

OpenAI Codex, GPT-6. Tool use and code execution were used. The runtime does not expose a more specific model ID or context-window size.

## Checklist

- [x] I have included a thinking path that traces from project context to this change
- [x] I have specified the model used (with version and capability details)
- [x] I have checked ROADMAP.md and confirmed this PR does not duplicate planned core work
- [x] I have searched GitHub for duplicate or related PRs and linked them above
- [x] I have either (a) linked existing issues with `Fixes: #` / `Closes #` / `Refs #` OR (b) described the issue in-PR following the relevant issue template
- [x] I have not referenced internal/instance-local Paperclip issues or links (only public GitHub references)
- [x] My branch name describes the change and contains no internal ticket ID
- [x] I have run tests locally and they pass
- [x] I have added or updated tests where applicable
- [x] I have updated relevant documentation to reflect my changes — test scope and limits are in this description; no public interface changed
- [x] I have considered and documented any risks above
- [ ] All Paperclip CI gates are green
- [ ] Greptile is 5/5 with no open P2s, recommendations, or follow-ups
- [x] I will address all Greptile and reviewer comments before requesting merge
